### PR TITLE
Update linux, macos and source downloader to use 2.1.2

### DIFF
--- a/tools/fetchTileDBLib.R
+++ b/tools/fetchTileDBLib.R
@@ -17,8 +17,8 @@ if (osarg == "url" && length(argv) <= 1) {
 }
 urlarg <- argv[2]
 
-ver <- "2.1.1"
-sha <- "db11399"
+ver <- "2.1.2"
+sha <- "4d3be6b"
 baseurl <- "https://github.com/TileDB-Inc/TileDB/releases/download"
 dlurl <- switch(osarg,
                 linux = file.path(baseurl,sprintf("%s/tiledb-linux-%s-%s-full.tar.gz", ver, ver, sha)),

--- a/tools/fetchTileDBSrc.R
+++ b/tools/fetchTileDBSrc.R
@@ -1,7 +1,7 @@
 #!/usr/bin/Rscript
 
 ## by default we download the source from a given release
-url <- "https://github.com/TileDB-Inc/TileDB/archive/2.1.1.tar.gz"
+url <- "https://github.com/TileDB-Inc/TileDB/archive/2.1.2.tar.gz"
 
 cat("Downloading ", url, "\n")
 op <- options()


### PR DESCRIPTION
Minor PR updating download URLs. No other changes.  Rebased to updated master.