### PR TITLE
Provide additional aliases for S4 subsetting methods

### DIFF
--- a/R/Config.R
+++ b/R/Config.R
@@ -51,7 +51,10 @@ tiledb_config <- function(config = NA_character_) {
 #' cfg <- tiledb_config()
 #' cfg["sm.tile_cache_size"]
 #' cfg["does_not_exist"]
-#'
+#' @aliases [,tiledb_config
+#' @aliases [,tiledb_config-method
+#' @aliases [,tiledb_config,ANY,tiledb_config-method
+#' @aliases [,tiledb_config,ANY,ANY,tiledb_config-method
 setMethod("[", "tiledb_config",
           function(x, i, j, ..., drop=FALSE) {
             if (!is.character(i)) {
@@ -79,6 +82,10 @@ setMethod("[", "tiledb_config",
 #' cfg["sm.tile_cache_size"] <- 100
 #' cfg["sm.tile_cache_size"]
 #'
+#' @aliases [<-,tiledb_config
+#' @aliases [<-,tiledb_config-method
+#' @aliases [<-,tiledb_config,ANY,tiledb_config-method
+#' @aliases [<-,tiledb_config,ANY,ANY,tiledb_config-method
 setMethod("[<-", "tiledb_config",
           function(x, i, j, value) {
             if (!is.character(i)) {

--- a/R/DenseArray.R
+++ b/R/DenseArray.R
@@ -234,6 +234,10 @@ attribute_buffers <- function(array, sch, dom, sub, selected) {
 #' @param ... Extra parameter for method signature, currently unused.
 #' @param drop Optional logical switch to drop dimensions, default FALSE, currently unused.
 #' @return An element from a dense array
+#' @aliases [,tiledb_dense
+#' @aliases [,tiledb_dense-method
+#' @aliases [,tiledb_dense,ANY,tiledb_dense-method
+#' @aliases [,tiledb_dense,ANY,ANY,tiledb_dense-method
 setMethod("[", "tiledb_dense",
           function(x, i, j, ..., drop = FALSE) {
             ## helper function to deal with i and/or j missing
@@ -356,6 +360,10 @@ setMethod("[", "tiledb_dense",
 #' @param value The value being assigned
 #' @return The modified object
 #' @importFrom utils head
+#' @aliases [<-,tiledb_dense
+#' @aliases [<-,tiledb_dense-method
+#' @aliases [<-,tiledb_dense,ANY,tiledb_dense-method
+#' @aliases [<-,tiledb_dense,ANY,ANY,tiledb_dense-method
 setMethod("[<-", "tiledb_dense",
           function(x, i, j, ..., value) {
             if (!is.list(value)) {

--- a/R/FilterList.R
+++ b/R/FilterList.R
@@ -117,6 +117,10 @@ setMethod("nfilters", signature(object = "tiledb_filter_list"),
 #' filter_list[0]
 #'
 #' @export
+#' @aliases [,tiledb_filter_list
+#' @aliases [,tiledb_filter_list-method
+#' @aliases [,tiledb_filter_list,ANY,tiledb_filter_list-method
+#' @aliases [,tiledb_filter_list,ANY,ANY,tiledb_filter_list-method
 setMethod("[", "tiledb_filter_list",
           function(x, i, j, ..., drop = FALSE) {
             tiledb_filter.from_ptr(libtiledb_filter_list_get_filter_from_index(x@ptr, i))

--- a/R/SparseArray.R
+++ b/R/SparseArray.R
@@ -148,6 +148,10 @@ as_data_frame <- function(dom, data, extended=FALSE) {
 #' @param ... Extra parameter for method signature, currently unused.
 #' @param drop Optional logical switch to drop dimensions, default FALSE, currently unused.
 #' @return An element from the sparse array
+#' @aliases [,tiledb_sparse
+#' @aliases [,tiledb_sparse-method
+#' @aliases [,tiledb_sparse,ANY,tiledb_sparse-method
+#' @aliases [,tiledb_sparse,ANY,ANY,tiledb_sparse-method
 setMethod("[", "tiledb_sparse",
           function(x, i, j, ..., drop = FALSE) {
             ## helper function to deal with i and/or j missing
@@ -265,6 +269,10 @@ setMethod("[", "tiledb_sparse",
 #' @param ... Extra parameter for method signature, currently unused.
 #' @param value The value being assigned
 #' @return The modified object
+#' @aliases [<-,tiledb_sparse
+#' @aliases [<-,tiledb_sparse-method
+#' @aliases [<-,tiledb_sparse,ANY,tiledb_sparse-method
+#' @aliases [<-,tiledb_sparse,ANY,ANY,tiledb_sparse-method
 setMethod("[<-", "tiledb_sparse",
           function(x, i, j, ..., value) {
             if (!is.list(value)) {

--- a/R/tiledb_array.R
+++ b/R/tiledb_array.R
@@ -112,6 +112,10 @@ setMethod("show",
 #' @param drop Optional logical switch to drop dimensions, default FALSE, currently unused.
 #' @return An element from the sparse array
 #' @import nanotime
+#' @aliases [,tiledb_array
+#' @aliases [,tiledb_array-method
+#' @aliases [,tiledb_array,ANY,tiledb_array-method
+#' @aliases [,tiledb_array,ANY,ANY,tiledb_array-method
 setMethod("[", "tiledb_array",
           function(x, i, j, ..., drop = FALSE) {
   ## add defaults
@@ -279,6 +283,10 @@ setMethod("[", "tiledb_array",
 #' arr[c(1,2), c(1,3)] <- c(42,43) ## two values
 #' arr[2, 4] <- 88                 ## or just one
 #' }
+#' @aliases [<-,tiledb_array
+#' @aliases [<-,tiledb_array-method
+#' @aliases [<-,tiledb_array,ANY,tiledb_array-method
+#' @aliases [<-,tiledb_array,ANY,ANY,tiledb_array-method
 setMethod("[<-", "tiledb_array",
           function(x, i, j, ..., value) {
   if (!is.data.frame(value)) {

--- a/inst/NEWS.md
+++ b/inst/NEWS.md
@@ -1,9 +1,14 @@
+# Ongoing
+
+* This release of the R package supports [TileDB 1.7.7](https://github.com/TileDB-Inc/TileDB/releases/tag/1.7.7) and [TileDB 2.0.0](https://github.com/TileDB-Inc/TileDB/releases/tag/2.0.0)
+
+## Improvements
+
+- All S4 classes are now consistently documented or aliased
 
 # 0.6.0
 
-* This release of the R package supports [TileDB
-  1.7.7](https://github.com/TileDB-Inc/TileDB/releases/tag/1.7.7) and
-  [TileDB 2.0.0](https://github.com/TileDB-Inc/TileDB/releases/tag/2.0.0)
+* This release of the R package supports [TileDB 1.7.7](https://github.com/TileDB-Inc/TileDB/releases/tag/1.7.7) and [TileDB 2.0.0](https://github.com/TileDB-Inc/TileDB/releases/tag/2.0.0)
 
 ## Improvements
 

--- a/man/sub-tiledb_array-ANY-method.Rd
+++ b/man/sub-tiledb_array-ANY-method.Rd
@@ -2,6 +2,10 @@
 % Please edit documentation in R/tiledb_array.R
 \name{[,tiledb_array,ANY-method}
 \alias{[,tiledb_array,ANY-method}
+\alias{[,tiledb_array}
+\alias{[,tiledb_array-method}
+\alias{[,tiledb_array,ANY,tiledb_array-method}
+\alias{[,tiledb_array,ANY,ANY,tiledb_array-method}
 \title{Returns a TileDB array, allowing for specific subset ranges.}
 \usage{
 \S4method{[}{tiledb_array,ANY}(x, i, j, ..., drop = FALSE)

--- a/man/sub-tiledb_config-ANY-method.Rd
+++ b/man/sub-tiledb_config-ANY-method.Rd
@@ -2,6 +2,10 @@
 % Please edit documentation in R/Config.R
 \name{[,tiledb_config,ANY-method}
 \alias{[,tiledb_config,ANY-method}
+\alias{[,tiledb_config}
+\alias{[,tiledb_config-method}
+\alias{[,tiledb_config,ANY,tiledb_config-method}
+\alias{[,tiledb_config,ANY,ANY,tiledb_config-method}
 \title{Gets a config parameter value}
 \usage{
 \S4method{[}{tiledb_config,ANY}(x, i, j, ..., drop = FALSE)
@@ -27,5 +31,4 @@ Gets a config parameter value
 cfg <- tiledb_config()
 cfg["sm.tile_cache_size"]
 cfg["does_not_exist"]
-
 }

--- a/man/sub-tiledb_dense-ANY-method.Rd
+++ b/man/sub-tiledb_dense-ANY-method.Rd
@@ -2,6 +2,10 @@
 % Please edit documentation in R/DenseArray.R
 \name{[,tiledb_dense,ANY-method}
 \alias{[,tiledb_dense,ANY-method}
+\alias{[,tiledb_dense}
+\alias{[,tiledb_dense-method}
+\alias{[,tiledb_dense,ANY,tiledb_dense-method}
+\alias{[,tiledb_dense,ANY,ANY,tiledb_dense-method}
 \title{Gets a dense array value}
 \usage{
 \S4method{[}{tiledb_dense,ANY}(x, i, j, ..., drop = FALSE)

--- a/man/sub-tiledb_filter_list-ANY-method.Rd
+++ b/man/sub-tiledb_filter_list-ANY-method.Rd
@@ -2,6 +2,10 @@
 % Please edit documentation in R/FilterList.R
 \name{[,tiledb_filter_list,ANY-method}
 \alias{[,tiledb_filter_list,ANY-method}
+\alias{[,tiledb_filter_list}
+\alias{[,tiledb_filter_list-method}
+\alias{[,tiledb_filter_list,ANY,tiledb_filter_list-method}
+\alias{[,tiledb_filter_list,ANY,ANY,tiledb_filter_list-method}
 \title{Returns the filter at given index}
 \usage{
 \S4method{[}{tiledb_filter_list,ANY}(x, i, j, ..., drop = FALSE)

--- a/man/sub-tiledb_sparse-ANY-method.Rd
+++ b/man/sub-tiledb_sparse-ANY-method.Rd
@@ -2,6 +2,10 @@
 % Please edit documentation in R/SparseArray.R
 \name{[,tiledb_sparse,ANY-method}
 \alias{[,tiledb_sparse,ANY-method}
+\alias{[,tiledb_sparse}
+\alias{[,tiledb_sparse-method}
+\alias{[,tiledb_sparse,ANY,tiledb_sparse-method}
+\alias{[,tiledb_sparse,ANY,ANY,tiledb_sparse-method}
 \title{Gets a sparse array value}
 \usage{
 \S4method{[}{tiledb_sparse,ANY}(x, i, j, ..., drop = FALSE)

--- a/man/subset-tiledb_array-ANY-ANY-ANY-method.Rd
+++ b/man/subset-tiledb_array-ANY-ANY-ANY-method.Rd
@@ -2,6 +2,10 @@
 % Please edit documentation in R/tiledb_array.R
 \name{[<-,tiledb_array,ANY,ANY,ANY-method}
 \alias{[<-,tiledb_array,ANY,ANY,ANY-method}
+\alias{[<-,tiledb_array}
+\alias{[<-,tiledb_array-method}
+\alias{[<-,tiledb_array,ANY,tiledb_array-method}
+\alias{[<-,tiledb_array,ANY,ANY,tiledb_array-method}
 \title{Sets a tiledb array value or value range}
 \usage{
 \S4method{[}{tiledb_array,ANY,ANY,ANY}(x, i, j, ...) <- value

--- a/man/subset-tiledb_config-ANY-ANY-ANY-method.Rd
+++ b/man/subset-tiledb_config-ANY-ANY-ANY-method.Rd
@@ -2,6 +2,10 @@
 % Please edit documentation in R/Config.R
 \name{[<-,tiledb_config,ANY,ANY,ANY-method}
 \alias{[<-,tiledb_config,ANY,ANY,ANY-method}
+\alias{[<-,tiledb_config}
+\alias{[<-,tiledb_config-method}
+\alias{[<-,tiledb_config,ANY,tiledb_config-method}
+\alias{[<-,tiledb_config,ANY,ANY,tiledb_config-method}
 \title{Sets a config parameter value}
 \usage{
 \S4method{[}{tiledb_config,ANY,ANY,ANY}(x, i, j) <- value

--- a/man/subset-tiledb_dense-ANY-ANY-ANY-method.Rd
+++ b/man/subset-tiledb_dense-ANY-ANY-ANY-method.Rd
@@ -2,6 +2,10 @@
 % Please edit documentation in R/DenseArray.R
 \name{[<-,tiledb_dense,ANY,ANY,ANY-method}
 \alias{[<-,tiledb_dense,ANY,ANY,ANY-method}
+\alias{[<-,tiledb_dense}
+\alias{[<-,tiledb_dense-method}
+\alias{[<-,tiledb_dense,ANY,tiledb_dense-method}
+\alias{[<-,tiledb_dense,ANY,ANY,tiledb_dense-method}
 \title{Sets a dense array value}
 \usage{
 \S4method{[}{tiledb_dense,ANY,ANY,ANY}(x, i, j, ...) <- value

--- a/man/subset-tiledb_sparse-ANY-ANY-ANY-method.Rd
+++ b/man/subset-tiledb_sparse-ANY-ANY-ANY-method.Rd
@@ -2,6 +2,10 @@
 % Please edit documentation in R/SparseArray.R
 \name{[<-,tiledb_sparse,ANY,ANY,ANY-method}
 \alias{[<-,tiledb_sparse,ANY,ANY,ANY-method}
+\alias{[<-,tiledb_sparse}
+\alias{[<-,tiledb_sparse-method}
+\alias{[<-,tiledb_sparse,ANY,tiledb_sparse-method}
+\alias{[<-,tiledb_sparse,ANY,ANY,tiledb_sparse-method}
 \title{Sets a sparse array value}
 \usage{
 \S4method{[}{tiledb_sparse,ANY,ANY,ANY}(x, i, j, ...) <- value


### PR DESCRIPTION
This suppresses an entirely _harmless_ but utterly annoying warning that pops up every now and then.  S4 methods are somewhere between wonderful, a can of worms, and a hornets.  The change is this PR votes for last option.  (Underlying cause may be a bug on [roxygen2](http://cloud.r-project.org/package=roxygen2) as the warning comes and goes over rebuilds.  Now it should be _gone_ with a capital G.)

No code changes.

Suppresses this beauty:

```r
✔  checking Rd cross-references
W  checking for missing documentation entries (702ms)
   Undocumented S4 methods:
     generic '[' and siglist 'tiledb_array'
     generic '[' and siglist 'tiledb_config'
     generic '[' and siglist 'tiledb_dense'
     generic '[' and siglist 'tiledb_filter_list'
     generic '[' and siglist 'tiledb_sparse'
     generic '[<-' and siglist 'tiledb_array'
     generic '[<-' and siglist 'tiledb_config'
     generic '[<-' and siglist 'tiledb_dense'
     generic '[<-' and siglist 'tiledb_sparse'
   All user-level objects in a package (including S4 classes and methods)
   should have documentation entries.
   See chapter ‘Writing R documentation files’ in the ‘Writing R
   Extensions’ manual.
✔  checking for code/documentation mismatches (2.1s)
```
