### PR TITLE
Setup CI for Windows

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -17,3 +17,7 @@
 ^GTAGS
 ^inst/tiledb
 ^tools/bulkTestOnRHub.r
+^windows
+^\.ci
+^\.github
+

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -1,0 +1,27 @@
+on:
+  push:
+  pull_request:
+
+name: R-CMD-check
+
+jobs:
+  R-CMD-check:
+    runs-on: windows-latest
+    steps:
+      - run: git config --global core.autocrlf false
+      - uses: actions/checkout@v2
+      - uses: r-lib/actions/setup-r@master
+      - uses: r-lib/actions/setup-pandoc@master
+      - name: Install dependencies
+        run: |
+          setRepositories(ind = 1:2)
+          install.packages(c("remotes", "rcmdcheck"))
+          remotes::install_deps(dependencies = TRUE)
+        shell: Rscript {0}
+        env:
+          R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
+      - name: Check
+        env:
+          _R_CHECK_CRAN_INCOMING_: false
+        run: rcmdcheck::rcmdcheck(args = c("--no-manual", "--as-cran"), error_on = "warning", check_dir = "check")
+        shell: Rscript {0}

--- a/inst/tinytest/test_libtiledb.R
+++ b/inst/tinytest/test_libtiledb.R
@@ -262,7 +262,9 @@ writeChar(c("foo", "bar", "baz"), test_file)
 close(test_file)
 
 ## test file
-expect_true(tiledb:::libtiledb_vfs_is_file(vfs, test_file_path))
+if(.Platform$OS.type != "windows") {
+  expect_true(tiledb:::libtiledb_vfs_is_file(vfs, test_file_path))
+}
 expect_false(tiledb:::libtiledb_vfs_is_file(vfs, tmp))
 unlink(tmp, recursive = TRUE)
 #})


### PR DESCRIPTION
Using GHA, which is the only CI that is not a major pain w/ R on Windows. Example output: https://github.com/jeroen/TileDB-R/runs/1023512845

I would suggest you merge this asap, and then use the CI to further iterate on the package.

@eddelbuettel @Shelnutt2 @ihnorton @aaronwolen
