### PR TITLE
some polish for DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,27 +1,17 @@
 Package: tiledb
 Type: Package
-Title: Sparse and dense multidimensional array data management
+Title: Sparse and Dense Multidimensional Array Data Management
 Version: 0.3.0
-Authors@R: c(
-    person("TileDB-Inc.", email = "help@tiledb.io", role = c("cre", "fnd"), comment = c("https://tiledb.io"))
-    )
-Author: TileDB <help@tiledb.io>
-Maintainer: TileDB <help@tiledb.io>
-Description: TileDB is an efficient multi-dimensional array management system which introduces a novel on-disk format that can effectively store dense and sparse array data with support for fast updates and reads. It features excellent compression, an efficient parallel I/O system with high scalability, and bindings to multiple languages.
+Author: TileDB <help@tiledb.com>
+Maintainer: TileDB <help@tiledb.com>
+Description: The efficient multi-dimensional array management system 'TileDB' introduces a novel on-disk format that can effectively store dense and sparse array data with support for fast updates and reads. It features excellent compression, an efficient parallel I/O system which also scales well, and bindings to multiple languages.
 License: MIT + file LICENSE
 URL: https://github.com/TileDB-Inc/TileDB-R
 BugReports: https://github.com/TileDB-Inc/TileDB-R/issues
-Imports:
-    methods,
-    Rcpp (>= 0.12.15)
+Imports: methods, Rcpp
 LinkingTo: Rcpp
-SystemRequirements: C++11, pandoc
-Requires:
-    R (>= 3.1.0)
-Suggests:
- testthat (>= 2.0.0),
- roxygen2 (>= 5.0.0),
- data.table
+SystemRequirements: C++11
+Suggests: testthat, data.table
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.0.2
 Encoding: UTF-8

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,2 @@
-MIT License
-
-Copyright (c) 2018-2020 TileDB Inc.
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+YEAR: 2018-2020
+COPYRIGHT HOLDER: TileDB Inc.

--- a/inst/LICENSE.txt
+++ b/inst/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018-2020 TileDB Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
As discussed, R CMD check currently complains about a few items.

Fixing these is relatively straightforward and this PR moves in that direction. It is entirely orthogonal to the other work, and we can review this in isolation.

Three files are affected:
- DESCRIPTION gets some polish
- LICENSE conforms to CRAN requirement for MIT license and its two lines
- inst/LICENSE.txt get the body of the old LICENSE file