### PR TITLE
(re)set timeout for download to accomodate CRAN using lower default

### DIFF
--- a/inst/NEWS.md
+++ b/inst/NEWS.md
@@ -8,6 +8,8 @@
 
 * The `tiledb_stats_reset()` function is now exported, and `tiledb_stats_print()` has been re-added as a wrapper to `tiledb_stats_dump()` (#174)
 
+* Configuration options for compute and input/output concurrency set only the new TileDB 2.1 configuration options; documentation on how to checking values has been expanded. (#175)
+
 
 # 0.8.1
 

--- a/tools/fetchTileDBLib.R
+++ b/tools/fetchTileDBLib.R
@@ -26,4 +26,7 @@ dlurl <- switch(osarg,
                 url = urlarg)
 
 cat("downloading", dlurl, "\n")
+op <- options()
+options(timeout=60)
 download.file(dlurl, "tiledb.tar.gz", quiet=TRUE)
+options(op)

--- a/tools/fetchTileDBSrc.R
+++ b/tools/fetchTileDBSrc.R
@@ -4,4 +4,7 @@
 url <- "https://github.com/TileDB-Inc/TileDB/archive/2.1.0.tar.gz"
 
 cat("Downloading ", url, "\n")
+op <- options()
+options(timeout=60)
 download.file(url, "tiledb.tar.gz", quiet=TRUE)
+options(op)

--- a/tools/winlibs.R
+++ b/tools/winlibs.R
@@ -2,7 +2,10 @@
 VERSION <- commandArgs(TRUE)
 if (!file.exists(sprintf("../windows/tiledb-%s/include/tiledb/tiledb.h", VERSION))) {
   if (getRversion() < "4") stop("This package requires Rtools40 or newer")
+  op <- options()
+  options(timeout=60)
   download.file(sprintf("https://github.com/rwinlib/tiledb/archive/v%s.zip", VERSION), "lib.zip", quiet = TRUE)
+  options(op)
   dir.create("../windows", showWarnings = FALSE)
   unzip("lib.zip", exdir = "../windows")
   unlink("lib.zip")


### PR DESCRIPTION
CRAN mentioned in an email that they see occasional failed downloads of our library from github---but also that they use a lowered download timeout of 10s.  So they recommended we set one explicitly. This PR (re-)sets the default value of 60 seconds in the three spots where we call `download.file()` for this build.