### PR TITLE
Throttle-by-default examples as well, using \dontshow{} wrapper

### DIFF
--- a/R/Array.R
+++ b/R/Array.R
@@ -26,6 +26,7 @@
 #' @param schema tiledb_array_schema object
 #'
 #' @examples
+#' \dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
 #' pth <- tempdir()
 #' dom <- tiledb_domain(dims = c(tiledb_dim("d1", c(1L, 10L), type = "INT32")))
 #' sch <- tiledb_array_schema(dom, attrs = c(tiledb_attr("a1", type = "INT32")))

--- a/R/ArraySchema.R
+++ b/R/ArraySchema.R
@@ -45,6 +45,7 @@ tiledb_array_schema.from_ptr <- function(ptr) {
 #' @param offsets_filter_list (optional)
 #' @param ctx tiledb_ctx object (optional)
 #' @examples
+#' \dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
 #' schema <- tiledb_array_schema(
 #'               dom = tiledb_domain(
 #'                         dims = c(tiledb_dim("rows", c(1L, 4L), 4L, "INT32"),
@@ -146,6 +147,7 @@ setGeneric("domain", function(object, ...) standardGeneric("domain"))
 #'
 #' @param object tiledb_array_schema
 #' @examples
+#' \dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
 #' dom <- tiledb_domain(dims = c(tiledb_dim("d1", c(1L, 10L), type = "INT32")))
 #' sch <- tiledb_array_schema(dom, attrs = c(tiledb_attr("a1", type = "INT32")))
 #' domain(sch)
@@ -166,6 +168,7 @@ setGeneric("dimensions", function(object, ...) standardGeneric("dimensions"))
 #' @param object tiledb_array_schema
 #' @return a list of tiledb_dim objects
 #' @examples
+#' \dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
 #' dom <- tiledb_domain(dims = c(tiledb_dim("d1", c(1L, 100L), type = "INT32"),
 #'                                    tiledb_dim("d2", c(1L, 50L), type = "INT32")))
 #' sch <- tiledb_array_schema(dom, attrs = c(tiledb_attr("a1", type = "INT32")))
@@ -188,6 +191,7 @@ setGeneric("attrs", function(object, idx, ...) standardGeneric("attrs"))
 #' @param ... Extra parameter for method signature, currently unused.
 #' @return a list of tiledb_attr objects
 #' @examples
+#' \dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
 #' dom <- tiledb_domain(dims = c(tiledb_dim("d1", c(1L, 10L), type = "INT32")))
 #' sch <- tiledb_array_schema(dom, attrs = c(tiledb_attr("a1", type = "INT32"),
 #'                                                tiledb_attr("a2", type = "FLOAT64")))
@@ -214,6 +218,7 @@ setMethod("attrs", signature("tiledb_array_schema"),
 #' @param ... Extra parameter for method signature, currently unused.
 #' @return a `tiledb_attr` object
 #' @examples
+#' \dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
 #' dom <- tiledb_domain(dims = c(tiledb_dim("d1", c(1L, 10L), type = "INT32")))
 #' sch <- tiledb_array_schema(dom, attrs = c(tiledb_attr("a1", type = "INT32"),
 #'                                                tiledb_attr("a2", type = "FLOAT64")))
@@ -235,6 +240,7 @@ setMethod("attrs", signature("tiledb_array_schema", "character"),
 #' @param ... Extra parameter for method signature, currently unused.
 #' @return a `tiledb_attr` object
 #' @examples
+#' \dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
 #' dom <- tiledb_domain(dims = c(tiledb_dim("d1", c(1L, 10L), type = "INT32")))
 #' sch <- tiledb_array_schema(dom, attrs = c(tiledb_attr("a1", type = "INT32"),
 #'                                                tiledb_attr("a2", type = "FLOAT64")))
@@ -319,6 +325,7 @@ setGeneric("tiledb_ndim", function(object, ...) standardGeneric("tiledb_ndim"))
 #' @param object tiledb_array_schema
 #' @return integer number of dimensions
 #' @examples
+#' \dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
 #' dom <- tiledb_domain(dims = c(tiledb_dim("d1", c(1L, 10L), type = "INT32")))
 #' sch <- tiledb_array_schema(dom, attrs = c(tiledb_attr("a1", type = "INT32"),
 #'                                                tiledb_attr("a2", type = "FLOAT64")))
@@ -338,6 +345,7 @@ setMethod("tiledb_ndim", "tiledb_array_schema",
 #' @param x tiledb_array_schema
 #' @return a dimension vector
 #' @examples
+#' \dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
 #' dom <- tiledb_domain(dims = c(tiledb_dim("d1", c(1L, 10L), type = "INT32")))
 #' sch <- tiledb_array_schema(dom, attrs = c(tiledb_attr("a1", type = "INT32"),
 #'                                                tiledb_attr("a2", type = "FLOAT64")))

--- a/R/Attribute.R
+++ b/R/Attribute.R
@@ -44,6 +44,7 @@ tiledb_attr.from_ptr <- function(ptr) {
 #' @param ctx tiledb_ctx object (optional)
 #' @return `tiledb_dim` object
 #' @examples
+#' \dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
 #' flt <- tiledb_filter_list(list(tiledb_filter("GZIP")))
 #' attr <- tiledb_attr(name = "a1", type = "INT32",
 #'                     filter_list = flt)
@@ -93,6 +94,7 @@ setGeneric("name", function(object) standardGeneric("name"))
 #' @param object `tiledb_attr` object
 #' @return string name, empty string if the attribute is anonymous
 #' @examples
+#' \dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
 #' a1 <- tiledb_attr("a1", type = "INT32")
 #' name(a1)
 #'
@@ -131,6 +133,7 @@ setMethod("datatype", signature(object = "tiledb_attr"),
 #' @param object tiledb_attr
 #' @return a tiledb_filter_list object
 #' @examples
+#' \dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
 #' attr <- tiledb_attr(type = "INT32", filter_list=tiledb_filter_list(list(tiledb_filter("ZSTD"))))
 #' filter_list(attr)
 #'
@@ -150,6 +153,7 @@ setGeneric("cell_val_num", function(object) standardGeneric("cell_val_num"))
 #' @param object `tiledb_attr` object
 #' @return integer number of cells
 #' @examples
+#' \dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
 #' a1 <- tiledb_attr("a1", type = "FLOAT64", ncells = 1)
 #' cell_val_num(a1)
 #'
@@ -166,6 +170,7 @@ setMethod("cell_val_num", signature(object = "tiledb_attr"),
 #' @param object `tiledb_attr` object
 #' @return TRUE or FALSE
 #' @examples
+#' \dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
 #' a1 <- tiledb_attr("a1", type = "FLOAT64")
 #' is.anonymous(a1)
 #'

--- a/R/Config.R
+++ b/R/Config.R
@@ -40,6 +40,7 @@ tiledb_config.from_ptr <- function(ptr) {
 #' @param config (optonal) character vector of config parameter names, values
 #' @return `tiledb_config` object
 #' @examples
+#' \dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
 #' cfg <- tiledb_config()
 #' cfg["sm.tile_cache_size"]
 #'
@@ -70,6 +71,7 @@ tiledb_config <- function(config = NA_character_) {
 #' @param drop Optional logical switch to drop dimensions, default FALSE, currently unused.
 #' @return a config string value if parameter exists, else NA
 #' @examples
+#' \dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
 #' cfg <- tiledb_config()
 #' cfg["sm.tile_cache_size"]
 #' cfg["does_not_exist"]
@@ -97,6 +99,7 @@ setMethod("[", "tiledb_config",
 #' @param value value to set, will be converted into a stringa
 #' @return updated `tiledb_config` object
 #' @examples
+#' \dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
 #' cfg <- tiledb_config()
 #' cfg["sm.tile_cache_size"]
 #'
@@ -131,6 +134,7 @@ setMethod("[<-", "tiledb_config",
 #'
 #' @param object `tiledb_config` object
 #' @examples
+#' \dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
 #' cfg <- tiledb_config()
 #' show(cfg)
 #' @export
@@ -145,6 +149,7 @@ setMethod("show", signature(object = "tiledb_config"),
 #' @param path The path to config file to be created
 #' @return path to created config file
 #' @examples
+#' \dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
 #' tmp <- tempfile()
 #' cfg <- tiledb_config(c("sm.tile_cache_size" = "10"))
 #' pth <- tiledb_config_save(cfg, tmp)
@@ -162,6 +167,7 @@ tiledb_config_save <- function(config, path) {
 #'
 #' @param path path to the config file
 #' @examples
+#' \dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
 #' tmp <- tempfile()
 #' cfg <- tiledb_config(c("sm.tile_cache_size" = "10"))
 #' pth <- tiledb_config_save(cfg, tmp)
@@ -181,6 +187,7 @@ tiledb_config_load <- function(path) {
 #' @param mode Character value `"any"`, currently unused
 #' @return a character vector of config parameter names, values
 #' @examples
+#' \dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
 #' cfg <- tiledb_config()
 #' as.vector(cfg)
 #'

--- a/R/Ctx.R
+++ b/R/Ctx.R
@@ -69,6 +69,7 @@ setContext <- function(ctx) tiledb_set_context(ctx)
 #' @param cached (optional) logical switch to force new creation
 #' @return `tiledb_ctx` object
 #' @examples
+#' \dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
 #' # default configuration
 #' ctx <- tiledb_ctx()
 #'
@@ -118,6 +119,7 @@ setGeneric("config", function(object, ...) {
 #' @param object tiledb_ctx object
 #' @return `tiledb_config` object associated with the `tiledb_ctx` instance
 #' @examples
+#' \dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
 #' ctx <- tiledb_ctx(c("sm.tile_cache_size" = "10"))
 #' cfg <- config(ctx)
 #' cfg["sm.tile_cache_size"]
@@ -142,6 +144,7 @@ setMethod("config", signature(object = "tiledb_ctx"),
 #' @param scheme URI string scheme ("file", "hdfs", "s3")
 #' @return TRUE if tiledb backend is supported, FALSE otherwise
 #' @examples
+#' \dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
 #' tiledb_is_supported_fs("file")
 #' tiledb_is_supported_fs("s3")
 #'
@@ -156,6 +159,7 @@ tiledb_is_supported_fs <- function(scheme, object = tiledb_get_context()) {
 #' @param key string
 #' @param value string
 #' @examples
+#' \dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
 #' ctx <- tiledb_ctx(c("sm.tile_cache_size" = "10"))
 #' cfg <- tiledb_ctx_set_tag(ctx, "tag", "value")
 #'

--- a/R/DataFrame.R
+++ b/R/DataFrame.R
@@ -37,6 +37,7 @@
 ##' @param uri A character variable with an Array URI.
 ##' @return Null, invisibly.
 ##' @examples
+##' \dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
 ##' uri <- tempfile()
 ##' ## turn factor into character
 ##' irisdf <- within(iris, Species <- as.character(Species))

--- a/R/Dim.R
+++ b/R/Dim.R
@@ -48,6 +48,7 @@ tiledb_dim.from_ptr <- function(ptr) {
 #' @param ctx tiledb_ctx object (optional)
 #' @return `tiledb_dim` object
 #' @examples
+#' \dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
 #' tiledb_dim(name = "d1", domain = c(1L, 10L), tile = 5L, type = "INT32")
 #'
 #' @importFrom methods new
@@ -93,6 +94,7 @@ tiledb_dim <- function(name, domain, tile, type, ctx = tiledb_get_context()) {
 #' @param object `tiledb_dim` object
 #' @return string name, empty string if the dimension is anonymous
 #' @examples
+#' \dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
 #' d1 <- tiledb_dim("d1", c(1L, 10L))
 #' name(d1)
 #'
@@ -110,6 +112,7 @@ setMethod("name", signature(object = "tiledb_dim"),
 #' @param object `tiledb_dim` object
 #' @return a vector of (lb, ub) inclusive domain of the dimension
 #' @examples
+#' \dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
 #' d1 <- tiledb_dim("d1", domain = c(5L, 10L))
 #' domain(d1)
 #'
@@ -128,6 +131,7 @@ setGeneric("tile", function(object) standardGeneric("tile"))
 #' @param object `tiledb_dim` object
 #' @return a scalar tile extent
 #' @examples
+#' \dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
 #' d1 <- tiledb_dim("d1", domain = c(5L, 10L), tile = 2L)
 #' tile(d1)
 #'
@@ -142,6 +146,7 @@ setMethod("tile", signature(object = "tiledb_dim"),
 #' @param object tiledb_dim object
 #' @return tiledb datatype string
 #' @examples
+#' \dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
 #' d1 <- tiledb_dim("d1", domain = c(5L, 10L), tile = 2L, type = "INT32")
 #' datatype(d1)
 #'
@@ -156,6 +161,7 @@ setMethod("datatype", signature(object = "tiledb_dim"),
 #' @param object tiledb_ndim object
 #' @return 1L
 #' @examples
+#' \dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
 #' d1 <- tiledb_dim("d1", c(1L, 10L), 10L)
 #' tiledb_ndim(d1)
 #'
@@ -172,6 +178,7 @@ setMethod("tiledb_ndim", "tiledb_dim",
 #' @param object `tiledb_dim` object
 #' @return TRUE or FALSE
 #' @examples
+#' \dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
 #' d1 <- tiledb_dim("d1", c(1L, 10L), 10L)
 #' is.anonymous(d1)
 #'
@@ -189,6 +196,7 @@ is.anonymous.tiledb_dim <- function(object) {
 #' @param x `tiledb_dim` object
 #' @return a vector of the tile_dim domain type, of the dim domain dimension (extent)
 #' @examples
+#' \dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
 #' d1 <- tiledb_dim("d1", c(1L, 10L), 5L)
 #' dim(d1)
 #'

--- a/R/Domain.R
+++ b/R/Domain.R
@@ -42,6 +42,7 @@ tiledb_domain.from_ptr <- function(ptr) {
 #' @param dims list() of tiledb_dim objects
 #' @return tiledb_domain
 #' @examples
+#' \dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
 #' dom <- tiledb_domain(dims = c(tiledb_dim("d1", c(1L, 100L), type = "INT32"),
 #'                               tiledb_dim("d2", c(1L, 50L), type = "INT32")))
 #' @importFrom methods slot
@@ -78,6 +79,7 @@ setMethod("show", "tiledb_domain",
 #' @param object tiledb_domain
 #' @return a list of tiledb_dim
 #' @examples
+#' \dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
 #' dom <- tiledb_domain(dims = c(tiledb_dim("d1", c(1L, 100L), type = "INT32"),
 #'                               tiledb_dim("d2", c(1L, 50L), type = "INT32")))
 #' dimensions(dom)
@@ -96,6 +98,7 @@ setMethod("dimensions", "tiledb_domain",
 #' @param object tiledb_domain
 #' @return tiledb_domain type string
 #' @examples
+#' \dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
 #' dom <- tiledb_domain(dims = c(tiledb_dim("d1", c(1L, 100L), type = "INT32")))
 #' datatype(dom)
 #' dom <- tiledb_domain(dims = c(tiledb_dim("d1", c(0.5, 100.0), type = "FLOAT64")))
@@ -116,6 +119,7 @@ setMethod("datatype", "tiledb_domain",
 #' @param object tiledb_domain
 #' @return integer number of dimensions
 #' @examples
+#' \dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
 #' dom <- tiledb_domain(dims = c(tiledb_dim("d1", c(0.5, 100.0), type = "FLOAT64")))
 #' tiledb_ndim(dom)
 #' dom <- tiledb_domain(dims = c(tiledb_dim("d1", c(0.5, 100.0), type = "FLOAT64"),
@@ -137,6 +141,7 @@ setGeneric("is.integral", function(object) standardGeneric("is.integral"))
 #' @param object tiledb_domain
 #' @return TRUE if the domain is an integral domain, else FALSE
 #' @examples
+#' \dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
 #' dom <- tiledb_domain(dims = c(tiledb_dim("d1", c(1L, 100L), type = "INT32")))
 #' is.integral(dom)
 #' dom <- tiledb_domain(dims = c(tiledb_dim("d1", c(0.5, 100.0), type = "FLOAT64")))
@@ -157,6 +162,7 @@ setMethod("is.integral", "tiledb_domain",
 #' @param x tiledb_domain
 #' @return dimension vector
 #' @examples
+#' \dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
 #' dom <- tiledb_domain(dims = c(tiledb_dim("d1", c(1L, 100L), type = "INT32"),
 #'                               tiledb_dim("d2", c(1L, 100L), type = "INT32")))
 #' dim(dom)

--- a/R/Filter.R
+++ b/R/Filter.R
@@ -54,6 +54,7 @@ tiledb_filter.from_ptr <- function(ptr) {
 #' @param ctx tiledb_ctx object (optional)
 #' @return tiledb_filter object
 #' @examples
+#' \dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
 #' tiledb_filter("ZSTD")
 #'
 #' @export tiledb_filter
@@ -72,6 +73,7 @@ tiledb_filter <- function(name = "NONE", ctx = tiledb_get_context()) {
 #' @param object tiledb_filter
 #' @return TileDB filter type string
 #' @examples
+#' \dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
 #' c <- tiledb_filter("ZSTD")
 #' tiledb_filter_type(c)
 #'
@@ -87,6 +89,7 @@ tiledb_filter_type <- function(object) {
 #' @param option string
 #' @param value int
 #' @examples
+#' \dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
 #' c <- tiledb_filter("ZSTD")
 #' tiledb_filter_set_option(c,"COMPRESSION_LEVEL", 5)
 #' tiledb_filter_get_option(c, "COMPRESSION_LEVEL")
@@ -102,6 +105,7 @@ tiledb_filter_set_option <- function(object, option, value) {
 #' @param option string
 #' @return Integer value
 #' @examples
+#' \dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
 #' c <- tiledb_filter("ZSTD")
 #' tiledb_filter_set_option(c,"COMPRESSION_LEVEL", 5)
 #' tiledb_filter_get_option(c, "COMPRESSION_LEVEL")

--- a/R/FilterList.R
+++ b/R/FilterList.R
@@ -39,6 +39,7 @@ tiledb_filter_list.from_ptr <- function(ptr) {
 #' @param ctx tiledb_ctx object (optional)
 #' @return tiledb_filter_list object
 #' @examples
+#' \dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
 #' flt <- tiledb_filter("ZSTD")
 #' tiledb_filter_set_option(flt, "COMPRESSION_LEVEL", 5)
 #' filter_list <- tiledb_filter_list(c(flt))
@@ -73,6 +74,7 @@ setGeneric("set_max_chunk_size", function(object, value) standardGeneric("set_ma
 #' @param object tiledb_filter_list
 #' @param value string
 #' @examples
+#' \dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
 #' flt <- tiledb_filter("ZSTD")
 #' tiledb_filter_set_option(flt, "COMPRESSION_LEVEL", 5)
 #' filter_list <- tiledb_filter_list(c(flt))
@@ -92,6 +94,7 @@ setGeneric("max_chunk_size", function(object) standardGeneric("max_chunk_size"))
 #' @param object tiledb_filter_list
 #' @return integer max_chunk_size
 #' @examples
+#' \dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
 #' flt <- tiledb_filter("ZSTD")
 #' tiledb_filter_set_option(flt, "COMPRESSION_LEVEL", 5)
 #' filter_list <- tiledb_filter_list(c(flt))
@@ -112,6 +115,7 @@ setGeneric("nfilters", function(object) standardGeneric("nfilters"))
 #' @param object tiledb_filter_list
 #' @return integer number of filters
 #' @examples
+#' \dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
 #' flt <- tiledb_filter("ZSTD")
 #' tiledb_filter_set_option(flt, "COMPRESSION_LEVEL", 5)
 #' filter_list <- tiledb_filter_list(c(flt))
@@ -133,6 +137,7 @@ setMethod("nfilters", signature(object = "tiledb_filter_list"),
 #' @param drop Optional logical switch to drop dimensions, default false.
 #' @return object tiledb_filter
 #' @examples
+#' \dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
 #' flt <- tiledb_filter("ZSTD")
 #' tiledb_filter_set_option(flt, "COMPRESSION_LEVEL", 5)
 #' filter_list <- tiledb_filter_list(c(flt))

--- a/R/Object.R
+++ b/R/Object.R
@@ -36,6 +36,7 @@ check_object_arguments <- function(uri, ctx = tiledb_get_context()) {
 #' @param ctx tiledb_ctx object (optional)
 #' @return uri of created group
 #' @examples
+#' \dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
 #' pth <- tempdir()
 #' tiledb_group_create(pth)
 #' tiledb_object_type(pth)

--- a/R/Stats.R
+++ b/R/Stats.R
@@ -39,6 +39,7 @@ tiledb_stats_disable <- function() {
 #' @param path to stats file
 #' @concept stats
 #' @examples
+#' \dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
 #' pth <- tempfile()
 #' tiledb_stats_dump(pth)
 #' cat(readLines(pth)[1:10], sep = "\n")

--- a/R/TileDBArray.R
+++ b/R/TileDBArray.R
@@ -408,6 +408,7 @@ setMethod("[", "tiledb_array",
 #' @param value The value being assigned
 #' @return The modified object
 #' @examples
+#' \dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
 #' \dontrun{
 #' uri <- "quickstart_sparse"      ## as created by the other example
 #' arr <- tiledb_array(uri)        ## open array

--- a/R/VFS.R
+++ b/R/VFS.R
@@ -33,6 +33,7 @@ setClass("tiledb_vfs",
 #' @param ctx (optonal) A TileDB Ctx object
 #' @return `tiledb_vfs` object
 #' @examples
+#' \dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
 #' # default configuration
 #' vfs <- tiledb_vfs()
 #'
@@ -86,6 +87,7 @@ tiledb_vfs_remove_bucket <- function(vfs, uri) {
 #' @return A boolean value indicating if it is a valid bucket
 #' @export
 #' @examples
+#' \dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
 #' \dontrun{
 #' cfg <- tiledb_config()
 #' cfg["vfs.s3.region"] <- "us-west-1"
@@ -106,6 +108,7 @@ tiledb_vfs_is_bucket <- function(vfs, uri) {
 #' @return A boolean value indicating if it is an empty bucket
 #' @export
 #' @examples
+#' \dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
 #' \dontrun{
 #' cfg <- tiledb_config()
 #' cfg["vfs.s3.region"] <- "us-west-1"

--- a/R/Version.R
+++ b/R/Version.R
@@ -27,6 +27,7 @@
 #' @return An named int vector c(major, minor, patch), or if select,
 #' a \code{package_version} object
 #' @examples
+#' \dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
 #' tiledb_version()
 #' tiledb_version(compact = TRUE)
 #' @export

--- a/man/as.vector.tiledb_config.Rd
+++ b/man/as.vector.tiledb_config.Rd
@@ -18,6 +18,7 @@ a character vector of config parameter names, values
 Convert a \code{tiledb_config} object to a R vector
 }
 \examples{
+\dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
 cfg <- tiledb_config()
 as.vector(cfg)
 

--- a/man/attrs-tiledb_array_schema-ANY-method.Rd
+++ b/man/attrs-tiledb_array_schema-ANY-method.Rd
@@ -20,6 +20,7 @@ a list of tiledb_attr objects
 Returns a list of all \code{tiledb_attr} objects associated with the \code{tiledb_array_schema}
 }
 \examples{
+\dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
 dom <- tiledb_domain(dims = c(tiledb_dim("d1", c(1L, 10L), type = "INT32")))
 sch <- tiledb_array_schema(dom, attrs = c(tiledb_attr("a1", type = "INT32"),
                                                tiledb_attr("a2", type = "FLOAT64")))

--- a/man/attrs-tiledb_array_schema-character-method.Rd
+++ b/man/attrs-tiledb_array_schema-character-method.Rd
@@ -20,6 +20,7 @@ a \code{tiledb_attr} object
 Returns a \code{tiledb_attr} object associated with the \code{tiledb_array_schema} with a given name.
 }
 \examples{
+\dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
 dom <- tiledb_domain(dims = c(tiledb_dim("d1", c(1L, 10L), type = "INT32")))
 sch <- tiledb_array_schema(dom, attrs = c(tiledb_attr("a1", type = "INT32"),
                                                tiledb_attr("a2", type = "FLOAT64")))

--- a/man/attrs-tiledb_array_schema-numeric-method.Rd
+++ b/man/attrs-tiledb_array_schema-numeric-method.Rd
@@ -20,6 +20,7 @@ a \code{tiledb_attr} object
 The attribute index is defined by the order the attributes were defined in the schema
 }
 \examples{
+\dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
 dom <- tiledb_domain(dims = c(tiledb_dim("d1", c(1L, 10L), type = "INT32")))
 sch <- tiledb_array_schema(dom, attrs = c(tiledb_attr("a1", type = "INT32"),
                                                tiledb_attr("a2", type = "FLOAT64")))

--- a/man/cell_val_num-tiledb_attr-method.Rd
+++ b/man/cell_val_num-tiledb_attr-method.Rd
@@ -16,6 +16,7 @@ integer number of cells
 Return the number of scalar values per attribute cell
 }
 \examples{
+\dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
 a1 <- tiledb_attr("a1", type = "FLOAT64", ncells = 1)
 cell_val_num(a1)
 

--- a/man/config-tiledb_ctx-method.Rd
+++ b/man/config-tiledb_ctx-method.Rd
@@ -16,6 +16,7 @@
 Retrieve the \code{tiledb_config} object from the \code{tiledb_ctx}
 }
 \examples{
+\dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
 ctx <- tiledb_ctx(c("sm.tile_cache_size" = "10"))
 cfg <- config(ctx)
 cfg["sm.tile_cache_size"]

--- a/man/datatype-tiledb_dim-method.Rd
+++ b/man/datatype-tiledb_dim-method.Rd
@@ -16,6 +16,7 @@ tiledb datatype string
 Return the \code{tiledb_dim} datatype
 }
 \examples{
+\dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
 d1 <- tiledb_dim("d1", domain = c(5L, 10L), tile = 2L, type = "INT32")
 datatype(d1)
 

--- a/man/datatype-tiledb_domain-method.Rd
+++ b/man/datatype-tiledb_domain-method.Rd
@@ -16,6 +16,7 @@ tiledb_domain type string
 Returns tiledb_domain TileDB type string
 }
 \examples{
+\dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
 dom <- tiledb_domain(dims = c(tiledb_dim("d1", c(1L, 100L), type = "INT32")))
 datatype(dom)
 dom <- tiledb_domain(dims = c(tiledb_dim("d1", c(0.5, 100.0), type = "FLOAT64")))

--- a/man/dim.tiledb_array_schema.Rd
+++ b/man/dim.tiledb_array_schema.Rd
@@ -16,6 +16,7 @@ a dimension vector
 Only valid for integral (integer) domains
 }
 \examples{
+\dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
 dom <- tiledb_domain(dims = c(tiledb_dim("d1", c(1L, 10L), type = "INT32")))
 sch <- tiledb_array_schema(dom, attrs = c(tiledb_attr("a1", type = "INT32"),
                                                tiledb_attr("a2", type = "FLOAT64")))

--- a/man/dim.tiledb_dim.Rd
+++ b/man/dim.tiledb_dim.Rd
@@ -16,6 +16,7 @@ a vector of the tile_dim domain type, of the dim domain dimension (extent)
 Retrieves the dimension of the tiledb_dim domain
 }
 \examples{
+\dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
 d1 <- tiledb_dim("d1", c(1L, 10L), 5L)
 dim(d1)
 

--- a/man/dim.tiledb_domain.Rd
+++ b/man/dim.tiledb_domain.Rd
@@ -16,6 +16,7 @@ dimension vector
 Only valid for integral (integer) domains
 }
 \examples{
+\dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
 dom <- tiledb_domain(dims = c(tiledb_dim("d1", c(1L, 100L), type = "INT32"),
                               tiledb_dim("d2", c(1L, 100L), type = "INT32")))
 dim(dom)

--- a/man/dimensions-tiledb_array_schema-method.Rd
+++ b/man/dimensions-tiledb_array_schema-method.Rd
@@ -16,6 +16,7 @@ a list of tiledb_dim objects
 Returns a list of \code{tiledb_dim} objects associated with the \code{tiledb_array_schema}
 }
 \examples{
+\dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
 dom <- tiledb_domain(dims = c(tiledb_dim("d1", c(1L, 100L), type = "INT32"),
                                    tiledb_dim("d2", c(1L, 50L), type = "INT32")))
 sch <- tiledb_array_schema(dom, attrs = c(tiledb_attr("a1", type = "INT32")))

--- a/man/dimensions-tiledb_domain-method.Rd
+++ b/man/dimensions-tiledb_domain-method.Rd
@@ -16,6 +16,7 @@ a list of tiledb_dim
 Returns a list of the tiledb_domain dimension objects
 }
 \examples{
+\dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
 dom <- tiledb_domain(dims = c(tiledb_dim("d1", c(1L, 100L), type = "INT32"),
                               tiledb_dim("d2", c(1L, 50L), type = "INT32")))
 dimensions(dom)

--- a/man/domain-tiledb_array_schema-method.Rd
+++ b/man/domain-tiledb_array_schema-method.Rd
@@ -13,6 +13,7 @@
 Returns the \code{tiledb_domain} object associated with a given \code{tiledb_array_schema}
 }
 \examples{
+\dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
 dom <- tiledb_domain(dims = c(tiledb_dim("d1", c(1L, 10L), type = "INT32")))
 sch <- tiledb_array_schema(dom, attrs = c(tiledb_attr("a1", type = "INT32")))
 domain(sch)

--- a/man/domain-tiledb_dim-method.Rd
+++ b/man/domain-tiledb_dim-method.Rd
@@ -16,6 +16,7 @@ a vector of (lb, ub) inclusive domain of the dimension
 Return the \code{tiledb_dim} domain
 }
 \examples{
+\dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
 d1 <- tiledb_dim("d1", domain = c(5L, 10L))
 domain(d1)
 

--- a/man/filter_list-tiledb_attr-method.Rd
+++ b/man/filter_list-tiledb_attr-method.Rd
@@ -16,6 +16,7 @@ a tiledb_filter_list object
 Returns the \code{tiledb_filter_list} object associated with the given \code{tiledb_attr}
 }
 \examples{
+\dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
 attr <- tiledb_attr(type = "INT32", filter_list=tiledb_filter_list(list(tiledb_filter("ZSTD"))))
 filter_list(attr)
 

--- a/man/fromDataFrame.Rd
+++ b/man/fromDataFrame.Rd
@@ -25,6 +25,7 @@ the \code{data.frame}.  Each attribute will be a single column.
 At present, factor variable are converted to character.
 }
 \examples{
+\dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
 uri <- tempfile()
 ## turn factor into character
 irisdf <- within(iris, Species <- as.character(Species))

--- a/man/is.anonymous.Rd
+++ b/man/is.anonymous.Rd
@@ -19,6 +19,7 @@ TRUE or FALSE
 A TileDB attribute is anonymous if no name/label is defined
 }
 \examples{
+\dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
 a1 <- tiledb_attr("a1", type = "FLOAT64")
 is.anonymous(a1)
 

--- a/man/is.anonymous.tiledb_dim.Rd
+++ b/man/is.anonymous.tiledb_dim.Rd
@@ -16,6 +16,7 @@ TRUE or FALSE
 A TileDB dimension is anonymous if no name/label is defined
 }
 \examples{
+\dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
 d1 <- tiledb_dim("d1", c(1L, 10L), 10L)
 is.anonymous(d1)
 

--- a/man/is.integral-tiledb_domain-method.Rd
+++ b/man/is.integral-tiledb_domain-method.Rd
@@ -16,6 +16,7 @@ TRUE if the domain is an integral domain, else FALSE
 Returns TRUE is tiledb_domain is an integral (integer) domain
 }
 \examples{
+\dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
 dom <- tiledb_domain(dims = c(tiledb_dim("d1", c(1L, 100L), type = "INT32")))
 is.integral(dom)
 dom <- tiledb_domain(dims = c(tiledb_dim("d1", c(0.5, 100.0), type = "FLOAT64")))

--- a/man/max_chunk_size-tiledb_filter_list-method.Rd
+++ b/man/max_chunk_size-tiledb_filter_list-method.Rd
@@ -16,6 +16,7 @@ integer max_chunk_size
 Returns the filter_list's max_chunk_size
 }
 \examples{
+\dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
 flt <- tiledb_filter("ZSTD")
 tiledb_filter_set_option(flt, "COMPRESSION_LEVEL", 5)
 filter_list <- tiledb_filter_list(c(flt))

--- a/man/name-tiledb_attr-method.Rd
+++ b/man/name-tiledb_attr-method.Rd
@@ -16,6 +16,7 @@ string name, empty string if the attribute is anonymous
 Return the \code{tiledb_attr} name
 }
 \examples{
+\dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
 a1 <- tiledb_attr("a1", type = "INT32")
 name(a1)
 

--- a/man/name-tiledb_dim-method.Rd
+++ b/man/name-tiledb_dim-method.Rd
@@ -16,6 +16,7 @@ string name, empty string if the dimension is anonymous
 Return the \code{tiledb_dim} name
 }
 \examples{
+\dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
 d1 <- tiledb_dim("d1", c(1L, 10L))
 name(d1)
 

--- a/man/nfilters-tiledb_filter_list-method.Rd
+++ b/man/nfilters-tiledb_filter_list-method.Rd
@@ -16,6 +16,7 @@ integer number of filters
 Returns the filter_list's number of filters
 }
 \examples{
+\dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
 flt <- tiledb_filter("ZSTD")
 tiledb_filter_set_option(flt, "COMPRESSION_LEVEL", 5)
 filter_list <- tiledb_filter_list(c(flt))

--- a/man/set_max_chunk_size-tiledb_filter_list-numeric-method.Rd
+++ b/man/set_max_chunk_size-tiledb_filter_list-numeric-method.Rd
@@ -15,6 +15,7 @@
 Set the filter_list's max_chunk_size
 }
 \examples{
+\dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
 flt <- tiledb_filter("ZSTD")
 tiledb_filter_set_option(flt, "COMPRESSION_LEVEL", 5)
 filter_list <- tiledb_filter_list(c(flt))

--- a/man/show-tiledb_config-method.Rd
+++ b/man/show-tiledb_config-method.Rd
@@ -13,6 +13,7 @@
 Prints the config object to STDOUT
 }
 \examples{
+\dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
 cfg <- tiledb_config()
 show(cfg)
 }

--- a/man/sub-tiledb_config-ANY-method.Rd
+++ b/man/sub-tiledb_config-ANY-method.Rd
@@ -28,6 +28,7 @@ a config string value if parameter exists, else NA
 Gets a config parameter value
 }
 \examples{
+\dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
 cfg <- tiledb_config()
 cfg["sm.tile_cache_size"]
 cfg["does_not_exist"]

--- a/man/sub-tiledb_filter_list-ANY-method.Rd
+++ b/man/sub-tiledb_filter_list-ANY-method.Rd
@@ -28,6 +28,7 @@ object tiledb_filter
 Returns the filter at given index
 }
 \examples{
+\dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
 flt <- tiledb_filter("ZSTD")
 tiledb_filter_set_option(flt, "COMPRESSION_LEVEL", 5)
 filter_list <- tiledb_filter_list(c(flt))

--- a/man/subset-tiledb_array-ANY-ANY-ANY-method.Rd
+++ b/man/subset-tiledb_array-ANY-ANY-ANY-method.Rd
@@ -37,6 +37,7 @@ This function may still still change; the current implementation should be
 considered as an initial draft.
 }
 \examples{
+\dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
 \dontrun{
 uri <- "quickstart_sparse"      ## as created by the other example
 arr <- tiledb_array(uri)        ## open array

--- a/man/subset-tiledb_config-ANY-ANY-ANY-method.Rd
+++ b/man/subset-tiledb_config-ANY-ANY-ANY-method.Rd
@@ -26,6 +26,7 @@ updated \code{tiledb_config} object
 Sets a config parameter value
 }
 \examples{
+\dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
 cfg <- tiledb_config()
 cfg["sm.tile_cache_size"]
 

--- a/man/tile-tiledb_dim-method.Rd
+++ b/man/tile-tiledb_dim-method.Rd
@@ -16,6 +16,7 @@ a scalar tile extent
 Return the \code{tiledb_dim} tile extent
 }
 \examples{
+\dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
 d1 <- tiledb_dim("d1", domain = c(5L, 10L), tile = 2L)
 tile(d1)
 

--- a/man/tiledb_array_create.Rd
+++ b/man/tiledb_array_create.Rd
@@ -15,6 +15,7 @@ tiledb_array_create(uri, schema)
 Creates a new TileDB array given an input schema.
 }
 \examples{
+\dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
 pth <- tempdir()
 dom <- tiledb_domain(dims = c(tiledb_dim("d1", c(1L, 10L), type = "INT32")))
 sch <- tiledb_array_schema(dom, attrs = c(tiledb_attr("a1", type = "INT32")))

--- a/man/tiledb_array_schema.Rd
+++ b/man/tiledb_array_schema.Rd
@@ -36,6 +36,7 @@ tiledb_array_schema(
 Constructs a \code{tiledb_array_schema} object
 }
 \examples{
+\dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
 schema <- tiledb_array_schema(
               dom = tiledb_domain(
                         dims = c(tiledb_dim("rows", c(1L, 4L), 4L, "INT32"),

--- a/man/tiledb_attr.Rd
+++ b/man/tiledb_attr.Rd
@@ -31,6 +31,7 @@ that this is a \emph{required} parameter.}
 Contructs a \code{tiledb_attr} object
 }
 \examples{
+\dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
 flt <- tiledb_filter_list(list(tiledb_filter("GZIP")))
 attr <- tiledb_attr(name = "a1", type = "INT32",
                     filter_list = flt)

--- a/man/tiledb_config.Rd
+++ b/man/tiledb_config.Rd
@@ -16,6 +16,7 @@ tiledb_config(config = NA_character_)
 Creates a \code{tiledb_config} object
 }
 \examples{
+\dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
 cfg <- tiledb_config()
 cfg["sm.tile_cache_size"]
 

--- a/man/tiledb_config_load.Rd
+++ b/man/tiledb_config_load.Rd
@@ -13,6 +13,7 @@ tiledb_config_load(path)
 Load a saved \code{tiledb_config} file from disk
 }
 \examples{
+\dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
 tmp <- tempfile()
 cfg <- tiledb_config(c("sm.tile_cache_size" = "10"))
 pth <- tiledb_config_save(cfg, tmp)

--- a/man/tiledb_config_save.Rd
+++ b/man/tiledb_config_save.Rd
@@ -18,6 +18,7 @@ path to created config file
 Save a \code{tiledb_config} object ot a local text file
 }
 \examples{
+\dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
 tmp <- tempfile()
 cfg <- tiledb_config(c("sm.tile_cache_size" = "10"))
 pth <- tiledb_config_save(cfg, tmp)

--- a/man/tiledb_ctx.Rd
+++ b/man/tiledb_ctx.Rd
@@ -18,6 +18,7 @@ tiledb_ctx(config = NULL, cached = TRUE)
 Creates a \code{tiledb_ctx} object
 }
 \examples{
+\dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
 # default configuration
 ctx <- tiledb_ctx()
 

--- a/man/tiledb_ctx_set_tag.Rd
+++ b/man/tiledb_ctx_set_tag.Rd
@@ -17,6 +17,7 @@ tiledb_ctx_set_tag(object, key, value)
 Sets a string:string "tag" on the Ctx
 }
 \examples{
+\dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
 ctx <- tiledb_ctx(c("sm.tile_cache_size" = "10"))
 cfg <- tiledb_ctx_set_tag(ctx, "tag", "value")
 

--- a/man/tiledb_dim.Rd
+++ b/man/tiledb_dim.Rd
@@ -28,6 +28,7 @@ type \code{integer} or \code{double} (i.e. \code{numeric}). For type,
 Contructs a \code{tiledb_dim} object
 }
 \examples{
+\dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
 tiledb_dim(name = "d1", domain = c(1L, 10L), tile = 5L, type = "INT32")
 
 }

--- a/man/tiledb_domain.Rd
+++ b/man/tiledb_domain.Rd
@@ -18,6 +18,7 @@ tiledb_domain
 All \code{tiledb_dim} must be of the same TileDB type.
 }
 \examples{
+\dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
 dom <- tiledb_domain(dims = c(tiledb_dim("d1", c(1L, 100L), type = "INT32"),
                               tiledb_dim("d2", c(1L, 50L), type = "INT32")))
 }

--- a/man/tiledb_filter.Rd
+++ b/man/tiledb_filter.Rd
@@ -35,6 +35,7 @@ Valid compression options vary depending on the filter used,
 consult the TileDB docs for more information.
 }
 \examples{
+\dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
 tiledb_filter("ZSTD")
 
 }

--- a/man/tiledb_filter_get_option.Rd
+++ b/man/tiledb_filter_get_option.Rd
@@ -18,6 +18,7 @@ Integer value
 Returns the filter's option
 }
 \examples{
+\dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
 c <- tiledb_filter("ZSTD")
 tiledb_filter_set_option(c,"COMPRESSION_LEVEL", 5)
 tiledb_filter_get_option(c, "COMPRESSION_LEVEL")

--- a/man/tiledb_filter_list.Rd
+++ b/man/tiledb_filter_list.Rd
@@ -18,6 +18,7 @@ tiledb_filter_list object
 Constructs a \code{tiledb_filter_list} object
 }
 \examples{
+\dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
 flt <- tiledb_filter("ZSTD")
 tiledb_filter_set_option(flt, "COMPRESSION_LEVEL", 5)
 filter_list <- tiledb_filter_list(c(flt))

--- a/man/tiledb_filter_set_option.Rd
+++ b/man/tiledb_filter_set_option.Rd
@@ -17,6 +17,7 @@ tiledb_filter_set_option(object, option, value)
 Set the filter's option
 }
 \examples{
+\dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
 c <- tiledb_filter("ZSTD")
 tiledb_filter_set_option(c,"COMPRESSION_LEVEL", 5)
 tiledb_filter_get_option(c, "COMPRESSION_LEVEL")

--- a/man/tiledb_filter_type.Rd
+++ b/man/tiledb_filter_type.Rd
@@ -16,6 +16,7 @@ TileDB filter type string
 Returns the type of the filter used
 }
 \examples{
+\dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
 c <- tiledb_filter("ZSTD")
 tiledb_filter_type(c)
 

--- a/man/tiledb_group_create.Rd
+++ b/man/tiledb_group_create.Rd
@@ -18,6 +18,7 @@ uri of created group
 Creates a TileDB group object at given uri path
 }
 \examples{
+\dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
 pth <- tempdir()
 tiledb_group_create(pth)
 tiledb_object_type(pth)

--- a/man/tiledb_is_supported_fs.Rd
+++ b/man/tiledb_is_supported_fs.Rd
@@ -26,6 +26,7 @@ Ex:
 }
 }
 \examples{
+\dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
 tiledb_is_supported_fs("file")
 tiledb_is_supported_fs("s3")
 

--- a/man/tiledb_ndim-tiledb_array_schema-method.Rd
+++ b/man/tiledb_ndim-tiledb_array_schema-method.Rd
@@ -16,6 +16,7 @@ integer number of dimensions
 Return the number of dimensions associated with the \code{tiledb_array_schema}
 }
 \examples{
+\dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
 dom <- tiledb_domain(dims = c(tiledb_dim("d1", c(1L, 10L), type = "INT32")))
 sch <- tiledb_array_schema(dom, attrs = c(tiledb_attr("a1", type = "INT32"),
                                                tiledb_attr("a2", type = "FLOAT64")))

--- a/man/tiledb_ndim-tiledb_dim-method.Rd
+++ b/man/tiledb_ndim-tiledb_dim-method.Rd
@@ -16,6 +16,7 @@
 Returns the number of dimensions for a tiledb domain object
 }
 \examples{
+\dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
 d1 <- tiledb_dim("d1", c(1L, 10L), 10L)
 tiledb_ndim(d1)
 

--- a/man/tiledb_ndim-tiledb_domain-method.Rd
+++ b/man/tiledb_ndim-tiledb_domain-method.Rd
@@ -16,6 +16,7 @@ integer number of dimensions
 Returns the number of dimensions of the \code{tiledb_domain}
 }
 \examples{
+\dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
 dom <- tiledb_domain(dims = c(tiledb_dim("d1", c(0.5, 100.0), type = "FLOAT64")))
 tiledb_ndim(dom)
 dom <- tiledb_domain(dims = c(tiledb_dim("d1", c(0.5, 100.0), type = "FLOAT64"),

--- a/man/tiledb_stats_dump.Rd
+++ b/man/tiledb_stats_dump.Rd
@@ -13,6 +13,7 @@ tiledb_stats_dump(path)
 Dump stats to file
 }
 \examples{
+\dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
 pth <- tempfile()
 tiledb_stats_dump(pth)
 cat(readLines(pth)[1:10], sep = "\n")

--- a/man/tiledb_version.Rd
+++ b/man/tiledb_version.Rd
@@ -18,6 +18,7 @@ a \code{package_version} object
 The version of the libtiledb library
 }
 \examples{
+\dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
 tiledb_version()
 tiledb_version(compact = TRUE)
 }

--- a/man/tiledb_vfs.Rd
+++ b/man/tiledb_vfs.Rd
@@ -18,6 +18,7 @@ tiledb_vfs(config = NULL, ctx = tiledb_get_context())
 Creates a \code{tiledb_vfs} object
 }
 \examples{
+\dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
 # default configuration
 vfs <- tiledb_vfs()
 

--- a/man/tiledb_vfs_is_bucket.Rd
+++ b/man/tiledb_vfs_is_bucket.Rd
@@ -18,6 +18,7 @@ A boolean value indicating if it is a valid bucket
 Check for VFS Bucket
 }
 \examples{
+\dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
 \dontrun{
 cfg <- tiledb_config()
 cfg["vfs.s3.region"] <- "us-west-1"

--- a/man/tiledb_vfs_is_empty_bucket.Rd
+++ b/man/tiledb_vfs_is_empty_bucket.Rd
@@ -18,6 +18,7 @@ A boolean value indicating if it is an empty bucket
 Check for empty VFS Bucket
 }
 \examples{
+\dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
 \dontrun{
 cfg <- tiledb_config()
 cfg["vfs.s3.region"] <- "us-west-1"


### PR DESCRIPTION
Following the 0.7.0 upload, we now use a helper function to throttle tests as the [CRAN Respository Policy](https://cran.r-project.org/web/packages/policies.html) says

> If running a package uses multiple threads/cores it must never use more than two simultaneously: the check farm is a shared resource and will typically be running many checks simultaneously.

We need to do the same examples, and this PR does that injecting a call to the throttler function, wrapped by `\dontshow{}` so that it is not displayed in the generated documentation that each example is part of.  Help files were then regenerated from R sources via `roxygen2`.  No other changes.