### PR TITLE
Simpler base examples and consistent optional tags for ctx

### DIFF
--- a/R/ArraySchema.R
+++ b/R/ArraySchema.R
@@ -21,7 +21,7 @@ tiledb_array_schema.from_ptr <- function(ptr) {
 #' @param sparse (default FALSE)
 #' @param coords_filter_list (optional)
 #' @param offsets_filter_list (optional)
-#' @param ctx tiledb_ctx object
+#' @param ctx tiledb_ctx object (optional)
 #' @examples
 #' schema <- tiledb_array_schema(
 #'               dom = tiledb_domain(

--- a/R/Attribute.R
+++ b/R/Attribute.R
@@ -19,7 +19,7 @@ tiledb_attr.from_ptr <- function(ptr) {
 #' that this is a _required_ parameter.
 #' @param filter_list (default filter_list("NONE")) The tiledb_attr filter_list
 #' @param ncells (default 1) The number of cells, must be 1 for now
-#' @param ctx tiledb_ctx object
+#' @param ctx tiledb_ctx object (optional)
 #' @return `tiledb_dim` object
 #' @examples
 #' flt <- tiledb_filter_list(list(tiledb_filter("GZIP")))

--- a/R/DenseArray.R
+++ b/R/DenseArray.R
@@ -10,10 +10,10 @@ setClass("tiledb_dense",
 
 #' Constructs a tiledb_dense object backed by a persisted tiledb array uri
 #'
-#' @param ctx tiledb_ctx
 #' @param uri uri path to the tiledb dense array
 #' @param query_type optionally loads the array in "READ" or "WRITE" only modes.
 #' @param as.data.frame optional logical switch, defaults to "FALSE"
+#' @param ctx tiledb_ctx (optional)
 #' @return tiledb_dense array object
 #' @export
 tiledb_dense <- function(uri, query_type = c("READ", "WRITE"), as.data.frame=FALSE, ctx = tiledb:::ctx) {

--- a/R/Dim.R
+++ b/R/Dim.R
@@ -19,7 +19,7 @@ tiledb_dim.from_ptr <- function(ptr) {
 #' @param domain The dimension (inclusive) domain. The dimension’s domain is defined by a (lower bound, upper bound) vector
 #' @param tile The tile dimension tile extent
 #' @param type The dimension TileDB datatype string
-#' @param ctx tiledb_ctx object
+#' @param ctx tiledb_ctx object (optional)
 #' @return `tiledb_dim` object
 #' @examples
 #' tiledb_dim(name = "d1", domain = c(1L, 10L), tile = 5L, type = "INT32")

--- a/R/Domain.R
+++ b/R/Domain.R
@@ -16,7 +16,7 @@ tiledb_domain.from_ptr <- function(ptr) {
 #'
 #' All `tiledb_dim` must be of the same TileDB type.
 #'
-#' @param ctx tiledb_ctx
+#' @param ctx tiledb_ctx (optional)
 #' @param dims list() of tiledb_dim objects
 #' @return tiledb_domain
 #' @examples

--- a/R/Filter.R
+++ b/R/Filter.R
@@ -28,8 +28,8 @@ tiledb_filter.from_ptr <- function(ptr) {
 #' Valid compression options vary depending on the filter used,
 #' consult the TileDB docs for more information.
 #'
-#' @param ctx tiledb_ctx object
 #' @param name (default "NONE") TileDB filter name string
+#' @param ctx tiledb_ctx object (optional)
 #' @return tiledb_filter object
 #' @examples
 #' tiledb_filter("ZSTD")

--- a/R/FilterList.R
+++ b/R/FilterList.R
@@ -13,8 +13,8 @@ tiledb_filter_list.from_ptr <- function(ptr) {
 #' Constructs a `tiledb_filter_list` object
 #'
 #'
-#' @param ctx tiledb_ctx object
 #' @param filters an optional list of one or more tiledb_filter_list objects
+#' @param ctx tiledb_ctx object (optional)
 #' @return tiledb_filter_list object
 #' @examples
 #' flt <- tiledb_filter("ZSTD")

--- a/R/Object.R
+++ b/R/Object.R
@@ -10,8 +10,8 @@ check_object_arguments <- function(uri, ctx = tiledb:::ctx) {
 
 #' Creates a TileDB group object at given uri path
 #'
-#' @param ctx tiledb_ctx
 #' @param uri path which to create group
+#' @param ctx tiledb_ctx object (optional)
 #' @return uri of created group
 #' @examples
 #' pth <- tempdir()
@@ -31,8 +31,8 @@ tiledb_group_create <- function(uri, ctx = tiledb:::ctx) {
 #'  - `"GROUP"`, TileDB group
 #'  - `"INVALID"``, not a TileDB resource
 #'
-#' @param ctx tiledb_ctx
 #' @param uri path to TileDB resource
+#' @param ctx tiledb_ctx object (optional)
 #' @return TileDB object type string
 #'
 #' @export
@@ -46,7 +46,7 @@ tiledb_object_type <- function(uri, ctx = tiledb:::ctx) {
 #' Raises an error if the uri is invalid, or the uri resource is not a tiledb object
 #'
 #' @param uri path which to create group
-#' @param ctx tiledb_ctx object
+#' @param ctx tiledb_ctx object (optional)
 #' @return uri of removed TileDB resource
 #' @export
 tiledb_object_rm <- function(uri, ctx = tiledb:::ctx) {
@@ -58,9 +58,9 @@ tiledb_object_rm <- function(uri, ctx = tiledb:::ctx) {
 #'
 #' Raises an error if either uri is invalid, or the old uri resource is not a tiledb object
 #'
-#' @param ctx tiledb_ctx
 #' @param old_uri old uri of existing tiledb resource
 #' @param new_uri new uri to move tiledb resource
+#' @param ctx tiledb_ctx object (optional)
 #' @return new uri of moved tiledb resource
 #' @export
 tiledb_object_mv <- function(old_uri, new_uri, ctx = tiledb:::ctx) {
@@ -78,9 +78,9 @@ tiledb_object_mv <- function(old_uri, new_uri, ctx = tiledb:::ctx) {
 
 #' List TileDB resources at a given root URI path
 #'
-#' @param ctx tiledb_ctx
 #' @param uri uri path to walk
 #' @param filter optional filtering argument, default is "NULL", currently unused
+#' @param ctx tiledb_ctx object (optional)
 #' @return a dataframe with object type, object uri string columns
 #' @export
 tiledb_object_ls <- function(uri, filter = NULL, ctx = tiledb:::ctx) {
@@ -90,9 +90,9 @@ tiledb_object_ls <- function(uri, filter = NULL, ctx = tiledb:::ctx) {
 
 #' Recursively discover TileDB resources at a given root URI path
 #'
-#' @param ctx tiledb_ctx
 #' @param uri root uri path to walk
 #' @param order (default "PREORDER") specify "POSTORDER" for "POSTORDER" traversal
+#' @param ctx tiledb_ctx object (optional)
 #' @return a dataframe with object type, object uri string columns
 #' @export
 tiledb_object_walk <- function(uri, order = "PREORDER", ctx = tiledb:::ctx) {

--- a/R/SparseArray.R
+++ b/R/SparseArray.R
@@ -12,10 +12,10 @@ setClass("tiledb_sparse",
 #'
 #' tiledb_sparse returns a list of coordinates and attributes vectors for reads
 #'
-#' @param ctx tiledb_ctx
 #' @param uri uri path to the tiledb dense array
 #' @param query_type optionally loads the array in "READ" or "WRITE" only modes.
 #' @param as.data.frame optional logical switch, defaults to "FALSE"
+#' @param ctx tiledb_ctx (optional)
 #' @return tiledb_sparse array object
 #' @export
 tiledb_sparse <- function(uri, query_type = c("READ", "WRITE"), as.data.frame=FALSE, ctx = tiledb:::ctx) {

--- a/inst/examples/quickstart_dense.R
+++ b/inst/examples/quickstart_dense.R
@@ -39,21 +39,18 @@ library(tiledb)
 array_name <- "quickstart_dense"
 
 create_array <- function() {
-    # Create a TileDB context
-    ctx <- tiledb_ctx()
-
     # Check if the array already exists.
-    if (tiledb_object_type(array_name, ctx=ctx) == "ARRAY") {
+    if (tiledb_object_type(array_name) == "ARRAY") {
         message("Array already exists.")
         return(invisible(NULL))
     }
 
     # The array will be 4x4 with dimensions "rows" and "cols", with domain [1,4].
-    dom <- tiledb_domain(dims = c(tiledb_dim("rows", c(1L, 4L), 4L, "INT32", ctx=ctx),
-                                  tiledb_dim("cols", c(1L, 4L), 4L, "INT32", ctx=ctx)), ctx=ctx)
+    dom <- tiledb_domain(dims = c(tiledb_dim("rows", c(1L, 4L), 4L, "INT32"),
+                                  tiledb_dim("cols", c(1L, 4L), 4L, "INT32")))
 
     # The array will be dense with a single attribute "a" so each (i,j) cell can store an integer.
-    schema <- tiledb_array_schema(dom, attrs = c(tiledb_attr("a", type = "INT32", ctx=ctx)), ctx=ctx)
+    schema <- tiledb_array_schema(dom, attrs = c(tiledb_attr("a", type = "INT32")))
 
     # Create the (empty) array on disk.
     tiledb_array_create(array_name, schema)
@@ -65,15 +62,13 @@ write_array <- function() {
                     c(3L, 7L, 11L, 15L),
                     c(4L, 8L, 12L, 16L)), dim = c(4,4))
     # Open the array and write to it.
-    ctx <- tiledb_ctx()
-    A <- tiledb_dense(uri = array_name, ctx=ctx)
+    A <- tiledb_dense(uri = array_name)
     A[] <- data
 }
 
 read_array <- function() {
-    ctx = tiledb_ctx()
     # Open the array and read from it.
-    A <- tiledb_dense(uri = array_name, ctx=ctx)
+    A <- tiledb_dense(uri = array_name)
     data <- A[1:2, 2:4]
     show(data)
 }

--- a/inst/examples/quickstart_sparse.R
+++ b/inst/examples/quickstart_sparse.R
@@ -39,22 +39,18 @@ library(tiledb)
 array_name <- "quickstart_sparse"
 
 create_array <- function() {
-    # Create a TileDB context
-    ctx <- tiledb_ctx()
-
     # Check if the array already exists.
-    if (tiledb_object_type(array_name, ctx=ctx) == "ARRAY") {
+    if (tiledb_object_type(array_name) == "ARRAY") {
         message("Array already exists.")
         return(invisible(NULL))
     }
 
     # The array will be 4x4 with dimensions "rows" and "cols", with domain [1,4].
-    dom <- tiledb_domain(dims = c(tiledb_dim("rows", c(1L, 4L), 4L, "INT32", ctx=ctx),
-                                  tiledb_dim("cols", c(1L, 4L), 4L, "INT32", ctx=ctx)), ctx=ctx)
+    dom <- tiledb_domain(dims = c(tiledb_dim("rows", c(1L, 4L), 4L, "INT32"),
+                                  tiledb_dim("cols", c(1L, 4L), 4L, "INT32")))
 
    # The array will be dense with a single attribute "a" so each (i,j) cell can store an integer.
-    schema = tiledb_array_schema(dom, attrs=c(tiledb_attr("a", type = "INT32", ctx=ctx)),
-                                 sparse = TRUE, ctx=ctx)
+    schema = tiledb_array_schema(dom, attrs=c(tiledb_attr("a", type = "INT32")), sparse = TRUE)
 
     # Create the (empty) array on disk.
     tiledb_array_create(array_name, schema)
@@ -65,15 +61,13 @@ write_array <- function() {
     J <- c(1, 4, 3)
     data <- c(1L, 2L, 3L)
     # Open the array and write to it.
-    ctx <- tiledb_ctx()
-    A <- tiledb_sparse(uri = array_name, ctx=ctx)
+    A <- tiledb_sparse(uri = array_name)
     A[I, J] <- data
 }
 
 read_array <- function() {
-    ctx <- tiledb_ctx()
     # Open the array and read from it.
-    A <- tiledb_sparse(uri = array_name, ctx=ctx)
+    A <- tiledb_sparse(uri = array_name)
     data <- A[1:2, 2:4]
     coords <- data[["coords"]]
     a_vals <- data[["a"]]

--- a/man/tiledb_array_schema.Rd
+++ b/man/tiledb_array_schema.Rd
@@ -30,7 +30,7 @@ tiledb_array_schema(
 
 \item{offsets_filter_list}{(optional)}
 
-\item{ctx}{tiledb_ctx object}
+\item{ctx}{tiledb_ctx object (optional)}
 }
 \description{
 Constructs a \code{tiledb_array_schema} object

--- a/man/tiledb_attr.Rd
+++ b/man/tiledb_attr.Rd
@@ -22,7 +22,7 @@ that this is a \emph{required} parameter.}
 
 \item{ncells}{(default 1) The number of cells, must be 1 for now}
 
-\item{ctx}{tiledb_ctx object}
+\item{ctx}{tiledb_ctx object (optional)}
 }
 \value{
 \code{tiledb_dim} object

--- a/man/tiledb_dense.Rd
+++ b/man/tiledb_dense.Rd
@@ -18,7 +18,7 @@ tiledb_dense(
 
 \item{as.data.frame}{optional logical switch, defaults to "FALSE"}
 
-\item{ctx}{tiledb_ctx}
+\item{ctx}{tiledb_ctx (optional)}
 }
 \value{
 tiledb_dense array object

--- a/man/tiledb_dim.Rd
+++ b/man/tiledb_dim.Rd
@@ -15,7 +15,7 @@ tiledb_dim(name = "", domain, tile, type, ctx = tiledb:::ctx)
 
 \item{type}{The dimension TileDB datatype string}
 
-\item{ctx}{tiledb_ctx object}
+\item{ctx}{tiledb_ctx object (optional)}
 }
 \value{
 \code{tiledb_dim} object

--- a/man/tiledb_domain.Rd
+++ b/man/tiledb_domain.Rd
@@ -9,7 +9,7 @@ tiledb_domain(dims, ctx = tiledb:::ctx)
 \arguments{
 \item{dims}{list() of tiledb_dim objects}
 
-\item{ctx}{tiledb_ctx}
+\item{ctx}{tiledb_ctx (optional)}
 }
 \value{
 tiledb_domain

--- a/man/tiledb_filter.Rd
+++ b/man/tiledb_filter.Rd
@@ -9,7 +9,7 @@ tiledb_filter(name = "NONE", ctx = tiledb:::ctx)
 \arguments{
 \item{name}{(default "NONE") TileDB filter name string}
 
-\item{ctx}{tiledb_ctx object}
+\item{ctx}{tiledb_ctx object (optional)}
 }
 \value{
 tiledb_filter object

--- a/man/tiledb_filter_list.Rd
+++ b/man/tiledb_filter_list.Rd
@@ -9,7 +9,7 @@ tiledb_filter_list(filters = c(), ctx = tiledb:::ctx)
 \arguments{
 \item{filters}{an optional list of one or more tiledb_filter_list objects}
 
-\item{ctx}{tiledb_ctx object}
+\item{ctx}{tiledb_ctx object (optional)}
 }
 \value{
 tiledb_filter_list object

--- a/man/tiledb_group_create.Rd
+++ b/man/tiledb_group_create.Rd
@@ -9,7 +9,7 @@ tiledb_group_create(uri, ctx = tiledb:::ctx)
 \arguments{
 \item{uri}{path which to create group}
 
-\item{ctx}{tiledb_ctx}
+\item{ctx}{tiledb_ctx object (optional)}
 }
 \value{
 uri of created group

--- a/man/tiledb_object_ls.Rd
+++ b/man/tiledb_object_ls.Rd
@@ -11,7 +11,7 @@ tiledb_object_ls(uri, filter = NULL, ctx = tiledb:::ctx)
 
 \item{filter}{optional filtering argument, default is "NULL", currently unused}
 
-\item{ctx}{tiledb_ctx}
+\item{ctx}{tiledb_ctx object (optional)}
 }
 \value{
 a dataframe with object type, object uri string columns

--- a/man/tiledb_object_mv.Rd
+++ b/man/tiledb_object_mv.Rd
@@ -11,7 +11,7 @@ tiledb_object_mv(old_uri, new_uri, ctx = tiledb:::ctx)
 
 \item{new_uri}{new uri to move tiledb resource}
 
-\item{ctx}{tiledb_ctx}
+\item{ctx}{tiledb_ctx object (optional)}
 }
 \value{
 new uri of moved tiledb resource

--- a/man/tiledb_object_rm.Rd
+++ b/man/tiledb_object_rm.Rd
@@ -9,7 +9,7 @@ tiledb_object_rm(uri, ctx = tiledb:::ctx)
 \arguments{
 \item{uri}{path which to create group}
 
-\item{ctx}{tiledb_ctx object}
+\item{ctx}{tiledb_ctx object (optional)}
 }
 \value{
 uri of removed TileDB resource

--- a/man/tiledb_object_type.Rd
+++ b/man/tiledb_object_type.Rd
@@ -9,7 +9,7 @@ tiledb_object_type(uri, ctx = tiledb:::ctx)
 \arguments{
 \item{uri}{path to TileDB resource}
 
-\item{ctx}{tiledb_ctx}
+\item{ctx}{tiledb_ctx object (optional)}
 }
 \value{
 TileDB object type string

--- a/man/tiledb_object_walk.Rd
+++ b/man/tiledb_object_walk.Rd
@@ -11,7 +11,7 @@ tiledb_object_walk(uri, order = "PREORDER", ctx = tiledb:::ctx)
 
 \item{order}{(default "PREORDER") specify "POSTORDER" for "POSTORDER" traversal}
 
-\item{ctx}{tiledb_ctx}
+\item{ctx}{tiledb_ctx object (optional)}
 }
 \value{
 a dataframe with object type, object uri string columns

--- a/man/tiledb_sparse.Rd
+++ b/man/tiledb_sparse.Rd
@@ -18,7 +18,7 @@ tiledb_sparse(
 
 \item{as.data.frame}{optional logical switch, defaults to "FALSE"}
 
-\item{ctx}{tiledb_ctx}
+\item{ctx}{tiledb_ctx (optional)}
 }
 \value{
 tiledb_sparse array object


### PR DESCRIPTION
Two simple commits:
 - rewrite the two existing examples to not require `ctx` objects
 - ensure roxygen docs for ctx object consistently refer to it being optional