### PR TITLE
Refactor build script to deal with non-normalized tar.gz URLs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,12 +13,14 @@ jobs:
       env: DOCKER_CNTR="eddelbuettel/rocker-tiledb:dev"
     - name: 1.7.7
       env: DOCKER_CNTR="eddelbuettel/rocker-tiledb:1.7.7"
-    - name: 2.0.0
-      env: DOCKER_CNTR="eddelbuettel/rocker-tiledb:2.0.0"
+    #- name: 2.0.0
+    #  env: DOCKER_CNTR="eddelbuettel/rocker-tiledb:2.0.0"
     - name: 2.0.1
       env: DOCKER_CNTR="eddelbuettel/rocker-tiledb:2.0.1"
     - name: 2.0.2
       env: DOCKER_CNTR="eddelbuettel/rocker-tiledb:2.0.2"
+    - name: 2.0.3
+      env: DOCKER_CNTR="eddelbuettel/rocker-tiledb:2.0.3"
 
 env:
   global:

--- a/configure
+++ b/configure
@@ -3477,11 +3477,11 @@ $as_echo "downloading TileDB library..." >&6; }
             { $as_echo "$as_me:${as_lineno-$LINENO}: result: installing TileDB for ${osrel} ..." >&5
 $as_echo "installing TileDB for ${osrel} ..." >&6; }
             if test x"${uname}" = x"Darwin"; then
-                TARBALL=tiledb-macos-shared.tar.gz
+                os="macos"
             else
-                TARBALL=tiledb-ubuntu-16.04-shared.tar.gz
+                os="linux"
             fi
-            cd inst && ../src/tools/fetchTileDB.sh "${TARBALL}" && cd ..
+            cd inst && ../src/tools/fetchTileDB.sh "${os}" && cd ..
 
         ## default case: be unhappy
         else

--- a/configure.ac
+++ b/configure.ac
@@ -132,11 +132,11 @@ if test x"${have_tiledb}" = x"no"; then
             osrel=`src/tools/getOsRelease.sh`
             AC_MSG_RESULT([installing TileDB for ${osrel} ...])
             if test x"${uname}" = x"Darwin"; then
-                TARBALL=tiledb-macos-shared.tar.gz
+                os="macos"
             else
-                TARBALL=tiledb-ubuntu-16.04-shared.tar.gz
+                os="linux"
             fi
-            cd inst && ../src/tools/fetchTileDB.sh "${TARBALL}" && cd ..
+            cd inst && ../src/tools/fetchTileDB.sh "${os}" && cd ..
 
         ## default case: be unhappy
         else

--- a/src/tools/buildTileDB.sh
+++ b/src/tools/buildTileDB.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 if [ ! -d src ]; then
     echo "No src/ directory. Script should be invoked from top-level."
@@ -10,7 +10,7 @@ cd src
 if [ ! -f tiledb.tar.gz ]; then
     url=$(curl -Ls https://github.com/TileDB-Inc/TileDB/releases/latest | sed -n -e 's/.*href=\"\(.*tar.gz\)".*/\1/p' | grep archive)
     echo "Downloading ${url} as tiledb.tar.gz ..."
-    curl -s -k -L -o tiledb.tar.gz "https://github.com/TileDB-Inc/TileDB/archive/"${url}
+    curl -s -k -L -o tiledb.tar.gz "https://github.com/${url}"
 fi
 
 if [ ! -d tiledb-src ]; then

--- a/src/tools/buildTileDB.sh
+++ b/src/tools/buildTileDB.sh
@@ -8,8 +8,9 @@ fi
 cd src
 
 if [ ! -f tiledb.tar.gz ]; then
-    echo "Downloading...."
-    curl -s -k -L -o tiledb.tar.gz https://github.com/TileDB-Inc/TileDB/archive/2.0.2.tar.gz
+    url=$(curl -Ls https://github.com/TileDB-Inc/TileDB/releases/latest | sed -n -e 's/.*href=\"\(.*tar.gz\)".*/\1/p' | grep archive)
+    echo "Downloading ${url} as tiledb.tar.gz ..."
+    curl -s -k -L -o tiledb.tar.gz ${url}
 fi
 
 if [ ! -d tiledb-src ]; then

--- a/src/tools/buildTileDB.sh
+++ b/src/tools/buildTileDB.sh
@@ -10,7 +10,7 @@ cd src
 if [ ! -f tiledb.tar.gz ]; then
     url=$(curl -Ls https://github.com/TileDB-Inc/TileDB/releases/latest | sed -n -e 's/.*href=\"\(.*tar.gz\)".*/\1/p' | grep archive)
     echo "Downloading ${url} as tiledb.tar.gz ..."
-    curl -s -k -L -o tiledb.tar.gz ${url}
+    curl -s -k -L -o tiledb.tar.gz "https://github.com/TileDB-Inc/TileDB/archive/"${url}
 fi
 
 if [ ! -d tiledb-src ]; then

--- a/src/tools/bulkTestOnRHub.r
+++ b/src/tools/bulkTestOnRHub.r
@@ -12,7 +12,7 @@ selected <- c("debian-clang-devel",
               "macos-highsierra-release",
               "macos-highsierra-release-cran")
 
-check(".", platform = selected, email = geOption("email", "edd@debian.org"))
+check(".", platform = selected, email = getOption("email", "edd@debian.org"))
 
 
 ## just FYI on 2020-05-20 platform() returns

--- a/src/tools/fetchTileDB.sh
+++ b/src/tools/fetchTileDB.sh
@@ -32,8 +32,8 @@ downloadurl="https://github.com/TileDB-Inc/TileDB/releases/download/${ver}/${sou
 
 ## Download if need be
 if [ ! -f "${tarball}" ]; then
-    echo "Curling '${downloadurl}' into '${tarball}'"
-    curl -k -L -o ${tarball} ${downloadurl}
+    echo "downloading '${downloadurl}' as '${tarball}'"
+    curl -s -k -L -o ${tarball} ${downloadurl}
 fi
 
 ## Clean-up just in case

--- a/src/tools/fetchTileDB.sh
+++ b/src/tools/fetchTileDB.sh
@@ -1,14 +1,10 @@
 #!/bin/sh
 
-if [ $# -lt 1 ]; then
-    echo "Usage: fetchTileDB.sh tarfile"
+if [ $# -ne 1 ] || { [ "$1" != "linux" ] && [ "$1" != "macos" ]; }; then
+    echo "Usage: fetchTileDB.sh (linux|macos)"
     exit 1
 fi
-
-repo=https://tiledb-inc.github.io/tiledb-linux-library
-tarball="$1"
-
-#test -f /etc/os-release && echo "** On " && cat /etc/os-release
+os="${1}"
 
 if [ ! -f NEWS.md ]; then
     echo "This script should run from the inst/ directory."
@@ -16,9 +12,28 @@ if [ ! -f NEWS.md ]; then
     exit 1
 fi
 
+## source repo: the latest TileDB release
+## which redirects to latest tagged release
+repo=https://github.com/TileDB-Inc/TileDB/releases/latest
+tarball="tiledb.tar.gz"
+
+## use curl to download the release, follow redirects, and scan
+## the sed expression should result in two tarballs such as
+##   tiledb-linux-2.0.3-cf03c60.tar.gz
+##   tiledb-macos-2.0.3-cf03c60.tar.gz
+## where version and sha will vary
+sourcetgz=$(curl -Ls ${repo} | sed -n -e 's/.*<span.*>\(tiledb-.*tar.gz\).*/\1/p' | grep "${os}")
+
+## need to also extract release version ... because github
+ver=$(echo "${sourcetgz}" | cut -d- -f3)
+
+## construct actual url
+downloadurl="https://github.com/TileDB-Inc/TileDB/releases/download/${ver}/${sourcetgz}"
+
 ## Download if need be
-if [ ! -f ${tarball} ]; then
-    curl -s -k -L -O ${repo}/${tarball}
+if [ ! -f "${tarball}" ]; then
+    echo "Curling '${downloadurl}' into '${tarball}'"
+    curl -k -L -o ${tarball} ${downloadurl}
 fi
 
 ## Clean-up just in case


### PR DESCRIPTION
This pull request changes the build script to identify the most linux and macos shared library artifacts and uses them in the build of the R package (if no system TileDB has been found and download is the next best option).  

At current, the PR is for discussion. It should _not yet be merged_ as a likely issue with the library built needs to be sorted out first.