### PR TITLE
Release 0.8.2

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tiledb
 Type: Package
-Version: 0.8.1
+Version: 0.8.2
 Title: Sparse and Dense Multidimensional Array Storage Engine for Data Science
 Author: TileDB, Inc.
 Copyright: TileDB, Inc.

--- a/docs/404.html
+++ b/docs/404.html
@@ -71,7 +71,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/LICENSE-text.html
+++ b/docs/LICENSE-text.html
@@ -71,7 +71,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/articles/index.html
+++ b/docs/articles/index.html
@@ -71,7 +71,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/articles/introduction.html
+++ b/docs/articles/introduction.html
@@ -31,7 +31,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 
@@ -285,7 +285,7 @@ R&gt; A[as.POSIXct("2020-01-01 00:01:00"):as.POSIXct("2020-01-01 00:03:00")]
 <h1 class="hasAnchor">
 <a href="#additional-information" class="anchor"></a>Additional Information</h1>
 <p>The TileDB R package is documented via R help functions (<em>e.g.</em> <code><a href="../reference/tiledb_sparse.html">help("tiledb_sparse")</a></code> shows information for the <code><a href="../reference/tiledb_sparse.html">tiledb_sparse()</a></code> function) as well as via a <a href="https://tiledb-inc.github.io/TileDB-R/">website regrouping all documentation</a>. An extended <a href="https://tiledb-inc.github.io/TileDB-R/documentation.nb.html">notebook</a> is available, as are a numb <a href="https://github.com/TileDB-Inc/TileDB-R/tree/master/inst/examples">examples/</a> directory.</p>
-<p>TileDB itself has extensive <a href="https://docs.tiledb.com/developer/installation">installation</a>, <a href="https://docs.tiledb.com/developer/quickstart">quickstart</a>, and <a href="https://docs.tiledb.com/developer/">overall documentation</a> as well as a <a href="https://forum.tiledb.com/">support forum</a>.</p>
+<p>TileDB itself has extensive <a href="https://docs.tiledb.com/developer/installation">installation</a>, and <a href="https://docs.tiledb.com/developer/">overall documentation</a> as well as a <a href="https://forum.tiledb.com/">support forum</a>.</p>
 </div>
   </div>
 

--- a/docs/authors.html
+++ b/docs/authors.html
@@ -71,7 +71,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -39,7 +39,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/pkgdown.yml
+++ b/docs/pkgdown.yml
@@ -3,5 +3,5 @@ pkgdown: 1.6.1
 pkgdown_sha: ~
 articles:
   introduction: introduction.html
-last_built: 2020-10-07T00:29Z
+last_built: 2020-10-16T13:15Z
 

--- a/docs/reference/allows_dups-set-tiledb_array_schema-method.html
+++ b/docs/reference/allows_dups-set-tiledb_array_schema-method.html
@@ -75,7 +75,7 @@ This is only valid for sparse arrays." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/allows_dups-tiledb_array_schema-method.html
+++ b/docs/reference/allows_dups-tiledb_array_schema-method.html
@@ -75,7 +75,7 @@ This is only valid for sparse arrays." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/as.data.frame.tiledb_config.html
+++ b/docs/reference/as.data.frame.tiledb_config.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/as.vector.tiledb_config.html
+++ b/docs/reference/as.vector.tiledb_config.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/as_data_frame.html
+++ b/docs/reference/as_data_frame.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/attrs-set-tiledb_array-method.html
+++ b/docs/reference/attrs-set-tiledb_array-method.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/attrs-set-tiledb_dense-method.html
+++ b/docs/reference/attrs-set-tiledb_dense-method.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/attrs-set-tiledb_sparse-method.html
+++ b/docs/reference/attrs-set-tiledb_sparse-method.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/attrs-tiledb_array-ANY-method.html
+++ b/docs/reference/attrs-tiledb_array-ANY-method.html
@@ -74,7 +74,7 @@ will be queried.  This methods accesses the slot." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/attrs-tiledb_array_schema-ANY-method.html
+++ b/docs/reference/attrs-tiledb_array_schema-ANY-method.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/attrs-tiledb_array_schema-character-method.html
+++ b/docs/reference/attrs-tiledb_array_schema-character-method.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/attrs-tiledb_array_schema-numeric-method.html
+++ b/docs/reference/attrs-tiledb_array_schema-numeric-method.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/attrs-tiledb_dense-ANY-method.html
+++ b/docs/reference/attrs-tiledb_dense-ANY-method.html
@@ -74,7 +74,7 @@ will be queried.  This methods accesses the slot." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/attrs-tiledb_sparse-ANY-method.html
+++ b/docs/reference/attrs-tiledb_sparse-ANY-method.html
@@ -74,7 +74,7 @@ will be queried.  This methods accesses the slot." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/cell_order-tiledb_array_schema-method.html
+++ b/docs/reference/cell_order-tiledb_array_schema-method.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/cell_val_num-tiledb_attr-method.html
+++ b/docs/reference/cell_val_num-tiledb_attr-method.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/config-tiledb_ctx-method.html
+++ b/docs/reference/config-tiledb_ctx-method.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/datatype-tiledb_attr-method.html
+++ b/docs/reference/datatype-tiledb_attr-method.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/datatype-tiledb_dim-method.html
+++ b/docs/reference/datatype-tiledb_dim-method.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/datatype-tiledb_domain-method.html
+++ b/docs/reference/datatype-tiledb_domain-method.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/dim.tiledb_array_schema.html
+++ b/docs/reference/dim.tiledb_array_schema.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/dim.tiledb_dim.html
+++ b/docs/reference/dim.tiledb_dim.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/dim.tiledb_domain.html
+++ b/docs/reference/dim.tiledb_domain.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/dimensions-tiledb_array_schema-method.html
+++ b/docs/reference/dimensions-tiledb_array_schema-method.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 
@@ -154,13 +154,13 @@
 </div><div class='output co'>#&gt; [[1]]
 #&gt; An object of class "tiledb_dim"
 #&gt; Slot "ptr":
-#&gt; &lt;pointer: 0x55fa57448f90&gt;
+#&gt; &lt;pointer: 0x560bcf370f00&gt;
 #&gt; 
 #&gt; 
 #&gt; [[2]]
 #&gt; An object of class "tiledb_dim"
 #&gt; Slot "ptr":
-#&gt; &lt;pointer: 0x55fa57448fc0&gt;
+#&gt; &lt;pointer: 0x560bcf371210&gt;
 #&gt; 
 #&gt; </div><div class='input'>
 <span class='fu'><a href='https://rdrr.io/r/base/lapply.html'>lapply</a></span><span class='op'>(</span><span class='fu'><a href='domain.html'>dimensions</a></span><span class='op'>(</span><span class='va'>dom</span><span class='op'>)</span>, <span class='va'>name</span><span class='op'>)</span>

--- a/docs/reference/dimensions-tiledb_domain-method.html
+++ b/docs/reference/dimensions-tiledb_domain-method.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 
@@ -153,13 +153,13 @@
 </div><div class='output co'>#&gt; [[1]]
 #&gt; An object of class "tiledb_dim"
 #&gt; Slot "ptr":
-#&gt; &lt;pointer: 0x55fa4f7b5c50&gt;
+#&gt; &lt;pointer: 0x560bcf25ae80&gt;
 #&gt; 
 #&gt; 
 #&gt; [[2]]
 #&gt; An object of class "tiledb_dim"
 #&gt; Slot "ptr":
-#&gt; &lt;pointer: 0x55fa54b87090&gt;
+#&gt; &lt;pointer: 0x560bced858d0&gt;
 #&gt; 
 #&gt; </div><div class='input'>
 <span class='fu'><a href='https://rdrr.io/r/base/lapply.html'>lapply</a></span><span class='op'>(</span><span class='fu'><a href='domain.html'>dimensions</a></span><span class='op'>(</span><span class='va'>dom</span><span class='op'>)</span>, <span class='va'>name</span><span class='op'>)</span>

--- a/docs/reference/domain-tiledb_array_schema-method.html
+++ b/docs/reference/domain-tiledb_array_schema-method.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/domain-tiledb_dim-method.html
+++ b/docs/reference/domain-tiledb_dim-method.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/extended-set-tiledb_array-method.html
+++ b/docs/reference/extended-set-tiledb_array-method.html
@@ -74,7 +74,7 @@ if present) indices." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/extended-tiledb_array-method.html
+++ b/docs/reference/extended-tiledb_array-method.html
@@ -74,7 +74,7 @@ if present) indices." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/filter_list-tiledb_array_schema-method.html
+++ b/docs/reference/filter_list-tiledb_array_schema-method.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/filter_list-tiledb_attr-method.html
+++ b/docs/reference/filter_list-tiledb_attr-method.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 
@@ -151,7 +151,7 @@
 <span class='fu'><a href='domain.html'>filter_list</a></span><span class='op'>(</span><span class='va'>attr</span><span class='op'>)</span>
 </div><div class='output co'>#&gt; An object of class "tiledb_filter_list"
 #&gt; Slot "ptr":
-#&gt; &lt;pointer: 0x55fa558965f0&gt;
+#&gt; &lt;pointer: 0x560bcc4179e0&gt;
 #&gt; </div><div class='input'>
 </div></pre>
   </div>

--- a/docs/reference/fromDataFrame.html
+++ b/docs/reference/fromDataFrame.html
@@ -73,7 +73,7 @@ numeric, or character columns." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/generics.html
+++ b/docs/reference/generics.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/index.html
+++ b/docs/reference/index.html
@@ -71,7 +71,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 
@@ -1398,7 +1398,7 @@ This is only valid for sparse arrays.</p></td>
       </tr><tr>
         
         <td>
-          <p><code><a href="tiledb_stats_dump.html">tiledb_stats_dump()</a></code> </p>
+          <p><code><a href="tiledb_stats_dump.html">tiledb_stats_dump()</a></code> <code><a href="tiledb_stats_dump.html">tiledb_stats_print()</a></code> </p>
         </td>
         <td><p>Dump stats to file</p></td>
       </tr><tr>
@@ -1407,6 +1407,12 @@ This is only valid for sparse arrays.</p></td>
           <p><code><a href="tiledb_stats_enable.html">tiledb_stats_enable()</a></code> </p>
         </td>
         <td><p>Enable stats counters</p></td>
+      </tr><tr>
+        
+        <td>
+          <p><code><a href="tiledb_stats_reset.html">tiledb_stats_reset()</a></code> </p>
+        </td>
+        <td><p>Reset stats counters</p></td>
       </tr>
     </tbody><tbody>
       <tr>

--- a/docs/reference/is.anonymous.html
+++ b/docs/reference/is.anonymous.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/is.anonymous.tiledb_dim.html
+++ b/docs/reference/is.anonymous.tiledb_dim.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/is.integral-tiledb_domain-method.html
+++ b/docs/reference/is.integral-tiledb_domain-method.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/is.sparse-tiledb_array_schema-method.html
+++ b/docs/reference/is.sparse-tiledb_array_schema-method.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/is.sparse-tiledb_dense-method.html
+++ b/docs/reference/is.sparse-tiledb_dense-method.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/is.sparse-tiledb_sparse-method.html
+++ b/docs/reference/is.sparse-tiledb_sparse-method.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/limitTileDBCores.html
+++ b/docs/reference/limitTileDBCores.html
@@ -75,7 +75,7 @@ take a given number, or default to smaller of the &amp;#8216;Ncpus&amp;#8217; op
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 
@@ -155,8 +155,13 @@ user about the value set.</p></td>
 
     <h2 class="hasAnchor" id="value"><a class="anchor" href="#value"></a>Value</h2>
 
-    <p>The modified configuration object is returned invisibly. As a side-effect the
-updated config is also used to set the global context object.</p>
+    <p>The modified configuration object is returned invisibly.</p>
+    <h2 class="hasAnchor" id="details"><a class="anchor" href="#details"></a>Details</h2>
+
+    <p>As this function returns a config object, its intended use is as argument to the context
+creating functions: <code>ctx &lt;- tiledb_ctx(limitTileDBCores())</code>. To check that the values
+are set (or at a later point, still set) the config object should be retrieved via the
+corresponding method and this <code>ctx</code> object: <code>cfg &lt;- config(ctx)</code>.</p>
 
   </div>
   <div class="col-md-3 hidden-xs hidden-sm" id="pkgdown-sidebar">

--- a/docs/reference/max_chunk_size-tiledb_filter_list-method.html
+++ b/docs/reference/max_chunk_size-tiledb_filter_list-method.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/name-tiledb_attr-method.html
+++ b/docs/reference/name-tiledb_attr-method.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/name-tiledb_dim-method.html
+++ b/docs/reference/name-tiledb_dim-method.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/nfilters-tiledb_filter_list-method.html
+++ b/docs/reference/nfilters-tiledb_filter_list-method.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/print.tiledb_metadata.html
+++ b/docs/reference/print.tiledb_metadata.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/r_to_tiledb_type.html
+++ b/docs/reference/r_to_tiledb_type.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/return.data.frame-set-tiledb_array-method.html
+++ b/docs/reference/return.data.frame-set-tiledb_array-method.html
@@ -73,7 +73,7 @@ or, if select, as a data.frame. This methods sets the selection value." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/return.data.frame-set-tiledb_dense-method.html
+++ b/docs/reference/return.data.frame-set-tiledb_dense-method.html
@@ -73,7 +73,7 @@ or, if select, as a data.frame. This methods sets the selection value." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/return.data.frame-set-tiledb_sparse-method.html
+++ b/docs/reference/return.data.frame-set-tiledb_sparse-method.html
@@ -73,7 +73,7 @@ or, if select, as a data.frame. This methods sets the selection value." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/return.data.frame-tiledb_array-method.html
+++ b/docs/reference/return.data.frame-tiledb_array-method.html
@@ -73,7 +73,7 @@ or, if select, as a data.frame. This methods returns the selection value." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/return.data.frame-tiledb_dense-method.html
+++ b/docs/reference/return.data.frame-tiledb_dense-method.html
@@ -73,7 +73,7 @@ or, if select, as a data.frame. This methods returns the selection value." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/return.data.frame-tiledb_sparse-method.html
+++ b/docs/reference/return.data.frame-tiledb_sparse-method.html
@@ -73,7 +73,7 @@ or, if select, as a data.frame. This methods returns the selection value." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/schema-tiledb_array-method.html
+++ b/docs/reference/schema-tiledb_array-method.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/schema-tiledb_dense-method.html
+++ b/docs/reference/schema-tiledb_dense-method.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/schema-tiledb_sparse-method.html
+++ b/docs/reference/schema-tiledb_sparse-method.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/selected_ranges-set-tiledb_array-method.html
+++ b/docs/reference/selected_ranges-set-tiledb_array-method.html
@@ -75,7 +75,7 @@ each row describes one pair of minimum and maximum values." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/selected_ranges-tiledb_array-method.html
+++ b/docs/reference/selected_ranges-tiledb_array-method.html
@@ -75,7 +75,7 @@ each row describes one pair of minimum and maximum values." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/set_max_chunk_size-tiledb_filter_list-numeric-method.html
+++ b/docs/reference/set_max_chunk_size-tiledb_filter_list-numeric-method.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/show-tiledb_array-method.html
+++ b/docs/reference/show-tiledb_array-method.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/show-tiledb_array_schema-method.html
+++ b/docs/reference/show-tiledb_array_schema-method.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/show-tiledb_attr-method.html
+++ b/docs/reference/show-tiledb_attr-method.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/show-tiledb_config-method.html
+++ b/docs/reference/show-tiledb_config-method.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/show-tiledb_dense-method.html
+++ b/docs/reference/show-tiledb_dense-method.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/show-tiledb_domain-method.html
+++ b/docs/reference/show-tiledb_domain-method.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/show-tiledb_sparse-method.html
+++ b/docs/reference/show-tiledb_sparse-method.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/sub-tiledb_array-ANY-method.html
+++ b/docs/reference/sub-tiledb_array-ANY-method.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/sub-tiledb_config-ANY-method.html
+++ b/docs/reference/sub-tiledb_config-ANY-method.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/sub-tiledb_dense-ANY-method.html
+++ b/docs/reference/sub-tiledb_dense-ANY-method.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/sub-tiledb_filter_list-ANY-method.html
+++ b/docs/reference/sub-tiledb_filter_list-ANY-method.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 
@@ -169,7 +169,7 @@
 <span class='va'>filter_list</span><span class='op'>[</span><span class='fl'>0</span><span class='op'>]</span>
 </div><div class='output co'>#&gt; An object of class "tiledb_filter"
 #&gt; Slot "ptr":
-#&gt; &lt;pointer: 0x55fa56ed02b0&gt;
+#&gt; &lt;pointer: 0x560bcf346f70&gt;
 #&gt; </div><div class='input'>
 </div></pre>
   </div>

--- a/docs/reference/sub-tiledb_sparse-ANY-method.html
+++ b/docs/reference/sub-tiledb_sparse-ANY-method.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/subset-tiledb_array-ANY-ANY-ANY-method.html
+++ b/docs/reference/subset-tiledb_array-ANY-ANY-ANY-method.html
@@ -73,7 +73,7 @@ something that can be coerced to a data.frame, to a tiledb array." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/subset-tiledb_config-ANY-ANY-ANY-method.html
+++ b/docs/reference/subset-tiledb_config-ANY-ANY-ANY-method.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/subset-tiledb_dense-ANY-ANY-ANY-method.html
+++ b/docs/reference/subset-tiledb_dense-ANY-ANY-ANY-method.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/subset-tiledb_sparse-ANY-ANY-ANY-method.html
+++ b/docs/reference/subset-tiledb_sparse-ANY-ANY-ANY-method.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/tile-tiledb_dim-method.html
+++ b/docs/reference/tile-tiledb_dim-method.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/tile_order-tiledb_array_schema-method.html
+++ b/docs/reference/tile_order-tiledb_array_schema-method.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/tiledb-package.html
+++ b/docs/reference/tiledb-package.html
@@ -75,7 +75,7 @@ system which also scales well, and bindings to multiple languages." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/tiledb_array-class.html
+++ b/docs/reference/tiledb_array-class.html
@@ -74,7 +74,7 @@ based on refactored implementation utilising newer TileDB features." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/tiledb_array.html
+++ b/docs/reference/tiledb_array.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/tiledb_array_close.html
+++ b/docs/reference/tiledb_array_close.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/tiledb_array_create.html
+++ b/docs/reference/tiledb_array_create.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/tiledb_array_is_heterogeneous.html
+++ b/docs/reference/tiledb_array_is_heterogeneous.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/tiledb_array_is_homogeneous.html
+++ b/docs/reference/tiledb_array_is_homogeneous.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/tiledb_array_open.html
+++ b/docs/reference/tiledb_array_open.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/tiledb_array_schema-class.html
+++ b/docs/reference/tiledb_array_schema-class.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/tiledb_array_schema.html
+++ b/docs/reference/tiledb_array_schema.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/tiledb_attr-class.html
+++ b/docs/reference/tiledb_attr-class.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/tiledb_attr.html
+++ b/docs/reference/tiledb_attr.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/tiledb_config-class.html
+++ b/docs/reference/tiledb_config-class.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/tiledb_config.html
+++ b/docs/reference/tiledb_config.html
@@ -40,7 +40,12 @@
 
 
 <meta property="og:title" content="Creates a tiledb_config object — tiledb_config" />
-<meta property="og:description" content="Creates a tiledb_config object" />
+<meta property="og:description" content="Note that for actually setting persistent values, the (altered) config
+object needs to used to create (or update) the tiledb_ctx object. Similarly,
+to check whether values are set, one should use the config method
+of the of the tiledb_ctx object. Examples for this are
+ctx &amp;lt;- tiledb_ctx(limitTileDBCores()) to use updated configuration values to
+create a context object, and cfg &amp;lt;- config(ctx) to retrieve it." />
 
 
 
@@ -72,7 +77,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 
@@ -126,7 +131,12 @@
     </div>
 
     <div class="ref-description">
-    <p>Creates a <code>tiledb_config</code> object</p>
+    <p>Note that for actually setting persistent values, the (altered) config
+object needs to used to create (or update) the <code>tiledb_ctx</code> object. Similarly,
+to check whether values are set, one should use the <code>config</code> method
+of the of the <code>tiledb_ctx</code> object. Examples for this are
+<code>ctx &lt;- tiledb_ctx(limitTileDBCores())</code> to use updated configuration values to
+create a context object, and <code>cfg &lt;- config(ctx)</code> to retrieve it.</p>
     </div>
 
     <pre class="usage"><span class='fu'>tiledb_config</span><span class='op'>(</span>config <span class='op'>=</span> <span class='cn'>NA_character_</span><span class='op'>)</span></pre>

--- a/docs/reference/tiledb_config_load.html
+++ b/docs/reference/tiledb_config_load.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/tiledb_config_save.html
+++ b/docs/reference/tiledb_config_save.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/tiledb_ctx-class.html
+++ b/docs/reference/tiledb_ctx-class.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/tiledb_ctx.html
+++ b/docs/reference/tiledb_ctx.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/tiledb_ctx_set_default_tags.html
+++ b/docs/reference/tiledb_ctx_set_default_tags.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/tiledb_ctx_set_tag.html
+++ b/docs/reference/tiledb_ctx_set_tag.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/tiledb_delete_metadata.html
+++ b/docs/reference/tiledb_delete_metadata.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/tiledb_dense-class.html
+++ b/docs/reference/tiledb_dense-class.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/tiledb_dense.html
+++ b/docs/reference/tiledb_dense.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/tiledb_dim-class.html
+++ b/docs/reference/tiledb_dim-class.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/tiledb_dim.html
+++ b/docs/reference/tiledb_dim.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 
@@ -169,7 +169,7 @@ type <code>integer</code> or <code>double</code> (i.e. <code>numeric</code>). Fo
 <span class='fu'>tiledb_dim</span><span class='op'>(</span>name <span class='op'>=</span> <span class='st'>"d1"</span>, domain <span class='op'>=</span> <span class='fu'><a href='https://rdrr.io/r/base/c.html'>c</a></span><span class='op'>(</span><span class='fl'>1L</span>, <span class='fl'>10L</span><span class='op'>)</span>, tile <span class='op'>=</span> <span class='fl'>5L</span>, type <span class='op'>=</span> <span class='st'>"INT32"</span><span class='op'>)</span>
 </div><div class='output co'>#&gt; An object of class "tiledb_dim"
 #&gt; Slot "ptr":
-#&gt; &lt;pointer: 0x55fa54dd5020&gt;
+#&gt; &lt;pointer: 0x560bce090220&gt;
 #&gt; </div><div class='input'>
 </div></pre>
   </div>

--- a/docs/reference/tiledb_domain-class.html
+++ b/docs/reference/tiledb_domain-class.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/tiledb_domain.html
+++ b/docs/reference/tiledb_domain.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/tiledb_filter-class.html
+++ b/docs/reference/tiledb_filter-class.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/tiledb_filter.html
+++ b/docs/reference/tiledb_filter.html
@@ -85,7 +85,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 
@@ -183,7 +183,7 @@ consult the TileDB docs for more information.</p>
 <span class='fu'>tiledb_filter</span><span class='op'>(</span><span class='st'>"ZSTD"</span><span class='op'>)</span>
 </div><div class='output co'>#&gt; An object of class "tiledb_filter"
 #&gt; Slot "ptr":
-#&gt; &lt;pointer: 0x55fa524dcf30&gt;
+#&gt; &lt;pointer: 0x560bccb69510&gt;
 #&gt; </div><div class='input'>
 </div></pre>
   </div>

--- a/docs/reference/tiledb_filter_get_option.html
+++ b/docs/reference/tiledb_filter_get_option.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/tiledb_filter_list-class.html
+++ b/docs/reference/tiledb_filter_list-class.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/tiledb_filter_list.html
+++ b/docs/reference/tiledb_filter_list.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 
@@ -156,7 +156,7 @@
 <span class='va'>filter_list</span>
 </div><div class='output co'>#&gt; An object of class "tiledb_filter_list"
 #&gt; Slot "ptr":
-#&gt; &lt;pointer: 0x55fa575f2130&gt;
+#&gt; &lt;pointer: 0x560bcf26a9b0&gt;
 #&gt; </div><div class='input'>
 </div></pre>
   </div>

--- a/docs/reference/tiledb_filter_set_option.html
+++ b/docs/reference/tiledb_filter_set_option.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/tiledb_filter_type.html
+++ b/docs/reference/tiledb_filter_type.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/tiledb_get_all_metadata.html
+++ b/docs/reference/tiledb_get_all_metadata.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/tiledb_get_context.html
+++ b/docs/reference/tiledb_get_context.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/tiledb_get_metadata.html
+++ b/docs/reference/tiledb_get_metadata.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/tiledb_group_create.html
+++ b/docs/reference/tiledb_group_create.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/tiledb_has_metadata.html
+++ b/docs/reference/tiledb_has_metadata.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/tiledb_is_supported_fs.html
+++ b/docs/reference/tiledb_is_supported_fs.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/tiledb_ndim-tiledb_array_schema-method.html
+++ b/docs/reference/tiledb_ndim-tiledb_array_schema-method.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/tiledb_ndim-tiledb_dim-method.html
+++ b/docs/reference/tiledb_ndim-tiledb_dim-method.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/tiledb_ndim-tiledb_domain-method.html
+++ b/docs/reference/tiledb_ndim-tiledb_domain-method.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/tiledb_num_metadata.html
+++ b/docs/reference/tiledb_num_metadata.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/tiledb_object_ls.html
+++ b/docs/reference/tiledb_object_ls.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/tiledb_object_mv.html
+++ b/docs/reference/tiledb_object_mv.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/tiledb_object_rm.html
+++ b/docs/reference/tiledb_object_rm.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/tiledb_object_type.html
+++ b/docs/reference/tiledb_object_type.html
@@ -77,7 +77,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/tiledb_object_walk.html
+++ b/docs/reference/tiledb_object_walk.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/tiledb_put_metadata.html
+++ b/docs/reference/tiledb_put_metadata.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/tiledb_query-class.html
+++ b/docs/reference/tiledb_query-class.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/tiledb_query.html
+++ b/docs/reference/tiledb_query.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/tiledb_query_add_range.html
+++ b/docs/reference/tiledb_query_add_range.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/tiledb_query_add_range_with_type.html
+++ b/docs/reference/tiledb_query_add_range_with_type.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/tiledb_query_alloc_buffer_ptr_char.html
+++ b/docs/reference/tiledb_query_alloc_buffer_ptr_char.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/tiledb_query_alloc_buffer_ptr_char_subarray.html
+++ b/docs/reference/tiledb_query_alloc_buffer_ptr_char_subarray.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/tiledb_query_buffer_alloc_ptr.html
+++ b/docs/reference/tiledb_query_buffer_alloc_ptr.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/tiledb_query_create_buffer_ptr.html
+++ b/docs/reference/tiledb_query_create_buffer_ptr.html
@@ -73,7 +73,7 @@ type and assigns the object content to the buffer." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/tiledb_query_create_buffer_ptr_char.html
+++ b/docs/reference/tiledb_query_create_buffer_ptr_char.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/tiledb_query_finalize.html
+++ b/docs/reference/tiledb_query_finalize.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/tiledb_query_get_buffer_char.html
+++ b/docs/reference/tiledb_query_get_buffer_char.html
@@ -73,7 +73,7 @@ or dimension and returns its content." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/tiledb_query_get_buffer_ptr.html
+++ b/docs/reference/tiledb_query_get_buffer_ptr.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/tiledb_query_get_layout.html
+++ b/docs/reference/tiledb_query_get_layout.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/tiledb_query_result_buffer_elements.html
+++ b/docs/reference/tiledb_query_result_buffer_elements.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/tiledb_query_set_buffer.html
+++ b/docs/reference/tiledb_query_set_buffer.html
@@ -74,7 +74,7 @@ general types see tiledb_query_buffer_alloc_ptr." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/tiledb_query_set_buffer_ptr.html
+++ b/docs/reference/tiledb_query_set_buffer_ptr.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/tiledb_query_set_buffer_ptr_char.html
+++ b/docs/reference/tiledb_query_set_buffer_ptr_char.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/tiledb_query_set_layout.html
+++ b/docs/reference/tiledb_query_set_layout.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/tiledb_query_set_subarray.html
+++ b/docs/reference/tiledb_query_set_subarray.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/tiledb_query_status.html
+++ b/docs/reference/tiledb_query_status.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/tiledb_query_submit.html
+++ b/docs/reference/tiledb_query_submit.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/tiledb_query_type.html
+++ b/docs/reference/tiledb_query_type.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/tiledb_schema_get_names.html
+++ b/docs/reference/tiledb_schema_get_names.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/tiledb_schema_get_types.html
+++ b/docs/reference/tiledb_schema_get_types.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/tiledb_set_context.html
+++ b/docs/reference/tiledb_set_context.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/tiledb_sparse-class.html
+++ b/docs/reference/tiledb_sparse-class.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/tiledb_stats_disable.html
+++ b/docs/reference/tiledb_stats_disable.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/tiledb_stats_dump.html
+++ b/docs/reference/tiledb_stats_dump.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 
@@ -129,7 +129,9 @@
     <p>Dump stats to file</p>
     </div>
 
-    <pre class="usage"><span class='fu'>tiledb_stats_dump</span><span class='op'>(</span><span class='va'>path</span><span class='op'>)</span></pre>
+    <pre class="usage"><span class='fu'>tiledb_stats_dump</span><span class='op'>(</span><span class='va'>path</span><span class='op'>)</span>
+
+<span class='fu'>tiledb_stats_print</span><span class='op'>(</span><span class='op'>)</span></pre>
 
     <h2 class="hasAnchor" id="arguments"><a class="anchor" href="#arguments"></a>Arguments</h2>
     <table class="ref-arguments">

--- a/docs/reference/tiledb_stats_enable.html
+++ b/docs/reference/tiledb_stats_enable.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/tiledb_stats_reset.html
+++ b/docs/reference/tiledb_stats_reset.html
@@ -6,7 +6,7 @@
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-<title>Constructs a tiledb_sparse object backed by a persisted tiledb array uri — tiledb_sparse • tiledb</title>
+<title>Reset stats counters — tiledb_stats_reset • tiledb</title>
 
 
 <!-- jquery -->
@@ -39,8 +39,8 @@
 
 
 
-<meta property="og:title" content="Constructs a tiledb_sparse object backed by a persisted tiledb array uri — tiledb_sparse" />
-<meta property="og:description" content="tiledb_sparse returns a list of coordinates and attributes vectors for reads" />
+<meta property="og:title" content="Reset stats counters — tiledb_stats_reset" />
+<meta property="og:description" content="Reset stats counters" />
 
 
 
@@ -120,58 +120,18 @@
 <div class="row">
   <div class="col-md-9 contents">
     <div class="page-header">
-    <h1>Constructs a tiledb_sparse object backed by a persisted tiledb array uri</h1>
-    <small class="dont-index">Source: <a href='https://github.com/TileDB-Inc/TileDB-R/blob/master/R/SparseArray.R'><code>R/SparseArray.R</code></a></small>
-    <div class="hidden name"><code>tiledb_sparse.Rd</code></div>
+    <h1>Reset stats counters</h1>
+    <small class="dont-index">Source: <a href='https://github.com/TileDB-Inc/TileDB-R/blob/master/R/Stats.R'><code>R/Stats.R</code></a></small>
+    <div class="hidden name"><code>tiledb_stats_reset.Rd</code></div>
     </div>
 
     <div class="ref-description">
-    <p>tiledb_sparse returns a list of coordinates and attributes vectors for reads</p>
+    <p>Reset stats counters</p>
     </div>
 
-    <pre class="usage"><span class='fu'>tiledb_sparse</span><span class='op'>(</span>
-  <span class='va'>uri</span>,
-  query_type <span class='op'>=</span> <span class='fu'><a href='https://rdrr.io/r/base/c.html'>c</a></span><span class='op'>(</span><span class='st'>"READ"</span>, <span class='st'>"WRITE"</span><span class='op'>)</span>,
-  as.data.frame <span class='op'>=</span> <span class='cn'>FALSE</span>,
-  attrs <span class='op'>=</span> <span class='fu'><a href='https://rdrr.io/r/base/character.html'>character</a></span><span class='op'>(</span><span class='op'>)</span>,
-  extended <span class='op'>=</span> <span class='cn'>TRUE</span>,
-  ctx <span class='op'>=</span> <span class='fu'><a href='tiledb_get_context.html'>tiledb_get_context</a></span><span class='op'>(</span><span class='op'>)</span>
-<span class='op'>)</span></pre>
+    <pre class="usage"><span class='fu'>tiledb_stats_reset</span><span class='op'>(</span><span class='op'>)</span></pre>
 
-    <h2 class="hasAnchor" id="arguments"><a class="anchor" href="#arguments"></a>Arguments</h2>
-    <table class="ref-arguments">
-    <colgroup><col class="name" /><col class="desc" /></colgroup>
-    <tr>
-      <th>uri</th>
-      <td><p>uri path to the tiledb dense array</p></td>
-    </tr>
-    <tr>
-      <th>query_type</th>
-      <td><p>optionally loads the array in "READ" or "WRITE" only modes.</p></td>
-    </tr>
-    <tr>
-      <th>as.data.frame</th>
-      <td><p>optional logical switch, defaults to "FALSE"</p></td>
-    </tr>
-    <tr>
-      <th>attrs</th>
-      <td><p>optional character vector to select attributes, default is
-empty implying all are selected</p></td>
-    </tr>
-    <tr>
-      <th>extended</th>
-      <td><p>optional logical switch selecting wide &#8216;data.frame&#8217;
-format, defaults to "TRUE"</p></td>
-    </tr>
-    <tr>
-      <th>ctx</th>
-      <td><p>tiledb_ctx (optional)</p></td>
-    </tr>
-    </table>
 
-    <h2 class="hasAnchor" id="value"><a class="anchor" href="#value"></a>Value</h2>
-
-    <p>tiledb_sparse array object</p>
 
   </div>
   <div class="col-md-3 hidden-xs hidden-sm" id="pkgdown-sidebar">

--- a/docs/reference/tiledb_subarray.html
+++ b/docs/reference/tiledb_subarray.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/tiledb_version.html
+++ b/docs/reference/tiledb_version.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 
@@ -150,8 +150,8 @@ a <code>package_version</code> object</p>
     <pre class="examples"><div class='input'><span class='va'>ctx</span> <span class='op'>&lt;-</span> <span class='fu'><a href='tiledb_ctx.html'>tiledb_ctx</a></span><span class='op'>(</span><span class='fu'><a href='limitTileDBCores.html'>limitTileDBCores</a></span><span class='op'>(</span><span class='op'>)</span><span class='op'>)</span>
 <span class='fu'>tiledb_version</span><span class='op'>(</span><span class='op'>)</span>
 </div><div class='output co'>#&gt; major minor patch 
-#&gt;     2     1     0 </div><div class='input'><span class='fu'>tiledb_version</span><span class='op'>(</span>compact <span class='op'>=</span> <span class='cn'>TRUE</span><span class='op'>)</span>
-</div><div class='output co'>#&gt; [1] ‘2.1.0’</div></pre>
+#&gt;     2     2     0 </div><div class='input'><span class='fu'>tiledb_version</span><span class='op'>(</span>compact <span class='op'>=</span> <span class='cn'>TRUE</span><span class='op'>)</span>
+</div><div class='output co'>#&gt; [1] ‘2.2.0’</div></pre>
   </div>
   <div class="col-md-3 hidden-xs hidden-sm" id="pkgdown-sidebar">
     <nav id="toc" data-toggle="toc" class="sticky-top">

--- a/docs/reference/tiledb_vfs-class.html
+++ b/docs/reference/tiledb_vfs-class.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/tiledb_vfs.html
+++ b/docs/reference/tiledb_vfs.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/tiledb_vfs_create_bucket.html
+++ b/docs/reference/tiledb_vfs_create_bucket.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/tiledb_vfs_create_dir.html
+++ b/docs/reference/tiledb_vfs_create_dir.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/tiledb_vfs_empty_bucket.html
+++ b/docs/reference/tiledb_vfs_empty_bucket.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/tiledb_vfs_file_size.html
+++ b/docs/reference/tiledb_vfs_file_size.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/tiledb_vfs_is_bucket.html
+++ b/docs/reference/tiledb_vfs_is_bucket.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/tiledb_vfs_is_dir.html
+++ b/docs/reference/tiledb_vfs_is_dir.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/tiledb_vfs_is_empty_bucket.html
+++ b/docs/reference/tiledb_vfs_is_empty_bucket.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/tiledb_vfs_is_file.html
+++ b/docs/reference/tiledb_vfs_is_file.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/tiledb_vfs_move_dir.html
+++ b/docs/reference/tiledb_vfs_move_dir.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/tiledb_vfs_move_file.html
+++ b/docs/reference/tiledb_vfs_move_file.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/tiledb_vfs_remove_bucket.html
+++ b/docs/reference/tiledb_vfs_remove_bucket.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/tiledb_vfs_remove_dir.html
+++ b/docs/reference/tiledb_vfs_remove_dir.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/tiledb_vfs_remove_file.html
+++ b/docs/reference/tiledb_vfs_remove_file.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/docs/reference/tiledb_vfs_touch.html
+++ b/docs/reference/tiledb_vfs_touch.html
@@ -72,7 +72,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">tiledb</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.1</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.8.2</span>
       </span>
     </div>
 

--- a/inst/NEWS.md
+++ b/inst/NEWS.md
@@ -1,6 +1,9 @@
 # Ongoing
 
-* This release of the R package builds against [TileDB 2.1.0](https://github.com/TileDB-Inc/TileDB/releases/tag/2.1.0), but has also been tested against previous releases such as [TileDB 2.0.8](https://github.com/TileDB-Inc/TileDB/releases/tag/2.0.8).
+
+# 0.8.2
+
+* This release of the R package builds against [TileDB 2.1.1](https://github.com/TileDB-Inc/TileDB/releases/tag/2.1.1), but has also been tested against previous releases as well as the development version.
 
 ## Improvements
 
@@ -9,6 +12,10 @@
 * The `tiledb_stats_reset()` function is now exported, and `tiledb_stats_print()` has been re-added as a wrapper to `tiledb_stats_dump()` (#174)
 
 * Configuration options for compute and input/output concurrency set only the new TileDB 2.1 configuration options; documentation on how to checking values has been expanded. (#175)
+
+* The `download.file()` use now (re-)sets the timeout to the standard value to accomodate uses where a lower value may be set such as some CRAN builders (#176)
+
+* Build scripts have been updated for use of TileDB 2.1.1 on Windows, macOS and Linux (when no system library is found) (#178)
 
 
 # 0.8.1


### PR DESCRIPTION
This PR increases the version number, updates the NEWS files and updates the documentation in `docs/`. No functional changes.

The cloud instances at RHub seem clogged (but win-builder came back, but I overlooked for a moment it goes first to the other inbox where a filter is also in place....) so no results yet for the latest commit but our CI builds are clean, as were the prior runs at the external builders.

