### PR TITLE
Additional data.frame support

### DIFF
--- a/R/DenseArray.R
+++ b/R/DenseArray.R
@@ -475,7 +475,6 @@ setMethod("[<-", "tiledb_dense",
                 buflst[[idx]] <- libtiledb_query_buffer_assign_ptr(buflst[[idx]], "DATETIME_NS", val)
                 qry <- libtiledb_query_set_buffer_ptr(qry, aname, buflst[[idx]])
               } else {
-                #qry <- libtiledb_query_set_buffer(qry, aname, val)
                 buflst[[idx]] <- libtiledb_query_buffer_alloc_ptr(x@ptr, attrtype, length(val))
                 buflst[[idx]] <- libtiledb_query_buffer_assign_ptr(buflst[[idx]], attrtype, val)
                 qry <- libtiledb_query_set_buffer_ptr(qry, aname, buflst[[idx]])

--- a/R/tiledb_array.R
+++ b/R/tiledb_array.R
@@ -161,7 +161,6 @@ setMethod("[", "tiledb_array",
   }
   nonemptydom <- mapply(getDomain, dimnames, dimtypes, SIMPLIFY=FALSE)
 
-
   ## open query
   qryptr <- libtiledb_query(ctx@ptr, arrptr, "READ")
 
@@ -181,8 +180,10 @@ setMethod("[", "tiledb_array",
 
   ## set range(s) on  second dimension
   if (is.null(js)) {
-    qryptr <- libtiledb_query_add_range_with_type(qryptr, 1, dimtypes[2],
-                                                  nonemptydom[[2]][1], nonemptydom[[2]][2])
+    if (length(nonemptydom) == 2) {
+      qryptr <- libtiledb_query_add_range_with_type(qryptr, 1, dimtypes[2],
+                                                    nonemptydom[[2]][1], nonemptydom[[2]][2])
+    }
   } else {
     if (!identical(eval(js[[1]]),list)) stop("The col argument must be a list.")
     if (length(js) == 1) stop("No content to parse in col argument.")

--- a/inst/NEWS.md
+++ b/inst/NEWS.md
@@ -4,7 +4,9 @@
 
 ## Improvements
 
-- All S4 classes are now consistently documented or aliased
+- If needed, the build system now builds TileDB and its required component (#118)
+
+- All S4 classes are now consistently documented or aliased (#117)
 
 # 0.6.0
 

--- a/inst/examples/ex_1.R
+++ b/inst/examples/ex_1.R
@@ -76,9 +76,15 @@ open_read_change_read <- function(uri) {
   show(data)
 }
 
+simple_ex <- function(uri) {
+  arr <- tiledb_dense(uri, as.data.frame = TRUE)
+  show(arr[7:9, 2:3])
+}
+
 create_array(uri)
 write_array(uri)
 read_array(uri)
 read_as_df(uri)
 read_array_subset(uri)
 open_read_change_read(uri)
+simple_ex(uri)

--- a/tests/testthat/test_ArraySchema.R
+++ b/tests/testthat/test_ArraySchema.R
@@ -94,7 +94,7 @@ test_that("tiledb_array_schema full constructor argument values are correct",  {
 
 
 test_that("tiledb_array_schema created with encryption",  {
-  uri <- tempfile()
+  dir.create(uri <- tempfile())
   key <- "0123456789abcdeF0123456789abcdeF"
 
   dom <- tiledb_domain(dims = c(tiledb_dim("rows", c(1L, 4L), 4L, "INT32"),
@@ -112,4 +112,6 @@ test_that("tiledb_array_schema created with encryption",  {
   expect_true(is(A, "tiledb_dense"))
   ##expect_true(is(schema(A), "tiledb_dense"))
   ## can't yet read / write as scheme getter not generalized for encryption
+
+  unlink(uri, recursive=TRUE)
 })

--- a/tests/testthat/test_SparseArray.R
+++ b/tests/testthat/test_SparseArray.R
@@ -1,15 +1,6 @@
 library(tiledb)
 context("tiledb::SparseArray")
 
-unlink_and_create <- function(tmp) {
-  if (dir.exists(tmp)) {
-    unlink(tmp, recursive = TRUE)
-    dir.create(tmp)
-  } else {
-    dir.create(tmp)
-  }
-  return(tmp)
-}
 #
 # test_that("Can read / write simple 1D sparse vector", {
 #   tmp <- tempfile()
@@ -35,11 +26,7 @@ unlink_and_create <- function(tmp) {
 # })
 
 test_that("test tiledb_subarray read for sparse array", {
-  #tmp <- tempfile()
-  #setup({
-  #  unlink_and_create(tmp)
-  #})
-  tmp <- tempdir()
+  dir.create(tmp <- tempfile())
 
   d1  <- tiledb_dim("d1", domain = c(1L, 5L))
   d2  <- tiledb_dim("d2", domain = c(1L, 5L))
@@ -64,18 +51,11 @@ test_that("test tiledb_subarray read for sparse array", {
   # vector range syntax
   expect_equal(tiledb_subarray(arr, list(1,3,1,3))$val, unlist(as.list(dat[1:3, 1:3])))
 
-  #teardown({
-  #  unlink(tmp, recursive = TRUE)
-  #})
   unlink(tmp, recursive = TRUE)
 })
 
 test_that("test tiledb_subarray read for sparse array with attribute list", {
-  #tmp <- tempfile()
-  #setup({
-  #  unlink_and_create(tmp)
-  #})
-  tmp <- tempdir()
+  dir.create(tmp <- tempfile())
 
   d1  <- tiledb_dim("d1", domain = c(1L, 5L))
   d2  <- tiledb_dim("d2", domain = c(1L, 5L))
@@ -104,18 +84,11 @@ test_that("test tiledb_subarray read for sparse array with attribute list", {
   # vector range syntax
   expect_equal(tiledb_subarray(arr, list(1,3,1,3), attrs=c("val2"))$val2, unlist(as.list(dat2[1:3, 1:3])))
 
-  #teardown({
-  #  unlink(tmp, recursive = TRUE)
-  #})
   unlink(tmp, recursive = TRUE)
 })
 
 test_that("test tiledb_subarray read for sparse array as dataframe", {
-  #tmp <- tempfile()
-  #setup({
-  #  unlink_and_create(tmp)
-  #})
-  tmp <- tempdir()
+  dir.create(tmp <- tempfile())
 
   d1  <- tiledb_dim("d1", domain = c(1L, 5L))
   d2  <- tiledb_dim("d2", domain = c(1L, 5L))
@@ -145,19 +118,12 @@ test_that("test tiledb_subarray read for sparse array as dataframe", {
   # vector range syntax
   expect_equal(tiledb_subarray(arr, list(1,3,1,3), attrs=c("val2"))$val2, unlist(as.list(dat2[1:3, 1:3])))
 
-  #teardown({
-  #  unlink(tmp, recursive = TRUE)
-  #})
   unlink(tmp, recursive = TRUE)
 })
 
 
 test_that("test tiledb_subarray read/write for sparse array with list of coordinates", {
-  #tmp <- tempfile()
-  #setup({
-  #  unlink_and_create(tmp)
-  #})
-  tmp <- tempdir()
+  dir.create(tmp <- tempfile())
 
   d1  <- tiledb_dim("d1", domain = c(1L, 5L))
   d2  <- tiledb_dim("d2", domain = c(1L, 5L))
@@ -182,8 +148,5 @@ test_that("test tiledb_subarray read/write for sparse array with list of coordin
   # vector range syntax
   expect_equal(arr[list(c(1:3), c(1:3))]$val, unlist(as.list(dat[1:3, 1:3])))
 
-  #teardown({
-  #  unlink(tmp, recursive = TRUE)
-  #})
   unlink(tmp, recursive = TRUE)
 })


### PR DESCRIPTION
This PR regroups a few small enhancements for data.frame support motivated by the 'bank' example
for Python. We can now read both arrays created by Python, and similarly write two ourselves (via a simple 'fromDataFrame()' helper that creates a schema, as well as explicitly by providing a schema).

We could probably call this 0.6.1 as well, or equally well wait for a few more changes and call it 0.7.0.