### PR TITLE
Allow using list of coordinates for writes/reads

### DIFF
--- a/R/DenseArray.R
+++ b/R/DenseArray.R
@@ -175,6 +175,11 @@ attribute_buffers <- function(array, sch, dom, sub, filter_attributes=list()) {
 setMethod("[", "tiledb_dense",
           function(x, i, j, ..., drop = FALSE) {
             index <- nd_index_from_syscall(sys.call(), parent.frame())
+            # If we have a list of lists of lists we need to remove one layer
+            # This happens when a user uses a list of coordinates
+            if (isNestedList(index[1])) {
+              index <- index[[1]]
+            }
             ctx <- x@ctx
             uri <- x@uri
             schema <- tiledb::schema(x)
@@ -256,6 +261,11 @@ setMethod("[<-", "tiledb_dense",
               }
             }
             index <- nd_index_from_syscall(sys.call(), parent.frame())
+            # If we have a list of lists of lists we need to remove one layer
+            # This happens when a user uses a list of coordinates
+            if (isNestedList(index[1])) {
+              index <- index[[1]]
+            }
             ctx <- x@ctx
             schema <- tiledb::schema(x)
             uri <- x@uri

--- a/R/SparseArray.R
+++ b/R/SparseArray.R
@@ -87,6 +87,11 @@ as_data_frame <- function(dom, data) {
 setMethod("[", "tiledb_sparse",
           function(x, i, j, ..., drop = FALSE) {
             index <- nd_index_from_syscall(sys.call(), parent.frame())
+            # If we have a list of lists of lists we need to remove one layer
+            # This happens when a user uses a list of coordinates
+            if (isNestedList(index[1])) {
+              index <- index[[1]]
+            }
             ctx <- x@ctx
             uri <- x@uri
             schema <- tiledb::schema(x)
@@ -161,6 +166,11 @@ setMethod("[<-", "tiledb_sparse",
               }
             }
             index <- nd_index_from_syscall(sys.call(), parent.frame())
+            # If we have a list of lists of lists we need to remove one layer
+            # This happens when a user uses a list of coordinates
+            if (isNestedList(index[1])) {
+              index <- index[[1]]
+            }
             ctx <- x@ctx
             schema <- tiledb::schema(x)
             uri <- x@uri

--- a/R/utils.R
+++ b/R/utils.R
@@ -19,3 +19,11 @@ nd_index_from_syscall <- function(call, env_frame) {
     index <- list() 
   return(index)
 }
+
+isNestedList <- function(l) {
+  stopifnot(is.list(l))
+  for (i in l) {
+    if (is.list(i)) return(TRUE)
+  }
+  return(FALSE)
+}

--- a/tests/testthat/test_DenseArray.R
+++ b/tests/testthat/test_DenseArray.R
@@ -391,3 +391,38 @@ test_that("test tiledb_subarray read for dense array as dataframe", {
     unlink(tmp, recursive = TRUE)
   })
 })
+
+test_that("Can read / write a simple 2D matrix with list of coordinates", {
+  tmp <- tempdir()
+  setup({
+    unlink_and_create(tmp)
+  })
+
+  ctx <- tiledb_ctx()
+  d1  <- tiledb_dim(ctx, domain = c(1L, 5L))
+  d2  <- tiledb_dim(ctx, domain = c(1L, 5L))
+  dom <- tiledb_domain(ctx, c(d1, d2))
+  val <- tiledb_attr(ctx, name="val")
+  sch <- tiledb_array_schema(ctx, dom, c(val))
+  tiledb_array_create(tmp, sch)
+
+  dat <- matrix(rnorm(25), 5, 5)
+  arr <- tiledb_dense(ctx, tmp, as.data.frame=FALSE)
+
+  arr[] <- dat
+  expect_equal(arr[], dat)
+
+  # explicit range enumeration
+  expect_equal(arr[list(c(3,4,5), c(3,4,5))],
+               dat[c(3,4,5), c(3,4,5)])
+
+  # vector range syntax
+  expect_equal(arr[list(c(1:3), c(1:3))], dat[1:3, 1:3])
+
+  # scalar indexing
+  expect_equal(arr[list(c(3), c(3))], dat[3, 3])
+
+  teardown({
+    unlink(tmp, recursive = TRUE)
+  })
+})


### PR DESCRIPTION
Allow using list of coordinates for writes/reads. Dense currently does not support sparse writes, but the foundation was laid for support.