### PR TITLE
Minor clarification for configuration settings and docs

### DIFF
--- a/inst/NEWS.md
+++ b/inst/NEWS.md
@@ -1,5 +1,13 @@
 # Ongoing
 
+* This release of the R package builds against [TileDB 2.1.0](https://github.com/TileDB-Inc/TileDB/releases/tag/2.1.0), but has also been tested against previous releases such as [TileDB 2.0.8](https://github.com/TileDB-Inc/TileDB/releases/tag/2.0.8).
+
+## Improvements
+
+## Bug Fixes
+
+* The `tiledb_stats_reset()` function is now exported, and `tiledb_stats_print()` has been re-added as a wrapper to `tiledb_stats_dump()` (#174)
+
 
 # 0.8.1
 

--- a/man/limitTileDBCores.Rd
+++ b/man/limitTileDBCores.Rd
@@ -15,12 +15,17 @@ used.}
 user about the value set.}
 }
 \value{
-The modified configuration object is returned invisibly. As a side-effect the
-updated config is also used to set the global context object.
+The modified configuration object is returned invisibly.
 }
 \description{
 By default, TileDB will use all available cores on a given machine. In multi-user or
 multi-process settings, one may want to reduce the number of core. This function will
 take a given number, or default to smaller of the \sQuote{Ncpus} options value or the
 \sQuote{"OMP_THREAD_LIMIT"} enviroment variable (or two as hard fallback).
+}
+\details{
+As this function returns a config object, its intended use is as argument to the context
+creating functions: \code{ctx <- tiledb_ctx(limitTileDBCores())}. To check that the values
+are set (or at a later point, still set) the config object should be retrieved via the
+corresponding method and this \code{ctx} object: \code{cfg <- config(ctx)}.
 }

--- a/man/tiledb_config.Rd
+++ b/man/tiledb_config.Rd
@@ -13,7 +13,12 @@ tiledb_config(config = NA_character_)
 \code{tiledb_config} object
 }
 \description{
-Creates a \code{tiledb_config} object
+Note that for actually setting persistent values, the (altered) config
+object needs to used to create (or update) the \code{tiledb_ctx} object. Similarly,
+to check whether values are set, one should use the \code{config} method
+of the of the \code{tiledb_ctx} object. Examples for this are
+\code{ctx <- tiledb_ctx(limitTileDBCores())} to use updated configuration values to
+create a context object, and \code{cfg <- config(ctx)} to retrieve it.
 }
 \examples{
 \dontshow{ctx <- tiledb_ctx(limitTileDBCores())}


### PR DESCRIPTION
This small PR clarifies some of the usage around Config and Ctx objects from R, and in particular stresses that one uses a Config object (possibly with locally changed values) to set a Ctx object---and should then query the Ctx object for its current Config (rather than asking for a new, vanilla, and possibly different one).  Ensure that post 2.1.0 only the new 'core-use' values are set.  Also reindented some of the S4 methods.  

Special thanks to @joe-maley for lending an ear when I had myself confused about the very last aspect (as I had checked changed values against a vanilla new config which won't work ...)