### PR TITLE
Adding variable length array support for int32 and double

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -433,6 +433,10 @@ libtiledb_query_set_buffer_var_vec <- function(query, attr, sexp, typestr) {
     .Call(`_tiledb_libtiledb_query_set_buffer_var_vec`, query, attr, sexp, typestr)
 }
 
+libtiledb_query_get_buffer_var_vec <- function(sexp, typestr) {
+    .Call(`_tiledb_libtiledb_query_get_buffer_var_vec`, sexp, typestr)
+}
+
 libtiledb_query_submit <- function(query) {
     .Call(`_tiledb_libtiledb_query_submit`, query)
 }

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -421,20 +421,20 @@ libtiledb_query_get_buffer_var_char <- function(bufptr) {
     .Call(`_tiledb_libtiledb_query_get_buffer_var_char`, bufptr)
 }
 
-libtiledb_query_buffer_var_vec_alloc <- function(array, subarray, attribute, typestr, szoffsets = 0L, szdata = 0L) {
-    .Call(`_tiledb_libtiledb_query_buffer_var_vec_alloc`, array, subarray, attribute, typestr, szoffsets, szdata)
+libtiledb_query_buffer_var_vec_alloc <- function(array, subarray, attribute, szoffsets = 0L, szdata = 0L) {
+    .Call(`_tiledb_libtiledb_query_buffer_var_vec_alloc`, array, subarray, attribute, szoffsets, szdata)
 }
 
 libtiledb_query_buffer_var_vec_create <- function(intoffsets, data) {
     .Call(`_tiledb_libtiledb_query_buffer_var_vec_create`, intoffsets, data)
 }
 
-libtiledb_query_set_buffer_var_vec <- function(query, attr, sexp, typestr) {
-    .Call(`_tiledb_libtiledb_query_set_buffer_var_vec`, query, attr, sexp, typestr)
+libtiledb_query_set_buffer_var_vec <- function(query, attr, buf) {
+    .Call(`_tiledb_libtiledb_query_set_buffer_var_vec`, query, attr, buf)
 }
 
-libtiledb_query_get_buffer_var_vec <- function(query, attr, sexp, typestr) {
-    .Call(`_tiledb_libtiledb_query_get_buffer_var_vec`, query, attr, sexp, typestr)
+libtiledb_query_get_buffer_var_vec <- function(query, attr, buf) {
+    .Call(`_tiledb_libtiledb_query_get_buffer_var_vec`, query, attr, buf)
 }
 
 libtiledb_query_submit <- function(query) {

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -433,8 +433,8 @@ libtiledb_query_set_buffer_var_vec <- function(query, attr, sexp, typestr) {
     .Call(`_tiledb_libtiledb_query_set_buffer_var_vec`, query, attr, sexp, typestr)
 }
 
-libtiledb_query_get_buffer_var_vec <- function(sexp, typestr) {
-    .Call(`_tiledb_libtiledb_query_get_buffer_var_vec`, sexp, typestr)
+libtiledb_query_get_buffer_var_vec <- function(query, attr, sexp, typestr) {
+    .Call(`_tiledb_libtiledb_query_get_buffer_var_vec`, query, attr, sexp, typestr)
 }
 
 libtiledb_query_submit <- function(query) {

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -421,8 +421,8 @@ libtiledb_query_get_buffer_var_char <- function(bufptr) {
     .Call(`_tiledb_libtiledb_query_get_buffer_var_char`, bufptr)
 }
 
-libtiledb_query_buffer_var_vec_alloc <- function(array, subarray, attribute, szoffsets = 0L, szdata = 0L) {
-    .Call(`_tiledb_libtiledb_query_buffer_var_vec_alloc`, array, subarray, attribute, szoffsets, szdata)
+libtiledb_query_buffer_var_vec_alloc <- function(array, subarray, attribute, typestr, szoffsets = 0L, szdata = 0L) {
+    .Call(`_tiledb_libtiledb_query_buffer_var_vec_alloc`, array, subarray, attribute, typestr, szoffsets, szdata)
 }
 
 libtiledb_query_buffer_var_vec_create <- function(intoffsets, data) {

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -421,6 +421,18 @@ libtiledb_query_get_buffer_var_char <- function(bufptr) {
     .Call(`_tiledb_libtiledb_query_get_buffer_var_char`, bufptr)
 }
 
+libtiledb_query_buffer_var_vec_alloc <- function(array, subarray, attribute, szoffsets = 0L, szdata = 0L) {
+    .Call(`_tiledb_libtiledb_query_buffer_var_vec_alloc`, array, subarray, attribute, szoffsets, szdata)
+}
+
+libtiledb_query_buffer_var_vec_create <- function(intoffsets, data) {
+    .Call(`_tiledb_libtiledb_query_buffer_var_vec_create`, intoffsets, data)
+}
+
+libtiledb_query_set_buffer_var_vec <- function(query, attr, sexp, typestr) {
+    .Call(`_tiledb_libtiledb_query_set_buffer_var_vec`, query, attr, sexp, typestr)
+}
+
 libtiledb_query_submit <- function(query) {
     .Call(`_tiledb_libtiledb_query_submit`, query)
 }

--- a/inst/examples/ex_var_length_double.R
+++ b/inst/examples/ex_var_length_double.R
@@ -45,7 +45,7 @@ write_array <- function() {
   qryptr <- tiledb:::libtiledb_query_set_layout(qryptr, "ROW_MAJOR")
 
   bufptr <- tiledb:::libtiledb_query_buffer_var_vec_create(offsets, data)
-  qryptr <- tiledb:::libtiledb_query_set_buffer_var_vec(qryptr, "a", bufptr, "FLOAT64")
+  qryptr <- tiledb:::libtiledb_query_set_buffer_var_vec(qryptr, "a", bufptr)
   qryptr <- tiledb:::libtiledb_query_submit(qryptr)
   tiledb:::libtiledb_array_close(arrptr)
   invisible(NULL)
@@ -63,17 +63,17 @@ read_array <- function(txt="", subarr=NULL) {
       subarr <- c(tiledb:::libtiledb_dim_get_domain(lst[[1]]),
                   tiledb:::libtiledb_dim_get_domain(lst[[2]]))
   }
-  bufptr <- tiledb:::libtiledb_query_buffer_var_vec_alloc(arrptr, subarr, "a", "FLOAT64")
+  bufptr <- tiledb:::libtiledb_query_buffer_var_vec_alloc(arrptr, subarr, "a")
 
   qryptr <- tiledb:::libtiledb_query(ctx@ptr, arrptr, "READ")
   qryptr <- tiledb:::libtiledb_query_set_subarray(qryptr, subarr)
   qryptr <- tiledb:::libtiledb_query_set_layout(qryptr, "ROW_MAJOR")
 
-  qryptr <- tiledb:::libtiledb_query_set_buffer_var_vec(qryptr, "a", bufptr, "FLOAT64")
+  qryptr <- tiledb:::libtiledb_query_set_buffer_var_vec(qryptr, "a", bufptr)
   qryptr <- tiledb:::libtiledb_query_submit(qryptr)
   tiledb:::libtiledb_array_close(arrptr)
 
-  rl <- tiledb:::libtiledb_query_get_buffer_var_vec(qryptr, "a", bufptr, "FLOAT64")
+  rl <- tiledb:::libtiledb_query_get_buffer_var_vec(qryptr, "a", bufptr)
   invisible(rl)
 }
 
@@ -91,7 +91,7 @@ write_subarray <- function() {
   qryptr <- tiledb:::libtiledb_query_set_layout(qryptr, "ROW_MAJOR")
 
   bufptr <- tiledb:::libtiledb_query_buffer_var_vec_create(offsets, data)
-  qryptr <- tiledb:::libtiledb_query_set_buffer_var_vec(qryptr, "a", bufptr, "FLOAT64")
+  qryptr <- tiledb:::libtiledb_query_set_buffer_var_vec(qryptr, "a", bufptr)
   qryptr <- tiledb:::libtiledb_query_submit(qryptr)
   tiledb:::libtiledb_array_close(arrptr)
   invisible(NULL)

--- a/inst/examples/ex_var_length_double.R
+++ b/inst/examples/ex_var_length_double.R
@@ -16,7 +16,7 @@ create_array <- function() {
                                 tiledb_dim("cols", c(1L, 4L), 4L, "INT32")))
 
 
-  attr <- tiledb_attr("a", type = "INT32")
+  attr <- tiledb_attr("a", type = "FLOAT64")
   ## set to variable length
   tiledb:::libtiledb_attribute_set_cell_val_num(attr@ptr, NA)
 
@@ -34,18 +34,18 @@ create_array <- function() {
 }
 
 write_array <- function() {
-  data <- c(1L, 1L, 2L, 2L, 3L, 4L, 5L, 6L, 6L, 7L, 7L, 8L, 8L, 8L, 9L, 9L, 10L,
-            11L, 12L, 12L, 13L, 14L, 14L, 14L, 15L, 16L)
+  data <- c(1.1, 1.1, 2.2, 2.2, 3.3, 4.4, 5.5, 6.6, 6.6, 7.7, 7.7, 8.8, 8.8, 8.8, 9.9, 9.0, 10.0,
+            11.1, 12.2, 12.2, 13.3, 14.4, 14.4, 14.4, 15.5, 16.6)
   offsets <- c(0L, 2L, 4L, 5L, 6L, 7L, 9L, 11L, 14L, 16L, 17L, 18L, 20L, 21L, 24L, 25L)
-  offsets <- offsets * 4 # known fixed size of integer
-
+  offsets <- offsets * 8 # known and fixed size of double
+  print(offsets)
   ctx <- tiledb_ctx()
   arrptr <- tiledb:::libtiledb_array_open(ctx@ptr, array_name, "WRITE")
   qryptr <- tiledb:::libtiledb_query(ctx@ptr, arrptr, "WRITE")
   qryptr <- tiledb:::libtiledb_query_set_layout(qryptr, "ROW_MAJOR")
 
   bufptr <- tiledb:::libtiledb_query_buffer_var_vec_create(offsets, data)
-  qryptr <- tiledb:::libtiledb_query_set_buffer_var_vec(qryptr, "a", bufptr, "INT32")
+  qryptr <- tiledb:::libtiledb_query_set_buffer_var_vec(qryptr, "a", bufptr, "FLOAT64")
   qryptr <- tiledb:::libtiledb_query_submit(qryptr)
   tiledb:::libtiledb_array_close(arrptr)
   invisible(NULL)
@@ -63,17 +63,17 @@ read_array <- function(txt="", subarr=NULL) {
       subarr <- c(tiledb:::libtiledb_dim_get_domain(lst[[1]]),
                   tiledb:::libtiledb_dim_get_domain(lst[[2]]))
   }
-  bufptr <- tiledb:::libtiledb_query_buffer_var_vec_alloc(arrptr, subarr, "a", "INT32")
+  bufptr <- tiledb:::libtiledb_query_buffer_var_vec_alloc(arrptr, subarr, "a", "FLOAT64")
 
   qryptr <- tiledb:::libtiledb_query(ctx@ptr, arrptr, "READ")
   qryptr <- tiledb:::libtiledb_query_set_subarray(qryptr, subarr)
   qryptr <- tiledb:::libtiledb_query_set_layout(qryptr, "ROW_MAJOR")
 
-  qryptr <- tiledb:::libtiledb_query_set_buffer_var_vec(qryptr, "a", bufptr, "INT32")
+  qryptr <- tiledb:::libtiledb_query_set_buffer_var_vec(qryptr, "a", bufptr, "FLOAT64")
   qryptr <- tiledb:::libtiledb_query_submit(qryptr)
   tiledb:::libtiledb_array_close(arrptr)
 
-  rl <- tiledb:::libtiledb_query_get_buffer_var_vec(qryptr, "a", bufptr, "INT32")
+  rl <- tiledb:::libtiledb_query_get_buffer_var_vec(qryptr, "a", bufptr, "FLOAT64")
   invisible(rl)
 }
 

--- a/inst/examples/ex_var_length_double.R
+++ b/inst/examples/ex_var_length_double.R
@@ -38,7 +38,7 @@ write_array <- function() {
             11.1, 12.2, 12.2, 13.3, 14.4, 14.4, 14.4, 15.5, 16.6)
   offsets <- c(0L, 2L, 4L, 5L, 6L, 7L, 9L, 11L, 14L, 16L, 17L, 18L, 20L, 21L, 24L, 25L)
   offsets <- offsets * 8 # known and fixed size of double
-  print(offsets)
+
   ctx <- tiledb_ctx()
   arrptr <- tiledb:::libtiledb_array_open(ctx@ptr, array_name, "WRITE")
   qryptr <- tiledb:::libtiledb_query(ctx@ptr, arrptr, "WRITE")
@@ -77,8 +77,31 @@ read_array <- function(txt="", subarr=NULL) {
   invisible(rl)
 }
 
+write_subarray <- function() {
+  data <- c(11.1, 11.1, 22.2, 22.2, 33.3, 44.4)
+  offsets <- c(0L, 2L, 4L, 5L)
+  offsets <- offsets * 4 # known fixed size of integer
+
+  subarr <- c(2L,3L, 2L,3L)
+
+  ctx <- tiledb_ctx()
+  arrptr <- tiledb:::libtiledb_array_open(ctx@ptr, array_name, "WRITE")
+  qryptr <- tiledb:::libtiledb_query(ctx@ptr, arrptr, "WRITE")
+  qryptr <- tiledb:::libtiledb_query_set_subarray(qryptr, subarr)
+  qryptr <- tiledb:::libtiledb_query_set_layout(qryptr, "ROW_MAJOR")
+
+  bufptr <- tiledb:::libtiledb_query_buffer_var_vec_create(offsets, data)
+  qryptr <- tiledb:::libtiledb_query_set_buffer_var_vec(qryptr, "a", bufptr, "FLOAT64")
+  qryptr <- tiledb:::libtiledb_query_submit(qryptr)
+  tiledb:::libtiledb_array_close(arrptr)
+  invisible(NULL)
+}
+
 create_array()
 write_array()
-print(read_array())
+print(read_array("original"))
+write_subarray()
+print(read_array("after subarray"))
+print(read_array("after subarray, subset", c(2L,3L, 2L,3L)))
 
 cat("Done.\n")

--- a/inst/examples/ex_var_length_int32.R
+++ b/inst/examples/ex_var_length_int32.R
@@ -45,7 +45,7 @@ write_array <- function() {
   qryptr <- tiledb:::libtiledb_query_set_layout(qryptr, "ROW_MAJOR")
 
   bufptr <- tiledb:::libtiledb_query_buffer_var_vec_create(offsets, data)
-  qryptr <- tiledb:::libtiledb_query_set_buffer_var_vec(qryptr, "a", bufptr, "INT32")
+  qryptr <- tiledb:::libtiledb_query_set_buffer_var_vec(qryptr, "a", bufptr)
   qryptr <- tiledb:::libtiledb_query_submit(qryptr)
   tiledb:::libtiledb_array_close(arrptr)
   invisible(NULL)
@@ -63,17 +63,17 @@ read_array <- function(txt="", subarr=NULL) {
       subarr <- c(tiledb:::libtiledb_dim_get_domain(lst[[1]]),
                   tiledb:::libtiledb_dim_get_domain(lst[[2]]))
   }
-  bufptr <- tiledb:::libtiledb_query_buffer_var_vec_alloc(arrptr, subarr, "a", "INT32")
+  bufptr <- tiledb:::libtiledb_query_buffer_var_vec_alloc(arrptr, subarr, "a")
 
   qryptr <- tiledb:::libtiledb_query(ctx@ptr, arrptr, "READ")
   qryptr <- tiledb:::libtiledb_query_set_subarray(qryptr, subarr)
   qryptr <- tiledb:::libtiledb_query_set_layout(qryptr, "ROW_MAJOR")
 
-  qryptr <- tiledb:::libtiledb_query_set_buffer_var_vec(qryptr, "a", bufptr, "INT32")
+  qryptr <- tiledb:::libtiledb_query_set_buffer_var_vec(qryptr, "a", bufptr)
   qryptr <- tiledb:::libtiledb_query_submit(qryptr)
   tiledb:::libtiledb_array_close(arrptr)
 
-  rl <- tiledb:::libtiledb_query_get_buffer_var_vec(qryptr, "a", bufptr, "INT32")
+  rl <- tiledb:::libtiledb_query_get_buffer_var_vec(qryptr, "a", bufptr)
   invisible(rl)
 }
 
@@ -91,7 +91,7 @@ write_subarray <- function() {
   qryptr <- tiledb:::libtiledb_query_set_layout(qryptr, "ROW_MAJOR")
 
   bufptr <- tiledb:::libtiledb_query_buffer_var_vec_create(offsets, data)
-  qryptr <- tiledb:::libtiledb_query_set_buffer_var_vec(qryptr, "a", bufptr, "INT32")
+  qryptr <- tiledb:::libtiledb_query_set_buffer_var_vec(qryptr, "a", bufptr)
   qryptr <- tiledb:::libtiledb_query_submit(qryptr)
   tiledb:::libtiledb_array_close(arrptr)
   invisible(NULL)

--- a/inst/examples/ex_var_length_int32.R
+++ b/inst/examples/ex_var_length_int32.R
@@ -77,8 +77,31 @@ read_array <- function(txt="", subarr=NULL) {
   invisible(rl)
 }
 
+write_subarray <- function() {
+  data <- c(11L, 11L, 22L, 22L, 33L, 44L)
+  offsets <- c(0L, 2L, 4L, 5L)
+  offsets <- offsets * 4 # known fixed size of integer
+
+  subarr <- c(2L,3L, 2L,3L)
+
+  ctx <- tiledb_ctx()
+  arrptr <- tiledb:::libtiledb_array_open(ctx@ptr, array_name, "WRITE")
+  qryptr <- tiledb:::libtiledb_query(ctx@ptr, arrptr, "WRITE")
+  qryptr <- tiledb:::libtiledb_query_set_subarray(qryptr, subarr)
+  qryptr <- tiledb:::libtiledb_query_set_layout(qryptr, "ROW_MAJOR")
+
+  bufptr <- tiledb:::libtiledb_query_buffer_var_vec_create(offsets, data)
+  qryptr <- tiledb:::libtiledb_query_set_buffer_var_vec(qryptr, "a", bufptr, "INT32")
+  qryptr <- tiledb:::libtiledb_query_submit(qryptr)
+  tiledb:::libtiledb_array_close(arrptr)
+  invisible(NULL)
+}
+
 create_array()
 write_array()
-print(read_array())
+print(read_array("original"))
+write_subarray()
+print(read_array("after subarray"))
+print(read_array("after subarray, subset", c(2L,3L, 2L,3L)))
 
 cat("Done.\n")

--- a/inst/include/tiledb.h
+++ b/inst/include/tiledb.h
@@ -21,15 +21,25 @@ typedef struct var_length_char_buffer vlc_buf_t;
 // using vli_buf_t_old = struct var_length_vec_buffer_initial<int32_t>;
 // using vld_buf_t_old = struct var_length_vec_buffer_initial<double>;
 
+// THIS WORKS
+// template <typename T>
+// struct var_length_vec_buffer {
+// public:
+//   std::vector<uint64_t> offsets;  // vector for offset values
+//   std::vector<T> data;            // vector for data values
+// };
+// using vli_buf_t = struct var_length_vec_buffer<int32_t>;
+// using vld_buf_t = struct var_length_vec_buffer<double>;
 
-template <typename T>
 struct var_length_vec_buffer {
 public:
   std::vector<uint64_t> offsets;  // vector for offset values
-  std::vector<T> data;            // vector for data values
+  // cannot template as cannot have the template type in the C interface for created functions
+  // void *dataptr;                  // vector for data values
+  std::vector<int32_t> idata;        // vector for data values
+  std::vector<double> ddata;         // vector for data values
+  tiledb_datatype_t dtype;           // data type
 };
-using vli_buf_t = struct var_length_vec_buffer<int32_t>;
-using vld_buf_t = struct var_length_vec_buffer<double>;
-
+typedef struct var_length_vec_buffer vlv_buf_t;
 
 #endif // __tiledb_h__

--- a/inst/include/tiledb.h
+++ b/inst/include/tiledb.h
@@ -6,11 +6,30 @@
 
 using namespace Rcpp;
 
-struct var_length_string_buffer {
+struct var_length_char_buffer {
   std::vector<uint64_t> offsets;  // vector for offset values
   std::string str;              	// string for data values
   int32_t rows, cols;             // dimension from subarray
 };
-typedef struct var_length_string_buffer vlsbuf_t;
+typedef struct var_length_char_buffer vlc_buf_t;
+
+// template <typename T>
+// struct var_length_vec_buffer_initial {
+//   std::vector<uint64_t> offsets;  // vector for offset values
+//   std::vector<T> data;            // vector for data values
+// };
+// using vli_buf_t_old = struct var_length_vec_buffer_initial<int32_t>;
+// using vld_buf_t_old = struct var_length_vec_buffer_initial<double>;
+
+
+template <typename T>
+struct var_length_vec_buffer {
+public:
+  std::vector<uint64_t> offsets;  // vector for offset values
+  std::vector<T> data;            // vector for data values
+};
+using vli_buf_t = struct var_length_vec_buffer<int32_t>;
+using vld_buf_t = struct var_length_vec_buffer<double>;
+
 
 #endif // __tiledb_h__

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -1268,6 +1268,18 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// libtiledb_query_get_buffer_var_vec
+List libtiledb_query_get_buffer_var_vec(SEXP sexp, std::string typestr);
+RcppExport SEXP _tiledb_libtiledb_query_get_buffer_var_vec(SEXP sexpSEXP, SEXP typestrSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< SEXP >::type sexp(sexpSEXP);
+    Rcpp::traits::input_parameter< std::string >::type typestr(typestrSEXP);
+    rcpp_result_gen = Rcpp::wrap(libtiledb_query_get_buffer_var_vec(sexp, typestr));
+    return rcpp_result_gen;
+END_RCPP
+}
 // libtiledb_query_submit
 XPtr<tiledb::Query> libtiledb_query_submit(XPtr<tiledb::Query> query);
 RcppExport SEXP _tiledb_libtiledb_query_submit(SEXP querySEXP) {
@@ -1765,6 +1777,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_tiledb_libtiledb_query_buffer_var_vec_alloc", (DL_FUNC) &_tiledb_libtiledb_query_buffer_var_vec_alloc, 5},
     {"_tiledb_libtiledb_query_buffer_var_vec_create", (DL_FUNC) &_tiledb_libtiledb_query_buffer_var_vec_create, 2},
     {"_tiledb_libtiledb_query_set_buffer_var_vec", (DL_FUNC) &_tiledb_libtiledb_query_set_buffer_var_vec, 4},
+    {"_tiledb_libtiledb_query_get_buffer_var_vec", (DL_FUNC) &_tiledb_libtiledb_query_get_buffer_var_vec, 2},
     {"_tiledb_libtiledb_query_submit", (DL_FUNC) &_tiledb_libtiledb_query_submit, 1},
     {"_tiledb_libtiledb_query_finalize", (DL_FUNC) &_tiledb_libtiledb_query_finalize, 1},
     {"_tiledb_libtiledb_query_status", (DL_FUNC) &_tiledb_libtiledb_query_status, 1},

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -1228,17 +1228,18 @@ BEGIN_RCPP
 END_RCPP
 }
 // libtiledb_query_buffer_var_vec_alloc
-SEXP libtiledb_query_buffer_var_vec_alloc(XPtr<tiledb::Array> array, SEXP subarray, std::string attribute, int szoffsets, int szdata);
-RcppExport SEXP _tiledb_libtiledb_query_buffer_var_vec_alloc(SEXP arraySEXP, SEXP subarraySEXP, SEXP attributeSEXP, SEXP szoffsetsSEXP, SEXP szdataSEXP) {
+SEXP libtiledb_query_buffer_var_vec_alloc(XPtr<tiledb::Array> array, SEXP subarray, std::string attribute, std::string typestr, int szoffsets, int szdata);
+RcppExport SEXP _tiledb_libtiledb_query_buffer_var_vec_alloc(SEXP arraySEXP, SEXP subarraySEXP, SEXP attributeSEXP, SEXP typestrSEXP, SEXP szoffsetsSEXP, SEXP szdataSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< XPtr<tiledb::Array> >::type array(arraySEXP);
     Rcpp::traits::input_parameter< SEXP >::type subarray(subarraySEXP);
     Rcpp::traits::input_parameter< std::string >::type attribute(attributeSEXP);
+    Rcpp::traits::input_parameter< std::string >::type typestr(typestrSEXP);
     Rcpp::traits::input_parameter< int >::type szoffsets(szoffsetsSEXP);
     Rcpp::traits::input_parameter< int >::type szdata(szdataSEXP);
-    rcpp_result_gen = Rcpp::wrap(libtiledb_query_buffer_var_vec_alloc(array, subarray, attribute, szoffsets, szdata));
+    rcpp_result_gen = Rcpp::wrap(libtiledb_query_buffer_var_vec_alloc(array, subarray, attribute, typestr, szoffsets, szdata));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -1776,7 +1777,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_tiledb_libtiledb_query_buffer_var_char_create", (DL_FUNC) &_tiledb_libtiledb_query_buffer_var_char_create, 2},
     {"_tiledb_libtiledb_query_set_buffer_var_char", (DL_FUNC) &_tiledb_libtiledb_query_set_buffer_var_char, 3},
     {"_tiledb_libtiledb_query_get_buffer_var_char", (DL_FUNC) &_tiledb_libtiledb_query_get_buffer_var_char, 1},
-    {"_tiledb_libtiledb_query_buffer_var_vec_alloc", (DL_FUNC) &_tiledb_libtiledb_query_buffer_var_vec_alloc, 5},
+    {"_tiledb_libtiledb_query_buffer_var_vec_alloc", (DL_FUNC) &_tiledb_libtiledb_query_buffer_var_vec_alloc, 6},
     {"_tiledb_libtiledb_query_buffer_var_vec_create", (DL_FUNC) &_tiledb_libtiledb_query_buffer_var_vec_create, 2},
     {"_tiledb_libtiledb_query_set_buffer_var_vec", (DL_FUNC) &_tiledb_libtiledb_query_set_buffer_var_vec, 4},
     {"_tiledb_libtiledb_query_get_buffer_var_vec", (DL_FUNC) &_tiledb_libtiledb_query_get_buffer_var_vec, 4},

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -1177,7 +1177,7 @@ BEGIN_RCPP
 END_RCPP
 }
 // libtiledb_query_buffer_var_char_alloc
-XPtr<vlsbuf_t> libtiledb_query_buffer_var_char_alloc(XPtr<tiledb::Array> array, SEXP subarray, std::string attribute, int szoffsets, int szdata);
+XPtr<vlc_buf_t> libtiledb_query_buffer_var_char_alloc(XPtr<tiledb::Array> array, SEXP subarray, std::string attribute, int szoffsets, int szdata);
 RcppExport SEXP _tiledb_libtiledb_query_buffer_var_char_alloc(SEXP arraySEXP, SEXP subarraySEXP, SEXP attributeSEXP, SEXP szoffsetsSEXP, SEXP szdataSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
@@ -1192,7 +1192,7 @@ BEGIN_RCPP
 END_RCPP
 }
 // libtiledb_query_buffer_var_char_create
-XPtr<vlsbuf_t> libtiledb_query_buffer_var_char_create(IntegerVector intoffsets, std::string data);
+XPtr<vlc_buf_t> libtiledb_query_buffer_var_char_create(IntegerVector intoffsets, std::string data);
 RcppExport SEXP _tiledb_libtiledb_query_buffer_var_char_create(SEXP intoffsetsSEXP, SEXP dataSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
@@ -1204,26 +1204,67 @@ BEGIN_RCPP
 END_RCPP
 }
 // libtiledb_query_set_buffer_var_char
-XPtr<tiledb::Query> libtiledb_query_set_buffer_var_char(XPtr<tiledb::Query> query, std::string attr, XPtr<vlsbuf_t> bufptr);
+XPtr<tiledb::Query> libtiledb_query_set_buffer_var_char(XPtr<tiledb::Query> query, std::string attr, XPtr<vlc_buf_t> bufptr);
 RcppExport SEXP _tiledb_libtiledb_query_set_buffer_var_char(SEXP querySEXP, SEXP attrSEXP, SEXP bufptrSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< XPtr<tiledb::Query> >::type query(querySEXP);
     Rcpp::traits::input_parameter< std::string >::type attr(attrSEXP);
-    Rcpp::traits::input_parameter< XPtr<vlsbuf_t> >::type bufptr(bufptrSEXP);
+    Rcpp::traits::input_parameter< XPtr<vlc_buf_t> >::type bufptr(bufptrSEXP);
     rcpp_result_gen = Rcpp::wrap(libtiledb_query_set_buffer_var_char(query, attr, bufptr));
     return rcpp_result_gen;
 END_RCPP
 }
 // libtiledb_query_get_buffer_var_char
-CharacterMatrix libtiledb_query_get_buffer_var_char(XPtr<vlsbuf_t> bufptr);
+CharacterMatrix libtiledb_query_get_buffer_var_char(XPtr<vlc_buf_t> bufptr);
 RcppExport SEXP _tiledb_libtiledb_query_get_buffer_var_char(SEXP bufptrSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< XPtr<vlsbuf_t> >::type bufptr(bufptrSEXP);
+    Rcpp::traits::input_parameter< XPtr<vlc_buf_t> >::type bufptr(bufptrSEXP);
     rcpp_result_gen = Rcpp::wrap(libtiledb_query_get_buffer_var_char(bufptr));
+    return rcpp_result_gen;
+END_RCPP
+}
+// libtiledb_query_buffer_var_vec_alloc
+SEXP libtiledb_query_buffer_var_vec_alloc(XPtr<tiledb::Array> array, SEXP subarray, std::string attribute, int szoffsets, int szdata);
+RcppExport SEXP _tiledb_libtiledb_query_buffer_var_vec_alloc(SEXP arraySEXP, SEXP subarraySEXP, SEXP attributeSEXP, SEXP szoffsetsSEXP, SEXP szdataSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< XPtr<tiledb::Array> >::type array(arraySEXP);
+    Rcpp::traits::input_parameter< SEXP >::type subarray(subarraySEXP);
+    Rcpp::traits::input_parameter< std::string >::type attribute(attributeSEXP);
+    Rcpp::traits::input_parameter< int >::type szoffsets(szoffsetsSEXP);
+    Rcpp::traits::input_parameter< int >::type szdata(szdataSEXP);
+    rcpp_result_gen = Rcpp::wrap(libtiledb_query_buffer_var_vec_alloc(array, subarray, attribute, szoffsets, szdata));
+    return rcpp_result_gen;
+END_RCPP
+}
+// libtiledb_query_buffer_var_vec_create
+SEXP libtiledb_query_buffer_var_vec_create(IntegerVector intoffsets, SEXP data);
+RcppExport SEXP _tiledb_libtiledb_query_buffer_var_vec_create(SEXP intoffsetsSEXP, SEXP dataSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< IntegerVector >::type intoffsets(intoffsetsSEXP);
+    Rcpp::traits::input_parameter< SEXP >::type data(dataSEXP);
+    rcpp_result_gen = Rcpp::wrap(libtiledb_query_buffer_var_vec_create(intoffsets, data));
+    return rcpp_result_gen;
+END_RCPP
+}
+// libtiledb_query_set_buffer_var_vec
+XPtr<tiledb::Query> libtiledb_query_set_buffer_var_vec(XPtr<tiledb::Query> query, std::string attr, SEXP sexp, std::string typestr);
+RcppExport SEXP _tiledb_libtiledb_query_set_buffer_var_vec(SEXP querySEXP, SEXP attrSEXP, SEXP sexpSEXP, SEXP typestrSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< XPtr<tiledb::Query> >::type query(querySEXP);
+    Rcpp::traits::input_parameter< std::string >::type attr(attrSEXP);
+    Rcpp::traits::input_parameter< SEXP >::type sexp(sexpSEXP);
+    Rcpp::traits::input_parameter< std::string >::type typestr(typestrSEXP);
+    rcpp_result_gen = Rcpp::wrap(libtiledb_query_set_buffer_var_vec(query, attr, sexp, typestr));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -1721,6 +1762,9 @@ static const R_CallMethodDef CallEntries[] = {
     {"_tiledb_libtiledb_query_buffer_var_char_create", (DL_FUNC) &_tiledb_libtiledb_query_buffer_var_char_create, 2},
     {"_tiledb_libtiledb_query_set_buffer_var_char", (DL_FUNC) &_tiledb_libtiledb_query_set_buffer_var_char, 3},
     {"_tiledb_libtiledb_query_get_buffer_var_char", (DL_FUNC) &_tiledb_libtiledb_query_get_buffer_var_char, 1},
+    {"_tiledb_libtiledb_query_buffer_var_vec_alloc", (DL_FUNC) &_tiledb_libtiledb_query_buffer_var_vec_alloc, 5},
+    {"_tiledb_libtiledb_query_buffer_var_vec_create", (DL_FUNC) &_tiledb_libtiledb_query_buffer_var_vec_create, 2},
+    {"_tiledb_libtiledb_query_set_buffer_var_vec", (DL_FUNC) &_tiledb_libtiledb_query_set_buffer_var_vec, 4},
     {"_tiledb_libtiledb_query_submit", (DL_FUNC) &_tiledb_libtiledb_query_submit, 1},
     {"_tiledb_libtiledb_query_finalize", (DL_FUNC) &_tiledb_libtiledb_query_finalize, 1},
     {"_tiledb_libtiledb_query_status", (DL_FUNC) &_tiledb_libtiledb_query_status, 1},

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -1228,23 +1228,22 @@ BEGIN_RCPP
 END_RCPP
 }
 // libtiledb_query_buffer_var_vec_alloc
-SEXP libtiledb_query_buffer_var_vec_alloc(XPtr<tiledb::Array> array, SEXP subarray, std::string attribute, std::string typestr, int szoffsets, int szdata);
-RcppExport SEXP _tiledb_libtiledb_query_buffer_var_vec_alloc(SEXP arraySEXP, SEXP subarraySEXP, SEXP attributeSEXP, SEXP typestrSEXP, SEXP szoffsetsSEXP, SEXP szdataSEXP) {
+XPtr<vlv_buf_t> libtiledb_query_buffer_var_vec_alloc(XPtr<tiledb::Array> array, SEXP subarray, std::string attribute, int szoffsets, int szdata);
+RcppExport SEXP _tiledb_libtiledb_query_buffer_var_vec_alloc(SEXP arraySEXP, SEXP subarraySEXP, SEXP attributeSEXP, SEXP szoffsetsSEXP, SEXP szdataSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< XPtr<tiledb::Array> >::type array(arraySEXP);
     Rcpp::traits::input_parameter< SEXP >::type subarray(subarraySEXP);
     Rcpp::traits::input_parameter< std::string >::type attribute(attributeSEXP);
-    Rcpp::traits::input_parameter< std::string >::type typestr(typestrSEXP);
     Rcpp::traits::input_parameter< int >::type szoffsets(szoffsetsSEXP);
     Rcpp::traits::input_parameter< int >::type szdata(szdataSEXP);
-    rcpp_result_gen = Rcpp::wrap(libtiledb_query_buffer_var_vec_alloc(array, subarray, attribute, typestr, szoffsets, szdata));
+    rcpp_result_gen = Rcpp::wrap(libtiledb_query_buffer_var_vec_alloc(array, subarray, attribute, szoffsets, szdata));
     return rcpp_result_gen;
 END_RCPP
 }
 // libtiledb_query_buffer_var_vec_create
-SEXP libtiledb_query_buffer_var_vec_create(IntegerVector intoffsets, SEXP data);
+XPtr<vlv_buf_t> libtiledb_query_buffer_var_vec_create(IntegerVector intoffsets, SEXP data);
 RcppExport SEXP _tiledb_libtiledb_query_buffer_var_vec_create(SEXP intoffsetsSEXP, SEXP dataSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
@@ -1256,30 +1255,28 @@ BEGIN_RCPP
 END_RCPP
 }
 // libtiledb_query_set_buffer_var_vec
-XPtr<tiledb::Query> libtiledb_query_set_buffer_var_vec(XPtr<tiledb::Query> query, std::string attr, SEXP sexp, std::string typestr);
-RcppExport SEXP _tiledb_libtiledb_query_set_buffer_var_vec(SEXP querySEXP, SEXP attrSEXP, SEXP sexpSEXP, SEXP typestrSEXP) {
+XPtr<tiledb::Query> libtiledb_query_set_buffer_var_vec(XPtr<tiledb::Query> query, std::string attr, XPtr<vlv_buf_t> buf);
+RcppExport SEXP _tiledb_libtiledb_query_set_buffer_var_vec(SEXP querySEXP, SEXP attrSEXP, SEXP bufSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< XPtr<tiledb::Query> >::type query(querySEXP);
     Rcpp::traits::input_parameter< std::string >::type attr(attrSEXP);
-    Rcpp::traits::input_parameter< SEXP >::type sexp(sexpSEXP);
-    Rcpp::traits::input_parameter< std::string >::type typestr(typestrSEXP);
-    rcpp_result_gen = Rcpp::wrap(libtiledb_query_set_buffer_var_vec(query, attr, sexp, typestr));
+    Rcpp::traits::input_parameter< XPtr<vlv_buf_t> >::type buf(bufSEXP);
+    rcpp_result_gen = Rcpp::wrap(libtiledb_query_set_buffer_var_vec(query, attr, buf));
     return rcpp_result_gen;
 END_RCPP
 }
 // libtiledb_query_get_buffer_var_vec
-List libtiledb_query_get_buffer_var_vec(XPtr<tiledb::Query> query, std::string attr, SEXP sexp, std::string typestr);
-RcppExport SEXP _tiledb_libtiledb_query_get_buffer_var_vec(SEXP querySEXP, SEXP attrSEXP, SEXP sexpSEXP, SEXP typestrSEXP) {
+List libtiledb_query_get_buffer_var_vec(XPtr<tiledb::Query> query, std::string attr, XPtr<vlv_buf_t> buf);
+RcppExport SEXP _tiledb_libtiledb_query_get_buffer_var_vec(SEXP querySEXP, SEXP attrSEXP, SEXP bufSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< XPtr<tiledb::Query> >::type query(querySEXP);
     Rcpp::traits::input_parameter< std::string >::type attr(attrSEXP);
-    Rcpp::traits::input_parameter< SEXP >::type sexp(sexpSEXP);
-    Rcpp::traits::input_parameter< std::string >::type typestr(typestrSEXP);
-    rcpp_result_gen = Rcpp::wrap(libtiledb_query_get_buffer_var_vec(query, attr, sexp, typestr));
+    Rcpp::traits::input_parameter< XPtr<vlv_buf_t> >::type buf(bufSEXP);
+    rcpp_result_gen = Rcpp::wrap(libtiledb_query_get_buffer_var_vec(query, attr, buf));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -1777,10 +1774,10 @@ static const R_CallMethodDef CallEntries[] = {
     {"_tiledb_libtiledb_query_buffer_var_char_create", (DL_FUNC) &_tiledb_libtiledb_query_buffer_var_char_create, 2},
     {"_tiledb_libtiledb_query_set_buffer_var_char", (DL_FUNC) &_tiledb_libtiledb_query_set_buffer_var_char, 3},
     {"_tiledb_libtiledb_query_get_buffer_var_char", (DL_FUNC) &_tiledb_libtiledb_query_get_buffer_var_char, 1},
-    {"_tiledb_libtiledb_query_buffer_var_vec_alloc", (DL_FUNC) &_tiledb_libtiledb_query_buffer_var_vec_alloc, 6},
+    {"_tiledb_libtiledb_query_buffer_var_vec_alloc", (DL_FUNC) &_tiledb_libtiledb_query_buffer_var_vec_alloc, 5},
     {"_tiledb_libtiledb_query_buffer_var_vec_create", (DL_FUNC) &_tiledb_libtiledb_query_buffer_var_vec_create, 2},
-    {"_tiledb_libtiledb_query_set_buffer_var_vec", (DL_FUNC) &_tiledb_libtiledb_query_set_buffer_var_vec, 4},
-    {"_tiledb_libtiledb_query_get_buffer_var_vec", (DL_FUNC) &_tiledb_libtiledb_query_get_buffer_var_vec, 4},
+    {"_tiledb_libtiledb_query_set_buffer_var_vec", (DL_FUNC) &_tiledb_libtiledb_query_set_buffer_var_vec, 3},
+    {"_tiledb_libtiledb_query_get_buffer_var_vec", (DL_FUNC) &_tiledb_libtiledb_query_get_buffer_var_vec, 3},
     {"_tiledb_libtiledb_query_submit", (DL_FUNC) &_tiledb_libtiledb_query_submit, 1},
     {"_tiledb_libtiledb_query_finalize", (DL_FUNC) &_tiledb_libtiledb_query_finalize, 1},
     {"_tiledb_libtiledb_query_status", (DL_FUNC) &_tiledb_libtiledb_query_status, 1},

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -1269,14 +1269,16 @@ BEGIN_RCPP
 END_RCPP
 }
 // libtiledb_query_get_buffer_var_vec
-List libtiledb_query_get_buffer_var_vec(SEXP sexp, std::string typestr);
-RcppExport SEXP _tiledb_libtiledb_query_get_buffer_var_vec(SEXP sexpSEXP, SEXP typestrSEXP) {
+List libtiledb_query_get_buffer_var_vec(XPtr<tiledb::Query> query, std::string attr, SEXP sexp, std::string typestr);
+RcppExport SEXP _tiledb_libtiledb_query_get_buffer_var_vec(SEXP querySEXP, SEXP attrSEXP, SEXP sexpSEXP, SEXP typestrSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< XPtr<tiledb::Query> >::type query(querySEXP);
+    Rcpp::traits::input_parameter< std::string >::type attr(attrSEXP);
     Rcpp::traits::input_parameter< SEXP >::type sexp(sexpSEXP);
     Rcpp::traits::input_parameter< std::string >::type typestr(typestrSEXP);
-    rcpp_result_gen = Rcpp::wrap(libtiledb_query_get_buffer_var_vec(sexp, typestr));
+    rcpp_result_gen = Rcpp::wrap(libtiledb_query_get_buffer_var_vec(query, attr, sexp, typestr));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -1777,7 +1779,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_tiledb_libtiledb_query_buffer_var_vec_alloc", (DL_FUNC) &_tiledb_libtiledb_query_buffer_var_vec_alloc, 5},
     {"_tiledb_libtiledb_query_buffer_var_vec_create", (DL_FUNC) &_tiledb_libtiledb_query_buffer_var_vec_create, 2},
     {"_tiledb_libtiledb_query_set_buffer_var_vec", (DL_FUNC) &_tiledb_libtiledb_query_set_buffer_var_vec, 4},
-    {"_tiledb_libtiledb_query_get_buffer_var_vec", (DL_FUNC) &_tiledb_libtiledb_query_get_buffer_var_vec, 2},
+    {"_tiledb_libtiledb_query_get_buffer_var_vec", (DL_FUNC) &_tiledb_libtiledb_query_get_buffer_var_vec, 4},
     {"_tiledb_libtiledb_query_submit", (DL_FUNC) &_tiledb_libtiledb_query_submit, 1},
     {"_tiledb_libtiledb_query_finalize", (DL_FUNC) &_tiledb_libtiledb_query_finalize, 1},
     {"_tiledb_libtiledb_query_status", (DL_FUNC) &_tiledb_libtiledb_query_status, 1},

--- a/src/libtiledb.cpp
+++ b/src/libtiledb.cpp
@@ -1473,7 +1473,10 @@ XPtr<tiledb::Query> libtiledb_query_set_buffer_var_vec(XPtr<tiledb::Query> query
 }
 
 // [[Rcpp::export]]
-List libtiledb_query_get_buffer_var_vec(SEXP sexp, std::string typestr) {
+List libtiledb_query_get_buffer_var_vec(XPtr<tiledb::Query> query, std::string attr,
+                                        SEXP sexp, std::string typestr) {
+
+  auto dims = query->result_buffer_elements()[attr]; // actual result dims post query
 
   if (typestr == "INT32") {
     XPtr<vli_buf_t> bufptr(sexp);
@@ -1482,7 +1485,7 @@ List libtiledb_query_get_buffer_var_vec(SEXP sexp, std::string typestr) {
     for (int i=0; i<n; i++) {
       ivec[i] = static_cast<int32_t>(bufptr->offsets[i]);
     }
-    n = bufptr->data.size();
+    n = dims.second;            // actual size, not allocated size
     IntegerVector dvec(n);
     for (int i=0; i<n; i++) {
       dvec[i] = static_cast<int32_t>(bufptr->data[i]);
@@ -1497,7 +1500,7 @@ List libtiledb_query_get_buffer_var_vec(SEXP sexp, std::string typestr) {
     for (int i=0; i<n; i++) {
       ivec[i] = static_cast<int32_t>(bufptr->offsets[i]);
     }
-    n = bufptr->data.size();
+    n = dims.second;            // actual size, not allocated size
     NumericVector dvec(n);
     for (int i=0; i<n; i++) {
       dvec[i] = static_cast<double>(bufptr->data[i]);
@@ -1548,8 +1551,7 @@ std::string libtiledb_query_status(XPtr<tiledb::Query> query) {
 }
 
 // [[Rcpp::export]]
-R_xlen_t libtiledb_query_result_buffer_elements(XPtr<tiledb::Query> query,
-                                                std::string attribute) {
+R_xlen_t libtiledb_query_result_buffer_elements(XPtr<tiledb::Query> query, std::string attribute) {
   R_xlen_t nelem = query->result_buffer_elements()[attribute].second;
   return nelem;
 }

--- a/src/libtiledb.cpp
+++ b/src/libtiledb.cpp
@@ -1401,11 +1401,11 @@ XPtr<vlv_buf_t> libtiledb_query_buffer_var_vec_alloc(XPtr<tiledb::Array> array,
   auto sub = as<std::vector<int32_t>>(subarray);
   auto max_elements = array->max_buffer_elements(sub);
   buf->offsets.resize(szoffsets <= 0 ? max_elements[attribute].first : szoffsets);
-  if (typestr == "INT32") { //TYPEOF(subarray) == INTSXP) {
+  if (typestr == "INT32") {
     buf->idata.resize(szdata <= 0 ? max_elements[attribute].second : szdata);
     buf->ddata.clear();
     buf->dtype = TILEDB_INT32;
-  } else if (typestr == "FLOAT64") { //(TYPEOF(subarray) == REALSXP) {
+  } else if (typestr == "FLOAT64") {
     buf->ddata.resize(szdata <= 0 ? max_elements[attribute].second : szdata);
     buf->idata.clear();
     buf->dtype = TILEDB_FLOAT64;

--- a/src/libtiledb.cpp
+++ b/src/libtiledb.cpp
@@ -1385,44 +1385,24 @@ CharacterMatrix libtiledb_query_get_buffer_var_char(XPtr<vlc_buf_t> bufptr) {
 
 // -- vlv_buf_t functions below
 
-// // [ [Rcpp::export ] ]
-// XPtr<vli_buf_t_old> libtiledb_query_buffer_var_vec_alloc_INT(XPtr<tiledb::Array> array,
-//                                                              SEXP subarray, std::string attribute,
-//                                                              int szoffsets = 0, int szdata = 0) {
-//   XPtr<vli_buf_t_old> buf = XPtr<vli_buf_t_old>(new vli_buf_t_old);
-//   if (TYPEOF(subarray) == INTSXP) {
-//     auto sub = as<std::vector<int32_t>>(subarray);
-//     auto max_elements = array->max_buffer_elements(sub);
-//     buf->offsets.resize(szoffsets <= 0 ? max_elements[attribute].first : szoffsets);
-//     buf->data.resize(szdata <= 0 ? max_elements[attribute].second : szdata);
-//   } else if (TYPEOF(subarray) == REALSXP) {
-//     auto sub = as<std::vector<double>>(subarray);
-//     auto max_elements = array->max_buffer_elements(sub);
-//     buf->offsets.resize(szoffsets <= 0 ? max_elements[attribute].first : szoffsets);
-//     buf->data.resize(szdata <= 0 ? max_elements[attribute].second : szdata);
-//   } else {
-//     Rcpp::stop("Invalid subarray buffer type for domain: '%s'", Rcpp::type2name(subarray));
-//   }
-//   return buf;
-// }
-
 // In the following signature we cannot have a templated type as the return type so we have
 // to bring the switch between types 'inside' and make it run-time dependent on the subarray
 // type we already had
 // [[Rcpp::export]]
 SEXP libtiledb_query_buffer_var_vec_alloc(XPtr<tiledb::Array> array,
                                           SEXP subarray, std::string attribute,
+                                          std::string typestr,
                                           int szoffsets = 0, int szdata = 0) {
-  if (TYPEOF(subarray) == INTSXP) {
+  if (typestr == "INT32") { //TYPEOF(subarray) == INTSXP) {
     XPtr<vli_buf_t> buf = XPtr<vli_buf_t>(new vli_buf_t);
     auto sub = as<std::vector<int32_t>>(subarray);
     auto max_elements = array->max_buffer_elements(sub);
     buf->offsets.resize(szoffsets <= 0 ? max_elements[attribute].first : szoffsets);
     buf->data.resize(szdata <= 0 ? max_elements[attribute].second : szdata);
     return Rcpp::wrap(buf);
-  } else if (TYPEOF(subarray) == REALSXP) {
+  } else if (typestr == "FLOAT64") { //(TYPEOF(subarray) == REALSXP) {
     XPtr<vld_buf_t> buf = XPtr<vld_buf_t>(new vld_buf_t);
-    auto sub = as<std::vector<double>>(subarray);
+    auto sub = as<std::vector<int32_t>>(subarray);
     auto max_elements = array->max_buffer_elements(sub);
     buf->offsets.resize(szoffsets <= 0 ? max_elements[attribute].first : szoffsets);
     buf->data.resize(szdata <= 0 ? max_elements[attribute].second : szdata);

--- a/src/libtiledb.cpp
+++ b/src/libtiledb.cpp
@@ -1463,13 +1463,52 @@ XPtr<tiledb::Query> libtiledb_query_set_buffer_var_vec(XPtr<tiledb::Query> query
   if (typestr == "INT32") {
     XPtr<vli_buf_t> bufptr(sexp);
     query->set_buffer(attr, bufptr->offsets, bufptr->data);
-  } else if (typestr == "DOUBLE") {
+  } else if (typestr == "FLOAT64") {
     XPtr<vld_buf_t> bufptr(sexp);
     query->set_buffer(attr, bufptr->offsets, bufptr->data);
   } else {
     Rcpp::stop("Unsupported type '%s' for buffer", typestr.c_str());
   }
   return query;
+}
+
+// [[Rcpp::export]]
+List libtiledb_query_get_buffer_var_vec(SEXP sexp, std::string typestr) {
+
+  if (typestr == "INT32") {
+    XPtr<vli_buf_t> bufptr(sexp);
+    int n = bufptr->offsets.size();
+    IntegerVector ivec(n);
+    for (int i=0; i<n; i++) {
+      ivec[i] = static_cast<int32_t>(bufptr->offsets[i]);
+    }
+    n = bufptr->data.size();
+    IntegerVector dvec(n);
+    for (int i=0; i<n; i++) {
+      dvec[i] = static_cast<int32_t>(bufptr->data[i]);
+    }
+    List rl = List::create(Rcpp::Named("offsets") = ivec,
+                           Rcpp::Named("data")    = dvec);
+    return(rl);
+  } else if (typestr == "FLOAT64") {
+    XPtr<vld_buf_t> bufptr(sexp);
+    int n = bufptr->offsets.size();
+    IntegerVector ivec(n);
+    for (int i=0; i<n; i++) {
+      ivec[i] = static_cast<int32_t>(bufptr->offsets[i]);
+    }
+    n = bufptr->data.size();
+    NumericVector dvec(n);
+    for (int i=0; i<n; i++) {
+      dvec[i] = static_cast<double>(bufptr->data[i]);
+    }
+    List rl = List::create(Rcpp::Named("offsets") = ivec,
+                           Rcpp::Named("data")    = dvec);
+    return(rl);
+  } else {
+    Rcpp::stop("Unsupported type '%s' for buffer", typestr.c_str());
+  }
+  return Rcpp::as<Rcpp::List>(R_NilValue); // not reached
 }
 
 

--- a/tests/testthat/test_DenseArray.R
+++ b/tests/testthat/test_DenseArray.R
@@ -792,5 +792,124 @@ test_that("low-level variable-length character array write and read works", {
   expect_equal(tiledb:::libtiledb_query_status(qryptr), "INCOMPLETE")
   tiledb:::libtiledb_array_close(arrptr)
 
+})
+
+
+test_that("low-level variable-length int32 array write and read works", {
+  array_name <- tempfile()
+  setup({
+    unlink_and_create(array_name)
+  })
+
+  ## The array will be 4x4 with dimensions "rows" and "cols", with domain [1,4].
+  dom <- tiledb_domain(dims = c(tiledb_dim("rows", c(1L, 4L), 4L, "INT32"),
+                                tiledb_dim("cols", c(1L, 4L), 4L, "INT32")))
+
+
+  attr <- tiledb_attr("a", type = "INT32")
+  ## set to variable length
+  tiledb:::libtiledb_attribute_set_cell_val_num(attr@ptr, NA)
+
+  ## now set the schema
+  ctx <- tiledb_ctx()
+  schptr <- tiledb:::libtiledb_array_schema_create(ctx@ptr, "DENSE")
+  tiledb:::libtiledb_array_schema_set_domain(schptr, dom@ptr)
+  tiledb:::libtiledb_array_schema_set_cell_order(schptr, "ROW_MAJOR")
+  tiledb:::libtiledb_array_schema_set_tile_order(schptr, "ROW_MAJOR")
+  tiledb:::libtiledb_array_schema_add_attribute(schptr, attr@ptr)
+
+  ## Create the (empty) array on disk.
+  tiledb:::libtiledb_array_create(array_name, schptr)
+
+
+  data <- c(1L, 1L, 2L, 2L, 3L, 4L, 5L, 6L, 6L, 7L, 7L, 8L, 8L, 8L, 9L, 9L, 10L,
+            11L, 12L, 12L, 13L, 14L, 14L, 14L, 15L, 16L)
+  offsets <- c(0L, 2L, 4L, 5L, 6L, 7L, 9L, 11L, 14L, 16L, 17L, 18L, 20L, 21L, 24L, 25L)
+  offsets <- offsets * 4 # known fixed size of integer
+
+
+  #ctx <- tiledb_ctx()
+  arrptr <- tiledb:::libtiledb_array_open(ctx@ptr, array_name, "WRITE")
+  qryptr <- tiledb:::libtiledb_query(ctx@ptr, arrptr, "WRITE")
+  qryptr <- tiledb:::libtiledb_query_set_layout(qryptr, "ROW_MAJOR")
+
+  bufptr <- tiledb:::libtiledb_query_buffer_var_vec_create(offsets, data)
+  qryptr <- tiledb:::libtiledb_query_set_buffer_var_vec(qryptr, "a", bufptr)
+  qryptr <- tiledb:::libtiledb_query_submit(qryptr)
+  expect_equal(tiledb:::libtiledb_query_status(qryptr), "COMPLETE")
+  tiledb:::libtiledb_array_close(arrptr)
+
+  ## read and test
+  #ctx <- tiledb_ctx()
+  subarr <- NULL
+  arrptr <- tiledb:::libtiledb_array_open(ctx@ptr, array_name, "READ")
+  if (is.null(subarr)) {
+      schptr <- tiledb:::libtiledb_array_get_schema(arrptr)
+      domptr <- tiledb:::libtiledb_array_schema_get_domain(schptr)
+      lst <- tiledb:::libtiledb_domain_get_dimensions(domptr)
+      subarr <- c(tiledb:::libtiledb_dim_get_domain(lst[[1]]),
+                  tiledb:::libtiledb_dim_get_domain(lst[[2]]))
+  }
+  bufptr <- tiledb:::libtiledb_query_buffer_var_vec_alloc(arrptr, subarr, "a")
+
+  qryptr <- tiledb:::libtiledb_query(ctx@ptr, arrptr, "READ")
+  qryptr <- tiledb:::libtiledb_query_set_subarray(qryptr, subarr)
+  qryptr <- tiledb:::libtiledb_query_set_layout(qryptr, "ROW_MAJOR")
+
+  qryptr <- tiledb:::libtiledb_query_set_buffer_var_vec(qryptr, "a", bufptr)
+  qryptr <- tiledb:::libtiledb_query_submit(qryptr)
+  expect_equal(tiledb:::libtiledb_query_status(qryptr), "COMPLETE")
+  tiledb:::libtiledb_array_close(arrptr)
+
+  rl <- tiledb:::libtiledb_query_get_buffer_var_vec(qryptr, "a", bufptr)
+  expect_equal(rl[[1]], offsets)
+  expect_equal(rl[[2]], data)
+
+
+
+  data <- c(11L, 11L, 22L, 22L, 33L, 44L)
+  offsets <- c(0L, 2L, 4L, 5L)
+  offsets <- offsets * 4 # known fixed size of integer
+
+  subarr <- c(2L,3L, 2L,3L)
+
+  #ctx <- tiledb_ctx()
+  arrptr <- tiledb:::libtiledb_array_open(ctx@ptr, array_name, "WRITE")
+  qryptr <- tiledb:::libtiledb_query(ctx@ptr, arrptr, "WRITE")
+  qryptr <- tiledb:::libtiledb_query_set_subarray(qryptr, subarr)
+  qryptr <- tiledb:::libtiledb_query_set_layout(qryptr, "ROW_MAJOR")
+
+  bufptr <- tiledb:::libtiledb_query_buffer_var_vec_create(offsets, data)
+  qryptr <- tiledb:::libtiledb_query_set_buffer_var_vec(qryptr, "a", bufptr)
+  qryptr <- tiledb:::libtiledb_query_submit(qryptr)
+  expect_equal(tiledb:::libtiledb_query_status(qryptr), "COMPLETE")
+  tiledb:::libtiledb_array_close(arrptr)
+
+
+  ## read and test again
+  #ctx <- tiledb_ctx()
+  subarr <- c(2L,3L, 2L,3L)
+  arrptr <- tiledb:::libtiledb_array_open(ctx@ptr, array_name, "READ")
+  if (is.null(subarr)) {
+      schptr <- tiledb:::libtiledb_array_get_schema(arrptr)
+      domptr <- tiledb:::libtiledb_array_schema_get_domain(schptr)
+      lst <- tiledb:::libtiledb_domain_get_dimensions(domptr)
+      subarr <- c(tiledb:::libtiledb_dim_get_domain(lst[[1]]),
+                  tiledb:::libtiledb_dim_get_domain(lst[[2]]))
+  }
+  bufptr <- tiledb:::libtiledb_query_buffer_var_vec_alloc(arrptr, subarr, "a")
+
+  qryptr <- tiledb:::libtiledb_query(ctx@ptr, arrptr, "READ")
+  qryptr <- tiledb:::libtiledb_query_set_subarray(qryptr, subarr)
+  qryptr <- tiledb:::libtiledb_query_set_layout(qryptr, "ROW_MAJOR")
+
+  qryptr <- tiledb:::libtiledb_query_set_buffer_var_vec(qryptr, "a", bufptr)
+  qryptr <- tiledb:::libtiledb_query_submit(qryptr)
+  expect_equal(tiledb:::libtiledb_query_status(qryptr), "COMPLETE")
+  tiledb:::libtiledb_array_close(arrptr)
+
+  rl <- tiledb:::libtiledb_query_get_buffer_var_vec(qryptr, "a", bufptr)
+  expect_equal(rl[[1]], offsets)
+  expect_equal(rl[[2]], data)
 
 })

--- a/tests/testthat/test_DenseArray.R
+++ b/tests/testthat/test_DenseArray.R
@@ -822,6 +822,7 @@ test_that("low-level variable-length int32 array write and read works", {
   tiledb:::libtiledb_array_create(array_name, schptr)
 
 
+  ## write the data
   data <- c(1L, 1L, 2L, 2L, 3L, 4L, 5L, 6L, 6L, 7L, 7L, 8L, 8L, 8L, 9L, 9L, 10L,
             11L, 12L, 12L, 13L, 14L, 14L, 14L, 15L, 16L)
   offsets <- c(0L, 2L, 4L, 5L, 6L, 7L, 9L, 11L, 14L, 16L, 17L, 18L, 20L, 21L, 24L, 25L)
@@ -866,7 +867,7 @@ test_that("low-level variable-length int32 array write and read works", {
   expect_equal(rl[[2]], data)
 
 
-
+  ## write subset
   data <- c(11L, 11L, 22L, 22L, 33L, 44L)
   offsets <- c(0L, 2L, 4L, 5L)
   offsets <- offsets * 4 # known fixed size of integer
@@ -887,6 +888,129 @@ test_that("low-level variable-length int32 array write and read works", {
 
 
   ## read and test again
+  #ctx <- tiledb_ctx()
+  subarr <- c(2L,3L, 2L,3L)
+  arrptr <- tiledb:::libtiledb_array_open(ctx@ptr, array_name, "READ")
+  if (is.null(subarr)) {
+      schptr <- tiledb:::libtiledb_array_get_schema(arrptr)
+      domptr <- tiledb:::libtiledb_array_schema_get_domain(schptr)
+      lst <- tiledb:::libtiledb_domain_get_dimensions(domptr)
+      subarr <- c(tiledb:::libtiledb_dim_get_domain(lst[[1]]),
+                  tiledb:::libtiledb_dim_get_domain(lst[[2]]))
+  }
+  bufptr <- tiledb:::libtiledb_query_buffer_var_vec_alloc(arrptr, subarr, "a")
+
+  qryptr <- tiledb:::libtiledb_query(ctx@ptr, arrptr, "READ")
+  qryptr <- tiledb:::libtiledb_query_set_subarray(qryptr, subarr)
+  qryptr <- tiledb:::libtiledb_query_set_layout(qryptr, "ROW_MAJOR")
+
+  qryptr <- tiledb:::libtiledb_query_set_buffer_var_vec(qryptr, "a", bufptr)
+  qryptr <- tiledb:::libtiledb_query_submit(qryptr)
+  expect_equal(tiledb:::libtiledb_query_status(qryptr), "COMPLETE")
+  tiledb:::libtiledb_array_close(arrptr)
+
+  rl <- tiledb:::libtiledb_query_get_buffer_var_vec(qryptr, "a", bufptr)
+  expect_equal(rl[[1]], offsets)
+  expect_equal(rl[[2]], data)
+
+})
+
+
+
+test_that("low-level variable-length double array write and read works", {
+  array_name <- tempfile()
+  setup({
+    unlink_and_create(array_name)
+  })
+
+
+  ## The array will be 4x4 with dimensions "rows" and "cols", with domain [1,4].
+  dom <- tiledb_domain(dims = c(tiledb_dim("rows", c(1L, 4L), 4L, "INT32"),
+                                tiledb_dim("cols", c(1L, 4L), 4L, "INT32")))
+
+
+  attr <- tiledb_attr("a", type = "FLOAT64")
+  ## set to variable length
+  tiledb:::libtiledb_attribute_set_cell_val_num(attr@ptr, NA)
+
+  ## now set the schema
+  ctx <- tiledb_ctx()
+  schptr <- tiledb:::libtiledb_array_schema_create(ctx@ptr, "DENSE")
+  tiledb:::libtiledb_array_schema_set_domain(schptr, dom@ptr)
+  tiledb:::libtiledb_array_schema_set_cell_order(schptr, "ROW_MAJOR")
+  tiledb:::libtiledb_array_schema_set_tile_order(schptr, "ROW_MAJOR")
+  tiledb:::libtiledb_array_schema_add_attribute(schptr, attr@ptr)
+
+  ## Create the (empty) array on disk.
+  tiledb:::libtiledb_array_create(array_name, schptr)
+
+
+  ## write the data
+  data <- c(1.1, 1.1, 2.2, 2.2, 3.3, 4.4, 5.5, 6.6, 6.6, 7.7, 7.7, 8.8, 8.8, 8.8, 9.9, 9.0, 10.0,
+            11.1, 12.2, 12.2, 13.3, 14.4, 14.4, 14.4, 15.5, 16.6)
+  offsets <- c(0L, 2L, 4L, 5L, 6L, 7L, 9L, 11L, 14L, 16L, 17L, 18L, 20L, 21L, 24L, 25L)
+  offsets <- offsets * 8 # known and fixed size of double
+
+  #ctx <- tiledb_ctx()
+  arrptr <- tiledb:::libtiledb_array_open(ctx@ptr, array_name, "WRITE")
+  qryptr <- tiledb:::libtiledb_query(ctx@ptr, arrptr, "WRITE")
+  qryptr <- tiledb:::libtiledb_query_set_layout(qryptr, "ROW_MAJOR")
+
+  bufptr <- tiledb:::libtiledb_query_buffer_var_vec_create(offsets, data)
+  qryptr <- tiledb:::libtiledb_query_set_buffer_var_vec(qryptr, "a", bufptr)
+  qryptr <- tiledb:::libtiledb_query_submit(qryptr)
+  expect_equal(tiledb:::libtiledb_query_status(qryptr), "COMPLETE")
+  tiledb:::libtiledb_array_close(arrptr)
+
+
+  ## read and test
+  #ctx <- tiledb_ctx()
+  subarr <- NULL
+  arrptr <- tiledb:::libtiledb_array_open(ctx@ptr, array_name, "READ")
+  if (is.null(subarr)) {
+      schptr <- tiledb:::libtiledb_array_get_schema(arrptr)
+      domptr <- tiledb:::libtiledb_array_schema_get_domain(schptr)
+      lst <- tiledb:::libtiledb_domain_get_dimensions(domptr)
+      subarr <- c(tiledb:::libtiledb_dim_get_domain(lst[[1]]),
+                  tiledb:::libtiledb_dim_get_domain(lst[[2]]))
+  }
+  bufptr <- tiledb:::libtiledb_query_buffer_var_vec_alloc(arrptr, subarr, "a")
+
+  qryptr <- tiledb:::libtiledb_query(ctx@ptr, arrptr, "READ")
+  qryptr <- tiledb:::libtiledb_query_set_subarray(qryptr, subarr)
+  qryptr <- tiledb:::libtiledb_query_set_layout(qryptr, "ROW_MAJOR")
+
+  qryptr <- tiledb:::libtiledb_query_set_buffer_var_vec(qryptr, "a", bufptr)
+  qryptr <- tiledb:::libtiledb_query_submit(qryptr)
+  expect_equal(tiledb:::libtiledb_query_status(qryptr), "COMPLETE")
+  tiledb:::libtiledb_array_close(arrptr)
+
+  rl <- tiledb:::libtiledb_query_get_buffer_var_vec(qryptr, "a", bufptr)
+  expect_equal(rl[[1]], offsets)
+  expect_equal(rl[[2]], data)
+
+
+  ## write subset
+  data <- c(11.1, 11.1, 22.2, 22.2, 33.3, 44.4)
+  offsets <- c(0L, 2L, 4L, 5L)
+  offsets <- offsets * 4 # known fixed size of integer
+
+  subarr <- c(2L,3L, 2L,3L)
+
+  #ctx <- tiledb_ctx()
+  arrptr <- tiledb:::libtiledb_array_open(ctx@ptr, array_name, "WRITE")
+  qryptr <- tiledb:::libtiledb_query(ctx@ptr, arrptr, "WRITE")
+  qryptr <- tiledb:::libtiledb_query_set_subarray(qryptr, subarr)
+  qryptr <- tiledb:::libtiledb_query_set_layout(qryptr, "ROW_MAJOR")
+
+  bufptr <- tiledb:::libtiledb_query_buffer_var_vec_create(offsets, data)
+  qryptr <- tiledb:::libtiledb_query_set_buffer_var_vec(qryptr, "a", bufptr)
+  qryptr <- tiledb:::libtiledb_query_submit(qryptr)
+  expect_equal(tiledb:::libtiledb_query_status(qryptr), "COMPLETE")
+  tiledb:::libtiledb_array_close(arrptr)
+
+
+    ## read and test again
   #ctx <- tiledb_ctx()
   subarr <- c(2L,3L, 2L,3L)
   arrptr <- tiledb:::libtiledb_array_open(ctx@ptr, array_name, "READ")


### PR DESCRIPTION
This adds support, and examples, for `int32_t` and `double`.  I tried a templated version first but the fact that exported (to R) interfaces need C signatures got in the way.  I will add simple unit tests for this next which will probably get done before this is merged.

The internal buffer struct currently has two entries for double and int vectors. This makes the code much simpler, but is of course not as minimalistic as the C interface with a void pointer. It does save on a few helper functions to cast and resize.  I am open to changing it; the key part is that the interface exposed will not have to change now.