### PR TITLE
Small refinements for configure and DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,7 +17,11 @@ Description: The data science storage engine 'TileDB' introduces a
 License: MIT + file LICENSE
 URL: https://github.com/TileDB-Inc/TileDB-R
 BugReports: https://github.com/TileDB-Inc/TileDB-R/issues
-SystemRequirements: cmake (only when TileDB source build selected), git (only when TileDB source build selected)
+SystemRequirements: cmake (only when TileDB source build selected),
+ git (only when TileDB source build selected); on x86_64 platforms
+ pre-built TileDB Embedded libraries are available at GitHub and
+ are used if no TileDB installation is detected, and no other
+ option to build or download was specified by by the user.
 Imports: methods, Rcpp, nanotime
 LinkingTo: Rcpp
 Suggests: tinytest, rmarkdown, knitr, BiocStyle, curl, bit64

--- a/configure
+++ b/configure
@@ -1998,6 +1998,8 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
 
 
 
+## -- Part 1: Setup -------------------------------------------------------------
+##
 ## this has to come early to affect other queries involving R
 : ${R_HOME=`R RHOME`}
 if test -z "${R_HOME}"; then
@@ -2994,7 +2996,11 @@ fi
 ## Various Linux distribution have been tested and work, as do various macOS releases
 uname=`uname`
 #AC_MSG_RESULT([running on ${uname} (${on_macos})...])
+## Also look at hardware platform aka 'machine' description
+machine=`uname -m`
 
+## -- Part 2: User preferences --------------------------------------------------
+##
 ## Allow forced build override, value of 'yes' or 'no' set in enable_building variable
 ## (and sets by autoconf standards the 'enable_building' variable to 'yes' or 'no')
 # Check whether --enable-building was given.
@@ -3051,6 +3057,8 @@ origLDFLAGS="${LDFLAGS}"
 CPPFLAGS="${origCPPFLAGS} ${TILEDB_INCLUDE}"
 LDFLAGS="${origLDFLAGS} ${TILEDB_LIBS} ${TILEDB_RPATH}"
 
+## -- Part 3: Check for TileDB --------------------------------------------------
+##
 ## Check for TileDB -- either just probing the header, or by compilations (~ 1 second)
 checkTileDBViaHeader="yes"
 
@@ -3350,13 +3358,8 @@ fi
 rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
 
-## On Solaris can only build from source
-## But this does not currently work so we will bail out with error instead
-## This can be overridden by selecting --enable-building but is not default
-#if test x"${uname}" = x"SunOS"; then
-#     enable_building="yes"
-#fi
-
+## -- Part 4: Branch on Setup and Choices ---------------------------------------
+##
 ## to test one can force some selections here
 #have_tiledb="no"
 #enable_building="yes"
@@ -3454,6 +3457,7 @@ $as_echo "installing TileDB via building locally..." >&6; }
     ##   - on macOS or Linux a 'fast and slim' build with external (pinned) library
     ##   - but if a download URL given, use it
     ##   - otherwise error
+    ##   - but also check we're on x86_64 before downloading
     else
         ## download URL given by user
         if test x"${TILEDB_LIB_URL}" != x; then
@@ -3463,7 +3467,7 @@ $as_echo "downloading given TileDB library..." >&6; }
             ## and downloads as the same file name
             cd inst && ../tools/fetchTileDB.sh url ${TILEDB_LIB_URL} && cd ..
 
-        elif test x"${uname}" = x"Linux" -o x"${uname}" = x"Darwin"; then
+        elif test x"${machine}" = x"x86_64" && test x"${uname}" = x"Linux" -o x"${uname}" = x"Darwin"; then
             { $as_echo "$as_me:${as_lineno-$LINENO}: result: downloading TileDB library..." >&5
 $as_echo "downloading TileDB library..." >&6; }
 
@@ -3479,7 +3483,7 @@ $as_echo "installing TileDB for ${osrel}..." >&6; }
 
         ## default case: be unhappy
         else
-            as_fn_error $? "currently unsupported system ${uname}" "$LINENO" 5
+            as_fn_error $? "currently unsupported system ${uname} on ${machine}" "$LINENO" 5
         fi
 
     fi

--- a/configure.ac
+++ b/configure.ac
@@ -26,6 +26,8 @@
 AC_PREREQ([2.69])
 AC_INIT([TileDB-R], [0.8.0])
 
+## -- Part 1: Setup -------------------------------------------------------------
+##
 ## this has to come early to affect other queries involving R
 : ${R_HOME=`R RHOME`}
 if test -z "${R_HOME}"; then
@@ -70,7 +72,11 @@ fi
 ## Various Linux distribution have been tested and work, as do various macOS releases
 uname=`uname`
 #AC_MSG_RESULT([running on ${uname} (${on_macos})...])
+## Also look at hardware platform aka 'machine' description
+machine=`uname -m`
 
+## -- Part 2: User preferences --------------------------------------------------
+##
 ## Allow forced build override, value of 'yes' or 'no' set in enable_building variable
 ## (and sets by autoconf standards the 'enable_building' variable to 'yes' or 'no')
 AC_ARG_ENABLE([building],
@@ -122,6 +128,8 @@ origLDFLAGS="${LDFLAGS}"
 CPPFLAGS="${origCPPFLAGS} ${TILEDB_INCLUDE}"
 LDFLAGS="${origLDFLAGS} ${TILEDB_LIBS} ${TILEDB_RPATH}"
 
+## -- Part 3: Check for TileDB --------------------------------------------------
+##
 ## Check for TileDB -- either just probing the header, or by compilations (~ 1 second)
 checkTileDBViaHeader="yes"
 
@@ -138,13 +146,8 @@ else
                                        [have_tiledb="no"; AC_MSG_RESULT(no, need to install TileDB)])
 fi
 
-## On Solaris can only build from source
-## But this does not currently work so we will bail out with error instead
-## This can be overridden by selecting --enable-building but is not default
-#if test x"${uname}" = x"SunOS"; then
-#     enable_building="yes"
-#fi
-
+## -- Part 4: Branch on Setup and Choices ---------------------------------------
+##
 ## to test one can force some selections here
 #have_tiledb="no"
 #enable_building="yes"
@@ -169,6 +172,7 @@ if test x"${have_tiledb}" = x"no"; then
     ##   - on macOS or Linux a 'fast and slim' build with external (pinned) library
     ##   - but if a download URL given, use it
     ##   - otherwise error
+    ##   - but also check we're on x86_64 before downloading
     else
         ## download URL given by user
         if test x"${TILEDB_LIB_URL}" != x; then
@@ -177,7 +181,7 @@ if test x"${have_tiledb}" = x"no"; then
             ## and downloads as the same file name
             cd inst && ../tools/fetchTileDB.sh url ${TILEDB_LIB_URL} && cd ..
 
-        elif test x"${uname}" = x"Linux" -o x"${uname}" = x"Darwin"; then
+        elif test x"${machine}" = x"x86_64" && test x"${uname}" = x"Linux" -o x"${uname}" = x"Darwin"; then
             AC_MSG_RESULT([downloading TileDB library...])
 
             osrel=`tools/getOsRelease.sh`
@@ -191,7 +195,7 @@ if test x"${have_tiledb}" = x"no"; then
 
         ## default case: be unhappy
         else
-            AC_MSG_ERROR([currently unsupported system ${uname}])
+            AC_MSG_ERROR([currently unsupported system ${uname} on ${machine}])
         fi
 
     fi


### PR DESCRIPTION
This should (hopefully) address some emailed concerns by the CRAN maintainers who wanted more clarity on when / where libraries are downloaded, and who (correctly) pointed out that we are not yet supporting Apple Silicone (!!).   

Also added a little more comments to `configure.ac` along with check for suitable `uname -m` output.