### PR TITLE
Check for CXX11FLAGS after CXX1XFLAGS

### DIFF
--- a/configure
+++ b/configure
@@ -1978,7 +1978,7 @@ if test -z "${R_HOME}" ; then
     exit 1
 fi
 
-CXXFLAGS=`"${R_HOME}/bin/R" CMD config CXX1XFLAGS`
+CXXFLAGS=$(`${R_HOME}/bin/R" CMD config CXX1XFLAGS` || `${R_HOME}/bin/R CMD config CXX11FLAGS`)
 CPPFLAGS=`"${R_HOME}/bin/R" CMD config CPPFLAGS`
 ac_ext=cpp
 ac_cpp='$CXXCPP $CPPFLAGS'


### PR DESCRIPTION
R 3.6 no longer provides CXX1XFLAGS (unclear what version this change applies to, so I made
the check a fallback for now).

x-ref:
- addition of CXX11FLAGS: https://github.com/wch/r-source/commit/45899dba734cbd80a77432af9a3a7829a9ad48da#diff-da6461f4fb981956d8255c29cfb8ed55
- removal of CXX1XFLAGS: https://github.com/wch/r-source/commit/e73ffbc51884d695caa9ef57cac909faa0fd2baf#diff-da6461f4fb981956d8255c29cfb8ed55