### PR TITLE
Relax test restrictions 

### DIFF
--- a/R/Array.R
+++ b/R/Array.R
@@ -27,11 +27,13 @@
 #'
 #' @examples
 #' \dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
+#' \dontrun{
 #' pth <- tempdir()
 #' dom <- tiledb_domain(dims = c(tiledb_dim("d1", c(1L, 10L), type = "INT32")))
 #' sch <- tiledb_array_schema(dom, attrs = c(tiledb_attr("a1", type = "INT32")))
 #' tiledb_array_create(pth, sch)
 #' tiledb_object_type(pth)
+#' }
 #'
 #' @export
 tiledb_array_create <- function(uri, schema) {

--- a/R/DataFrame.R
+++ b/R/DataFrame.R
@@ -38,6 +38,7 @@
 ##' @return Null, invisibly.
 ##' @examples
 ##' \dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
+##' \dontrun{
 ##' uri <- tempfile()
 ##' ## turn factor into character
 ##' irisdf <- within(iris, Species <- as.character(Species))
@@ -45,6 +46,7 @@
 ##' arr <- tiledb_dense(uri, as.data.frame=TRUE)
 ##' newdf <- arr[]
 ##' all.equal(iris, newdf)
+##' }
 ##' @export
 fromDataFrame <- function(obj, uri) {
   dims <- dim(obj)

--- a/R/Object.R
+++ b/R/Object.R
@@ -37,10 +37,11 @@ check_object_arguments <- function(uri, ctx = tiledb_get_context()) {
 #' @return uri of created group
 #' @examples
 #' \dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
+#' \dontrun{
 #' pth <- tempdir()
 #' tiledb_group_create(pth)
 #' tiledb_object_type(pth)
-#'
+#' }
 #'@export
 tiledb_group_create <- function(uri, ctx = tiledb_get_context()) {
   check_object_arguments(uri, ctx)

--- a/inst/tinytest/test_arrayschema.R
+++ b/inst/tinytest/test_arrayschema.R
@@ -1,8 +1,7 @@
 library(tinytest)
 library(tiledb)
 
-isWindows <- Sys.info()[["sysname"]] == "Windows"
-isRelease <- TRUE #length(unclass(utils::packageVersion("anytime"))[[1]]) == 3
+isOldWindows <- Sys.info()[["sysname"]] == "Windows" && grepl('Windows Server 2008', osVersion)
 
 ctx <- tiledb_ctx(limitTileDBCores())
 
@@ -96,7 +95,7 @@ expect_error(tiledb:::libtiledb_array_schema_set_capacity(sch@ptr, -10))
 
 
 #test_that("tiledb_array_schema created with encryption",  {
-if (!(isWindows && isRelease)) {
+if (!(isOldWindows)) {
   dir.create(uri <- tempfile())
   key <- "0123456789abcdeF0123456789abcdeF"
 

--- a/inst/tinytest/test_arrayschema.R
+++ b/inst/tinytest/test_arrayschema.R
@@ -1,6 +1,9 @@
 library(tinytest)
 library(tiledb)
 
+isWindows <- Sys.info()[["sysname"]] == "Windows"
+isRelease <- TRUE #length(unclass(utils::packageVersion("anytime"))[[1]]) == 3
+
 ctx <- tiledb_ctx(limitTileDBCores())
 
 #test_that("tiledb_array_schema default constructor works", {
@@ -93,26 +96,28 @@ expect_error(tiledb:::libtiledb_array_schema_set_capacity(sch@ptr, -10))
 
 
 #test_that("tiledb_array_schema created with encryption",  {
-dir.create(uri <- tempfile())
-key <- "0123456789abcdeF0123456789abcdeF"
+if (!(isWindows && isRelease)) {
+  dir.create(uri <- tempfile())
+  key <- "0123456789abcdeF0123456789abcdeF"
 
-dom <- tiledb_domain(dims = c(tiledb_dim("rows", c(1L, 4L), 4L, "INT32"),
-                              tiledb_dim("cols", c(1L, 4L), 4L, "INT32")))
-schema <- tiledb_array_schema(dom, attrs = c(tiledb_attr("a", type = "INT32")))
+  dom <- tiledb_domain(dims = c(tiledb_dim("rows", c(1L, 4L), 4L, "INT32"),
+                                tiledb_dim("cols", c(1L, 4L), 4L, "INT32")))
+  schema <- tiledb_array_schema(dom, attrs = c(tiledb_attr("a", type = "INT32")))
 
-##tiledb_array_create_with_key(uri, schema, key)
-## for now calling into function
-tiledb:::libtiledb_array_create_with_key(uri, schema@ptr, key)
+  ##tiledb_array_create_with_key(uri, schema, key)
+  ## for now calling into function
+  tiledb:::libtiledb_array_create_with_key(uri, schema@ptr, key)
 
-ctx <- tiledb_ctx()
-arrptr <- tiledb:::libtiledb_array_open_with_key(ctx@ptr, uri, "WRITE", key)
-A <- new("tiledb_dense", ctx=ctx, uri=uri, as.data.frame=FALSE, ptr=arrptr)
+  ctx <- tiledb_ctx()
+  arrptr <- tiledb:::libtiledb_array_open_with_key(ctx@ptr, uri, "WRITE", key)
+  A <- new("tiledb_dense", ctx=ctx, uri=uri, as.data.frame=FALSE, ptr=arrptr)
 
-expect_true(is(A, "tiledb_dense"))
-##expect_true(is(schema(A), "tiledb_dense"))
-## can't yet read / write as scheme getter not generalized for encryption
+  expect_true(is(A, "tiledb_dense"))
+  ##expect_true(is(schema(A), "tiledb_dense"))
+  ## can't yet read / write as scheme getter not generalized for encryption
 
-unlink(uri, recursive=TRUE)
+  unlink(uri, recursive=TRUE)
+}
 #})
 
 #test_that("tiledb_array_schema dups setter/getter",  {

--- a/inst/tinytest/test_dataframe.R
+++ b/inst/tinytest/test_dataframe.R
@@ -1,6 +1,11 @@
 library(tinytest)
 library(tiledb)
 
+isWindows <- Sys.info()[["sysname"]] == "Windows"
+isRelease <- TRUE #length(unclass(utils::packageVersion("anytime"))[[1]]) == 3
+
+if (isWindows && isRelease) exit_file("skip this")
+
 ctx <- tiledb_ctx(limitTileDBCores())
 
 #test_that("tiledb_fromdataframe", {

--- a/inst/tinytest/test_dataframe.R
+++ b/inst/tinytest/test_dataframe.R
@@ -1,10 +1,8 @@
 library(tinytest)
 library(tiledb)
 
-isWindows <- Sys.info()[["sysname"]] == "Windows"
-isRelease <- TRUE #length(unclass(utils::packageVersion("anytime"))[[1]]) == 3
-
-if (isWindows && isRelease) exit_file("skip this")
+isOldWindows <- Sys.info()[["sysname"]] == "Windows" && grepl('Windows Server 2008', osVersion)
+if (isOldWindows) exit_file("skip this file on old Windows releases")
 
 ctx <- tiledb_ctx(limitTileDBCores())
 

--- a/inst/tinytest/test_datetime.R
+++ b/inst/tinytest/test_datetime.R
@@ -1,10 +1,8 @@
 library(tinytest)
 library(tiledb)
 
-isWindows <- Sys.info()[["sysname"]] == "Windows"
-isRelease <- TRUE #length(unclass(utils::packageVersion("anytime"))[[1]]) == 3
-
-if (isWindows && isRelease) exit_file("skip this")
+isOldWindows <- Sys.info()[["sysname"]] == "Windows" && grepl('Windows Server 2008', osVersion)
+if (isOldWindows) exit_file("skip this file on old Windows releases")
 
 ctx <- tiledb_ctx(limitTileDBCores())
 
@@ -45,7 +43,8 @@ arr <- tiledb_dense(uri)
 arr[] <- datetimes
 
 arr2 <- tiledb_dense(uri)
-expect_equal(trunc(datetimes), arr2[])
+## different tzone behavior between r-release and r-devel so comparing numerically
+expect_equal(as.numeric(trunc(datetimes)), as.numeric(arr2[]))
 
 unlink(uri, recursive=TRUE)
 
@@ -160,7 +159,8 @@ arr <- tiledb_sparse(uri)
 arr[1:60] <- datetimes
 
 arr2 <- tiledb_sparse(uri)
-expect_equal(trunc(datetimes), arr2[]$dat)
+## different tzone behavior between r-release and r-devel so comparing numerically
+expect_equal(as.numeric(trunc(datetimes)), as.numeric(arr2[]$dat))
 
 unlink(uri, recursive=TRUE)
 

--- a/inst/tinytest/test_datetime.R
+++ b/inst/tinytest/test_datetime.R
@@ -1,6 +1,11 @@
 library(tinytest)
 library(tiledb)
 
+isWindows <- Sys.info()[["sysname"]] == "Windows"
+isRelease <- TRUE #length(unclass(utils::packageVersion("anytime"))[[1]]) == 3
+
+if (isWindows && isRelease) exit_file("skip this")
+
 ctx <- tiledb_ctx(limitTileDBCores())
 
 #test_that("Can read / write a simple Date dense vector", {

--- a/inst/tinytest/test_densearray.R
+++ b/inst/tinytest/test_densearray.R
@@ -1,10 +1,8 @@
 library(tinytest)
 library(tiledb)
 
-isWindows <- Sys.info()[["sysname"]] == "Windows"
-isRelease <- TRUE #length(unclass(utils::packageVersion("anytime"))[[1]]) == 3
-
-if (isWindows && isRelease) exit_file("skip this")
+isOldWindows <- Sys.info()[["sysname"]] == "Windows" && grepl('Windows Server 2008', osVersion)
+if (isOldWindows) exit_file("skip this file on old Windows releases")
 
 ctx <- tiledb_ctx(limitTileDBCores())
 

--- a/inst/tinytest/test_densearray.R
+++ b/inst/tinytest/test_densearray.R
@@ -1,6 +1,11 @@
 library(tinytest)
 library(tiledb)
 
+isWindows <- Sys.info()[["sysname"]] == "Windows"
+isRelease <- TRUE #length(unclass(utils::packageVersion("anytime"))[[1]]) == 3
+
+if (isWindows && isRelease) exit_file("skip this")
+
 ctx <- tiledb_ctx(limitTileDBCores())
 
 unlink_and_create <- function(tmp) {

--- a/inst/tinytest/test_dim.R
+++ b/inst/tinytest/test_dim.R
@@ -1,10 +1,8 @@
 library(tinytest)
 library(tiledb)
 
-isWindows <- Sys.info()[["sysname"]] == "Windows"
-isRelease <- TRUE #length(unclass(utils::packageVersion("anytime"))[[1]]) == 3
-
-if (isWindows && isRelease) exit_file("skip this")
+isOldWindows <- Sys.info()[["sysname"]] == "Windows" && grepl('Windows Server 2008', osVersion)
+if (isOldWindows) exit_file("skip this file on old Windows releases")
 
 ctx <- tiledb_ctx(limitTileDBCores())
 

--- a/inst/tinytest/test_dim.R
+++ b/inst/tinytest/test_dim.R
@@ -1,6 +1,11 @@
 library(tinytest)
 library(tiledb)
 
+isWindows <- Sys.info()[["sysname"]] == "Windows"
+isRelease <- TRUE #length(unclass(utils::packageVersion("anytime"))[[1]]) == 3
+
+if (isWindows && isRelease) exit_file("skip this")
+
 ctx <- tiledb_ctx(limitTileDBCores())
 
 #test_that("tiledb_dim default constructor", {

--- a/inst/tinytest/test_domain.R
+++ b/inst/tinytest/test_domain.R
@@ -1,10 +1,8 @@
 library(tinytest)
 library(tiledb)
 
-isWindows <- Sys.info()[["sysname"]] == "Windows"
-isRelease <- TRUE #length(unclass(utils::packageVersion("anytime"))[[1]]) == 3
-
-if (isWindows && isRelease) exit_file("skip this")
+isOldWindows <- Sys.info()[["sysname"]] == "Windows" && grepl('Windows Server 2008', osVersion)
+if (isOldWindows) exit_file("skip this file on old Windows releases")
 
 ctx <- tiledb_ctx(limitTileDBCores())
 

--- a/inst/tinytest/test_domain.R
+++ b/inst/tinytest/test_domain.R
@@ -1,6 +1,11 @@
 library(tinytest)
 library(tiledb)
 
+isWindows <- Sys.info()[["sysname"]] == "Windows"
+isRelease <- TRUE #length(unclass(utils::packageVersion("anytime"))[[1]]) == 3
+
+if (isWindows && isRelease) exit_file("skip this")
+
 ctx <- tiledb_ctx(limitTileDBCores())
 
 #test_that("tiledb_domain basic constructor", {

--- a/inst/tinytest/test_filter.R
+++ b/inst/tinytest/test_filter.R
@@ -1,6 +1,11 @@
 library(tinytest)
 library(tiledb)
 
+isWindows <- Sys.info()[["sysname"]] == "Windows"
+isRelease <- TRUE #length(unclass(utils::packageVersion("anytime"))[[1]]) == 3
+
+if (isWindows && isRelease) exit_file("skip this")
+
 ctx <- tiledb_ctx(limitTileDBCores())
 
 #test_that("tiledb_filter default constructor", {

--- a/inst/tinytest/test_filter.R
+++ b/inst/tinytest/test_filter.R
@@ -1,10 +1,8 @@
 library(tinytest)
 library(tiledb)
 
-isWindows <- Sys.info()[["sysname"]] == "Windows"
-isRelease <- TRUE #length(unclass(utils::packageVersion("anytime"))[[1]]) == 3
-
-if (isWindows && isRelease) exit_file("skip this")
+isOldWindows <- Sys.info()[["sysname"]] == "Windows" && grepl('Windows Server 2008', osVersion)
+if (isOldWindows) exit_file("skip this file on old Windows releases")
 
 ctx <- tiledb_ctx(limitTileDBCores())
 

--- a/inst/tinytest/test_filterlist.R
+++ b/inst/tinytest/test_filterlist.R
@@ -1,10 +1,8 @@
 library(tinytest)
 library(tiledb)
 
-isWindows <- Sys.info()[["sysname"]] == "Windows"
-isRelease <- TRUE #length(unclass(utils::packageVersion("anytime"))[[1]]) == 3
-
-if (isWindows && isRelease) exit_file("skip this")
+isOldWindows <- Sys.info()[["sysname"]] == "Windows" && grepl('Windows Server 2008', osVersion)
+if (isOldWindows) exit_file("skip this file on old Windows releases")
 
 ctx <- tiledb_ctx(limitTileDBCores())
 

--- a/inst/tinytest/test_filterlist.R
+++ b/inst/tinytest/test_filterlist.R
@@ -1,6 +1,11 @@
 library(tinytest)
 library(tiledb)
 
+isWindows <- Sys.info()[["sysname"]] == "Windows"
+isRelease <- TRUE #length(unclass(utils::packageVersion("anytime"))[[1]]) == 3
+
+if (isWindows && isRelease) exit_file("skip this")
+
 ctx <- tiledb_ctx(limitTileDBCores())
 
 #test_that("tiledb_filter_list default constructor", {

--- a/inst/tinytest/test_libtiledb.R
+++ b/inst/tinytest/test_libtiledb.R
@@ -1,6 +1,11 @@
 library(tinytest)
 library(tiledb)
 
+isWindows <- Sys.info()[["sysname"]] == "Windows"
+isRelease <- TRUE #length(unclass(utils::packageVersion("anytime"))[[1]]) == 3
+
+if (isWindows && isRelease) exit_file("skip this")
+
 tiledb_ctx(limitTileDBCores())
 
 #test_that("version is valid", {

--- a/inst/tinytest/test_libtiledb.R
+++ b/inst/tinytest/test_libtiledb.R
@@ -1,10 +1,8 @@
 library(tinytest)
 library(tiledb)
 
-isWindows <- Sys.info()[["sysname"]] == "Windows"
-isRelease <- TRUE #length(unclass(utils::packageVersion("anytime"))[[1]]) == 3
-
-if (isWindows && isRelease) exit_file("skip this")
+isOldWindows <- Sys.info()[["sysname"]] == "Windows" && grepl('Windows Server 2008', osVersion)
+if (isOldWindows) exit_file("skip this file on old Windows releases")
 
 tiledb_ctx(limitTileDBCores())
 

--- a/inst/tinytest/test_metadata.R
+++ b/inst/tinytest/test_metadata.R
@@ -1,10 +1,8 @@
 library(tinytest)
 library(tiledb)
 
-isWindows <- Sys.info()[["sysname"]] == "Windows"
-isRelease <- TRUE #length(unclass(utils::packageVersion("anytime"))[[1]]) == 3
-
-if (isWindows && isRelease) exit_file("skip this")
+isOldWindows <- Sys.info()[["sysname"]] == "Windows" && grepl('Windows Server 2008', osVersion)
+if (isOldWindows) exit_file("skip this file on old Windows releases")
 
 ctx <- tiledb_ctx(limitTileDBCores())
 

--- a/inst/tinytest/test_metadata.R
+++ b/inst/tinytest/test_metadata.R
@@ -1,6 +1,11 @@
 library(tinytest)
 library(tiledb)
 
+isWindows <- Sys.info()[["sysname"]] == "Windows"
+isRelease <- TRUE #length(unclass(utils::packageVersion("anytime"))[[1]]) == 3
+
+if (isWindows && isRelease) exit_file("skip this")
+
 ctx <- tiledb_ctx(limitTileDBCores())
 
 tmp <- tempfile()

--- a/inst/tinytest/test_query.R
+++ b/inst/tinytest/test_query.R
@@ -1,6 +1,11 @@
 library(tinytest)
 library(tiledb)
 
+isWindows <- Sys.info()[["sysname"]] == "Windows"
+isRelease <- TRUE #length(unclass(utils::packageVersion("anytime"))[[1]]) == 3
+
+if (isWindows && isRelease) exit_file("skip this")
+
 tiledb_ctx(limitTileDBCores())
 
 .createArray <- function(tmp) {

--- a/inst/tinytest/test_query.R
+++ b/inst/tinytest/test_query.R
@@ -1,10 +1,8 @@
 library(tinytest)
 library(tiledb)
 
-isWindows <- Sys.info()[["sysname"]] == "Windows"
-isRelease <- TRUE #length(unclass(utils::packageVersion("anytime"))[[1]]) == 3
-
-if (isWindows && isRelease) exit_file("skip this")
+isOldWindows <- Sys.info()[["sysname"]] == "Windows" && grepl('Windows Server 2008', osVersion)
+if (isOldWindows) exit_file("skip this file on old Windows releases")
 
 tiledb_ctx(limitTileDBCores())
 

--- a/inst/tinytest/test_sparsearray.R
+++ b/inst/tinytest/test_sparsearray.R
@@ -1,6 +1,11 @@
 library(tinytest)
 library(tiledb)
 
+isWindows <- Sys.info()[["sysname"]] == "Windows"
+isRelease <- TRUE #length(unclass(utils::packageVersion("anytime"))[[1]]) == 3
+
+if (isWindows && isRelease) exit_file("skip this")
+
 ctx <- tiledb_ctx(limitTileDBCores())
 
 #test_that("Can read / write simple 1D sparse vector", {

--- a/inst/tinytest/test_sparsearray.R
+++ b/inst/tinytest/test_sparsearray.R
@@ -1,10 +1,8 @@
 library(tinytest)
 library(tiledb)
 
-isWindows <- Sys.info()[["sysname"]] == "Windows"
-isRelease <- TRUE #length(unclass(utils::packageVersion("anytime"))[[1]]) == 3
-
-if (isWindows && isRelease) exit_file("skip this")
+isOldWindows <- Sys.info()[["sysname"]] == "Windows" && grepl('Windows Server 2008', osVersion)
+if (isOldWindows) exit_file("skip this file on old Windows releases")
 
 ctx <- tiledb_ctx(limitTileDBCores())
 

--- a/inst/tinytest/test_tiledbarray.R
+++ b/inst/tinytest/test_tiledbarray.R
@@ -1,6 +1,11 @@
 library(tinytest)
 library(tiledb)
 
+isWindows <- Sys.info()[["sysname"]] == "Windows"
+isRelease <- TRUE #length(unclass(utils::packageVersion("anytime"))[[1]]) == 3
+
+if (isWindows && isRelease) exit_file("skip this")
+
 ctx <- tiledb_ctx(limitTileDBCores())
 
 if (tiledb_version(TRUE) < "2.0.0") exit_file("TileDB Array types required TileDB 2.0.* or greater")

--- a/inst/tinytest/test_tiledbarray.R
+++ b/inst/tinytest/test_tiledbarray.R
@@ -1,10 +1,8 @@
 library(tinytest)
 library(tiledb)
 
-isWindows <- Sys.info()[["sysname"]] == "Windows"
-isRelease <- TRUE #length(unclass(utils::packageVersion("anytime"))[[1]]) == 3
-
-if (isWindows && isRelease) exit_file("skip this")
+isOldWindows <- Sys.info()[["sysname"]] == "Windows" && grepl('Windows Server 2008', osVersion)
+if (isOldWindows) exit_file("skip this file on old Windows releases")
 
 ctx <- tiledb_ctx(limitTileDBCores())
 

--- a/inst/tinytest/test_vfs.R
+++ b/inst/tinytest/test_vfs.R
@@ -1,6 +1,11 @@
 library(tinytest)
 library(tiledb)
 
+isWindows <- Sys.info()[["sysname"]] == "Windows"
+isRelease <- TRUE #length(unclass(utils::packageVersion("anytime"))[[1]]) == 3
+
+if (isWindows && isRelease) exit_file("skip this")
+
 tiledb_ctx(limitTileDBCores())
 
 #test_that("tiledb_vfs default constructor", {

--- a/inst/tinytest/test_vfs.R
+++ b/inst/tinytest/test_vfs.R
@@ -1,10 +1,8 @@
 library(tinytest)
 library(tiledb)
 
-isWindows <- Sys.info()[["sysname"]] == "Windows"
-isRelease <- TRUE #length(unclass(utils::packageVersion("anytime"))[[1]]) == 3
-
-if (isWindows && isRelease) exit_file("skip this")
+isOldWindows <- Sys.info()[["sysname"]] == "Windows" && grepl('Windows Server 2008', osVersion)
+if (isOldWindows) exit_file("skip this file on old Windows releases")
 
 tiledb_ctx(limitTileDBCores())
 

--- a/man/fromDataFrame.Rd
+++ b/man/fromDataFrame.Rd
@@ -26,6 +26,7 @@ At present, factor variable are converted to character.
 }
 \examples{
 \dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
+\dontrun{
 uri <- tempfile()
 ## turn factor into character
 irisdf <- within(iris, Species <- as.character(Species))
@@ -33,4 +34,5 @@ fromDataFrame(irisdf, uri)
 arr <- tiledb_dense(uri, as.data.frame=TRUE)
 newdf <- arr[]
 all.equal(iris, newdf)
+}
 }

--- a/man/tiledb_array_create.Rd
+++ b/man/tiledb_array_create.Rd
@@ -16,10 +16,12 @@ Creates a new TileDB array given an input schema.
 }
 \examples{
 \dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
+\dontrun{
 pth <- tempdir()
 dom <- tiledb_domain(dims = c(tiledb_dim("d1", c(1L, 10L), type = "INT32")))
 sch <- tiledb_array_schema(dom, attrs = c(tiledb_attr("a1", type = "INT32")))
 tiledb_array_create(pth, sch)
 tiledb_object_type(pth)
+}
 
 }

--- a/man/tiledb_group_create.Rd
+++ b/man/tiledb_group_create.Rd
@@ -19,8 +19,9 @@ Creates a TileDB group object at given uri path
 }
 \examples{
 \dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
+\dontrun{
 pth <- tempdir()
 tiledb_group_create(pth)
 tiledb_object_type(pth)
-
+}
 }


### PR DESCRIPTION
This uses a direct check for Windows 2008 to skip tests that would otherwise fail.  (The suggestion in https://github.com/TileDB-Inc/TileDB-R/issues/163#issuecomment-680216334 is good too and may allow us to do away with the test but we need it for now.)

For simplicity also wraps `\dontrun{}` around the examples that break.   

Compares two timestamps numerically as r-devel very recently changed something with respect to the timezone attribute.

