### PR TITLE
Windows: update to TileDB 2.1.0, fix typo.

### DIFF
--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,5 +1,5 @@
 CXX_STD = CXX11
-VERSION = 2.0.8
+VERSION = 2.1.0
 RWINLIB=../windows/tiledb-$(VERSION)
 
 PKG_CPPFLAGS = -I../inst/include -I$(RWINLIB)/include -DTILEDB_STATIC_DEFINE

--- a/tools/winlibs.R
+++ b/tools/winlibs.R
@@ -1,7 +1,7 @@
 # Build against static libraries from rwinlib
 VERSION <- commandArgs(TRUE)
 if(!file.exists(sprintf("../windows/tiledb-%s/include/tiledb/tiledb.h", VERSION))){
-  if(getRversion() < "4") stop("This packge requires R-4.0 or newer")
+  if(getRversion() < "4") stop("This package requires Rtools40 or newer")
   download.file(sprintf("https://github.com/rwinlib/tiledb/archive/v%s.zip", VERSION), "lib.zip", quiet = TRUE)
   dir.create("../windows", showWarnings = FALSE)
   unzip("lib.zip", exdir = "../windows")


### PR DESCRIPTION
Using fresh binaries from: https://github.com/rwinlib/tiledb/releases/tag/v2.1.0