### PR TITLE
Enable storage of raw vectors in metadata

### DIFF
--- a/inst/tinytest/test_metadata.R
+++ b/inst/tinytest/test_metadata.R
@@ -128,6 +128,12 @@ expect_true(tiledb_put_metadata(arr, "char", vec))
 close_and_reopen(arr, "READ")
 expect_equal(tiledb_get_metadata(arr, "char"), vec)
 
+vec <- c(0x10, 0x20, 0x30, 0x40, 0x80)
+close_and_reopen(arr, "WRITE")
+expect_true(tiledb_put_metadata(arr, "raw", vec))
+close_and_reopen(arr, "READ")
+expect_equal(tiledb_get_metadata(arr, "raw"), vec)
+
 vec <- c(TRUE, FALSE, TRUE)
 close_and_reopen(arr, "WRITE")
 expect_true(tiledb_put_metadata(arr, "lvec", vec))

--- a/src/libtiledb.cpp
+++ b/src/libtiledb.cpp
@@ -1850,6 +1850,11 @@ bool libtiledb_array_put_metadata(XPtr<tiledb::Array> array,
       array->put_metadata(key.c_str(), TILEDB_INT8, ints.size(), ints.data());
       break;
     }
+    case RAWSXP: {
+      Rcpp::RawVector v(obj);
+      array->put_metadata(key.c_str(), TILEDB_CHAR, v.size(), v.begin());
+      break;
+    }
     default: {
       Rcpp::stop("No support (yet) for type '%d'.", TYPEOF(obj));
       break; // not reached
@@ -1896,7 +1901,11 @@ SEXP _metadata_to_sexp(const tiledb_datatype_t v_type, const uint32_t v_num, con
     size_t n = static_cast<size_t>(v_num);
     for (size_t i=0; i<n; i++) vec[i] = static_cast<double>(fvec[i]);
     return(vec);
-  } else if (v_type == TILEDB_CHAR || v_type == TILEDB_STRING_ASCII) {
+  } else if (v_type == TILEDB_CHAR) {
+    Rcpp::RawVector vec(v_num);
+    std::memcpy(vec.begin(), v, v_num*sizeof(char));
+    return(vec);
+  } else if (v_type == TILEDB_STRING_ASCII) {
     std::string s(static_cast<const char*>(v), v_num);
     return(Rcpp::wrap(s));
   } else if (v_type == TILEDB_INT8) {

--- a/src/libtiledb.cpp
+++ b/src/libtiledb.cpp
@@ -1838,8 +1838,7 @@ bool libtiledb_array_put_metadata(XPtr<tiledb::Array> array,
     case STRSXP: {
       Rcpp::CharacterVector v(obj);
       std::string s(v[0]);
-      // We use TILEDB_CHAR interchangeably with TILEDB_STRING_ASCII is this best string type?
-      array->put_metadata(key.c_str(), TILEDB_CHAR, s.length(), s.c_str());
+      array->put_metadata(key.c_str(), TILEDB_STRING_ASCII, s.length(), s.c_str());
       break;
     }
     case LGLSXP: {              // experimental: map R logical (ie TRUE, FALSE, NA) to int8


### PR DESCRIPTION
Pretty much as the title says. This allows us to do neat stuff like stuffing serialized R objects in the metadata:

```r
library(tiledb)

# Copied from inst/tinytest/test_metadata.R
tmp <- tempfile()
dim <- tiledb_dim("dim", domain = c(1L, 4L))
dom <- tiledb_domain(c(dim))
a1  <- tiledb_attr("a1", type = "INT32")
a2  <- tiledb_attr("a2", type = "INT32")
sch <- tiledb_array_schema(dom, c(a1, a2), sparse=TRUE)
tiledb_array_create(tmp, sch)

# Not quite sure why I have to open it again, oh well.
# Seems like it would be more intuitive to do:
# arr <- tiledb_array(tmp, query_type="WRITE")
arr <- tiledb_sparse(tmp)
arr <- tiledb_array_open(arr, "WRITE") 

# Saving an arbitrary R object as a raw vector in the metadata:
some_arbitrary_r_object <- list(whee=runif(1), blah=letters, stuff=Sys.Date())

con <- rawConnection(raw(0), "r+")
serialize(some_arbitrary_r_object, con)
thing <- memCompress(rawConnectionValue(con), "gzip")
close(con)

tiledb_put_metadata(arr, "vec", thing)

# Restoring said object.
tiledb_array_close(arr)
arr <- tiledb_array_open(arr, "READ") 
out <- tiledb_get_metadata(arr, "vec")
unserialize(memDecompress(out, "gzip"))
## $whee
## [1] 0.2894501
## 
## $blah
##  [1] "a" "b" "c" "d" "e" "f" "g" "h" "i" "j" "k" "l" "m" "n" "o" "p" "q" "r" "s"
## [20] "t" "u" "v" "w" "x" "y" "z"
## 
## $stuff
## [1] "2020-09-06"
```

 As a side-effect, any strings passed to `tiledb_put_metadata` are now written as `TILEDB_STRING_ASCII`; conversely, any strings previously written as `TILEDB_CHAR` are now interpreted as raw vectors, which is a breaking change. Wasn't sure how to best handle the deprecation process for this.
