### PR TITLE
De/array metadata

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -33,6 +33,14 @@ put_metadata <- function(array, key, obj) {
     .Call(`_tiledb_put_metadata`, array, key, obj)
 }
 
+get_metadata_from_index <- function(array, idx) {
+    .Call(`_tiledb_get_metadata_from_index`, array, idx)
+}
+
+get_metadata_from_index_simple <- function(array_name, idx) {
+    .Call(`_tiledb_get_metadata_from_index_simple`, array_name, idx)
+}
+
 tiledb_datatype_R_type <- function(datatype) {
     .Call(`_tiledb_tiledb_datatype_R_type`, datatype)
 }

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -102,6 +102,30 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// get_metadata_from_index
+SEXP get_metadata_from_index(Rcpp::XPtr<tiledb::Array> array, const int idx);
+RcppExport SEXP _tiledb_get_metadata_from_index(SEXP arraySEXP, SEXP idxSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< Rcpp::XPtr<tiledb::Array> >::type array(arraySEXP);
+    Rcpp::traits::input_parameter< const int >::type idx(idxSEXP);
+    rcpp_result_gen = Rcpp::wrap(get_metadata_from_index(array, idx));
+    return rcpp_result_gen;
+END_RCPP
+}
+// get_metadata_from_index_simple
+SEXP get_metadata_from_index_simple(const std::string array_name, const int idx);
+RcppExport SEXP _tiledb_get_metadata_from_index_simple(SEXP array_nameSEXP, SEXP idxSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< const std::string >::type array_name(array_nameSEXP);
+    Rcpp::traits::input_parameter< const int >::type idx(idxSEXP);
+    rcpp_result_gen = Rcpp::wrap(get_metadata_from_index_simple(array_name, idx));
+    return rcpp_result_gen;
+END_RCPP
+}
 // tiledb_datatype_R_type
 std::string tiledb_datatype_R_type(std::string datatype);
 RcppExport SEXP _tiledb_tiledb_datatype_R_type(SEXP datatypeSEXP) {
@@ -1237,6 +1261,8 @@ static const R_CallMethodDef CallEntries[] = {
     {"_tiledb_get_metadata", (DL_FUNC) &_tiledb_get_metadata, 2},
     {"_tiledb_put_metadata_simple", (DL_FUNC) &_tiledb_put_metadata_simple, 3},
     {"_tiledb_put_metadata", (DL_FUNC) &_tiledb_put_metadata, 3},
+    {"_tiledb_get_metadata_from_index", (DL_FUNC) &_tiledb_get_metadata_from_index, 2},
+    {"_tiledb_get_metadata_from_index_simple", (DL_FUNC) &_tiledb_get_metadata_from_index_simple, 2},
     {"_tiledb_tiledb_datatype_R_type", (DL_FUNC) &_tiledb_tiledb_datatype_R_type, 1},
     {"_tiledb_libtiledb_version", (DL_FUNC) &_tiledb_libtiledb_version, 0},
     {"_tiledb_libtiledb_ctx", (DL_FUNC) &_tiledb_libtiledb_ctx, 1},

--- a/tests/testthat/test_Metadata.R
+++ b/tests/testthat/test_Metadata.R
@@ -23,6 +23,8 @@ unlink_and_create_ptr <- function(tmp) {
 
   arrW <- tiledb:::libtiledb_array_open(arr@ptr, "WRITE")
   tiledb:::put_metadata(arrW, "vec", c(1.1, 2.2, 3.3))
+  arrW <- tiledb:::libtiledb_array_open(arr@ptr, "WRITE")
+  tiledb:::put_metadata(arrW, "txt", "the quick brown fox")
   tiledb:::libtiledb_array_close(arrW)
 
   arrR <- tiledb:::libtiledb_array_open(arr@ptr, "READ")
@@ -46,6 +48,7 @@ test_that("Can check presence of metadata", {
   expect_error(tiledb:::has_metadata(NULL, ""))
   expect_false(tiledb:::has_metadata(arr, ""))
   expect_true(tiledb:::has_metadata(arr, "vec"))
+  expect_true(tiledb:::has_metadata(arr, "txt"))
 
   unlink(tmp, recursive = TRUE, force = TRUE)
 })
@@ -54,7 +57,7 @@ test_that("Can retrieve count of metadata", {
   arr <- unlink_and_create_ptr(tmp)
 
   expect_error(tiledb:::num_metadata(NULL))
-  expect_equal(tiledb:::num_metadata(arr), 1L)
+  expect_equal(tiledb:::num_metadata(arr), 2L)
 
   unlink(tmp, recursive = TRUE, force = TRUE)
 })
@@ -98,6 +101,17 @@ test_that("Can do round trip", {
   vec <- "the quick brown fox"
   expect_true(tiledb:::put_metadata_simple(tmp, "char", vec))
   expect_equal(tiledb:::get_metadata_simple(tmp, "char"), vec)
+
+  unlink(tmp, recursive = TRUE, force = TRUE)
+})
+
+test_that("Can get by index", {
+  arr <- unlink_and_create_ptr(tmp)
+
+  expect_error(tiledb:::get_metadata_from_index(NULL, ""))
+  expect_error(tiledb:::get_metadata_from_index(arr, -1))
+  expect_equal(tiledb:::get_metadata_from_index(arr, 0), "the quick brown fox")
+  expect_equal(tiledb:::get_metadata_from_index(arr, 1), c(1.1, 2.2, 3.3))
 
   unlink(tmp, recursive = TRUE, force = TRUE)
 })

--- a/tests/testthat/test_Metadata.R
+++ b/tests/testthat/test_Metadata.R
@@ -1,4 +1,3 @@
-library(testthat)
 library(tiledb)
 context("tiledb_metadata")
 
@@ -84,20 +83,21 @@ test_that("Can put metadata", {
   unlink(tmp, recursive = TRUE, force = TRUE)
 })
 
-test_that("Can round trip", {
+test_that("Can do round trip", {
   ## will use 'simpler' accessors to not have to flip between read and write
   arr <- unlink_and_create_simple(tmp)
 
   vec <- c(1.1, 2.2, 3.3)
-  tiledb:::put_metadata_simple(tmp, "dvec", vec)
+  expect_true(tiledb:::put_metadata_simple(tmp, "dvec", vec))
   expect_equal(tiledb:::get_metadata_simple(tmp, "dvec"), vec)
 
   vec <- c(1L, 2L, 3L)
-  tiledb:::put_metadata_simple(tmp, "ivec", vec)
+  expect_true(tiledb:::put_metadata_simple(tmp, "ivec", vec))
   expect_equal(tiledb:::get_metadata_simple(tmp, "ivec"), vec)
 
   vec <- "the quick brown fox"
-  tiledb:::put_metadata_simple(tmp, "char", vec)
+  expect_true(tiledb:::put_metadata_simple(tmp, "char", vec))
   expect_equal(tiledb:::get_metadata_simple(tmp, "char"), vec)
+
   unlink(tmp, recursive = TRUE, force = TRUE)
 })


### PR DESCRIPTION
This builds upon #85 by extending unit tests, and adding a new 'by index' metadata accessor.