### PR TITLE
Update library download by accomodating changed asset set

### DIFF
--- a/tools/fetchTileDBLib.R
+++ b/tools/fetchTileDBLib.R
@@ -18,8 +18,9 @@ if (requireNamespace("jsonlite", quietly=TRUE) == FALSE) {
 
 res <- jsonlite::fromJSON("https://api.github.com/repos/TileDB-Inc/TileDB/releases/latest")
 urls <- res$assets$browser_download_url
+tgt <- paste0(argv[1], ".*without_tbb")
 
-ind <- grep(argv[1], urls)
+ind <- grep(tgt, urls)
 if (length(ind) == 0) {
   message("No matching file for OS ", argv[1])
   q()


### PR DESCRIPTION
This re-establishes buildability in the third case where a pre-made library is downloaded on macOS or linux by sharpening the pertinent regular expression to the enlarged set from the unanticipated change on Friday.  In doing so it also switches to the non-TBB flavor.

It was tested via [RHub](https://builder.r-hub.io/) on both relevant architectures.

