### PR TITLE
Update to TileDB 2.1.1

### DIFF
--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,5 +1,5 @@
 CXX_STD = CXX11
-VERSION = 2.1.0
+VERSION = 2.1.1
 RWINLIB=../windows/tiledb-$(VERSION)
 
 PKG_CPPFLAGS = -I../inst/include -I$(RWINLIB)/include -DTILEDB_STATIC_DEFINE

--- a/tools/fetchTileDBLib.R
+++ b/tools/fetchTileDBLib.R
@@ -25,6 +25,14 @@ dlurl <- switch(osarg,
                 macos = file.path(baseurl,sprintf("%s/tiledb-macos-%s-%s-full.tar.gz", ver, ver, sha)),
                 url = urlarg)
 
+ver <- "2.1"
+sha <- "9161cf2"
+baseurl <- "http://dirk.eddelbuettel.com/tmp/tiledb/"
+dlurl <- switch(osarg,
+                linux = file.path(baseurl,sprintf("tiledb-linux.tar.gz", ver, ver, sha)),
+                macos = file.path(baseurl,sprintf("tiledb-macos.tar.gz", ver, ver, sha)),
+                url = urlarg)
+
 cat("downloading", dlurl, "\n")
 op <- options()
 options(timeout=60)

--- a/tools/fetchTileDBLib.R
+++ b/tools/fetchTileDBLib.R
@@ -17,22 +17,13 @@ if (osarg == "url" && length(argv) <= 1) {
 }
 urlarg <- argv[2]
 
-ver <- "2.1.0"
-sha <- "1073faa"
+ver <- "2.1.1"
+sha <- "db11399"
 baseurl <- "https://github.com/TileDB-Inc/TileDB/releases/download"
 dlurl <- switch(osarg,
                 linux = file.path(baseurl,sprintf("%s/tiledb-linux-%s-%s-full.tar.gz", ver, ver, sha)),
                 macos = file.path(baseurl,sprintf("%s/tiledb-macos-%s-%s-full.tar.gz", ver, ver, sha)),
                 url = urlarg)
-
-ver <- "2.1"
-sha <- "9161cf2"
-baseurl <- "http://dirk.eddelbuettel.com/tmp/tiledb/"
-dlurl <- switch(osarg,
-                linux = file.path(baseurl,sprintf("tiledb-linux.tar.gz", ver, ver, sha)),
-                macos = file.path(baseurl,sprintf("tiledb-macos.tar.gz", ver, ver, sha)),
-                url = urlarg)
-
 cat("downloading", dlurl, "\n")
 op <- options()
 options(timeout=60)

--- a/tools/fetchTileDBSrc.R
+++ b/tools/fetchTileDBSrc.R
@@ -1,7 +1,7 @@
 #!/usr/bin/Rscript
 
 ## by default we download the source from a given release
-url <- "https://github.com/TileDB-Inc/TileDB/archive/2.1.0.tar.gz"
+url <- "https://github.com/TileDB-Inc/TileDB/archive/2.1.1.tar.gz"
 
 cat("Downloading ", url, "\n")
 op <- options()


### PR DESCRIPTION
This PR updates the package from using 2.1.0 artifacts to using 2.1.1; this has now been tested on three platforms.

As Windows libraries require an initial external step (of a PR and build [to this repo here](https://github.com/r-windows/rtools-packages/pull/161)) its build failed initially but now completes as can be seen in the GitHub Action of the underlying commit which has been re-run.