### PR TITLE
Use pkg-config if available

### DIFF
--- a/configure
+++ b/configure
@@ -628,6 +628,7 @@ GREP
 TILEDB_RPATH
 TILEDB_LIBS
 TILEDB_INCLUDE
+have_pkg_config
 CXXCPP
 OBJEXT
 EXEEXT
@@ -2911,13 +2912,79 @@ ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ex
 ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
 
 
-## Default values suitable for system install, overridde as needed below
-TILEDB_INCLUDE=""
+## Can we use pkg-config?
+# Extract the first word of "pkg-config", so it can be a program name with args.
+set dummy pkg-config; ac_word=$2
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+$as_echo_n "checking for $ac_word... " >&6; }
+if ${ac_cv_path_have_pkg_config+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  case $have_pkg_config in
+  [\\/]* | ?:[\\/]*)
+  ac_cv_path_have_pkg_config="$have_pkg_config" # Let the user override the test with a path.
+  ;;
+  *)
+  as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
+for as_dir in $PATH
+do
+  IFS=$as_save_IFS
+  test -z "$as_dir" && as_dir=.
+    for ac_exec_ext in '' $ac_executable_extensions; do
+  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
+    ac_cv_path_have_pkg_config="$as_dir/$ac_word$ac_exec_ext"
+    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
+    break 2
+  fi
+done
+  done
+IFS=$as_save_IFS
 
-TILEDB_LIBS="-ltiledb"
+  test -z "$ac_cv_path_have_pkg_config" && ac_cv_path_have_pkg_config="no"
+  ;;
+esac
+fi
+have_pkg_config=$ac_cv_path_have_pkg_config
+if test -n "$have_pkg_config"; then
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $have_pkg_config" >&5
+$as_echo "$have_pkg_config" >&6; }
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+fi
 
-TILEDB_RPATH=""
 
+## If yes, also check for whether pkg-config knows tiledb
+if test x"${have_pkg_config}" != x"no"; then
+    { $as_echo "$as_me:${as_lineno-$LINENO}: checking pkg-config knows TileDB" >&5
+$as_echo_n "checking pkg-config knows TileDB... " >&6; }
+    if pkg-config --exists aatiledb; then
+        { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+        tiledb_include=$(pkg-config --cflags tiledb)
+        tiledb_libs=$(pkg-config --libs tiledb)
+        TILEDB_INCLUDE="${tiledb_include}"
+
+        TILEDB_LIBS="${tiledb_libs}"
+
+        TILEDB_RPATH=""
+
+    else
+        { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+        have_pkg_config="no"
+    fi
+fi
+## Otherwise use fallback values
+if test x"${have_pkg_config}" = x"no"; then
+    ## Default values suitable for system install, overridde as needed below
+    TILEDB_INCLUDE=""
+
+    TILEDB_LIBS="-ltiledb"
+
+    TILEDB_RPATH=""
+
+fi
 
 ## Top-level system, recognising SunOS (Solaris), Darwin (macOS), Linux
 uname=`uname`

--- a/configure
+++ b/configure
@@ -2958,7 +2958,7 @@ fi
 if test x"${have_pkg_config}" != x"no"; then
     { $as_echo "$as_me:${as_lineno-$LINENO}: checking pkg-config knows TileDB" >&5
 $as_echo_n "checking pkg-config knows TileDB... " >&6; }
-    if pkg-config --exists aatiledb; then
+    if pkg-config --exists tiledb; then
         { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
 $as_echo "yes" >&6; }
         tiledb_include=$(pkg-config --cflags tiledb)

--- a/configure.ac
+++ b/configure.ac
@@ -13,10 +13,30 @@ AC_LANG(C++)
 AC_REQUIRE_CPP
 AC_PROG_CXX
 
-## Default values suitable for system install, overridde as needed below
-AC_SUBST([TILEDB_INCLUDE], "")
-AC_SUBST([TILEDB_LIBS], "-ltiledb")
-AC_SUBST([TILEDB_RPATH], "")
+## Can we use pkg-config?
+AC_PATH_PROG(have_pkg_config, pkg-config, no)
+## If yes, also check for whether pkg-config knows tiledb
+if test x"${have_pkg_config}" != x"no"; then
+    AC_MSG_CHECKING([pkg-config knows TileDB])
+    if pkg-config --exists tiledb; then
+        AC_MSG_RESULT([yes])
+        tiledb_include=$(pkg-config --cflags tiledb)
+        tiledb_libs=$(pkg-config --libs tiledb)
+        AC_SUBST([TILEDB_INCLUDE], "${tiledb_include}")
+        AC_SUBST([TILEDB_LIBS],    "${tiledb_libs}")
+        AC_SUBST([TILEDB_RPATH],   "")
+    else
+        AC_MSG_RESULT([no])
+        have_pkg_config="no"
+    fi
+fi
+## Otherwise use fallback values
+if test x"${have_pkg_config}" = x"no"; then
+    ## Default values suitable for system install, overridde as needed below
+    AC_SUBST([TILEDB_INCLUDE], "")
+    AC_SUBST([TILEDB_LIBS], "-ltiledb")
+    AC_SUBST([TILEDB_RPATH], "")
+fi
 
 ## Top-level system, recognising SunOS (Solaris), Darwin (macOS), Linux
 uname=`uname`


### PR DESCRIPTION
This is a small and  very self-contained change using `pkg-config` to set compilation defaults if and when it is available (as a binary) and has a recent-enough TileDB build with a`tiledb.pc`.

Probably nice enough to have in the next release but not of utmost urgency as the build system already works.