### PR TITLE
Support additional types in dense arrays and as attributes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,18 +13,21 @@ jobs:
       env: DOCKER_CNTR="eddelbuettel/rocker-tiledb:dev"
     - name: 1.7.7
       env: DOCKER_CNTR="eddelbuettel/rocker-tiledb:1.7.7"
-    - name: 2.0.4
-      env: DOCKER_CNTR="eddelbuettel/rocker-tiledb:2.0.4"
     - name: 2.0.5
       env: DOCKER_CNTR="eddelbuettel/rocker-tiledb:2.0.5"
     - name: 2.0.6
       env: DOCKER_CNTR="eddelbuettel/rocker-tiledb:2.0.6"
+    - name: 2.0.7
+      env: DOCKER_CNTR="eddelbuettel/rocker-tiledb:2.0.7"
 
 env:
   global:
     - DOCKER_OPTS="--rm -ti -v $(pwd):/mnt -w /mnt"
       R_BLD_OPTS="--no-manual"
       R_CHK_OPTS="--no-manual"
+      PKG_NAME=$(awk '/Package:/ {print $2}' DESCRIPTION)
+      PKG_VER=$(awk '/Version:/ {print $2}' DESCRIPTION)
+      PKG_TGZ="${PKG_NAME}_${PKG_VER}.tar.gz"
 
 before_install:
   - docker pull ${DOCKER_CNTR}
@@ -34,7 +37,7 @@ install:
   - docker run ${DOCKER_OPTS} ${DOCKER_CNTR} R CMD build ${R_BLD_OPTS} .
 
 script:
-  - docker run ${DOCKER_OPTS} ${DOCKER_CNTR} R CMD check ${R_CHK_OPTS} tiledb_*.tar.gz
+  - docker run ${DOCKER_OPTS} ${DOCKER_CNTR} R CMD check ${R_CHK_OPTS} ${PKG_TGZ}
 
 notifications:
   email:

--- a/R/TileDBArray.R
+++ b/R/TileDBArray.R
@@ -476,8 +476,8 @@ setMethod("[<-", "tiledb_array",
 
   ## Case 2
   if (length(colnames(value)) == length(attrnames)) {
-    if (is.null(i)) stop("For sparse arrays a row index has to be supplied.")
-    if (is.null(j)) stop("For sparse arrays a column index has to be supplied.")
+    if (is.null(i)) stop("For arrays a row index has to be supplied.")
+    if (is.null(j)) stop("For arrays a column index has to be supplied.")
     #if (length(i) != nrow(value)) stop("Row index must have same number of observations as data")
     if (length(j) == 1) j <- rep(j, nrow(value))
     if (length(colnames(value)) == 1 && colnames(value) == "value") colnames(value) <- attrnames

--- a/src/libtiledb.cpp
+++ b/src/libtiledb.cpp
@@ -1157,17 +1157,21 @@ XPtr<tiledb::Attribute> libtiledb_attribute(XPtr<tiledb::Context> ctx,
              attr_dtype == TILEDB_DATETIME_MS  ||
              attr_dtype == TILEDB_DATETIME_US  ||
              attr_dtype == TILEDB_DATETIME_NS) {
-    //using DType = tiledb::impl::tiledb_to_type<TILEDB_FLOAT64>::type;
     auto attr = XPtr<tiledb::Attribute>(new tiledb::Attribute(*ctx.get(), name, attr_dtype));
     attr->set_filter_list(*filter_list);
     return attr;
-  } else if (attr_dtype == TILEDB_INT64) {
-    //using DType = tiledb::impl::tiledb_to_type<TILEDB_FLOAT64>::type;
+  } else if (attr_dtype == TILEDB_INT64  ||
+             attr_dtype == TILEDB_UINT64 ||
+             attr_dtype == TILEDB_UINT32 ||
+             attr_dtype == TILEDB_INT16  ||
+             attr_dtype == TILEDB_UINT16 ||
+             attr_dtype == TILEDB_INT8   ||
+             attr_dtype == TILEDB_UINT8    ) {
     auto attr = XPtr<tiledb::Attribute>(new tiledb::Attribute(*ctx.get(), name, attr_dtype));
     attr->set_filter_list(*filter_list);
     return attr;
   } else {
-    Rcpp::stop("Only integer (INT32,INT64), logical (INT32), real (FLOAT64), "
+    Rcpp::stop("Only integer ((U)INT{8,16,32,64}), logical (INT32), real (FLOAT64), "
                "Date (DATEIME_DAY), Datetime (DATETIME_{SEC,MS,US}), "
                "nanotime (DATETIME_NS) and character (CHAR) attributes "
                "are supported");

--- a/tests/testthat/test-TileDBArray.R
+++ b/tests/testthat/test-TileDBArray.R
@@ -592,3 +592,253 @@ test_that("test uint8 dimension for sparse arrays", {
 
   unlink(tmp, recursive = TRUE)
 })
+
+test_that("test int8 dimension for dense arrays", {
+  skip_if(tiledb_version(TRUE) < "2.0.0")
+  skip_if(!requireNamespace("bit64", quietly=TRUE))
+  suppressMessages(library(bit64))
+
+  tmp <- tempfile()
+  dir.create(tmp)
+
+  ## The array will be 4x4 with dimensions "rows" and "cols", with domain [1,4]
+  dom <- tiledb_domain(dims = c(tiledb_dim("rows", c(1L,4L), 4L, "INT8"),
+                                tiledb_dim("cols", c(1L,4L), 4L, "INT8")))
+  schema <- tiledb_array_schema(dom, attrs = c(tiledb_attr("a", type = "INT32")), sparse=FALSE)
+  tiledb_array_create(uri = tmp, schema)
+  #print(schema)
+  A <- tiledb_array(uri = tmp)
+
+  data <- 1:16
+  ## can write as data.frame
+  A[] <- data.frame(rows=rep(1:4,each=4), cols=rep(1:4,4), a=data)
+  ## or with indices
+  A[rep(1:4,each=4), rep(1:4,4)] <- data
+
+  A <- tiledb_array(uri = tmp, as.data.frame=TRUE)
+  newdata <- A[1:2, 2:3]
+  expect_equal(newdata[,"a"], c(2L, 3L, 6L, 7L))
+  expect_equal(newdata[,"rows"], c(1L, 1L, 2L, 2L))
+  expect_equal(newdata[,"cols"], c(2L, 3L, 2L, 3L))
+
+  unlink(tmp, recursive = TRUE)
+})
+
+test_that("test uint8 dimension for dense arrays", {
+  skip_if(tiledb_version(TRUE) < "2.0.0")
+  skip_if(!requireNamespace("bit64", quietly=TRUE))
+  suppressMessages(library(bit64))
+
+  tmp <- tempfile()
+  dir.create(tmp)
+
+  ## The array will be 4x4 with dimensions "rows" and "cols", with domain [1,4]
+  dom <- tiledb_domain(dims = c(tiledb_dim("rows", c(1L,4L), 4L, "UINT8"),
+                                tiledb_dim("cols", c(1L,4L), 4L, "UINT8")))
+  schema <- tiledb_array_schema(dom, attrs = c(tiledb_attr("a", type = "INT32")), sparse=FALSE)
+  tiledb_array_create(uri = tmp, schema)
+  #print(schema)
+  A <- tiledb_array(uri = tmp)
+
+  data <- 1:16
+  ## can write as data.frame
+  A[] <- data.frame(rows=rep(1:4,each=4), cols=rep(1:4,4), a=data)
+  ## or with indices
+  A[rep(1:4,each=4), rep(1:4,4)] <- data
+
+  A <- tiledb_array(uri = tmp, as.data.frame=TRUE)
+  newdata <- A[1:2, 2:3]
+  expect_equal(newdata[,"a"], c(2L, 3L, 6L, 7L))
+  expect_equal(newdata[,"rows"], c(1L, 1L, 2L, 2L))
+  expect_equal(newdata[,"cols"], c(2L, 3L, 2L, 3L))
+
+  unlink(tmp, recursive = TRUE)
+})
+
+test_that("test int16 dimension for dense arrays", {
+  skip_if(tiledb_version(TRUE) < "2.0.0")
+  skip_if(!requireNamespace("bit64", quietly=TRUE))
+  suppressMessages(library(bit64))
+
+  tmp <- tempfile()
+  dir.create(tmp)
+
+  ## The array will be 4x4 with dimensions "rows" and "cols", with domain [1,4]
+  dom <- tiledb_domain(dims = c(tiledb_dim("rows", c(1L,4L), 4L, "INT16"),
+                                tiledb_dim("cols", c(1L,4L), 4L, "INT16")))
+  schema <- tiledb_array_schema(dom, attrs = c(tiledb_attr("a", type = "INT32")), sparse=FALSE)
+  tiledb_array_create(uri = tmp, schema)
+  #print(schema)
+  A <- tiledb_array(uri = tmp)
+
+  data <- 1:16
+  ## can write as data.frame
+  A[] <- data.frame(rows=rep(1:4,each=4), cols=rep(1:4,4), a=data)
+  ## or with indices
+  A[rep(1:4,each=4), rep(1:4,4)] <- data
+
+  A <- tiledb_array(uri = tmp, as.data.frame=TRUE)
+  newdata <- A[1:2, 2:3]
+  expect_equal(newdata[,"a"], c(2L, 3L, 6L, 7L))
+  expect_equal(newdata[,"rows"], c(1L, 1L, 2L, 2L))
+  expect_equal(newdata[,"cols"], c(2L, 3L, 2L, 3L))
+
+  unlink(tmp, recursive = TRUE)
+})
+
+test_that("test uint16 dimension for dense arrays", {
+  skip_if(tiledb_version(TRUE) < "2.0.0")
+  skip_if(!requireNamespace("bit64", quietly=TRUE))
+  suppressMessages(library(bit64))
+
+  tmp <- tempfile()
+  dir.create(tmp)
+
+  ## The array will be 4x4 with dimensions "rows" and "cols", with domain [1,4]
+  dom <- tiledb_domain(dims = c(tiledb_dim("rows", c(1L,4L), 4L, "UINT16"),
+                                tiledb_dim("cols", c(1L,4L), 4L, "UINT16")))
+  schema <- tiledb_array_schema(dom, attrs = c(tiledb_attr("a", type = "INT32")), sparse=FALSE)
+  tiledb_array_create(uri = tmp, schema)
+  #print(schema)
+  A <- tiledb_array(uri = tmp)
+
+  data <- 1:16
+  ## can write as data.frame
+  A[] <- data.frame(rows=rep(1:4,each=4), cols=rep(1:4,4), a=data)
+  ## or with indices
+  A[rep(1:4,each=4), rep(1:4,4)] <- data
+
+  A <- tiledb_array(uri = tmp, as.data.frame=TRUE)
+  newdata <- A[1:2, 2:3]
+  expect_equal(newdata[,"a"], c(2L, 3L, 6L, 7L))
+  expect_equal(newdata[,"rows"], c(1L, 1L, 2L, 2L))
+  expect_equal(newdata[,"cols"], c(2L, 3L, 2L, 3L))
+
+  unlink(tmp, recursive = TRUE)
+})
+
+test_that("test int32 dimension for dense arrays", {
+  skip_if(tiledb_version(TRUE) < "2.0.0")
+  skip_if(!requireNamespace("bit64", quietly=TRUE))
+  suppressMessages(library(bit64))
+
+  tmp <- tempfile()
+  dir.create(tmp)
+
+  ## The array will be 4x4 with dimensions "rows" and "cols", with domain [1,4]
+  dom <- tiledb_domain(dims = c(tiledb_dim("rows", c(1L,4L), 4L, "INT32"),
+                                tiledb_dim("cols", c(1L,4L), 4L, "INT32")))
+  schema <- tiledb_array_schema(dom, attrs = c(tiledb_attr("a", type = "INT32")), sparse=FALSE)
+  tiledb_array_create(uri = tmp, schema)
+  #print(schema)
+  A <- tiledb_array(uri = tmp)
+
+  data <- 1:16
+  ## can write as data.frame
+  A[] <- data.frame(rows=rep(1:4,each=4), cols=rep(1:4,4), a=data)
+  ## or with indices
+  A[rep(1:4,each=4), rep(1:4,4)] <- data
+
+  A <- tiledb_array(uri = tmp, as.data.frame=TRUE)
+  newdata <- A[1:2, 2:3]
+  expect_equal(newdata[,"a"], c(2L, 3L, 6L, 7L))
+  expect_equal(newdata[,"rows"], c(1L, 1L, 2L, 2L))
+  expect_equal(newdata[,"cols"], c(2L, 3L, 2L, 3L))
+
+  unlink(tmp, recursive = TRUE)
+})
+
+test_that("test uint32 dimension for dense arrays", {
+  skip_if(tiledb_version(TRUE) < "2.0.0")
+  skip_if(!requireNamespace("bit64", quietly=TRUE))
+  suppressMessages(library(bit64))
+
+  tmp <- tempfile()
+  dir.create(tmp)
+
+  ## The array will be 4x4 with dimensions "rows" and "cols", with domain [1,4]
+  dom <- tiledb_domain(dims = c(tiledb_dim("rows", c(1L,4L), 4L, "UINT32"),
+                                tiledb_dim("cols", c(1L,4L), 4L, "UINT32")))
+  schema <- tiledb_array_schema(dom, attrs = c(tiledb_attr("a", type = "INT32")), sparse=FALSE)
+  tiledb_array_create(uri = tmp, schema)
+  #print(schema)
+  A <- tiledb_array(uri = tmp)
+
+  data <- 1:16
+  ## can write as data.frame
+  A[] <- data.frame(rows=rep(1:4,each=4), cols=rep(1:4,4), a=data)
+  ## or with indices
+  A[rep(1:4,each=4), rep(1:4,4)] <- data
+
+  A <- tiledb_array(uri = tmp, as.data.frame=TRUE)
+  newdata <- A[1:2, 2:3]
+  expect_equal(newdata[,"a"], c(2L, 3L, 6L, 7L))
+  expect_equal(newdata[,"rows"], c(1L, 1L, 2L, 2L))
+  expect_equal(newdata[,"cols"], c(2L, 3L, 2L, 3L))
+
+  unlink(tmp, recursive = TRUE)
+})
+
+test_that("test int64 dimension for dense arrays", {
+  skip_if(tiledb_version(TRUE) < "2.0.0")
+  skip_if(!requireNamespace("bit64", quietly=TRUE))
+  suppressMessages(library(bit64))
+
+  tmp <- tempfile()
+  dir.create(tmp)
+
+  ## The array will be 4x4 with dimensions "rows" and "cols", with domain [1,4]
+  dom <- tiledb_domain(dims = c(tiledb_dim("rows", as.integer64(c(1,4)), as.integer64(4), "INT64"),
+                                tiledb_dim("cols", as.integer64(c(1,4)), as.integer64(4), "INT64")))
+  schema <- tiledb_array_schema(dom, attrs = c(tiledb_attr("a", type = "INT32")), sparse=FALSE)
+  tiledb_array_create(uri = tmp, schema)
+  #print(schema)
+  A <- tiledb_array(uri = tmp)
+
+  data <- 1:16
+  ## can write as data.frame
+  A[] <- data.frame(rows=as.integer64(rep(1:4,each=4)), cols=as.integer64(rep(1:4,4)), a=data)
+  ## or with indices
+  A[as.integer64(rep(1:4,each=4)), as.integer64(rep(1:4,4))] <- data
+
+  A <- tiledb_array(uri = tmp, as.data.frame=TRUE)
+  newdata <- A[1:2, 2:3]
+  expect_equal(newdata[,"a"], c(2L, 3L, 6L, 7L))
+  expect_equal(newdata[,"rows"], c(1L, 1L, 2L, 2L))
+  expect_equal(newdata[,"cols"], c(2L, 3L, 2L, 3L))
+
+
+  unlink(tmp, recursive = TRUE)
+})
+
+test_that("test uint64 dimension for dense arrays", {
+  skip_if(tiledb_version(TRUE) < "2.0.0")
+  skip_if(!requireNamespace("bit64", quietly=TRUE))
+  suppressMessages(library(bit64))
+
+  tmp <- tempfile()
+  dir.create(tmp)
+
+  ## The array will be 4x4 with dimensions "rows" and "cols", with domain [1,4]
+  dom <- tiledb_domain(dims = c(tiledb_dim("rows", as.integer64(c(1,4)), as.integer64(4), "UINT64"),
+                                tiledb_dim("cols", as.integer64(c(1,4)), as.integer64(4), "UINT64")))
+  schema <- tiledb_array_schema(dom, attrs = c(tiledb_attr("a", type = "INT32")), sparse=FALSE)
+  tiledb_array_create(uri = tmp, schema)
+  #print(schema)
+  A <- tiledb_array(uri = tmp)
+
+  data <- 1:16
+  ## can write as data.frame
+  A[] <- data.frame(rows=as.integer64(rep(1:4,each=4)), cols=as.integer64(rep(1:4,4)), a=data)
+  ## or with indices
+  A[as.integer64(rep(1:4,each=4)), as.integer64(rep(1:4,4))] <- data
+
+  A <- tiledb_array(uri = tmp, as.data.frame=TRUE)
+  newdata <- A[1:2, 2:3]
+  expect_equal(newdata[,"a"], c(2L, 3L, 6L, 7L))
+  expect_equal(newdata[,"rows"], c(1L, 1L, 2L, 2L))
+  expect_equal(newdata[,"cols"], c(2L, 3L, 2L, 3L))
+
+
+  unlink(tmp, recursive = TRUE)
+})

--- a/tests/testthat/test-TileDBArray.R
+++ b/tests/testthat/test-TileDBArray.R
@@ -842,3 +842,117 @@ test_that("test uint64 dimension for dense arrays", {
 
   unlink(tmp, recursive = TRUE)
 })
+
+test_that("test all integer types as attributes for dense arrays", {
+  skip_if(tiledb_version(TRUE) < "2.0.0")
+  skip_if(!requireNamespace("bit64", quietly=TRUE))
+  suppressMessages(library(bit64))
+
+  tmp <- tempfile()
+  dir.create(tmp)
+
+  ## The array will be 4x4 with dimensions "rows" and "cols", with domain [1,4]
+  dom <- tiledb_domain(dims = c(tiledb_dim("rows", c(1L,4L), 4L, "INT32"),
+                                tiledb_dim("cols", c(1L,4L), 4L, "INT32")))
+  schema <- tiledb_array_schema(dom,
+                                attrs = c(tiledb_attr("a1", type = "INT8"),
+                                          tiledb_attr("a2", type = "UINT8"),
+                                          tiledb_attr("a3", type = "INT16"),
+                                          tiledb_attr("a4", type = "UINT16"),
+                                          tiledb_attr("a5", type = "INT32"),
+                                          tiledb_attr("a6", type = "UINT32"),
+                                          tiledb_attr("a7", type = "INT64"),
+                                          tiledb_attr("a8", type = "UINT64")
+                                          ),
+                                sparse=FALSE)
+  tiledb_array_create(uri = tmp, schema)
+  #print(schema)
+  A <- tiledb_array(uri = tmp)
+
+  data <- data.frame(a1=1:16,
+                     a2=1:16,
+                     a3=1:16,
+                     a4=1:16,
+                     a5=1:16,
+                     a6=1:16,
+                     a7=as.integer64(1:16),
+                     a8=as.integer64(1:16))
+  ## can write as data.frame
+  A[] <- data.frame(rows=rep(1:4,each=4),
+                    cols=rep(1:4,4),
+                    data)
+  ## or with indices
+  A[rep(1:4,each=4), rep(1:4,4)] <- data
+
+  A <- tiledb_array(uri = tmp, as.data.frame=TRUE)
+  newdata <- A[1:2, 2:3]
+  expect_equal(newdata[,"rows"], c(1L, 1L, 2L, 2L))
+  expect_equal(newdata[,"cols"], c(2L, 3L, 2L, 3L))
+  expect_equal(newdata[,"a1"], c(2L, 3L, 6L, 7L))
+  expect_equal(newdata[,"a2"], c(2L, 3L, 6L, 7L))
+  expect_equal(newdata[,"a3"], c(2L, 3L, 6L, 7L))
+  expect_equal(newdata[,"a4"], c(2L, 3L, 6L, 7L))
+  expect_equal(newdata[,"a5"], c(2L, 3L, 6L, 7L))
+  expect_equal(newdata[,"a6"], c(2L, 3L, 6L, 7L))
+  expect_equal(newdata[,"a7"], c(2L, 3L, 6L, 7L))
+  expect_equal(newdata[,"a8"], c(2L, 3L, 6L, 7L))
+
+  unlink(tmp, recursive = TRUE)
+})
+
+test_that("test all integer types as attributes for sparse arrays", {
+  skip_if(tiledb_version(TRUE) < "2.0.0")
+  skip_if(!requireNamespace("bit64", quietly=TRUE))
+  suppressMessages(library(bit64))
+
+  tmp <- tempfile()
+  dir.create(tmp)
+
+  ## The array will be 4x4 with dimensions "rows" and "cols", with domain [1,4]
+  dom <- tiledb_domain(dims = c(tiledb_dim("rows", c(1L,4L), 4L, "INT32"),
+                                tiledb_dim("cols", c(1L,4L), 4L, "INT32")))
+  schema <- tiledb_array_schema(dom,
+                                attrs = c(tiledb_attr("a1", type = "INT8"),
+                                          tiledb_attr("a2", type = "UINT8"),
+                                          tiledb_attr("a3", type = "INT16"),
+                                          tiledb_attr("a4", type = "UINT16"),
+                                          tiledb_attr("a5", type = "INT32"),
+                                          tiledb_attr("a6", type = "UINT32"),
+                                          tiledb_attr("a7", type = "INT64"),
+                                          tiledb_attr("a8", type = "UINT64")
+                                          ),
+                                sparse=TRUE)
+  tiledb_array_create(uri = tmp, schema)
+  #print(schema)
+  A <- tiledb_array(uri = tmp)
+
+  data <- data.frame(a1=1:16,
+                     a2=1:16,
+                     a3=1:16,
+                     a4=1:16,
+                     a5=1:16,
+                     a6=1:16,
+                     a7=as.integer64(1:16),
+                     a8=as.integer64(1:16))
+  ## can write as data.frame
+  A[] <- data.frame(rows=rep(1:4,each=4),
+                    cols=rep(1:4,4),
+                    data)
+  ## or with indices
+  A[rep(1:4,each=4), rep(1:4,4)] <- data
+
+  A <- tiledb_array(uri = tmp, as.data.frame=TRUE)
+  newdata <- A[1:2, 2:3]
+  expect_equal(newdata[,"rows"], c(1L, 1L, 2L, 2L))
+  expect_equal(newdata[,"cols"], c(2L, 3L, 2L, 3L))
+  expect_equal(newdata[,"a1"], c(2L, 3L, 6L, 7L))
+  expect_equal(newdata[,"a2"], c(2L, 3L, 6L, 7L))
+  expect_equal(newdata[,"a3"], c(2L, 3L, 6L, 7L))
+  expect_equal(newdata[,"a4"], c(2L, 3L, 6L, 7L))
+  expect_equal(newdata[,"a5"], c(2L, 3L, 6L, 7L))
+  expect_equal(newdata[,"a6"], c(2L, 3L, 6L, 7L))
+  expect_equal(newdata[,"a7"], c(2L, 3L, 6L, 7L))
+  expect_equal(newdata[,"a8"], c(2L, 3L, 6L, 7L))
+
+  unlink(tmp, recursive = TRUE)
+})


### PR DESCRIPTION
This extends the work in #143 to cover dense arrays and attributes -- and leverage the earlier leaving mostly just tests to add.  Also expands Travis to use 2.0.7 in the matrix.