### PR TITLE
Man page typo correction and small README update

### DIFF
--- a/R/Config.R
+++ b/R/Config.R
@@ -37,7 +37,7 @@ tiledb_config.from_ptr <- function(ptr) {
 
 #' Creates a `tiledb_config` object
 #'
-#' @param config (optonal) character vector of config parameter names, values
+#' @param config (optional) character vector of config parameter names, values
 #' @return `tiledb_config` object
 #' @examples
 #' \dontshow{ctx <- tiledb_ctx(limitTileDBCores())}

--- a/R/Ctx.R
+++ b/R/Ctx.R
@@ -65,7 +65,7 @@ setContext <- function(ctx) tiledb_set_context(ctx)
 
 #' Creates a `tiledb_ctx` object
 #'
-#' @param config (optonal) character vector of config parameter names, values
+#' @param config (optional) character vector of config parameter names, values
 #' @param cached (optional) logical switch to force new creation
 #' @return `tiledb_ctx` object
 #' @examples

--- a/R/Query.R
+++ b/R/Query.R
@@ -31,7 +31,7 @@ setClass("tiledb_query",
 #'
 #' @param array A TileDB Array object
 #' @param type A character value that must be one of 'READ' or 'WRITE'
-#' @param ctx (optonal) A TileDB Ctx object
+#' @param ctx (optional) A TileDB Ctx object
 #' @return 'tiledb_query' object
 #' @export tiledb_query
 tiledb_query <- function(array, type = c("READ", "WRITE"), ctx = tiledb_get_context()) {

--- a/R/VFS.R
+++ b/R/VFS.R
@@ -29,8 +29,8 @@ setClass("tiledb_vfs",
 
 #' Creates a `tiledb_vfs` object
 #'
-#' @param config (optonal) character vector of config parameter names, values
-#' @param ctx (optonal) A TileDB Ctx object
+#' @param config (optional) character vector of config parameter names, values
+#' @param ctx (optional) A TileDB Ctx object
 #' @return `tiledb_vfs` object
 #' @examples
 #' \dontshow{ctx <- tiledb_ctx(limitTileDBCores())}

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Build Status](https://img.shields.io/azure-devops/build/tiledb-inc/836549eb-f74a-4986-a18f-7fbba6bbb5f0/24/master?label=Azure%20Pipelines&logo=azure-pipelines&style=flat-square)](https://dev.azure.com/TileDB-Inc/CI/_build/latest?definitionId=24&branchName=master)
 ![R-CMD-check](https://github.com/TileDB-Inc/TileDB-R/workflows/R-CMD-check/badge.svg)
+[![CRAN](https://www.r-pkg.org/badges/version/tiledb)](https://cran.r-project.org/package=tiledb)
 
 # TileDB-R
 
@@ -18,12 +19,16 @@ API](https://docs.tiledb.com/main/).
 
 ## Installation
 
-TileDB Embedded needs to be present, and can to be installed first (from a package or from source)
-for the TileDB R package to build and link correctly. If no system installation is found, a
-precompiled shared library is used during the installation of this R package.
+TileDB Embedded needs to be present, and can be installed first (from a package or from source) for
+the TileDB R package to build and link correctly. Alternatively, if no system installation is found,
+a precompiled shared library is used during the installation of this R package.
 
-As the TileDB R package has not been published on [CRAN](https://cran.r-project.org/), it must be
-installed from source.
+The TileDB R package has been published on [CRAN](https://cran.r-project.org/) and be
+installed directly via
+
+    > install.packages("tiledb")
+
+as usual.
 
 The most recent released version can be installed from
 [Github](https://github.com/TileDB-Inc/TileDB-R) using the package

--- a/docs/articles/introduction.html
+++ b/docs/articles/introduction.html
@@ -99,7 +99,7 @@
 <a href="#getting-started" class="anchor"></a>Getting started</h1>
 <p>Once the TileDB R package is installed, it can be loaded via <code><a href="https://rdrr.io/pkg/tiledb/man">library(tiledb)</a></code>. Installation is supported on Linux and macOS.</p>
 <p>Documentation for the TileDB R package is available via the <code>help()</code> function from within R as well as via the <a href="https://tiledb-inc.github.io/TileDB-R/">package documentation</a> and an <a href="https://tiledb-inc.github.io/TileDB-R/documentation.nb.html">introductory notebook</a>. Documentation about TileDB itself is <a href="https://docs.tiledb.com/main/">also available</a>.</p>
-<p>Several “quickstart” examples that are discussed on the website are available in the <a href="https://github.com/TileDB-Inc/TileDB-R/blob/master/inst/examples/">examples</a> directory. This vignette discusses similar examples.</p>
+<p>Several “quickstart” examples that are discussed on the website are available in the <a href="https://github.com/TileDB-Inc/TileDB-R/tree/master/inst/examples">examples</a> directory. This vignette discusses similar examples.</p>
 <p>In the following examples, the URIs describing arrays point to local file system object. When TileDB has been built with S3 support, and with proper AWS credentials in the usual environment variables, URIs such as <code>s3://some/data/bucket</code> can be used where a local file would be used. See the script <a href="https://github.com/TileDB-Inc/TileDB-R/blob/master/inst/examples/ex_S3.R">examples/ex_S3.R</a> for an example.</p>
 </div>
 <div id="dense-arrays" class="section level1">

--- a/docs/pkgdown.yml
+++ b/docs/pkgdown.yml
@@ -3,5 +3,5 @@ pkgdown: 1.5.1
 pkgdown_sha: ~
 articles:
   introduction: introduction.html
-last_built: 2020-08-28T01:05Z
+last_built: 2020-09-05T17:33Z
 

--- a/docs/reference/dimensions-tiledb_array_schema-method.html
+++ b/docs/reference/dimensions-tiledb_array_schema-method.html
@@ -153,13 +153,13 @@
 <span class='fu'><a href='generics.html'>dimensions</a></span>(<span class='no'>dom</span>)</div><div class='output co'>#&gt; [[1]]
 #&gt; An object of class "tiledb_dim"
 #&gt; Slot "ptr":
-#&gt; &lt;pointer: 0x561eb3e78d40&gt;
+#&gt; &lt;pointer: 0x5588dde6ef20&gt;
 #&gt; 
 #&gt; 
 #&gt; [[2]]
 #&gt; An object of class "tiledb_dim"
 #&gt; Slot "ptr":
-#&gt; &lt;pointer: 0x561eb0e68290&gt;
+#&gt; &lt;pointer: 0x5588dde6ef50&gt;
 #&gt; 
 #&gt; </div><div class='input'>
 <span class='fu'><a href='https://rdrr.io/r/base/lapply.html'>lapply</a></span>(<span class='fu'><a href='generics.html'>dimensions</a></span>(<span class='no'>dom</span>), <span class='no'>name</span>)</div><div class='output co'>#&gt; [[1]]

--- a/docs/reference/dimensions-tiledb_domain-method.html
+++ b/docs/reference/dimensions-tiledb_domain-method.html
@@ -152,13 +152,13 @@
 <span class='fu'><a href='generics.html'>dimensions</a></span>(<span class='no'>dom</span>)</div><div class='output co'>#&gt; [[1]]
 #&gt; An object of class "tiledb_dim"
 #&gt; Slot "ptr":
-#&gt; &lt;pointer: 0x561eb2679350&gt;
+#&gt; &lt;pointer: 0x5588dfa6b210&gt;
 #&gt; 
 #&gt; 
 #&gt; [[2]]
 #&gt; An object of class "tiledb_dim"
 #&gt; Slot "ptr":
-#&gt; &lt;pointer: 0x561eb3e78d40&gt;
+#&gt; &lt;pointer: 0x5588e042bfe0&gt;
 #&gt; 
 #&gt; </div><div class='input'>
 <span class='fu'><a href='https://rdrr.io/r/base/lapply.html'>lapply</a></span>(<span class='fu'><a href='generics.html'>dimensions</a></span>(<span class='no'>dom</span>), <span class='no'>name</span>)</div><div class='output co'>#&gt; [[1]]

--- a/docs/reference/filter_list-tiledb_attr-method.html
+++ b/docs/reference/filter_list-tiledb_attr-method.html
@@ -150,7 +150,7 @@
 <span class='no'>attr</span> <span class='kw'>&lt;-</span> <span class='fu'><a href='tiledb_attr.html'>tiledb_attr</a></span>(<span class='kw'>type</span> <span class='kw'>=</span> <span class='st'>"INT32"</span>, <span class='kw'>filter_list</span><span class='kw'>=</span><span class='fu'><a href='tiledb_filter_list.html'>tiledb_filter_list</a></span>(<span class='fu'><a href='https://rdrr.io/r/base/list.html'>list</a></span>(<span class='fu'><a href='tiledb_filter.html'>tiledb_filter</a></span>(<span class='st'>"ZSTD"</span>))))
 <span class='fu'><a href='generics.html'>filter_list</a></span>(<span class='no'>attr</span>)</div><div class='output co'>#&gt; An object of class "tiledb_filter_list"
 #&gt; Slot "ptr":
-#&gt; &lt;pointer: 0x561eb19301d0&gt;
+#&gt; &lt;pointer: 0x5588dd31ea60&gt;
 #&gt; </div><div class='input'>
 </div></pre>
   </div>

--- a/docs/reference/sub-tiledb_filter_list-ANY-method.html
+++ b/docs/reference/sub-tiledb_filter_list-ANY-method.html
@@ -168,7 +168,7 @@
 <span class='no'>filter_list</span> <span class='kw'>&lt;-</span> <span class='fu'><a href='tiledb_filter_list.html'>tiledb_filter_list</a></span>(<span class='fu'><a href='https://rdrr.io/r/base/c.html'>c</a></span>(<span class='no'>flt</span>))
 <span class='no'>filter_list</span>[<span class='fl'>0</span>]</div><div class='output co'>#&gt; An object of class "tiledb_filter"
 #&gt; Slot "ptr":
-#&gt; &lt;pointer: 0x561eb09ee610&gt;
+#&gt; &lt;pointer: 0x5588dfd99270&gt;
 #&gt; </div><div class='input'>
 </div></pre>
   </div>

--- a/docs/reference/tiledb_config.html
+++ b/docs/reference/tiledb_config.html
@@ -136,7 +136,7 @@
     <colgroup><col class="name" /><col class="desc" /></colgroup>
     <tr>
       <th>config</th>
-      <td><p>(optonal) character vector of config parameter names, values</p></td>
+      <td><p>(optional) character vector of config parameter names, values</p></td>
     </tr>
     </table>
 

--- a/docs/reference/tiledb_ctx.html
+++ b/docs/reference/tiledb_ctx.html
@@ -136,7 +136,7 @@
     <colgroup><col class="name" /><col class="desc" /></colgroup>
     <tr>
       <th>config</th>
-      <td><p>(optonal) character vector of config parameter names, values</p></td>
+      <td><p>(optional) character vector of config parameter names, values</p></td>
     </tr>
     <tr>
       <th>cached</th>

--- a/docs/reference/tiledb_dim.html
+++ b/docs/reference/tiledb_dim.html
@@ -168,7 +168,7 @@ type <code>integer</code> or <code>double</code> (i.e. <code>numeric</code>). Fo
     <pre class="examples"><div class='input'><span class='no'>ctx</span> <span class='kw'>&lt;-</span> <span class='fu'><a href='tiledb_ctx.html'>tiledb_ctx</a></span>(<span class='fu'><a href='limitTileDBCores.html'>limitTileDBCores</a></span>())
 <span class='fu'>tiledb_dim</span>(<span class='kw'>name</span> <span class='kw'>=</span> <span class='st'>"d1"</span>, <span class='kw'>domain</span> <span class='kw'>=</span> <span class='fu'><a href='https://rdrr.io/r/base/c.html'>c</a></span>(<span class='fl'>1L</span>, <span class='fl'>10L</span>), <span class='kw'>tile</span> <span class='kw'>=</span> <span class='fl'>5L</span>, <span class='kw'>type</span> <span class='kw'>=</span> <span class='st'>"INT32"</span>)</div><div class='output co'>#&gt; An object of class "tiledb_dim"
 #&gt; Slot "ptr":
-#&gt; &lt;pointer: 0x561eae602800&gt;
+#&gt; &lt;pointer: 0x5588dfd047b0&gt;
 #&gt; </div><div class='input'>
 </div></pre>
   </div>

--- a/docs/reference/tiledb_filter.html
+++ b/docs/reference/tiledb_filter.html
@@ -182,7 +182,7 @@ consult the TileDB docs for more information.</p>
     <pre class="examples"><div class='input'><span class='no'>ctx</span> <span class='kw'>&lt;-</span> <span class='fu'><a href='tiledb_ctx.html'>tiledb_ctx</a></span>(<span class='fu'><a href='limitTileDBCores.html'>limitTileDBCores</a></span>())
 <span class='fu'>tiledb_filter</span>(<span class='st'>"ZSTD"</span>)</div><div class='output co'>#&gt; An object of class "tiledb_filter"
 #&gt; Slot "ptr":
-#&gt; &lt;pointer: 0x561eb3b35430&gt;
+#&gt; &lt;pointer: 0x5588df7c0720&gt;
 #&gt; </div><div class='input'>
 </div></pre>
   </div>

--- a/docs/reference/tiledb_filter_list.html
+++ b/docs/reference/tiledb_filter_list.html
@@ -155,7 +155,7 @@
 <span class='no'>filter_list</span> <span class='kw'>&lt;-</span> <span class='fu'>tiledb_filter_list</span>(<span class='fu'><a href='https://rdrr.io/r/base/c.html'>c</a></span>(<span class='no'>flt</span>))
 <span class='no'>filter_list</span></div><div class='output co'>#&gt; An object of class "tiledb_filter_list"
 #&gt; Slot "ptr":
-#&gt; &lt;pointer: 0x561eb0c0a320&gt;
+#&gt; &lt;pointer: 0x5588dfaf2400&gt;
 #&gt; </div><div class='input'>
 </div></pre>
   </div>

--- a/docs/reference/tiledb_query.html
+++ b/docs/reference/tiledb_query.html
@@ -144,7 +144,7 @@
     </tr>
     <tr>
       <th>ctx</th>
-      <td><p>(optonal) A TileDB Ctx object</p></td>
+      <td><p>(optional) A TileDB Ctx object</p></td>
     </tr>
     </table>
 

--- a/docs/reference/tiledb_vfs.html
+++ b/docs/reference/tiledb_vfs.html
@@ -136,11 +136,11 @@
     <colgroup><col class="name" /><col class="desc" /></colgroup>
     <tr>
       <th>config</th>
-      <td><p>(optonal) character vector of config parameter names, values</p></td>
+      <td><p>(optional) character vector of config parameter names, values</p></td>
     </tr>
     <tr>
       <th>ctx</th>
-      <td><p>(optonal) A TileDB Ctx object</p></td>
+      <td><p>(optional) A TileDB Ctx object</p></td>
     </tr>
     </table>
 

--- a/man/tiledb_config.Rd
+++ b/man/tiledb_config.Rd
@@ -7,7 +7,7 @@
 tiledb_config(config = NA_character_)
 }
 \arguments{
-\item{config}{(optonal) character vector of config parameter names, values}
+\item{config}{(optional) character vector of config parameter names, values}
 }
 \value{
 \code{tiledb_config} object

--- a/man/tiledb_ctx.Rd
+++ b/man/tiledb_ctx.Rd
@@ -7,7 +7,7 @@
 tiledb_ctx(config = NULL, cached = TRUE)
 }
 \arguments{
-\item{config}{(optonal) character vector of config parameter names, values}
+\item{config}{(optional) character vector of config parameter names, values}
 
 \item{cached}{(optional) logical switch to force new creation}
 }

--- a/man/tiledb_query.Rd
+++ b/man/tiledb_query.Rd
@@ -11,7 +11,7 @@ tiledb_query(array, type = c("READ", "WRITE"), ctx = tiledb_get_context())
 
 \item{type}{A character value that must be one of 'READ' or 'WRITE'}
 
-\item{ctx}{(optonal) A TileDB Ctx object}
+\item{ctx}{(optional) A TileDB Ctx object}
 }
 \value{
 'tiledb_query' object

--- a/man/tiledb_vfs.Rd
+++ b/man/tiledb_vfs.Rd
@@ -7,9 +7,9 @@
 tiledb_vfs(config = NULL, ctx = tiledb_get_context())
 }
 \arguments{
-\item{config}{(optonal) character vector of config parameter names, values}
+\item{config}{(optional) character vector of config parameter names, values}
 
-\item{ctx}{(optonal) A TileDB Ctx object}
+\item{ctx}{(optional) A TileDB Ctx object}
 }
 \value{
 \code{tiledb_vfs} object


### PR DESCRIPTION
A few of the manual pages had a (seemingly copied across) typo in "optional" lacking the "i".  This has been fixed, and  the pkgdown documentation in `docs/` has been updated too.

Now that the package is on CRAN, the installation paragrah in the README.md was extended a little as well, and a badge for the CRAN version was added.