### PR TITLE
do not attempt to alter num_tbb_threads

### DIFF
--- a/R/Config.R
+++ b/R/Config.R
@@ -238,7 +238,7 @@ limitTileDBCores <- function(ncores, verbose=FALSE) {
   }
   cfg <- tiledb_config()
   cfg["sm.num_reader_threads"] <- ncores
-  cfg["sm.num_tbb_threads"] <- ncores
+  #cfg["sm.num_tbb_threads"] <- ncores
   cfg["sm.num_writer_threads"] <- ncores
   cfg["vfs.file.max_parallel_ops"] <- ncores
   cfg["vfs.num_threads"] <- ncores


### PR DESCRIPTION
The `num_tbb_threads` entry does not like to encounter a changed a value, so not setting it from here prevents some initialization failures seen in some instances.