### PR TITLE
Windows: build against tiledb 2.0.8 binaries from rwinlib

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,7 +18,6 @@ License: MIT + file LICENSE
 URL: https://github.com/TileDB-Inc/TileDB-R
 BugReports: https://github.com/TileDB-Inc/TileDB-R/issues
 SystemRequirements: cmake (only when TileDB source build selected), git (only when TileDB source build selected)
-OS_type: unix
 Imports: methods, Rcpp, nanotime
 LinkingTo: Rcpp
 Suggests: tinytest, rmarkdown, knitr, BiocStyle, curl, bit64

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,7 +1,19 @@
-## We need C++11 to use TileDB's C++ API
 CXX_STD = CXX11
+VERSION = 2.0.8
+RWINLIB=../windows/tiledb-$(VERSION)
 
-### We need the libtiledb library
-PKG_CPPFLAGS =	-I../inst/include/
-TILEDB_LIBS = -ltiledb
-PKG_LIBS = $(TILEDB_LIBS)
+PKG_CPPFLAGS = -I../inst/include -I$(RWINLIB)/include -DTILEDB_STATIC_DEFINE
+PKG_LIBS = \
+	-L$(RWINLIB)/lib$(subst gcc,,$(COMPILED_BY))$(R_ARCH) \
+	-L$(RWINLIB)/lib$(R_ARCH) \
+	-ltiledbstatic -lbz2 -lzstd -llz4 -lz \
+	-laws-cpp-sdk-s3 -laws-cpp-sdk-core -laws-c-event-stream -laws-checksums -laws-c-common \
+	-lShlwapi -lBcrypt -lRpcrt4 -lWininet -lWinhttp -lws2_32 -lVersion -lUserenv
+
+all: clean winlibs
+
+winlibs:
+	"$(R_HOME)/bin$(R_ARCH_BIN)/Rscript.exe" "../tools/winlibs.R" $(VERSION)
+
+clean:
+	rm -f $(SHLIB) $(OBJECTS)

--- a/tools/winlibs.R
+++ b/tools/winlibs.R
@@ -1,0 +1,9 @@
+# Build against static libraries from rwinlib
+VERSION <- commandArgs(TRUE)
+if(!file.exists(sprintf("../windows/tiledb-%s/include/tiledb/tiledb.h", VERSION))){
+  if(getRversion() < "4") stop("This packge requires R-4.0 or newer")
+  download.file(sprintf("https://github.com/rwinlib/tiledb/archive/v%s.zip", VERSION), "lib.zip", quiet = TRUE)
+  dir.create("../windows", showWarnings = FALSE)
+  unzip("lib.zip", exdir = "../windows")
+  unlink("lib.zip")
+}


### PR DESCRIPTION
This makes it easy to install the R package on Windows.