### PR TITLE
Simplified detection of macOS for install_name_tool

### DIFF
--- a/src/Makevars.in
+++ b/src/Makevars.in
@@ -8,10 +8,9 @@ PKG_CPPFLAGS =	-I../inst/include/ @TILEDB_INCLUDE@
 PKG_LIBS = @TILEDB_LIBS@ @TILEDB_RPATH@
 
 all: $(SHLIB)
-ifneq "${CONDA_BUILD_STATE}" ""
-	@if command -v install_name_tool; then \
-	echo "updating rpath on macOS..."; \
-	install_name_tool -change libz.1.dylib @rpath/libz.1.dylib ../inst/tiledb/lib/libtiledb.dylib; \
-	install_name_tool -add_rpath @loader_path/../tiledb/lib tiledb.so; \
-	fi
-endif
+        # if we are
+        #  - not on Window NT (a tip from data.table)
+        #  - on macOS aka Darwin which needs this
+        #  - the library is present (implying non-system library use)
+        # then let us call install_name_tool
+	if [ "$(OS)" != "Windows_NT" ] && [ `uname -s` = 'Darwin' ] && [ -f ../inst/tiledb/lib/libtiledb.dylib ] && [ -f tiledb.so ]; then install_name_tool -change libz.1.dylib @rpath/libz.1.dylib ../inst/tiledb/lib/libtiledb.dylib; install_name_tool -add_rpath @loader_path/../tiledb/lib tiledb.so; fi


### PR DESCRIPTION
The previous addition to protect use of `install_name_tool` upset Conda, so it was changed.

Which upsets `R CMD check` because it used `ifneq` which, according to the gospel of CRAN, is non-portable.

So I changed it again, borrowing the construct from `data.table` which, as I checked, has a conda build so the new double test appears to hold water.   Actual call unchanged, all we loose is the "non-portable if" and an echo statement we do not really need.