### PR TITLE
Quick update copyrights to 2020

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018 TileDB Inc.
+Copyright (c) 2018-2020 TileDB Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/docs/LICENSE-text.html
+++ b/docs/LICENSE-text.html
@@ -105,7 +105,7 @@
 
 <pre>MIT License
 
-Copyright (c) 2018 TileDB Inc.
+Copyright (c) 2018-2020 TileDB Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/examples/quickstart_dense.R
+++ b/examples/quickstart_dense.R
@@ -4,7 +4,7 @@
 #
 # The MIT License
 #
-# Copyright (c) 2018 - 2020 TileDB, Inc.
+# Copyright (c) 2018-2020 TileDB, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/examples/quickstart_sparse.R
+++ b/examples/quickstart_sparse.R
@@ -4,7 +4,7 @@
 #
 # The MIT License
 #
-# Copyright (c) 2018 - 2020 TileDB, Inc.
+# Copyright (c) 2018-2020 TileDB, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
and standardizes the multi-year form to not use extra spaces

Also filed a ticket to add copyright statements to source files which do not have them yet.