### PR TITLE
Add some missing C++ functions from 

### DIFF
--- a/R/Attribute.R
+++ b/R/Attribute.R
@@ -132,7 +132,7 @@ setGeneric("ncells", function(object) standardGeneric("ncells"))
 #' @export
 setMethod("ncells", signature(object = "tiledb_attr"),
           function(object) {
-            libtiledb_attr_ncells(object@ptr)
+            libtiledb_attr_get_cell_val_num(object@ptr)
           })
 
 #' Returns TRUE if the tiledb_dim is anonymous

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -205,12 +205,12 @@ libtiledb_attr_filter_list <- function(attr) {
     .Call(`_tiledb_libtiledb_attr_filter_list`, attr)
 }
 
-libtiledb_attr_ncells <- function(attr) {
-    .Call(`_tiledb_libtiledb_attr_ncells`, attr)
+libtiledb_attr_get_cell_val_num <- function(attr) {
+    .Call(`_tiledb_libtiledb_attr_get_cell_val_num`, attr)
 }
 
-libtiledb_attr_ncells_set <- function(attr, num) {
-    invisible(.Call(`_tiledb_libtiledb_attr_ncells_set`, attr, num))
+libtiledb_attr_set_cell_val_num <- function(attr, num) {
+    invisible(.Call(`_tiledb_libtiledb_attr_set_cell_val_num`, attr, num))
 }
 
 libtiledb_attr_dump <- function(attr) {
@@ -281,8 +281,8 @@ libtiledb_array <- function(ctx, uri, type) {
     .Call(`_tiledb_libtiledb_array`, ctx, uri, type)
 }
 
-libtiledb_array_encrypted <- function(ctx, uri, type, encryption_key) {
-    .Call(`_tiledb_libtiledb_array_encrypted`, ctx, uri, type, encryption_key)
+libtiledb_array_encrypted <- function(ctx, uri, type, enc_key) {
+    .Call(`_tiledb_libtiledb_array_encrypted`, ctx, uri, type, enc_key)
 }
 
 libtiledb_array_is_open <- function(array) {

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -265,6 +265,10 @@ libtiledb_array_schema_dump <- function(schema) {
     invisible(.Call(`_tiledb_libtiledb_array_schema_dump`, schema))
 }
 
+libtiledb_array_schema_check <- function(schema) {
+    invisible(.Call(`_tiledb_libtiledb_array_schema_check`, schema))
+}
+
 libtiledb_array_create <- function(uri, schema) {
     .Call(`_tiledb_libtiledb_array_create`, uri, schema)
 }

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -273,6 +273,10 @@ libtiledb_array_create <- function(uri, schema) {
     .Call(`_tiledb_libtiledb_array_create`, uri, schema)
 }
 
+libtiledb_array_create_encrypted <- function(uri, schema, encryption_key) {
+    .Call(`_tiledb_libtiledb_array_create_encrypted`, uri, schema, encryption_key)
+}
+
 libtiledb_array <- function(ctx, uri, type) {
     .Call(`_tiledb_libtiledb_array`, ctx, uri, type)
 }

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -209,6 +209,10 @@ libtiledb_attr_ncells <- function(attr) {
     .Call(`_tiledb_libtiledb_attr_ncells`, attr)
 }
 
+libtiledb_attr_ncells_set <- function(attr, num) {
+    invisible(.Call(`_tiledb_libtiledb_attr_ncells_set`, attr, num))
+}
+
 libtiledb_attr_dump <- function(attr) {
     invisible(.Call(`_tiledb_libtiledb_attr_dump`, attr))
 }

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -237,6 +237,14 @@ libtiledb_array_schema_tile_order <- function(schema) {
     .Call(`_tiledb_libtiledb_array_schema_tile_order`, schema)
 }
 
+libtiledb_array_schema_tile_set_capacity <- function(schema, cap) {
+    invisible(.Call(`_tiledb_libtiledb_array_schema_tile_set_capacity`, schema, cap))
+}
+
+libtiledb_array_schema_tile_get_capacity <- function(schema) {
+    .Call(`_tiledb_libtiledb_array_schema_tile_get_capacity`, schema)
+}
+
 libtiledb_array_schema_coords_filter_list <- function(schema) {
     .Call(`_tiledb_libtiledb_array_schema_coords_filter_list`, schema)
 }

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -281,6 +281,10 @@ libtiledb_array <- function(ctx, uri, type) {
     .Call(`_tiledb_libtiledb_array`, ctx, uri, type)
 }
 
+libtiledb_array_encrypted <- function(ctx, uri, type, encryption_key) {
+    .Call(`_tiledb_libtiledb_array_encrypted`, ctx, uri, type, encryption_key)
+}
+
 libtiledb_array_is_open <- function(array) {
     .Call(`_tiledb_libtiledb_array_is_open`, array)
 }

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -691,6 +691,28 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// libtiledb_array_schema_tile_set_capacity
+void libtiledb_array_schema_tile_set_capacity(XPtr<tiledb::ArraySchema> schema, int cap);
+RcppExport SEXP _tiledb_libtiledb_array_schema_tile_set_capacity(SEXP schemaSEXP, SEXP capSEXP) {
+BEGIN_RCPP
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< XPtr<tiledb::ArraySchema> >::type schema(schemaSEXP);
+    Rcpp::traits::input_parameter< int >::type cap(capSEXP);
+    libtiledb_array_schema_tile_set_capacity(schema, cap);
+    return R_NilValue;
+END_RCPP
+}
+// libtiledb_array_schema_tile_get_capacity
+int libtiledb_array_schema_tile_get_capacity(XPtr<tiledb::ArraySchema> schema);
+RcppExport SEXP _tiledb_libtiledb_array_schema_tile_get_capacity(SEXP schemaSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< XPtr<tiledb::ArraySchema> >::type schema(schemaSEXP);
+    rcpp_result_gen = Rcpp::wrap(libtiledb_array_schema_tile_get_capacity(schema));
+    return rcpp_result_gen;
+END_RCPP
+}
 // libtiledb_array_schema_coords_filter_list
 XPtr<tiledb::FilterList> libtiledb_array_schema_coords_filter_list(XPtr<tiledb::ArraySchema> schema);
 RcppExport SEXP _tiledb_libtiledb_array_schema_coords_filter_list(SEXP schemaSEXP) {
@@ -1391,6 +1413,8 @@ static const R_CallMethodDef CallEntries[] = {
     {"_tiledb_libtiledb_array_schema_attributes", (DL_FUNC) &_tiledb_libtiledb_array_schema_attributes, 1},
     {"_tiledb_libtiledb_array_schema_cell_order", (DL_FUNC) &_tiledb_libtiledb_array_schema_cell_order, 1},
     {"_tiledb_libtiledb_array_schema_tile_order", (DL_FUNC) &_tiledb_libtiledb_array_schema_tile_order, 1},
+    {"_tiledb_libtiledb_array_schema_tile_set_capacity", (DL_FUNC) &_tiledb_libtiledb_array_schema_tile_set_capacity, 2},
+    {"_tiledb_libtiledb_array_schema_tile_get_capacity", (DL_FUNC) &_tiledb_libtiledb_array_schema_tile_get_capacity, 1},
     {"_tiledb_libtiledb_array_schema_coords_filter_list", (DL_FUNC) &_tiledb_libtiledb_array_schema_coords_filter_list, 1},
     {"_tiledb_libtiledb_array_schema_offsets_filter_list", (DL_FUNC) &_tiledb_libtiledb_array_schema_offsets_filter_list, 1},
     {"_tiledb_libtiledb_array_schema_sparse", (DL_FUNC) &_tiledb_libtiledb_array_schema_sparse, 1},

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -768,6 +768,16 @@ BEGIN_RCPP
     return R_NilValue;
 END_RCPP
 }
+// libtiledb_array_schema_check
+void libtiledb_array_schema_check(XPtr<tiledb::ArraySchema> schema);
+RcppExport SEXP _tiledb_libtiledb_array_schema_check(SEXP schemaSEXP) {
+BEGIN_RCPP
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< XPtr<tiledb::ArraySchema> >::type schema(schemaSEXP);
+    libtiledb_array_schema_check(schema);
+    return R_NilValue;
+END_RCPP
+}
 // libtiledb_array_create
 std::string libtiledb_array_create(std::string uri, XPtr<tiledb::ArraySchema> schema);
 RcppExport SEXP _tiledb_libtiledb_array_create(SEXP uriSEXP, SEXP schemaSEXP) {
@@ -1420,6 +1430,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_tiledb_libtiledb_array_schema_sparse", (DL_FUNC) &_tiledb_libtiledb_array_schema_sparse, 1},
     {"_tiledb_libtiledb_array_schema_load", (DL_FUNC) &_tiledb_libtiledb_array_schema_load, 2},
     {"_tiledb_libtiledb_array_schema_dump", (DL_FUNC) &_tiledb_libtiledb_array_schema_dump, 1},
+    {"_tiledb_libtiledb_array_schema_check", (DL_FUNC) &_tiledb_libtiledb_array_schema_check, 1},
     {"_tiledb_libtiledb_array_create", (DL_FUNC) &_tiledb_libtiledb_array_create, 2},
     {"_tiledb_libtiledb_array", (DL_FUNC) &_tiledb_libtiledb_array, 3},
     {"_tiledb_libtiledb_array_is_open", (DL_FUNC) &_tiledb_libtiledb_array_is_open, 1},

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -608,6 +608,17 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// libtiledb_attr_ncells_set
+void libtiledb_attr_ncells_set(XPtr<tiledb::Attribute> attr, int num);
+RcppExport SEXP _tiledb_libtiledb_attr_ncells_set(SEXP attrSEXP, SEXP numSEXP) {
+BEGIN_RCPP
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< XPtr<tiledb::Attribute> >::type attr(attrSEXP);
+    Rcpp::traits::input_parameter< int >::type num(numSEXP);
+    libtiledb_attr_ncells_set(attr, num);
+    return R_NilValue;
+END_RCPP
+}
 // libtiledb_attr_dump
 void libtiledb_attr_dump(XPtr<tiledb::Attribute> attr);
 RcppExport SEXP _tiledb_libtiledb_attr_dump(SEXP attrSEXP) {
@@ -1373,6 +1384,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_tiledb_libtiledb_attr_datatype", (DL_FUNC) &_tiledb_libtiledb_attr_datatype, 1},
     {"_tiledb_libtiledb_attr_filter_list", (DL_FUNC) &_tiledb_libtiledb_attr_filter_list, 1},
     {"_tiledb_libtiledb_attr_ncells", (DL_FUNC) &_tiledb_libtiledb_attr_ncells, 1},
+    {"_tiledb_libtiledb_attr_ncells_set", (DL_FUNC) &_tiledb_libtiledb_attr_ncells_set, 2},
     {"_tiledb_libtiledb_attr_dump", (DL_FUNC) &_tiledb_libtiledb_attr_dump, 1},
     {"_tiledb_libtiledb_array_schema", (DL_FUNC) &_tiledb_libtiledb_array_schema, 8},
     {"_tiledb_libtiledb_array_schema_domain", (DL_FUNC) &_tiledb_libtiledb_array_schema_domain, 1},

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -816,6 +816,20 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// libtiledb_array_encrypted
+XPtr<tiledb::Array> libtiledb_array_encrypted(XPtr<tiledb::Context> ctx, std::string uri, std::string type, std::string encryption_key);
+RcppExport SEXP _tiledb_libtiledb_array_encrypted(SEXP ctxSEXP, SEXP uriSEXP, SEXP typeSEXP, SEXP encryption_keySEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< XPtr<tiledb::Context> >::type ctx(ctxSEXP);
+    Rcpp::traits::input_parameter< std::string >::type uri(uriSEXP);
+    Rcpp::traits::input_parameter< std::string >::type type(typeSEXP);
+    Rcpp::traits::input_parameter< std::string >::type encryption_key(encryption_keySEXP);
+    rcpp_result_gen = Rcpp::wrap(libtiledb_array_encrypted(ctx, uri, type, encryption_key));
+    return rcpp_result_gen;
+END_RCPP
+}
 // libtiledb_array_is_open
 bool libtiledb_array_is_open(XPtr<tiledb::Array> array);
 RcppExport SEXP _tiledb_libtiledb_array_is_open(SEXP arraySEXP) {
@@ -1447,6 +1461,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_tiledb_libtiledb_array_create", (DL_FUNC) &_tiledb_libtiledb_array_create, 2},
     {"_tiledb_libtiledb_array_create_encrypted", (DL_FUNC) &_tiledb_libtiledb_array_create_encrypted, 3},
     {"_tiledb_libtiledb_array", (DL_FUNC) &_tiledb_libtiledb_array, 3},
+    {"_tiledb_libtiledb_array_encrypted", (DL_FUNC) &_tiledb_libtiledb_array_encrypted, 4},
     {"_tiledb_libtiledb_array_is_open", (DL_FUNC) &_tiledb_libtiledb_array_is_open, 1},
     {"_tiledb_libtiledb_array_is_open_for_reading", (DL_FUNC) &_tiledb_libtiledb_array_is_open_for_reading, 1},
     {"_tiledb_libtiledb_array_is_open_for_writing", (DL_FUNC) &_tiledb_libtiledb_array_is_open_for_writing, 1},

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -790,6 +790,19 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// libtiledb_array_create_encrypted
+std::string libtiledb_array_create_encrypted(std::string uri, XPtr<tiledb::ArraySchema> schema, std::string encryption_key);
+RcppExport SEXP _tiledb_libtiledb_array_create_encrypted(SEXP uriSEXP, SEXP schemaSEXP, SEXP encryption_keySEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< std::string >::type uri(uriSEXP);
+    Rcpp::traits::input_parameter< XPtr<tiledb::ArraySchema> >::type schema(schemaSEXP);
+    Rcpp::traits::input_parameter< std::string >::type encryption_key(encryption_keySEXP);
+    rcpp_result_gen = Rcpp::wrap(libtiledb_array_create_encrypted(uri, schema, encryption_key));
+    return rcpp_result_gen;
+END_RCPP
+}
 // libtiledb_array
 XPtr<tiledb::Array> libtiledb_array(XPtr<tiledb::Context> ctx, std::string uri, std::string type);
 RcppExport SEXP _tiledb_libtiledb_array(SEXP ctxSEXP, SEXP uriSEXP, SEXP typeSEXP) {
@@ -1432,6 +1445,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_tiledb_libtiledb_array_schema_dump", (DL_FUNC) &_tiledb_libtiledb_array_schema_dump, 1},
     {"_tiledb_libtiledb_array_schema_check", (DL_FUNC) &_tiledb_libtiledb_array_schema_check, 1},
     {"_tiledb_libtiledb_array_create", (DL_FUNC) &_tiledb_libtiledb_array_create, 2},
+    {"_tiledb_libtiledb_array_create_encrypted", (DL_FUNC) &_tiledb_libtiledb_array_create_encrypted, 3},
     {"_tiledb_libtiledb_array", (DL_FUNC) &_tiledb_libtiledb_array, 3},
     {"_tiledb_libtiledb_array_is_open", (DL_FUNC) &_tiledb_libtiledb_array_is_open, 1},
     {"_tiledb_libtiledb_array_is_open_for_reading", (DL_FUNC) &_tiledb_libtiledb_array_is_open_for_reading, 1},

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -597,25 +597,25 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
-// libtiledb_attr_ncells
-int libtiledb_attr_ncells(XPtr<tiledb::Attribute> attr);
-RcppExport SEXP _tiledb_libtiledb_attr_ncells(SEXP attrSEXP) {
+// libtiledb_attr_get_cell_val_num
+int libtiledb_attr_get_cell_val_num(XPtr<tiledb::Attribute> attr);
+RcppExport SEXP _tiledb_libtiledb_attr_get_cell_val_num(SEXP attrSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< XPtr<tiledb::Attribute> >::type attr(attrSEXP);
-    rcpp_result_gen = Rcpp::wrap(libtiledb_attr_ncells(attr));
+    rcpp_result_gen = Rcpp::wrap(libtiledb_attr_get_cell_val_num(attr));
     return rcpp_result_gen;
 END_RCPP
 }
-// libtiledb_attr_ncells_set
-void libtiledb_attr_ncells_set(XPtr<tiledb::Attribute> attr, int num);
-RcppExport SEXP _tiledb_libtiledb_attr_ncells_set(SEXP attrSEXP, SEXP numSEXP) {
+// libtiledb_attr_set_cell_val_num
+void libtiledb_attr_set_cell_val_num(XPtr<tiledb::Attribute> attr, int num);
+RcppExport SEXP _tiledb_libtiledb_attr_set_cell_val_num(SEXP attrSEXP, SEXP numSEXP) {
 BEGIN_RCPP
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< XPtr<tiledb::Attribute> >::type attr(attrSEXP);
     Rcpp::traits::input_parameter< int >::type num(numSEXP);
-    libtiledb_attr_ncells_set(attr, num);
+    libtiledb_attr_set_cell_val_num(attr, num);
     return R_NilValue;
 END_RCPP
 }
@@ -817,16 +817,16 @@ BEGIN_RCPP
 END_RCPP
 }
 // libtiledb_array_encrypted
-XPtr<tiledb::Array> libtiledb_array_encrypted(XPtr<tiledb::Context> ctx, std::string uri, std::string type, std::string encryption_key);
-RcppExport SEXP _tiledb_libtiledb_array_encrypted(SEXP ctxSEXP, SEXP uriSEXP, SEXP typeSEXP, SEXP encryption_keySEXP) {
+XPtr<tiledb::Array> libtiledb_array_encrypted(XPtr<tiledb::Context> ctx, std::string uri, std::string type, std::string enc_key);
+RcppExport SEXP _tiledb_libtiledb_array_encrypted(SEXP ctxSEXP, SEXP uriSEXP, SEXP typeSEXP, SEXP enc_keySEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< XPtr<tiledb::Context> >::type ctx(ctxSEXP);
     Rcpp::traits::input_parameter< std::string >::type uri(uriSEXP);
     Rcpp::traits::input_parameter< std::string >::type type(typeSEXP);
-    Rcpp::traits::input_parameter< std::string >::type encryption_key(encryption_keySEXP);
-    rcpp_result_gen = Rcpp::wrap(libtiledb_array_encrypted(ctx, uri, type, encryption_key));
+    Rcpp::traits::input_parameter< std::string >::type enc_key(enc_keySEXP);
+    rcpp_result_gen = Rcpp::wrap(libtiledb_array_encrypted(ctx, uri, type, enc_key));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -1442,8 +1442,8 @@ static const R_CallMethodDef CallEntries[] = {
     {"_tiledb_libtiledb_attr_name", (DL_FUNC) &_tiledb_libtiledb_attr_name, 1},
     {"_tiledb_libtiledb_attr_datatype", (DL_FUNC) &_tiledb_libtiledb_attr_datatype, 1},
     {"_tiledb_libtiledb_attr_filter_list", (DL_FUNC) &_tiledb_libtiledb_attr_filter_list, 1},
-    {"_tiledb_libtiledb_attr_ncells", (DL_FUNC) &_tiledb_libtiledb_attr_ncells, 1},
-    {"_tiledb_libtiledb_attr_ncells_set", (DL_FUNC) &_tiledb_libtiledb_attr_ncells_set, 2},
+    {"_tiledb_libtiledb_attr_get_cell_val_num", (DL_FUNC) &_tiledb_libtiledb_attr_get_cell_val_num, 1},
+    {"_tiledb_libtiledb_attr_set_cell_val_num", (DL_FUNC) &_tiledb_libtiledb_attr_set_cell_val_num, 2},
     {"_tiledb_libtiledb_attr_dump", (DL_FUNC) &_tiledb_libtiledb_attr_dump, 1},
     {"_tiledb_libtiledb_array_schema", (DL_FUNC) &_tiledb_libtiledb_array_schema, 8},
     {"_tiledb_libtiledb_array_schema_domain", (DL_FUNC) &_tiledb_libtiledb_array_schema_domain, 1},

--- a/src/libtiledb.cpp
+++ b/src/libtiledb.cpp
@@ -836,6 +836,8 @@ void libtiledb_attr_ncells_set(XPtr<tiledb::Attribute> attr, int num) {
   uint64_t ncells = static_cast<uint64_t>(num);
   if (num == R_NaInt) {
     ncells = TILEDB_VAR_NUM;             // R's NA is different from TileDB's NA
+  } else if (num <= 0) {
+    Rcpp::stop("Variable cell number of '%d' not sensible", num);
   }
   attr->set_cell_val_num(ncells);        // returns reference to self so nothing for us to return
 }
@@ -920,6 +922,25 @@ std::string libtiledb_array_schema_cell_order(XPtr<tiledb::ArraySchema> schema) 
 std::string libtiledb_array_schema_tile_order(XPtr<tiledb::ArraySchema> schema) {
   auto order = schema->tile_order();
   return _tiledb_layout_to_string(order);
+}
+
+// [[Rcpp::export]]
+void libtiledb_array_schema_tile_set_capacity(XPtr<tiledb::ArraySchema> schema, int cap) {
+  if (cap <= 0) {
+    Rcpp::stop("Tile capacity of '%d' not sensible", cap);
+  }
+  uint64_t tilecap = static_cast<uint64_t>(cap);
+  schema->set_capacity(tilecap);
+}
+
+// [[Rcpp::export]]
+int libtiledb_array_schema_tile_get_capacity(XPtr<tiledb::ArraySchema> schema) {
+  // FIXME: we try to return a uint64_t as an int. Overflow possible
+  uint64_t cap = schema->capacity();
+  if (cap > std::numeric_limits<int32_t>::max()) {
+    Rcpp::stop("Overflow on schema capcity at '%ld'", cap);
+  }
+  return static_cast<int>(cap);
 }
 
 // [[Rcpp::export]]

--- a/src/libtiledb.cpp
+++ b/src/libtiledb.cpp
@@ -993,8 +993,19 @@ XPtr<tiledb::Array> libtiledb_array(XPtr<tiledb::Context> ctx,
                                     std::string uri,
                                     std::string type) {
   auto query_type = _string_to_tiledb_query_type(type);
-  auto array = XPtr<tiledb::Array>(
-      new tiledb::Array(tiledb::Array(*ctx.get(), uri, query_type)));
+  auto array = XPtr<tiledb::Array>(new tiledb::Array(tiledb::Array(*ctx.get(), uri, query_type)));
+  return array;
+}
+
+// [[Rcpp::export]]
+XPtr<tiledb::Array> libtiledb_array_encrypted(XPtr<tiledb::Context> ctx,
+                                              std::string uri, std::string type,
+                                              std::string enc_key) {
+  auto query_type = _string_to_tiledb_query_type(type);
+  auto array = XPtr<tiledb::Array>(new tiledb::Array(tiledb::Array(*ctx.get(), uri, query_type,
+                                                                   TILEDB_AES_256_GCM,
+                                                                   enc_key.data(),
+                                                                   (uint32_t)enc_key.size())));
   return array;
 }
 

--- a/src/libtiledb.cpp
+++ b/src/libtiledb.cpp
@@ -823,8 +823,10 @@ XPtr<tiledb::FilterList> libtiledb_attr_filter_list(XPtr<tiledb::Attribute> attr
 // [[Rcpp::export]]
 int libtiledb_attr_ncells(XPtr<tiledb::Attribute> attr) {
   unsigned int ncells = attr->cell_val_num();
-  if (ncells > std::numeric_limits<int32_t>::max()) {
-    throw Rcpp::exception("tiledb_attr ncells value not representable as an R integer");
+  if (ncells == TILEDB_VAR_NUM) {
+    return R_NaInt;          // set to R's NA for integer
+  } else if (ncells > std::numeric_limits<int32_t>::max()) {
+    Rcpp::stop("tiledb_attr ncells value not representable as an R integer");
   }
   return static_cast<int32_t>(ncells);
 }

--- a/src/libtiledb.cpp
+++ b/src/libtiledb.cpp
@@ -821,7 +821,7 @@ XPtr<tiledb::FilterList> libtiledb_attr_filter_list(XPtr<tiledb::Attribute> attr
 }
 
 // [[Rcpp::export]]
-int libtiledb_attr_ncells(XPtr<tiledb::Attribute> attr) {
+int libtiledb_attr_get_cell_val_num(XPtr<tiledb::Attribute> attr) {
   unsigned int ncells = attr->cell_val_num();
   if (ncells == TILEDB_VAR_NUM) {
     return R_NaInt;          // set to R's NA for integer
@@ -832,7 +832,7 @@ int libtiledb_attr_ncells(XPtr<tiledb::Attribute> attr) {
 }
 
 // [[Rcpp::export]]
-void libtiledb_attr_ncells_set(XPtr<tiledb::Attribute> attr, int num) {
+void libtiledb_attr_set_cell_val_num(XPtr<tiledb::Attribute> attr, int num) {
   uint64_t ncells = static_cast<uint64_t>(num);
   if (num == R_NaInt) {
     ncells = TILEDB_VAR_NUM;             // R's NA is different from TileDB's NA

--- a/src/libtiledb.cpp
+++ b/src/libtiledb.cpp
@@ -831,6 +831,15 @@ int libtiledb_attr_ncells(XPtr<tiledb::Attribute> attr) {
   return static_cast<int32_t>(ncells);
 }
 
+// [[Rcpp::export]]
+void libtiledb_attr_ncells_set(XPtr<tiledb::Attribute> attr, int num) {
+  uint64_t ncells = static_cast<uint64_t>(num);
+  if (num == R_NaInt) {
+    ncells = TILEDB_VAR_NUM;             // R's NA is different from TileDB's NA
+  }
+  attr->set_cell_val_num(ncells);        // returns reference to self so nothing for us to return
+}
+
 //[[Rcpp::export]]
 void libtiledb_attr_dump(XPtr<tiledb::Attribute> attr) {
   attr->dump();

--- a/src/libtiledb.cpp
+++ b/src/libtiledb.cpp
@@ -981,6 +981,14 @@ std::string libtiledb_array_create(std::string uri, XPtr<tiledb::ArraySchema> sc
 }
 
 // [[Rcpp::export]]
+std::string libtiledb_array_create_encrypted(std::string uri, XPtr<tiledb::ArraySchema> schema,
+                                             std::string encryption_key) {
+  tiledb::Array::create(uri, *schema.get(), TILEDB_AES_256_GCM,
+                        encryption_key.c_str(), encryption_key.size());
+  return uri;
+}
+
+// [[Rcpp::export]]
 XPtr<tiledb::Array> libtiledb_array(XPtr<tiledb::Context> ctx,
                                     std::string uri,
                                     std::string type) {

--- a/src/libtiledb.cpp
+++ b/src/libtiledb.cpp
@@ -970,6 +970,11 @@ void libtiledb_array_schema_dump(XPtr<tiledb::ArraySchema> schema) {
 }
 
 // [[Rcpp::export]]
+void libtiledb_array_schema_check(XPtr<tiledb::ArraySchema> schema) {
+  schema->check();   // throws, rather than returning bool
+}
+
+// [[Rcpp::export]]
 std::string libtiledb_array_create(std::string uri, XPtr<tiledb::ArraySchema> schema) {
   tiledb::Array::create(uri, *schema.get());
   return uri;

--- a/src/tiledb_declarations.h
+++ b/src/tiledb_declarations.h
@@ -72,6 +72,7 @@ std::string               libtiledb_attr_name(XPtr<tiledb::Attribute> attr);
 std::string               libtiledb_attr_datatype(XPtr<tiledb::Attribute> attr);
 XPtr<tiledb::FilterList>  libtiledb_attr_filter_list(XPtr<tiledb::Attribute> attr);
 int                       libtiledb_attr_ncells(XPtr<tiledb::Attribute> attr);
+void                      libtiledb_attr_ncells_set(XPtr<tiledb::Attribute> attr, int num);
 void                      libtiledb_attr_dump(XPtr<tiledb::Attribute> attr);
 
 
@@ -81,6 +82,8 @@ XPtr<tiledb::Domain>      libtiledb_array_schema_domain(XPtr<tiledb::ArraySchema
 List                      libtiledb_array_schema_attributes(XPtr<tiledb::ArraySchema> schema);
 std::string               libtiledb_array_schema_cell_order(XPtr<tiledb::ArraySchema> schema);
 std::string               libtiledb_array_schema_tile_order(XPtr<tiledb::ArraySchema> schema);
+void                      libtiledb_array_schema_tile_set_capacity(XPtr<tiledb::ArraySchema> schema, int cap);
+int                       libtiledb_array_schema_tile_get_capacity(XPtr<tiledb::ArraySchema> schema);
 XPtr<tiledb::FilterList>  libtiledb_array_schema_coords_filter_list(XPtr<tiledb::ArraySchema> schema);
 XPtr<tiledb::FilterList>  libtiledb_array_schema_offsets_filter_list(XPtr<tiledb::ArraySchema> schema);
 bool                      libtiledb_array_schema_sparse(XPtr<tiledb::ArraySchema> schema);

--- a/src/tiledb_declarations.h
+++ b/src/tiledb_declarations.h
@@ -77,7 +77,8 @@ void                      libtiledb_attr_dump(XPtr<tiledb::Attribute> attr);
 
 
 ## Array Schema
-XPtr<tiledb::ArraySchema> libtiledb_array_schema(XPtr<tiledb::Context> ctx, XPtr<tiledb::Domain> domain, List attributes, std::string cell_order, std::string tile_order, Nullable<XPtr<tiledb::FilterList>> coords_filter_list = R_NilValue, Nullable<XPtr<tiledb::FilterList>> offsets_filter_list = R_NilValue, bool sparse = false);
+XPtr<tiledb::ArraySchema> libtiledb_array_schema(XPtr<tiledb::Context> ctx, XPtr<tiledb::Domain> domain, List attributes, std::string cell_order, std::string tile_order,
+                                                 Nullable<XPtr<tiledb::FilterList>> coords_filter_list = R_NilValue, Nullable<XPtr<tiledb::FilterList>> offsets_filter_list = R_NilValue, bool sparse = false);
 XPtr<tiledb::Domain>      libtiledb_array_schema_domain(XPtr<tiledb::ArraySchema> schema);
 List                      libtiledb_array_schema_attributes(XPtr<tiledb::ArraySchema> schema);
 std::string               libtiledb_array_schema_cell_order(XPtr<tiledb::ArraySchema> schema);
@@ -96,6 +97,7 @@ std::string               libtiledb_array_create_encryptd(std::string uri, XPtr<
 
 ## Array
 XPtr<tiledb::Array>       libtiledb_array(XPtr<tiledb::Context> ctx, std::string uri, std::string type);
+XPtr<tiledb::Array>       libtiledb_array_encrypted(XPtr<tiledb::Context> ctx, std::string uri, std::string type, std::string enc_key);
 bool                      libtiledb_array_is_open(XPtr<tiledb::Array> array);
 bool                      libtiledb_array_is_open_for_reading(XPtr<tiledb::Array> array);
 bool                      libtiledb_array_is_open_for_writing(XPtr<tiledb::Array> array);

--- a/src/tiledb_declarations.h
+++ b/src/tiledb_declarations.h
@@ -1,0 +1,159 @@
+
+#include <Rcpp.h>
+
+using namespace Rcpp;
+
+## type helpers from/to string
+const char*               _tiledb_datatype_to_string(tiledb_datatype_t dtype);
+tiledb_datatype_t         _string_to_tiledb_datatype(std::string typestr);
+std::string               tiledb_datatype_R_type(std::string datatype);
+const char*               _tiledb_layout_to_string(tiledb_layout_t layout);
+tiledb_layout_t           _string_to_tiledb_layout(std::string lstr);
+tiledb_filter_type_t      _string_to_tiledb_filter(std::string filter);
+const char*               _tiledb_filter_to_string(tiledb_filter_type_t filter);
+tiledb_filter_option_t    _string_to_tiledb_filter_option(std::string filter_option);
+const char*               _tiledb_filter_option_to_string(tiledb_filter_option_t filter_option);
+tiledb_query_type_t       _string_to_tiledb_query_type(std::string qtstr);
+std::string               _tiledb_query_type_to_string(tiledb_query_type_t qtype);
+
+## version
+NumericVector             libtiledb_version();
+
+
+## Context and Config
+XPtr<tiledb::Context>     libtiledb_ctx(Nullable<XPtr<tiledb::Config>> config=R_NilValue);
+void                      libtiledb_ctx_set_tag(XPtr<tiledb::Context> ctx, std::string key, std::string value);
+std::string               libtiledb_config_save_to_file(XPtr<tiledb::Config> config, std::string filename);
+XPtr<tiledb::Config>      libtiledb_config_load_from_file(std::string filename);
+XPtr<tiledb::Config>      libtiledb_ctx_config(XPtr<tiledb::Context> ctx);
+bool                      libtiledb_ctx_is_supported_fs(XPtr<tiledb::Context> ctx, std::string scheme);
+XPtr<tiledb::Config>      libtiledb_config(Nullable<CharacterVector> config=R_NilValue);
+CharacterVector           libtiledb_config_vector(XPtr<tiledb::Config> config);
+XPtr<tiledb::Config>      libtiledb_config_set(XPtr<tiledb::Config> config, std::string param, std::string value);
+CharacterVector           libtiledb_config_get(XPtr<tiledb::Config> config, CharacterVector params);
+void                      libtiledb_config_dump(XPtr<tiledb::Config> config);
+
+
+## Dimension
+XPtr<tiledb::Dimension>   libtiledb_dim(XPtr<tiledb::Context> ctx, std::string name, std::string type, SEXP domain, SEXP tile_extent);
+std::string               libtiledb_dim_name(XPtr<tiledb::Dimension> dim);
+SEXP                      libtiledb_dim_domain(XPtr<tiledb::Dimension> dim);
+SEXP                      libtiledb_dim_tile_extent(XPtr<tiledb::Dimension> dim);
+std::string               libtiledb_dim_datatype(XPtr<tiledb::Dimension> dim);
+NumericVector             dim_domain_subarray(NumericVector domain, NumericVector subscript);
+
+
+## Domain
+XPtr<tiledb::Domain>      libtiledb_domain(XPtr<tiledb::Context> ctx, List dims);
+IntegerVector             libtiledb_domain_ndim(XPtr<tiledb::Domain> domain);
+List                      libtiledb_domain_dimensions(XPtr<tiledb::Domain> domain);
+std::string               libtiledb_domain_datatype(XPtr<tiledb::Domain> domain);
+void                      libtiledb_domain_dump(XPtr<tiledb::Domain> domain);
+
+
+## Filter
+XPtr<tiledb::Filter>      libtiledb_filter(XPtr<tiledb::Context> ctx, std::string filter);
+std::string               libtiledb_filter_type(XPtr<tiledb::Filter> filter);
+R_xlen_t                  libtiledb_filter_get_option(XPtr<tiledb::Filter> filter, std::string filter_option_str);
+void                      libtiledb_filter_set_option(XPtr<tiledb::Filter> filter, std::string filter_option_str, int value);
+
+
+## Filter List
+XPtr<tiledb::FilterList>  libtiledb_filter_list(XPtr<tiledb::Context> ctx, List filters);
+void                      libtiledb_filter_list_set_max_chunk_size(XPtr<tiledb::FilterList> filterList, uint32_t max_chunk_sie);
+int                       libtiledb_filter_list_max_chunk_size(XPtr<tiledb::FilterList> filterList);
+int                       libtiledb_filter_list_nfilters(XPtr<tiledb::FilterList> filterList);
+XPtr<tiledb::Filter>      libtiledb_filter_list_filter(XPtr<tiledb::FilterList> filterList, uint32_t filter_index);
+
+
+## Attribute
+XPtr<tiledb::Attribute>   libtiledb_attr(XPtr<tiledb::Context> ctx, std::string name, std::string type, XPtr<tiledb::FilterList> filter_list, int ncells);
+std::string               libtiledb_attr_name(XPtr<tiledb::Attribute> attr);
+std::string               libtiledb_attr_datatype(XPtr<tiledb::Attribute> attr);
+XPtr<tiledb::FilterList>  libtiledb_attr_filter_list(XPtr<tiledb::Attribute> attr);
+int                       libtiledb_attr_ncells(XPtr<tiledb::Attribute> attr);
+void                      libtiledb_attr_dump(XPtr<tiledb::Attribute> attr);
+
+
+## Array Schema
+XPtr<tiledb::ArraySchema> libtiledb_array_schema(XPtr<tiledb::Context> ctx, XPtr<tiledb::Domain> domain, List attributes, std::string cell_order, std::string tile_order, Nullable<XPtr<tiledb::FilterList>> coords_filter_list = R_NilValue, Nullable<XPtr<tiledb::FilterList>> offsets_filter_list = R_NilValue, bool sparse = false);
+XPtr<tiledb::Domain>      libtiledb_array_schema_domain(XPtr<tiledb::ArraySchema> schema);
+List                      libtiledb_array_schema_attributes(XPtr<tiledb::ArraySchema> schema);
+std::string               libtiledb_array_schema_cell_order(XPtr<tiledb::ArraySchema> schema);
+std::string               libtiledb_array_schema_tile_order(XPtr<tiledb::ArraySchema> schema);
+XPtr<tiledb::FilterList>  libtiledb_array_schema_coords_filter_list(XPtr<tiledb::ArraySchema> schema);
+XPtr<tiledb::FilterList>  libtiledb_array_schema_offsets_filter_list(XPtr<tiledb::ArraySchema> schema);
+bool                      libtiledb_array_schema_sparse(XPtr<tiledb::ArraySchema> schema);
+XPtr<tiledb::ArraySchema> libtiledb_array_schema_load(XPtr<tiledb::Context> ctx,std::string uri);
+void                      libtiledb_array_schema_dump(XPtr<tiledb::ArraySchema> schema);
+std::string               libtiledb_array_create(std::string uri, XPtr<tiledb::ArraySchema> schema);
+
+
+## Array
+XPtr<tiledb::Array>       libtiledb_array(XPtr<tiledb::Context> ctx, std::string uri, std::string type);
+bool                      libtiledb_array_is_open(XPtr<tiledb::Array> array);
+bool                      libtiledb_array_is_open_for_reading(XPtr<tiledb::Array> array);
+bool                      libtiledb_array_is_open_for_writing(XPtr<tiledb::Array> array);
+std::string               libtiledb_array_get_uri(XPtr<tiledb::Array> array);
+XPtr<tiledb::ArraySchema> libtiledb_array_get_schema(XPtr<tiledb::Array> array);
+XPtr<tiledb::Array>       libtiledb_array_open(XPtr<tiledb::Array> array, std::string query_type);
+XPtr<tiledb::Array>       libtiledb_array_reopen(XPtr<tiledb::Array> array);
+XPtr<tiledb::Array>       libtiledb_array_close(XPtr<tiledb::Array> array);
+std::string               libtiledb_array_query_type(XPtr<tiledb::Array> array);
+List                      libtiledb_array_nonempty_domain(XPtr<tiledb::Array> array);
+std::string               libtiledb_array_consolidate(XPtr<tiledb::Context> ctx, std::string uri);
+
+
+## Query
+XPtr<tiledb::Query>       libtiledb_query(XPtr<tiledb::Context> ctx, XPtr<tiledb::Array> array, std::string type);
+XPtr<tiledb::Query>       libtiledb_query_set_layout(XPtr<tiledb::Query> query, std::string layout);
+XPtr<tiledb::Query>       libtiledb_query_set_subarray(XPtr<tiledb::Query> query, SEXP subarray);
+XPtr<tiledb::Query>       libtiledb_query_set_coordinates(XPtr<tiledb::Query> query, SEXP coords);
+XPtr<tiledb::Query>       libtiledb_query_set_buffer(XPtr<tiledb::Query> query, std::string attr, SEXP buffer);
+XPtr<tiledb::Query>       libtiledb_query_submit(XPtr<tiledb::Query> query);
+XPtr<tiledb::Query>       libtiledb_query_finalize(XPtr<tiledb::Query> query);
+std::string               _query_status_to_string(tiledb::Query::Status status);
+std::string               libtiledb_query_status(XPtr<tiledb::Query> query);
+R_xlen_t                  libtiledb_query_result_buffer_elements(XPtr<tiledb::Query> query, std::string attribute);
+
+
+## Array Helpers
+NumericVector             libtiledb_zip_coords_numeric( List coords, R_xlen_t coord_length);
+IntegerVector             libtiledb_zip_coords_integer( List coords, R_xlen_t coord_length);
+std::string               libtiledb_coords();
+R_xlen_t                  libtiledb_array_max_buffer_elements(XPtr<tiledb::Array> array, SEXP subarray, std::string attribute);
+
+
+## Object functionality
+std::string               libtiledb_group_create(XPtr<tiledb::Context> ctx, std::string uri);
+std::string               _object_type_to_string(tiledb::Object::Type otype);
+std::string               libtiledb_object_type(XPtr<tiledb::Context> ctx, std::string uri);
+std::string               libtiledb_object_remove(XPtr<tiledb::Context> ctx, std::string uri);
+std::string               libtiledb_object_move(XPtr<tiledb::Context> ctx, std::string old_uri, std::string new_uri);
+tiledb::Object::Type      _string_to_object_type(std::string otype);
+DataFrame                 libtiledb_object_walk(XPtr<tiledb::Context> ctx, std::string uri, std::string order, bool recursive = false);
+
+
+## VFS
+XPtr<tiledb::VFS>         tiledb_vfs(XPtr<tiledb::Context> ctx, Nullable<XPtr<tiledb::Config>> config=R_NilValue);
+std::string               tiledb_vfs_create_bucket(XPtr<tiledb::VFS> vfs, std::string uri);
+std::string               tiledb_vfs_remove_bucket(XPtr<tiledb::VFS> vfs, std::string uri);
+bool                      tiledb_vfs_is_bucket(XPtr<tiledb::VFS> vfs, std::string uri);
+bool                      tiledb_vfs_is_empty_bucket(XPtr<tiledb::VFS> vfs, std::string uri);
+std::string               tiledb_vfs_empty_bucket(XPtr<tiledb::VFS> vfs, std::string uri);
+std::string               tiledb_vfs_create_dir(XPtr<tiledb::VFS> vfs, std::string uri);
+bool                      tiledb_vfs_is_dir(XPtr<tiledb::VFS> vfs, std::string uri);
+std::string               tiledb_vfs_remove_dir(XPtr<tiledb::VFS> vfs, std::string uri);
+bool                      tiledb_vfs_is_file(XPtr<tiledb::VFS> vfs, std::string uri);
+std::string               tiledb_vfs_remove_file(XPtr<tiledb::VFS> vfs, std::string uri);
+R_xlen_t                  tiledb_vfs_file_size(XPtr<tiledb::VFS> vfs, std::string uri);
+std::string               tiledb_vfs_move_file(XPtr<tiledb::VFS> vfs, std::string old_uri, std::string new_uri);
+std::string               tiledb_vfs_move_dir(XPtr<tiledb::VFS> vfs, std::string old_uri, std::string new_uri);
+std::string               tiledb_vfs_touch(XPtr<tiledb::VFS> vfs, std::string uri);
+
+
+## Stats
+void                      libtiledb_stats_enable();
+void                      libtiledb_stats_disable();
+void                      libtiledb_stats_dump(std::string path);
+void                      libtiledb_stats_print();

--- a/src/tiledb_declarations.h
+++ b/src/tiledb_declarations.h
@@ -71,8 +71,8 @@ XPtr<tiledb::Attribute>   libtiledb_attr(XPtr<tiledb::Context> ctx, std::string 
 std::string               libtiledb_attr_name(XPtr<tiledb::Attribute> attr);
 std::string               libtiledb_attr_datatype(XPtr<tiledb::Attribute> attr);
 XPtr<tiledb::FilterList>  libtiledb_attr_filter_list(XPtr<tiledb::Attribute> attr);
-int                       libtiledb_attr_ncells(XPtr<tiledb::Attribute> attr);
-void                      libtiledb_attr_ncells_set(XPtr<tiledb::Attribute> attr, int num);
+int                       libtiledb_attr_get_cell_val_num(XPtr<tiledb::Attribute> attr);
+void                      libtiledb_attr_set_cell_val_num(XPtr<tiledb::Attribute> attr, int num);
 void                      libtiledb_attr_dump(XPtr<tiledb::Attribute> attr);
 
 

--- a/src/tiledb_declarations.h
+++ b/src/tiledb_declarations.h
@@ -89,6 +89,7 @@ XPtr<tiledb::FilterList>  libtiledb_array_schema_offsets_filter_list(XPtr<tiledb
 bool                      libtiledb_array_schema_sparse(XPtr<tiledb::ArraySchema> schema);
 XPtr<tiledb::ArraySchema> libtiledb_array_schema_load(XPtr<tiledb::Context> ctx,std::string uri);
 void                      libtiledb_array_schema_dump(XPtr<tiledb::ArraySchema> schema);
+void                      libtiledb_array_schema_check(XPtr<tiledb::ArraySchema> schema);
 std::string               libtiledb_array_create(std::string uri, XPtr<tiledb::ArraySchema> schema);
 
 

--- a/src/tiledb_declarations.h
+++ b/src/tiledb_declarations.h
@@ -91,6 +91,7 @@ XPtr<tiledb::ArraySchema> libtiledb_array_schema_load(XPtr<tiledb::Context> ctx,
 void                      libtiledb_array_schema_dump(XPtr<tiledb::ArraySchema> schema);
 void                      libtiledb_array_schema_check(XPtr<tiledb::ArraySchema> schema);
 std::string               libtiledb_array_create(std::string uri, XPtr<tiledb::ArraySchema> schema);
+std::string               libtiledb_array_create_encryptd(std::string uri, XPtr<tiledb::ArraySchema> schema, std::string encryption_key);
 
 
 ## Array

--- a/tests/testthat/test_ArraySchema.R
+++ b/tests/testthat/test_ArraySchema.R
@@ -91,3 +91,25 @@ test_that("tiledb_array_schema full constructor argument values are correct",  {
   expect_error(tiledb:::libtiledb_array_schema_tile_set_capacity(sch@ptr, -10))
 
 })
+
+
+test_that("tiledb_array_schema created with encryption",  {
+  uri <- tempfile()
+  key <- "0123456789abcdeF0123456789abcdeF"
+
+  dom <- tiledb_domain(dims = c(tiledb_dim("rows", c(1L, 4L), 4L, "INT32"),
+                                tiledb_dim("cols", c(1L, 4L), 4L, "INT32")))
+  schema <- tiledb_array_schema(dom, attrs = c(tiledb_attr("a", type = "INT32")))
+
+  ##tiledb_array_create_encrypted(uri, schema, key)
+  ## for now calling into function
+  tiledb:::libtiledb_array_create_encrypted(uri, schema@ptr, key)
+
+  ctx <- tiledb_ctx()
+  arrptr <- tiledb:::libtiledb_array_encrypted(ctx@ptr, uri, "WRITE", key)
+  A <- new("tiledb_dense", ctx=ctx, uri=uri, as.data.frame=FALSE, ptr=arrptr)
+
+  expect_true(is(A, "tiledb_dense"))
+  ##expect_true(is(schema(A), "tiledb_dense"))
+  ## can't yet read / write as scheme getter not generalized for encryption
+})

--- a/tests/testthat/test_ArraySchema.R
+++ b/tests/testthat/test_ArraySchema.R
@@ -85,4 +85,9 @@ test_that("tiledb_array_schema full constructor argument values are correct",  {
   expect_equal(tiledb_filter_get_option(filter_list[["offsets"]][0], "COMPRESSION_LEVEL"), -1)
 
   expect_true(is.sparse(sch))
+
+  tiledb:::libtiledb_array_schema_tile_set_capacity(sch@ptr, 100000)
+  expect_equal(tiledb:::libtiledb_array_schema_tile_get_capacity(sch@ptr), 100000)
+  expect_error(tiledb:::libtiledb_array_schema_tile_set_capacity(sch@ptr, -10))
+
 })

--- a/tests/testthat/test_Attr.R
+++ b/tests/testthat/test_Attr.R
@@ -41,9 +41,9 @@ test_that("tiledb_attr set ncells", {
   attrs <- tiledb_attr("a", type = "INT32", ncells = 1)
   expect_equal(tiledb::ncells(attrs), 1) # as created
 
-  tiledb:::libtiledb_attr_ncells_set(attrs@ptr, 2)
+  tiledb:::libtiledb_attr_set_cell_val_num(attrs@ptr, 2)
   expect_equal(tiledb::ncells(attrs), 2) # as created
 
-  tiledb:::libtiledb_attr_ncells_set(attrs@ptr, NA_integer_)
+  tiledb:::libtiledb_attr_set_cell_val_num(attrs@ptr, NA_integer_)
   expect_true(is.na(tiledb::ncells(attrs)))
 })

--- a/tests/testthat/test_Attr.R
+++ b/tests/testthat/test_Attr.R
@@ -36,3 +36,14 @@ test_that("tiledb_attr throws an error with invalid ncells argument", {
   expect_equal(tiledb::ncells(a1), 1)
   expect_error(tiledb_attr("foo", ncells = 0))
 })
+
+test_that("tiledb_attr set ncells", {
+  attrs <- tiledb_attr("a", type = "INT32", ncells = 1)
+  expect_equal(tiledb::ncells(attrs), 1) # as created
+
+  tiledb:::libtiledb_attr_ncells_set(attrs@ptr, 2)
+  expect_equal(tiledb::ncells(attrs), 2) # as created
+
+  tiledb:::libtiledb_attr_ncells_set(attrs@ptr, NA_integer_)
+  expect_true(is.na(tiledb::ncells(attrs)))
+})


### PR DESCRIPTION
See https://docs.tiledb.com/developer/api-usage/creating-arrays

(The 'red crosses' below are from canceled jobs when, I presume, we waiting in line while other tests ran and a subsequent commit lead to a cancellation. They all passed locally.)

This one is a little shorter and simpler. Among the six files, two are auto-generated (the `RcppExports` C++ and R files), and `tiledb_declarations.h` is (currently) purely cosmetic as it is not actually sourced by any C++ files -- it simply helps to keep track of what is already accessible, and what naming convention has been used.