### PR TITLE
Reword DESCRIPTION to better match README of TileDB repo

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,7 +3,7 @@ Type: Package
 Version: 0.6.0
 Title: Sparse and Dense Multidimensional Array Storage Engine for Data Science
 Author: TileDB, Inc.
-Maintainer: TileDB <support@tiledb.com>
+Maintainer: Dirk Eddelbuettel <dirk@tiledb.com>
 Description: The data science storage engine 'TileDB' introduces a
  powerful on-disk format for multi-dimensional arrays. It supports
  dense and sparse arrays, dataframes and key-values stores, cloud

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,14 +1,18 @@
 Package: tiledb
 Type: Package
-Title: Sparse and Dense Multidimensional Array Data Management
 Version: 0.6.0
+Title: Sparse and Dense Multidimensional Array Storage Engine for Data Science
 Author: TileDB, Inc.
 Maintainer: TileDB <support@tiledb.com>
-Description: The efficient multi-dimensional array management system
- 'TileDB' introduces a novel on-disk format that can effectively store
- dense and sparse array data with support for fast updates and
- reads. It features excellent compression, an efficient parallel I/O
- system which also scales well, and bindings to multiple languages.
+Description: The data science storage engine 'TileDB' introduces a
+ powerful on-disk format for multi-dimensional arrays. It supports
+ dense and sparse arrays, dataframes and key-values stores, cloud
+ storage ('S3', 'GCS', 'Azure'), chunked arrays, multiple compression,
+ encryption and checksum filters, uses a fully multi-threaded
+ implementation, supports parallel I/O, data versioning ('time
+ travel'), metadata and groups. It is implemented as an embeddable
+ cross-platform C++ library with APIs from several languages, and
+ integrations.
 License: MIT + file LICENSE
 URL: https://github.com/TileDB-Inc/TileDB-R
 BugReports: https://github.com/TileDB-Inc/TileDB-R/issues

--- a/inst/NEWS.md
+++ b/inst/NEWS.md
@@ -4,9 +4,13 @@
 
 ## Improvements
 
+- All S4 classes are now consistently documented or aliased (#117)
+
 - If needed, the build system now builds TileDB and its required component (#118)
 
-- All S4 classes are now consistently documented or aliased (#117)
+- Data.frame support has been extended further and made more robust (#119)
+
+- The Description: in `DESCRIPTION` has been refreshed (#120)
 
 # 0.6.0
 


### PR DESCRIPTION
Updating meta-data in the DESCRIPTION file of the package.

`R CMD check --as-cran ...` actually checks this "hard".  One cannot start with 'The package' or name the package again (so I can't just copy the other README), has to use full sentences, use quotes around terms etc pp.  This commit passes all those tests.