### PR TITLE
Add "Windows/mingw" to CI action name for display clarity

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -6,6 +6,7 @@ name: R-CMD-check
 
 jobs:
   R-CMD-check:
+    name: (Windows/mingw-w64)
     runs-on: windows-latest
     steps:
       - run: git config --global core.autocrlf false


### PR DESCRIPTION
(I noticed in #164 that the Windows CI targets didn't specify - was momentarily confused)