### PR TITLE
Convert remaining throws to Rcpp::stop

### DIFF
--- a/src/libtiledb.cpp
+++ b/src/libtiledb.cpp
@@ -186,7 +186,7 @@ const char* _tiledb_layout_to_string(tiledb_layout_t layout) {
     case TILEDB_UNORDERED:
       return "UNORDERED";
     default:
-        throw Rcpp::exception("unknown tiledb_datatype_t");
+      Rcpp::stop("unknown tiledb_layout_t (%d)", layout);
   }
 }
 
@@ -200,9 +200,7 @@ tiledb_layout_t _string_to_tiledb_layout(std::string lstr) {
   } else if (lstr == "UNORDERED") {
     return TILEDB_UNORDERED;
   } else {
-    std::stringstream errmsg;
-    errmsg << "Unknown TileDB layout \"" << lstr << "\"";
-    throw Rcpp::exception(errmsg.str().c_str());
+    Rcpp::stop("Unknown TileDB layout '%s' ", lstr.c_str());
   }
 }
 
@@ -284,9 +282,7 @@ tiledb_filter_option_t _string_to_tiledb_filter_option(std::string filter_option
   } else if (filter_option == "POSITIVE_DELTA_MAX_WINDOW") {
     return TILEDB_POSITIVE_DELTA_MAX_WINDOW;
   } else {
-    std::stringstream errmsg;
-    errmsg << "Unknown TileDB filter option \"" << filter_option << "\"";
-    throw Rcpp::exception(errmsg.str().c_str());
+    Rcpp::stop("Unknown TileDB filter option '%s'", filter_option.c_str());
   }
 }
 
@@ -298,9 +294,8 @@ const char* _tiledb_filter_option_to_string(tiledb_filter_option_t filter_option
     return "BIT_WIDTH_MAX_WINDOW";
   case TILEDB_POSITIVE_DELTA_MAX_WINDOW:
     return "POSITIVE_DELTA_MAX_WINDOW";
-  default: {
-    throw Rcpp::exception("unknown tiledb_filter_option_t");
-  }
+  default:
+    Rcpp::stop("unknown tiledb_filter_option_t (%d)", filter_option);
   }
 }
 
@@ -310,9 +305,7 @@ tiledb_query_type_t _string_to_tiledb_query_type(std::string qtstr) {
   } else if (qtstr == "WRITE") {
     return TILEDB_WRITE;
   } else {
-    std::stringstream errmsg;
-    errmsg << "Unknown TileDB query type \"" << qtstr << "\"";
-    throw Rcpp::exception(errmsg.str().c_str());
+    Rcpp::stop("Unknown TileDB query type '%s'", qtstr.c_str());
   }
 }
 
@@ -323,7 +316,7 @@ std::string _tiledb_query_type_to_string(tiledb_query_type_t qtype) {
     case TILEDB_WRITE:
       return "WRITE";
     default:
-      throw Rcpp::exception("unknown tiledb_query_type_t");
+      Rcpp::stop("unknown tiledb_query_type_t (%d)", qtype);
   }
 }
 
@@ -402,9 +395,7 @@ bool libtiledb_ctx_is_supported_fs(XPtr<tiledb::Context> ctx, std::string scheme
   } else if (scheme == "hdfs") {
     return ctx->is_supported_fs(TILEDB_HDFS);
   } else {
-    std::stringstream errmsg;
-    errmsg << "Unknown TileDB fs scheme: \"" << scheme << "://\"";
-    throw Rcpp::exception(errmsg.str().c_str());
+    Rcpp::stop("Unknown TileDB fs scheme: '%s'", scheme.c_str());
   }
 }
 
@@ -701,7 +692,7 @@ SEXP libtiledb_dim_get_tile_extent(XPtr<tiledb::Dimension> dim) {
       using DataType = tiledb::impl::tiledb_to_type<TILEDB_FLOAT64>::type;
       auto t = dim->tile_extent<DataType>();
       if (t == R_NaReal) {
-        throw Rcpp::exception("tiledb_dim tile FLOAT64 value not representable as an R double");
+        Rcpp::stop("tiledb_dim tile FLOAT64 value not representable as an R double");
       }
       return NumericVector({t});
     }
@@ -725,7 +716,7 @@ SEXP libtiledb_dim_get_tile_extent(XPtr<tiledb::Dimension> dim) {
       using DataType = tiledb::impl::tiledb_to_type<TILEDB_INT32>::type;
       auto t = dim->tile_extent<DataType>();
       if (t == R_NaInt) {
-        throw Rcpp::exception("tiledb_dim tile INT32 value not representable as an R integer");
+        Rcpp::stop("tiledb_dim tile INT32 value not representable as an R integer");
       }
       return IntegerVector({t,});
     }
@@ -733,7 +724,7 @@ SEXP libtiledb_dim_get_tile_extent(XPtr<tiledb::Dimension> dim) {
       using DataType = tiledb::impl::tiledb_to_type<TILEDB_UINT32>::type;
       auto t = dim->tile_extent<DataType>();
       if (t > std::numeric_limits<int32_t>::max()) {
-        throw Rcpp::exception("tiledb_dim tile UINT32 value not representable as an R integer");
+        Rcpp::stop("tiledb_dim tile UINT32 value not representable as an R integer");
       }
       return IntegerVector({static_cast<int32_t>(t),});
     }
@@ -741,7 +732,7 @@ SEXP libtiledb_dim_get_tile_extent(XPtr<tiledb::Dimension> dim) {
       using DataType = tiledb::impl::tiledb_to_type<TILEDB_INT64>::type;
       auto t = dim->tile_extent<DataType>();
       if (t <= R_NaInt || t > std::numeric_limits<int32_t>::max()) {
-        throw Rcpp::exception("tiledb_dim tile INT64 value not representable as an R integer");
+        Rcpp::stop("tiledb_dim tile INT64 value not representable as an R integer");
       }
       return IntegerVector({static_cast<int32_t>(t),});
     }
@@ -749,12 +740,12 @@ SEXP libtiledb_dim_get_tile_extent(XPtr<tiledb::Dimension> dim) {
       using DataType = tiledb::impl::tiledb_to_type<TILEDB_UINT64>::type;
       auto t = dim->tile_extent<DataType>();
       if (t > std::numeric_limits<int32_t>::max()) {
-        throw Rcpp::exception("tiledb_dim tile UINT64 value not representable as an R integer");
+        Rcpp::stop("tiledb_dim tile UINT64 value not representable as an R integer");
       }
       return IntegerVector({static_cast<int32_t>(t),});
     }
     default:
-      throw Rcpp::exception("invalid tiledb_dim domain type");
+      Rcpp::stop("invalid tiledb_dim domain type");
   }
 }
 
@@ -767,16 +758,16 @@ std::string libtiledb_dim_get_datatype(XPtr<tiledb::Dimension> dim) {
 // [[Rcpp::export]]
 NumericVector dim_domain_subarray(NumericVector domain, NumericVector subscript) {
   if (domain.length() != 2) {
-    throw Rcpp::exception("invalid tiledb_dim domain");
+    Rcpp::stop("invalid tiledb_dim domain");
   }
   double domain_lb = domain[0];
   double domain_ub = domain[1];
   auto sub0 = subscript[0];
   if (sub0 == R_NaReal) {
-    throw Rcpp::exception("NA subscript not supported");
+    Rcpp::stop("NA subscript not supported");
   }
   if (sub0 < domain_lb || sub0 > domain_ub) {
-    throw Rcpp::exception("subscript out of domain bounds");
+    Rcpp::stop("subscript out of domain bounds");
   }
   if (subscript.length() == 1) {
     return NumericVector({sub0, sub0});
@@ -789,13 +780,11 @@ NumericVector dim_domain_subarray(NumericVector domain, NumericVector subscript)
     auto low = subscript[i - 1];
     auto high = subscript[i];
     if (high == R_NaReal) {
-      throw Rcpp::exception("NA subscripting not supported");
+      Rcpp::stop("NA subscripting not supported");
     }
     if (high < domain_lb || high > domain_ub) {
-      std::stringstream errmsg;
-      errmsg << "subscript out of domain bounds: (at index: [" << i << "] "
-             << high << " < " << domain_lb;
-      throw Rcpp::exception(errmsg.str().c_str());
+      Rcpp::stop("subscript out of domain bounds: (at index: [%d] %f < %f",
+                 i, high, domain_lb);
     }
     double diff = high - low;
     if (diff > 1.0 || diff < 1.0) {
@@ -819,27 +808,21 @@ NumericVector dim_domain_subarray(NumericVector domain, NumericVector subscript)
 XPtr<tiledb::Domain> libtiledb_domain(XPtr<tiledb::Context> ctx, List dims) {
   R_xlen_t ndims = dims.length();
   if (ndims == 0) {
-    throw Rcpp::exception("domain must have one or more dimensions");
+    Rcpp::stop("domain must have one or more dimensions");
   }
   for (R_xlen_t i=0; i < ndims; i++) {
     SEXP d = dims[i];
     if (TYPEOF(d) != EXTPTRSXP) {
-      std::stringstream errmsg;
-      errmsg << "Invalid tiledb_dim object at index " <<  i << " (type " << Rcpp::type2name(d) << ")";
-      throw Rcpp::exception(errmsg.str().c_str());
+      Rcpp::stop("Invalid tiledb_dim object at index %d (type %s)", i, Rcpp::type2name(d));
     }
   }
   XPtr<tiledb::Domain> domain(new tiledb::Domain(*ctx.get()));
-  try {
-    for (auto& val : dims) {
-      // TODO: we can't do much type checking for the cast here until we wrap EXTPTRSXP in S4 classes
-      auto dim = as<XPtr<tiledb::Dimension>>(val);
-      domain->add_dimension(*dim.get());
-    }
-    return domain;
-  } catch (tiledb::TileDBError& err) {
-    throw Rcpp::exception(err.what());
+  for (auto& val : dims) {
+    // TODO: we can't do much type checking for the cast here until we wrap EXTPTRSXP in S4 classes
+    auto dim = as<XPtr<tiledb::Dimension>>(val);
+    domain->add_dimension(*dim.get());
   }
+  return domain;
 }
 
 // [[Rcpp::export]]
@@ -852,7 +835,7 @@ std::string libtiledb_domain_get_type(XPtr<tiledb::Domain> domain) {
 int libtiledb_domain_get_ndim(XPtr<tiledb::Domain> domain) {
   uint32_t rank = domain->ndim();
   if (rank > std::numeric_limits<int32_t>::max()) {
-    throw Rcpp::exception("tiledb::Domain rank is not representable by an R integer");
+    Rcpp::stop("tiledb::Domain rank is not representable by an R integer");
   }
   return static_cast<int32_t>(rank);
 }
@@ -970,9 +953,7 @@ XPtr<tiledb::FilterList> libtiledb_filter_list(XPtr<tiledb::Context> ctx, List f
     for (R_xlen_t i=0; i < nfilters; i++)  {
       SEXP filter = filters[i];
       if (TYPEOF(filter) != EXTPTRSXP) {
-        std::stringstream errmsg;
-        errmsg << "Invalid filter object at index " <<  i << " (type " << Rcpp::type2name(filter) << ")";
-        throw Rcpp::exception(errmsg.str().c_str());
+        Rcpp::stop("Invalid filter object at index %d (type %s)", i, Rcpp::type2name(filter));
       }
     }
     for (SEXP f : filters) {
@@ -1123,14 +1104,12 @@ libtiledb_array_schema(XPtr<tiledb::Context> ctx,
   // check that external pointers are supported
   R_xlen_t nattr = attributes.length();
   if (nattr == 0) {
-    throw Rcpp::exception("libtiledb_array_schema requires one or more attributes");
+    Rcpp::stop("libtiledb_array_schema requires one or more attributes");
   }
   for (R_xlen_t i=0; i < nattr; i++)  {
     SEXP attr = attributes[i];
     if (TYPEOF(attr) != EXTPTRSXP) {
-      std::stringstream errmsg;
-      errmsg << "Invalid attribute object at index " <<  i << " (type " << Rcpp::type2name(attr) << ")";
-      throw Rcpp::exception(errmsg.str().c_str());
+      Rcpp::stop("Invalid attribute object at index %d (type %s)", i, Rcpp::type2name(attr));
     }
   }
   auto _cell_order = _string_to_tiledb_layout(cell_order);
@@ -1759,7 +1738,7 @@ XPtr<tiledb::Query> libtiledb_query_set_coordinates(XPtr<tiledb::Query> query,
     query->set_coordinates(sub.begin(), sub.length());
     return query;
   } else {
-    throw Rcpp::exception("invalid subarray datatype");
+    Rcpp::stop("invalid subarray datatype");
   }
 }
 
@@ -2433,10 +2412,7 @@ NumericVector libtiledb_array_max_buffer_elements_vec(XPtr<tiledb::Array> array,
     auto max_elements = array->max_buffer_elements(sub);
     return NumericVector::create(max_elements[attribute].first, max_elements[attribute].second);
   } else {
-    std::stringstream errmsg;
-    errmsg << "Invalid subarray buffer type for domain :"
-           << Rcpp::type2name(subarray);
-    throw Rcpp::exception(errmsg.str().c_str());
+    Rcpp::stop("Invalid subarray buffer type for domain %s", Rcpp::type2name(subarray));
   }
 }
 
@@ -2485,15 +2461,15 @@ tiledb::Object::Type _string_to_object_type(std::string otype) {
   } else if (otype == "GROUP") {
     return tiledb::Object::Type::Group;
   } else {
-    throw Rcpp::exception("invalid object type string");
+    Rcpp::stop("invalid object type string");
   }
 }
 
 // [[Rcpp::export]]
 DataFrame libtiledb_object_walk(XPtr<tiledb::Context> ctx,
-                              std::string uri,
-                              std::string order,
-                              bool recursive = false) {
+                                std::string uri,
+                                std::string order,
+                                bool recursive = false) {
   tiledb_walk_order_t walk_order;
   if (recursive) {
     if (order == "PREORDER") {
@@ -2501,7 +2477,7 @@ DataFrame libtiledb_object_walk(XPtr<tiledb::Context> ctx,
     } else if (order == "POSTORDER") {
       walk_order = TILEDB_POSTORDER;
     } else {
-      throw Rcpp::exception("invalid recursive walk order, must be \"PREORDER\" or \"POSTORDER\"");
+      Rcpp::stop("invalid recursive walk order, must be \"PREORDER\" or \"POSTORDER\"");
     }
   }
   std::vector<std::string> uris;
@@ -2597,7 +2573,7 @@ std::string tiledb_vfs_remove_file(XPtr<tiledb::VFS> vfs, std::string uri) {
 R_xlen_t tiledb_vfs_file_size(XPtr<tiledb::VFS> vfs, std::string uri) {
   uint64_t size = vfs->file_size(uri);
   if (size > std::numeric_limits<R_xlen_t>::max()) {
-    throw Rcpp::exception("file size is greater than maximum R integer");
+    Rcpp::stop("file size is greater than maximum R integer");
   }
   return static_cast<R_xlen_t>(size);
 }
@@ -2643,7 +2619,7 @@ void libtiledb_stats_dump(std::string path) {
   FILE* fptr = nullptr;
   fptr = fopen(path.c_str(), "w");
   if (fptr == nullptr) {
-    throw Rcpp::exception("error opening stats dump file for writing");
+    Rcpp::stop("error opening stats dump file for writing");
   }
   tiledb::Stats::dump(fptr);
   fclose(fptr);
@@ -2670,6 +2646,6 @@ void libtiledb_stats_print() {
   }
   // remove tempfile (though R would too at end of session)
   if (unlink(filename.c_str()) == -1) {
-    Rcpp::stop("Error removing temporary file ", filename);
+    Rcpp::stop("Error removing temporary file %s", filename.c_str());
   }
 }


### PR DESCRIPTION
Smaller PR with just one issue: 
- convert remaining `throw Rcpp::exception` to `Rcpp::stop` for consistency.

