### PR TITLE
Lazy context [ch1140]

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -6,4 +6,6 @@
 ^.*\.tar\.gz$
 ^docs
 ^_pkgdown.yml$
-^examples
+^inst/examples/quickstart_dense$
+^inst/examples/quickstart_sparse$
+^\.editorconfig$

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,20 @@
+# EditorConfig is awesome: http://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+# Matches multiple files with brace expansion notation
+# 4 space indentation
+[*.{c,cpp,h,hpp,R,r}]
+indent_style = space
+indent_size = 2
+
+# Tab indentation (no size specified)
+[Makefile]
+indent_style = tab

--- a/R/ArraySchema.R
+++ b/R/ArraySchema.R
@@ -42,7 +42,7 @@ tiledb_array_schema <- function(
                         sparse = FALSE,
                         coords_filter_list = NULL,
                         offsets_filter_list = NULL,
-                        ctx = tiledb:::ctx
+                        ctx = tiledb:::getContext()
                         ) {
   if (!is(ctx, "tiledb_ctx")) {
     stop("ctx argument must be a tiledb_ctx")
@@ -83,7 +83,7 @@ tiledb_array_schema <- function(
   return(new("tiledb_array_schema", ptr = ptr))
 }
 
-tiledb_array_schema.from_array <- function(x, ctx = tiledb:::ctx) {
+tiledb_array_schema.from_array <- function(x, ctx = tiledb:::getContext()) {
   if (!is(ctx, "tiledb_ctx")) {
     stop("ctx argument must be a tiledb_ctx")
   } else if (missing(x) || !is.array(x)) {

--- a/R/Attribute.R
+++ b/R/Attribute.R
@@ -33,7 +33,7 @@ tiledb_attr <- function(name,
                         type,
                         filter_list=tiledb_filter_list(),
                         ncells=1,
-                        ctx = tiledb:::ctx
+                        ctx = tiledb:::getContext()
                         ) {
     if (missing(name)) {
         name <- ""

--- a/R/DenseArray.R
+++ b/R/DenseArray.R
@@ -16,7 +16,7 @@ setClass("tiledb_dense",
 #' @param ctx tiledb_ctx (optional)
 #' @return tiledb_dense array object
 #' @export
-tiledb_dense <- function(uri, query_type = c("READ", "WRITE"), as.data.frame=FALSE, ctx = tiledb:::ctx) {
+tiledb_dense <- function(uri, query_type = c("READ", "WRITE"), as.data.frame=FALSE, ctx = tiledb:::getContext()) {
   query_type = match.arg(query_type)
   if (!is(ctx, "tiledb_ctx")) {
     stop("argument ctx must be a tiledb_ctx")

--- a/R/Dim.R
+++ b/R/Dim.R
@@ -26,7 +26,7 @@ tiledb_dim.from_ptr <- function(ptr) {
 #'
 #' @importFrom methods new
 #' @export tiledb_dim
-tiledb_dim <- function(name="", domain, tile, type, ctx = tiledb:::ctx) {
+tiledb_dim <- function(name="", domain, tile, type, ctx = tiledb:::getContext()) {
   if (!is(ctx, "tiledb_ctx")) {
     stop("ctx argument must be a tiledb_ctx")
   } else if (!is.scalar(name, "character")) {

--- a/R/Domain.R
+++ b/R/Domain.R
@@ -25,7 +25,7 @@ tiledb_domain.from_ptr <- function(ptr) {
 #' @importFrom methods slot
 #' @importFrom methods new
 #' @export tiledb_domain
-tiledb_domain <- function(dims, ctx = tiledb:::ctx) {
+tiledb_domain <- function(dims, ctx = tiledb:::getContext()) {
   if (!is(ctx, "tiledb_ctx")) {
     stop("argument ctx must be a tiledb_ctx")
   }

--- a/R/Filter.R
+++ b/R/Filter.R
@@ -35,7 +35,7 @@ tiledb_filter.from_ptr <- function(ptr) {
 #' tiledb_filter("ZSTD")
 #'
 #' @export tiledb_filter
-tiledb_filter <- function(name = "NONE", ctx = tiledb:::ctx) {
+tiledb_filter <- function(name = "NONE", ctx = tiledb:::getContext()) {
   if (!is(ctx, "tiledb_ctx")) {
     stop("argument ctx must be a tiledb_ctx")
   } else if (!is.scalar(name, "character")) {

--- a/R/FilterList.R
+++ b/R/FilterList.R
@@ -23,7 +23,7 @@ tiledb_filter_list.from_ptr <- function(ptr) {
 #' filter_list
 #'
 #' @export tiledb_filter_list
-tiledb_filter_list <- function(filters = c(), ctx = tiledb:::ctx) {
+tiledb_filter_list <- function(filters = c(), ctx = tiledb:::getContext()) {
   if (!is(ctx, "tiledb_ctx")) {
     stop("argument ctx must be a tiledb_ctx")
   }

--- a/R/Object.R
+++ b/R/Object.R
@@ -1,4 +1,4 @@
-check_object_arguments <- function(uri, ctx = tiledb:::ctx) {
+check_object_arguments <- function(uri, ctx = tiledb:::getContext()) {
   if (!is(ctx, "tiledb_ctx")) {
     stop("argument ctx must a a tiledb_ctx")
   }
@@ -19,7 +19,7 @@ check_object_arguments <- function(uri, ctx = tiledb:::ctx) {
 #' tiledb_object_type(pth)
 #'
 #'@export
-tiledb_group_create <- function(uri, ctx = tiledb:::ctx) {
+tiledb_group_create <- function(uri, ctx = tiledb:::getContext()) {
   check_object_arguments(uri, ctx)
   return(libtiledb_group_create(ctx@ptr, uri))
 }
@@ -36,7 +36,7 @@ tiledb_group_create <- function(uri, ctx = tiledb:::ctx) {
 #' @return TileDB object type string
 #'
 #' @export
-tiledb_object_type <- function(uri, ctx = tiledb:::ctx) {
+tiledb_object_type <- function(uri, ctx = tiledb:::getContext()) {
   check_object_arguments(uri, ctx)
   return(libtiledb_object_type(ctx@ptr, uri))
 }
@@ -49,7 +49,7 @@ tiledb_object_type <- function(uri, ctx = tiledb:::ctx) {
 #' @param ctx tiledb_ctx object (optional)
 #' @return uri of removed TileDB resource
 #' @export
-tiledb_object_rm <- function(uri, ctx = tiledb:::ctx) {
+tiledb_object_rm <- function(uri, ctx = tiledb:::getContext()) {
   check_object_arguments(uri, ctx)
   return(libtiledb_object_remove(ctx@ptr, uri))
 }
@@ -63,7 +63,7 @@ tiledb_object_rm <- function(uri, ctx = tiledb:::ctx) {
 #' @param ctx tiledb_ctx object (optional)
 #' @return new uri of moved tiledb resource
 #' @export
-tiledb_object_mv <- function(old_uri, new_uri, ctx = tiledb:::ctx) {
+tiledb_object_mv <- function(old_uri, new_uri, ctx = tiledb:::getContext()) {
   if (!is(ctx, "tiledb_ctx")) {
     stop("argument ctx must a a tiledb_ctx")
   }
@@ -83,7 +83,7 @@ tiledb_object_mv <- function(old_uri, new_uri, ctx = tiledb:::ctx) {
 #' @param ctx tiledb_ctx object (optional)
 #' @return a dataframe with object type, object uri string columns
 #' @export
-tiledb_object_ls <- function(uri, filter = NULL, ctx = tiledb:::ctx) {
+tiledb_object_ls <- function(uri, filter = NULL, ctx = tiledb:::getContext()) {
   check_object_arguments(uri, ctx)
   return(libtiledb_object_walk(ctx@ptr, uri, order = "PREORDER"))
 }
@@ -95,7 +95,7 @@ tiledb_object_ls <- function(uri, filter = NULL, ctx = tiledb:::ctx) {
 #' @param ctx tiledb_ctx object (optional)
 #' @return a dataframe with object type, object uri string columns
 #' @export
-tiledb_object_walk <- function(uri, order = "PREORDER", ctx = tiledb:::ctx) {
+tiledb_object_walk <- function(uri, order = "PREORDER", ctx = tiledb:::getContext()) {
   check_object_arguments(uri, ctx)
   return(libtiledb_object_walk(ctx@ptr, uri, order = order, recursive = TRUE))
 }

--- a/R/SparseArray.R
+++ b/R/SparseArray.R
@@ -18,7 +18,7 @@ setClass("tiledb_sparse",
 #' @param ctx tiledb_ctx (optional)
 #' @return tiledb_sparse array object
 #' @export
-tiledb_sparse <- function(uri, query_type = c("READ", "WRITE"), as.data.frame=FALSE, ctx = tiledb:::ctx) {
+tiledb_sparse <- function(uri, query_type = c("READ", "WRITE"), as.data.frame=FALSE, ctx = tiledb:::getContext()) {
     query_type = match.arg(query_type)
   if (!is(ctx, "tiledb_ctx")) {
     stop("argument ctx must be a tiledb_ctx")

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,8 +1,8 @@
+
+.pkgenv <- new.env(parent = emptyenv())
+
 .onLoad <- function(libname, pkgName) {
-  ns <- asNamespace(pkgName)
-  delayedAssign(
-      "ctx", tiledb_ctx(),
-      eval.env = ns, assign.env = ns
-  )
-  #namespaceExport(ns, "ctx") # uncomment to export and access via tiledb::ctx rather than tiledb:::ctx
+  ## create a slot for ctx in the per-package enviroment but do no fill it yet to allow 'lazy load'
+  ## this entry is generally accessed with a (non-exported) getter and setter in R/Ctx.R
+  .pkgenv[["ctx"]] <- NULL
 }

--- a/man/config-tiledb_ctx-method.Rd
+++ b/man/config-tiledb_ctx-method.Rd
@@ -4,7 +4,7 @@
 \alias{config,tiledb_ctx-method}
 \title{Retrieve the \code{tiledb_config} object from the \code{tiledb_ctx}}
 \usage{
-\S4method{config}{tiledb_ctx}(object = tiledb:::ctx)
+\S4method{config}{tiledb_ctx}(object = tiledb:::getContext())
 }
 \arguments{
 \item{object}{tiledb_ctx object}

--- a/man/tiledb_array_schema.Rd
+++ b/man/tiledb_array_schema.Rd
@@ -12,7 +12,7 @@ tiledb_array_schema(
   sparse = FALSE,
   coords_filter_list = NULL,
   offsets_filter_list = NULL,
-  ctx = tiledb:::ctx
+  ctx = tiledb:::getContext()
 )
 }
 \arguments{

--- a/man/tiledb_attr.Rd
+++ b/man/tiledb_attr.Rd
@@ -9,7 +9,7 @@ tiledb_attr(
   type,
   filter_list = tiledb_filter_list(),
   ncells = 1,
-  ctx = tiledb:::ctx
+  ctx = tiledb:::getContext()
 )
 }
 \arguments{

--- a/man/tiledb_ctx.Rd
+++ b/man/tiledb_ctx.Rd
@@ -4,10 +4,12 @@
 \alias{tiledb_ctx}
 \title{Creates a \code{tiledb_ctx} object}
 \usage{
-tiledb_ctx(config = NULL)
+tiledb_ctx(config = NULL, cached = TRUE)
 }
 \arguments{
 \item{config}{(optonal) character vector of config parameter names, values}
+
+\item{cached}{(optional) logical switch to force new creation}
 }
 \value{
 \code{tiledb_ctx} object

--- a/man/tiledb_dense.Rd
+++ b/man/tiledb_dense.Rd
@@ -8,7 +8,7 @@ tiledb_dense(
   uri,
   query_type = c("READ", "WRITE"),
   as.data.frame = FALSE,
-  ctx = tiledb:::ctx
+  ctx = tiledb:::getContext()
 )
 }
 \arguments{

--- a/man/tiledb_dim.Rd
+++ b/man/tiledb_dim.Rd
@@ -4,7 +4,7 @@
 \alias{tiledb_dim}
 \title{Contructs a \code{tiledb_dim} object}
 \usage{
-tiledb_dim(name = "", domain, tile, type, ctx = tiledb:::ctx)
+tiledb_dim(name = "", domain, tile, type, ctx = tiledb:::getContext())
 }
 \arguments{
 \item{name}{The dimension name / label string.  If emtpy, the domain is anonymous and will be assigned a positional label.}

--- a/man/tiledb_domain.Rd
+++ b/man/tiledb_domain.Rd
@@ -4,7 +4,7 @@
 \alias{tiledb_domain}
 \title{Constructs a \code{tiledb_domain} object}
 \usage{
-tiledb_domain(dims, ctx = tiledb:::ctx)
+tiledb_domain(dims, ctx = tiledb:::getContext())
 }
 \arguments{
 \item{dims}{list() of tiledb_dim objects}

--- a/man/tiledb_filter.Rd
+++ b/man/tiledb_filter.Rd
@@ -4,7 +4,7 @@
 \alias{tiledb_filter}
 \title{Constructs a \code{tiledb_filter} object}
 \usage{
-tiledb_filter(name = "NONE", ctx = tiledb:::ctx)
+tiledb_filter(name = "NONE", ctx = tiledb:::getContext())
 }
 \arguments{
 \item{name}{(default "NONE") TileDB filter name string}

--- a/man/tiledb_filter_list.Rd
+++ b/man/tiledb_filter_list.Rd
@@ -4,7 +4,7 @@
 \alias{tiledb_filter_list}
 \title{Constructs a \code{tiledb_filter_list} object}
 \usage{
-tiledb_filter_list(filters = c(), ctx = tiledb:::ctx)
+tiledb_filter_list(filters = c(), ctx = tiledb:::getContext())
 }
 \arguments{
 \item{filters}{an optional list of one or more tiledb_filter_list objects}

--- a/man/tiledb_group_create.Rd
+++ b/man/tiledb_group_create.Rd
@@ -4,7 +4,7 @@
 \alias{tiledb_group_create}
 \title{Creates a TileDB group object at given uri path}
 \usage{
-tiledb_group_create(uri, ctx = tiledb:::ctx)
+tiledb_group_create(uri, ctx = tiledb:::getContext())
 }
 \arguments{
 \item{uri}{path which to create group}

--- a/man/tiledb_is_supported_fs.Rd
+++ b/man/tiledb_is_supported_fs.Rd
@@ -4,7 +4,7 @@
 \alias{tiledb_is_supported_fs}
 \title{Query if a TileDB backend is supported}
 \usage{
-tiledb_is_supported_fs(scheme, object = tiledb:::ctx)
+tiledb_is_supported_fs(scheme, object = tiledb:::getContext())
 }
 \arguments{
 \item{scheme}{URI string scheme ("file", "hdfs", "s3")}

--- a/man/tiledb_object_ls.Rd
+++ b/man/tiledb_object_ls.Rd
@@ -4,7 +4,7 @@
 \alias{tiledb_object_ls}
 \title{List TileDB resources at a given root URI path}
 \usage{
-tiledb_object_ls(uri, filter = NULL, ctx = tiledb:::ctx)
+tiledb_object_ls(uri, filter = NULL, ctx = tiledb:::getContext())
 }
 \arguments{
 \item{uri}{uri path to walk}

--- a/man/tiledb_object_mv.Rd
+++ b/man/tiledb_object_mv.Rd
@@ -4,7 +4,7 @@
 \alias{tiledb_object_mv}
 \title{Move a TileDB resource to new uri path}
 \usage{
-tiledb_object_mv(old_uri, new_uri, ctx = tiledb:::ctx)
+tiledb_object_mv(old_uri, new_uri, ctx = tiledb:::getContext())
 }
 \arguments{
 \item{old_uri}{old uri of existing tiledb resource}

--- a/man/tiledb_object_rm.Rd
+++ b/man/tiledb_object_rm.Rd
@@ -4,7 +4,7 @@
 \alias{tiledb_object_rm}
 \title{Removes a TileDB resource}
 \usage{
-tiledb_object_rm(uri, ctx = tiledb:::ctx)
+tiledb_object_rm(uri, ctx = tiledb:::getContext())
 }
 \arguments{
 \item{uri}{path which to create group}

--- a/man/tiledb_object_type.Rd
+++ b/man/tiledb_object_type.Rd
@@ -4,7 +4,7 @@
 \alias{tiledb_object_type}
 \title{Return the TileDB object type string of a TileDB resource}
 \usage{
-tiledb_object_type(uri, ctx = tiledb:::ctx)
+tiledb_object_type(uri, ctx = tiledb:::getContext())
 }
 \arguments{
 \item{uri}{path to TileDB resource}

--- a/man/tiledb_object_walk.Rd
+++ b/man/tiledb_object_walk.Rd
@@ -4,7 +4,7 @@
 \alias{tiledb_object_walk}
 \title{Recursively discover TileDB resources at a given root URI path}
 \usage{
-tiledb_object_walk(uri, order = "PREORDER", ctx = tiledb:::ctx)
+tiledb_object_walk(uri, order = "PREORDER", ctx = tiledb:::getContext())
 }
 \arguments{
 \item{uri}{root uri path to walk}

--- a/man/tiledb_sparse.Rd
+++ b/man/tiledb_sparse.Rd
@@ -8,7 +8,7 @@ tiledb_sparse(
   uri,
   query_type = c("READ", "WRITE"),
   as.data.frame = FALSE,
-  ctx = tiledb:::ctx
+  ctx = tiledb:::getContext()
 )
 }
 \arguments{


### PR DESCRIPTION
This adds lazy context support.

We mostly keep all existing interfaces. Instead of the (non-exported, package global) constant `tiledb:::ctx` we now have non-exported getter and setter functions accessing a variable in a (also non-exported) package environment (essentially a hash).   

I kept it three commits below but can/will squash them easily.