### PR TITLE
Extended DataFrame support

### DIFF
--- a/R/ArraySchema.R
+++ b/R/ArraySchema.R
@@ -43,6 +43,7 @@ tiledb_array_schema.from_ptr <- function(ptr) {
 #' @param sparse (default FALSE)
 #' @param coords_filter_list (optional)
 #' @param offsets_filter_list (optional)
+#' @param capacity (optional)
 #' @param ctx tiledb_ctx object (optional)
 #' @examples
 #' \dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
@@ -64,6 +65,7 @@ tiledb_array_schema <- function(domain,
                                 sparse = FALSE,
                                 coords_filter_list = NULL,
                                 offsets_filter_list = NULL,
+                                capacity = 10000L,
                                 ctx = tiledb_get_context()) {
   if (!is(ctx, "tiledb_ctx")) {
     stop("ctx argument must be a tiledb_ctx")
@@ -104,6 +106,7 @@ tiledb_array_schema <- function(domain,
   }
   ptr <- libtiledb_array_schema(ctx@ptr, domain@ptr, attr_ptrs, cell_order, tile_order,
                                 coords_filter_list_ptr, offsets_filter_list_ptr, sparse)
+  libtiledb_array_schema_set_capacity(ptr, capacity)
   return(new("tiledb_array_schema", ptr = ptr))
 }
 

--- a/R/DataFrame.R
+++ b/R/DataFrame.R
@@ -31,7 +31,7 @@
 ##'
 ##' The created (dense or sparse) array will have as many attributes as there
 ##' are columns in the \code{data.frame}.  Each attribute will be a single column.
-##' For a sparse array, one or more columns have to be designated as dimenions.
+##' For a sparse array, one or more columns have to be designated as dimensions.
 ##'
 ##' At present, factor variable are converted to character.
 ##'

--- a/R/DataFrame.R
+++ b/R/DataFrame.R
@@ -93,7 +93,8 @@ fromDataFrame <- function(obj, uri, sparse=TRUE) {
   #cat("Schema written and array created.\n")
 
   df <- tiledb_array(uri)
-  df[] <- cbind(data.frame(rows=seq(1,dims[1])), obj)
+  if (sparse) obj <- cbind(data.frame(rows=seq(1,dims[1])), obj)
+  df[] <- obj
   invisible(NULL)
 }
 

--- a/R/DataFrame.R
+++ b/R/DataFrame.R
@@ -90,7 +90,6 @@ fromDataFrame <- function(obj, uri, sparse=TRUE) {
 
   schema <- tiledb_array_schema(dom, attrs = attributes, sparse=sparse)
   tiledb_array_create(uri, schema)
-  #cat("Schema written and array created.\n")
 
   df <- tiledb_array(uri)
   if (sparse) obj <- cbind(data.frame(rows=seq(1,dims[1])), obj)

--- a/R/TileDBArray.R
+++ b/R/TileDBArray.R
@@ -477,7 +477,7 @@ setMethod("[<-", "tiledb_array",
   }
 
   ## Case 2
-  if (length(colnames(value)) == length(attrnames)) { # FIXME: need to check for array or matrix arg?
+  if (sparse && length(colnames(value)) == length(attrnames)) { # FIXME: need to check for array or matrix arg?
     if (is.null(i)) stop("For arrays a row index has to be supplied.")
     if (is.null(j)) stop("For arrays a column index has to be supplied.")
     #if (length(i) != nrow(value)) stop("Row index must have same number of observations as data")
@@ -492,7 +492,9 @@ setMethod("[<-", "tiledb_array",
   ## Case 3: dense, length attributes == 1, i and j NULL
   ##         e.g. the quickstart_dense example where the RHS may be a matrix or data.frame
   ##         also need to guard against data.frame object which already have 'rows' and 'cols'
-  if (isFALSE(sparse) && is.null(i) && is.null(j) && length(attrnames) == 1) {
+  if (isFALSE(sparse) &&
+      ##is.null(i) && is.null(j) &&
+      length(attrnames) == 1) {
     d <- dim(value)
     if ((d[2] > 1) &&
         (inherits(value, "data.frame") || inherits(value, "matrix")) &&
@@ -506,11 +508,15 @@ setMethod("[<-", "tiledb_array",
     }
 
   ## Case 4: dense, list on RHS e.g. the ex_1.R example
-  } else if (isFALSE(sparse) && is.null(i) && is.null(j) && length(value) == length(attrnames)) {
-    nl <- length(value)
-    for (i in seq_len(nl)) {
-      d <- dim(value[[i]])
-      value[[i]] <- as.matrix(value[[i]])[seq(1, d[1]*d[2])]
+  } else if (isFALSE(sparse) &&
+             ##is.null(i) && is.null(j) &&
+             length(value) == length(attrnames)) {
+    if (!inherits(value, "data.frame")) {
+      nl <- length(value)
+      for (i in seq_len(nl)) {
+        d <- dim(value[[i]])
+        value[[i]] <- as.matrix(value[[i]])[seq(1, d[1]*d[2])]
+      }
     }
     names(value) <- attrnames
     allnames <- attrnames

--- a/inst/NEWS.md
+++ b/inst/NEWS.md
@@ -4,6 +4,8 @@
 
 * The older implementations `tiledb_dense` and `tiledb_sparse` are now marked as deprecated in favor of `tiledb_array`. No removal date is set or planned yet, but it is recommended to migrate new code. (#180)
 
+* Updated the underlying TileDB library to use TileDB 2.1.2 on macOS and Linux (when no system library is found) (#181)
+
 
 # 0.8.2
 

--- a/inst/NEWS.md
+++ b/inst/NEWS.md
@@ -1,11 +1,13 @@
 # Ongoing
 
+## Improvements
+
+* The older implementations `tiledb_dense` and `tiledb_sparse` are now marked as deprecated in favor of `tiledb_array`. No removal date is set or planned yet, but it is recommended to migrate new code. (#180)
+
 
 # 0.8.2
 
 * This release of the R package builds against [TileDB 2.1.1](https://github.com/TileDB-Inc/TileDB/releases/tag/2.1.1), but has also been tested against previous releases as well as the development version.
-
-## Improvements
 
 ## Bug Fixes
 

--- a/inst/examples/ex_benchmark_filters.R
+++ b/inst/examples/ex_benchmark_filters.R
@@ -1,0 +1,64 @@
+
+suppressMessages({
+    library(tiledb)
+    library(rbenchmark)
+})
+
+setwd("/tmp")
+
+## NYC Flights data
+url <- "https://raw.githubusercontent.com/eddelbuettel/data-examples/master/flights/flights14.csv"
+flights <- data.table::fread(url, data.table=FALSE)
+
+
+createArrays <- function() {
+    fromDataFrame(flights, "flightsNONE",  sparse = TRUE, allows_dups = TRUE, filter = "NONE")
+    fromDataFrame(flights, "flightsGZIP",  sparse = TRUE, allows_dups = TRUE, filter = "GZIP")
+    fromDataFrame(flights, "flightsZSTD",  sparse = TRUE, allows_dups = TRUE, filter = "ZSTD")
+    fromDataFrame(flights, "flightsLZ4",   sparse = TRUE, allows_dups = TRUE, filter = "LZ4")
+    fromDataFrame(flights, "flightsBZIP2", sparse = TRUE, allows_dups = TRUE, filter = "BZIP2")
+    fromDataFrame(flights, "flightsRLE",   sparse = TRUE, allows_dups = TRUE, filter = "RLE")
+    fromDataFrame(flights, "flightsDD",    sparse = TRUE, allows_dups = TRUE, filter = "DOUBLE_DELTA")
+}
+
+time1 <- function() {
+    get1 <- function(uri) {
+        arr <- tiledb_array(uri)
+        arr[]
+    }
+    cat("\nTiming reading all data\n")
+    res <- benchmark(none=get1("flightsNONE"),
+                     gzip=get1("flightsGZIP"),
+                     zstd=get1("flightsZSTD"),
+                     lz4=get1("flightsLZ4"),
+                     bz2=get1("flightsBZIP2"),
+                     rle=get1("flightsRLE"),
+                     dd=get1("flightsDD"),
+                     order="relative")
+    print(res[,1:4])
+    invisible(NULL)
+}
+
+time2 <- function() {
+    get <- function(uri) {
+        arr <- tiledb_array(uri)
+        selected_ranges(arr) <- list(matrix(c(100,200,1300,1400),2,2,byrow=TRUE))
+        arr[]
+    }
+
+    cat("\nTiming reading slice of data\n")
+    res <- benchmark(none=get("flightsNONE"),
+                     gzip=get("flightsGZIP"),
+                     zstd=get("flightsZSTD"),
+                     lz4=get("flightsLZ4"),
+                     bz2=get("flightsBZIP2"),
+                     rle=get("flightsRLE"),
+                     dd=get("flightsDD"),
+                     order="relative", replications=1000)
+    print(res[,1:4])
+    invisible(NULL)
+}
+
+createArrays()
+time1()
+time2()

--- a/inst/examples/quickstart_dense.R
+++ b/inst/examples/quickstart_dense.R
@@ -59,7 +59,7 @@ create_array <- function(uri) {
     tiledb_array_create(uri, schema)
 }
 
-write_arrayBORKED <- function(uri) {
+write_array <- function(uri) {
     ## equivalent to matrix(1:16, 4, 4, byrow=TRUE)
     data <- array(c(c(1L, 5L, 9L, 13L),
                     c(2L, 6L, 10L, 14L),
@@ -122,7 +122,7 @@ read_via_query_object <- function(array_name) {
 }
 
 create_array(uri)
-write_arrayBORKED(uri)
+write_array(uri)
 write_array_via_query(uri)
 write_array_via_query_piped(uri)
 read_array(uri)

--- a/inst/tinytest/test_dataframe.R
+++ b/inst/tinytest/test_dataframe.R
@@ -13,29 +13,29 @@ irisdf <- within(iris, Species <- as.character(Species))
 
 fromDataFrame(irisdf, uri)
 
-arr <- tiledb_dense(uri, as.data.frame=TRUE)
+arr <- tiledb_array(uri, as.data.frame=TRUE)
 newdf <- arr[]
 if (getRversion() >= '4.0.0') newdf$Species <- as.factor(newdf$Species)
-expect_equal(iris, newdf)
-expect_equal(dim(irisdf), dim(newdf))
+expect_equal(iris, newdf[,-1])
+expect_equal(dim(irisdf), dim(newdf[,-1]))
 
 ## result comes back as factor by default
 newdf <- within(newdf, Species <- as.character(Species))
-expect_equal(irisdf, newdf)
+expect_equal(irisdf, newdf[,-1])
 
 
 ## test attrs subselection
-arr <- tiledb_dense(uri, as.data.frame=TRUE,
+arr <- tiledb_array(uri, as.data.frame=TRUE,
                     attrs = c("Petal.Length", "Petal.Width"))
 newdf <- arr[]
-expect_equal(iris[, c("Petal.Length", "Petal.Width")], newdf)
+expect_equal(iris[, c("Petal.Length", "Petal.Width")], newdf[,-1])
 
 
 ## test list
-arr <- tiledb_dense(uri)
+arr <- tiledb_array(uri)
 res <- arr[]
 expect_equal(class(res), "list")
-expect_equal(length(res), 5)
+expect_equal(length(res), 6)            # plus one for 'rows'
 #})
 
 #test_that("tiledb_date_datetime_types", {
@@ -54,11 +54,11 @@ df <- data.frame(char=c("abc", "def", "g", "hijk"),
 
 fromDataFrame(df, uri)
 
-arr <- tiledb_dense(uri, as.data.frame=TRUE)
+arr <- tiledb_array(uri, as.data.frame=TRUE)
 newdf <- arr[]
 
 ## result comes back as factor by default
 newdf <- within(newdf, char <- as.character(char))
 
-expect_equal(df, newdf)
+expect_equal(df, newdf[,-1])
 #})

--- a/inst/tinytest/test_tiledbarray.R
+++ b/inst/tinytest/test_tiledbarray.R
@@ -80,9 +80,9 @@ dat <- readRDS(system.file("sampledata", "bankSample.rds", package="tiledb"))
 dir.create(tmpuri <- tempfile())
 fromDataFrame(dat[,-1], tmpuri)
 
-arr <- tiledb_dense(tmpuri, as.data.frame=TRUE)
+arr <- tiledb_array(tmpuri, as.data.frame=TRUE)
 newdat <- arr[]
-expect_equal(dat[,-1], newdat)
+expect_equal(dat[,-1], newdat[,-1])
 
 unlink(tmpuri, recursive = TRUE)
 options(op)

--- a/inst/tinytest/test_tiledbarray.R
+++ b/inst/tinytest/test_tiledbarray.R
@@ -214,7 +214,6 @@ unlink(tmpuri, recursive = TRUE)
 options(op)
 #})
 
-
 #test_that("test range selection on reading", {
 
 set.seed(100)
@@ -364,6 +363,7 @@ unlink(tmp, recursive = TRUE)
 if (requireNamespace("bit64", quietly=TRUE)) {
   suppressMessages(library(bit64))
 
+
   tmp <- tempfile()
   dir.create(tmp)
 
@@ -382,7 +382,7 @@ if (requireNamespace("bit64", quietly=TRUE)) {
   A[I,J] <- data
 
   A <- tiledb_array(uri = tmp, as.data.frame=TRUE)
-  newdata <- A[1:2, 2:4]
+  newdata <- A[as.integer64(1:2), as.integer64(2:4)]
   expect_equal(newdata[,"a"], c(3L, 2L))
   expect_equal(newdata[,"rows"], c(2L, 2L))
   expect_equal(newdata[,"cols"], c(3L, 4L))
@@ -416,7 +416,7 @@ if (requireNamespace("bit64", quietly=TRUE)) {
   A[I,J] <- data
 
   A <- tiledb_array(uri = tmp, as.data.frame=TRUE)
-  newdata <- A[1:2, 2:4]
+  newdata <- A[as.integer64(1:2), as.integer64(2:4)]
   expect_equal(newdata[,"a"], c(3L, 2L))
   expect_equal(newdata[,"rows"], c(2L, 2L))
   expect_equal(newdata[,"cols"], c(3L, 4L))
@@ -774,7 +774,7 @@ if (requireNamespace("bit64", quietly=TRUE)) {
   A[as.integer64(rep(1:4,each=4)), as.integer64(rep(1:4,4))] <- data
 
   A <- tiledb_array(uri = tmp, as.data.frame=TRUE)
-  newdata <- A[1:2, 2:3]
+  newdata <- A[as.integer64(1:2), as.integer64(2:3)]
   expect_equal(newdata[,"a"], c(2L, 3L, 6L, 7L))
   expect_equal(newdata[,"rows"], c(1L, 1L, 2L, 2L))
   expect_equal(newdata[,"cols"], c(2L, 3L, 2L, 3L))
@@ -805,7 +805,7 @@ if (requireNamespace("bit64", quietly=TRUE)) {
   A[as.integer64(rep(1:4,each=4)), as.integer64(rep(1:4,4))] <- data
 
   A <- tiledb_array(uri = tmp, as.data.frame=TRUE)
-  newdata <- A[1:2, 2:3]
+  newdata <- A[as.integer64(1:2), as.integer64(2:3)]
   expect_equal(newdata[,"a"], c(2L, 3L, 6L, 7L))
   expect_equal(newdata[,"rows"], c(1L, 1L, 2L, 2L))
   expect_equal(newdata[,"cols"], c(2L, 3L, 2L, 3L))

--- a/inst/tinytest/test_tiledbarray.R
+++ b/inst/tinytest/test_tiledbarray.R
@@ -326,7 +326,6 @@ expect_equal(nrow(val), 1L)
 unlink(tmp, recursive = TRUE)
 #})
 
-
 #test_that("test range selection for multiple dimensions", {
 tmp <- tempfile()
 dir.create(tmp)
@@ -591,7 +590,7 @@ if (requireNamespace("bit64", quietly=TRUE)) {
   ## can write as data.frame
   A[] <- data.frame(rows=rep(1:4,each=4), cols=rep(1:4,4), a=data)
   ## or with indices
-  A[rep(1:4,each=4), rep(1:4,4)] <- data
+  #A[rep(1:4,each=4), rep(1:4,4)] <- data
 
   A <- tiledb_array(uri = tmp, as.data.frame=TRUE)
   newdata <- A[1:2, 2:3]
@@ -621,7 +620,7 @@ if (requireNamespace("bit64", quietly=TRUE)) {
   ## can write as data.frame
   A[] <- data.frame(rows=rep(1:4,each=4), cols=rep(1:4,4), a=data)
   ## or with indices
-  A[rep(1:4,each=4), rep(1:4,4)] <- data
+  #A[rep(1:4,each=4), rep(1:4,4)] <- data
 
   A <- tiledb_array(uri = tmp, as.data.frame=TRUE)
   newdata <- A[1:2, 2:3]
@@ -651,7 +650,7 @@ if (requireNamespace("bit64", quietly=TRUE)) {
   ## can write as data.frame
   A[] <- data.frame(rows=rep(1:4,each=4), cols=rep(1:4,4), a=data)
   ## or with indices
-  A[rep(1:4,each=4), rep(1:4,4)] <- data
+  #A[rep(1:4,each=4), rep(1:4,4)] <- data
 
   A <- tiledb_array(uri = tmp, as.data.frame=TRUE)
   newdata <- A[1:2, 2:3]
@@ -681,7 +680,7 @@ if (requireNamespace("bit64", quietly=TRUE)) {
   ## can write as data.frame
   A[] <- data.frame(rows=rep(1:4,each=4), cols=rep(1:4,4), a=data)
   ## or with indices
-  A[rep(1:4,each=4), rep(1:4,4)] <- data
+  #A[rep(1:4,each=4), rep(1:4,4)] <- data
 
   A <- tiledb_array(uri = tmp, as.data.frame=TRUE)
   newdata <- A[1:2, 2:3]
@@ -711,7 +710,7 @@ if (requireNamespace("bit64", quietly=TRUE)) {
   ## can write as data.frame
   A[] <- data.frame(rows=rep(1:4,each=4), cols=rep(1:4,4), a=data)
   ## or with indices
-  A[rep(1:4,each=4), rep(1:4,4)] <- data
+  #A[rep(1:4,each=4), rep(1:4,4)] <- data
 
   A <- tiledb_array(uri = tmp, as.data.frame=TRUE)
   newdata <- A[1:2, 2:3]
@@ -741,7 +740,7 @@ if (requireNamespace("bit64", quietly=TRUE)) {
   ## can write as data.frame
   A[] <- data.frame(rows=rep(1:4,each=4), cols=rep(1:4,4), a=data)
   ## or with indices
-  A[rep(1:4,each=4), rep(1:4,4)] <- data
+  #A[rep(1:4,each=4), rep(1:4,4)] <- data
 
   A <- tiledb_array(uri = tmp, as.data.frame=TRUE)
   newdata <- A[1:2, 2:3]
@@ -771,7 +770,7 @@ if (requireNamespace("bit64", quietly=TRUE)) {
   ## can write as data.frame
   A[] <- data.frame(rows=as.integer64(rep(1:4,each=4)), cols=as.integer64(rep(1:4,4)), a=data)
   ## or with indices
-  A[as.integer64(rep(1:4,each=4)), as.integer64(rep(1:4,4))] <- data
+  #A[as.integer64(rep(1:4,each=4)), as.integer64(rep(1:4,4))] <- data
 
   A <- tiledb_array(uri = tmp, as.data.frame=TRUE)
   newdata <- A[as.integer64(1:2), as.integer64(2:3)]
@@ -802,7 +801,7 @@ if (requireNamespace("bit64", quietly=TRUE)) {
   ## can write as data.frame
   A[] <- data.frame(rows=as.integer64(rep(1:4,each=4)), cols=as.integer64(rep(1:4,4)), a=data)
   ## or with indices
-  A[as.integer64(rep(1:4,each=4)), as.integer64(rep(1:4,4))] <- data
+  #A[as.integer64(rep(1:4,each=4)), as.integer64(rep(1:4,4))] <- data
 
   A <- tiledb_array(uri = tmp, as.data.frame=TRUE)
   newdata <- A[as.integer64(1:2), as.integer64(2:3)]
@@ -852,7 +851,7 @@ if (requireNamespace("bit64", quietly=TRUE)) {
                     cols=rep(1:4,4),
                     data)
   ## or with indices
-  A[rep(1:4,each=4), rep(1:4,4)] <- data
+  #A[rep(1:4,each=4), rep(1:4,4)] <- data
 
   A <- tiledb_array(uri = tmp, as.data.frame=TRUE)
   newdata <- A[1:2, 2:3]

--- a/man/fromDataFrame.Rd
+++ b/man/fromDataFrame.Rd
@@ -4,7 +4,7 @@
 \alias{fromDataFrame}
 \title{Create a TileDB dense or sparse array from a given \code{data.frame} Object}
 \usage{
-fromDataFrame(obj, uri, sparse = TRUE)
+fromDataFrame(obj, uri, sparse = TRUE, filter = "NONE")
 }
 \arguments{
 \item{obj}{A \code{data.frame} object.}
@@ -12,6 +12,9 @@ fromDataFrame(obj, uri, sparse = TRUE)
 \item{uri}{A character variable with an Array URI.}
 
 \item{sparse}{A logical switch to select sparse (the default) or dense}
+
+\item{filter}{A character variable, defaults to \sQuote{NONE}, for one or more
+filter to be applied to each attribute.}
 }
 \value{
 Null, invisibly.

--- a/man/fromDataFrame.Rd
+++ b/man/fromDataFrame.Rd
@@ -4,7 +4,18 @@
 \alias{fromDataFrame}
 \title{Create a TileDB dense or sparse array from a given \code{data.frame} Object}
 \usage{
-fromDataFrame(obj, uri, sparse = TRUE, filter = "NONE")
+fromDataFrame(
+  obj,
+  uri,
+  sparse = TRUE,
+  allows_dups = TRUE,
+  cell_order = "COL_MAJOR",
+  tile_order = "COL_MAJOR",
+  filter = "NONE",
+  capacity = 1000L,
+  tile_domain,
+  tile_extent
+)
 }
 \arguments{
 \item{obj}{A \code{data.frame} object.}
@@ -13,8 +24,26 @@ fromDataFrame(obj, uri, sparse = TRUE, filter = "NONE")
 
 \item{sparse}{A logical switch to select sparse (the default) or dense}
 
-\item{filter}{A character variable, defaults to \sQuote{NONE}, for one or more
+\item{allows_dups}{A logical switch to select if duplicate values
+are allowed or not, default is \sQuote{TRUE}.}
+
+\item{cell_order}{A character variable with one of the TileDB cell order values,
+default is \dQuote{COL_MAJOR}.}
+
+\item{tile_order}{A character variable with one of the TileDB tile order values,
+default is \dQuote{COL_MAJOR}.}
+
+\item{filter}{A character variable, defaults to \sQuote{NONE}, for a
 filter to be applied to each attribute.}
+
+\item{capacity}{A integer value with the schema capacity, default is 1000.}
+
+\item{tile_domain}{An integer vector of size two specifying the integer domain of the row
+dimension; if missing the row dimension of the \code{obj} is used.}
+
+\item{tile_extent}{An integer value for the tile extent of the row dimensions;
+if missing the row dimension of the \code{obj} is used. Note that the \code{tile_extent}
+cannot exceed the tile domain.}
 }
 \value{
 Null, invisibly.

--- a/man/fromDataFrame.Rd
+++ b/man/fromDataFrame.Rd
@@ -56,7 +56,7 @@ with the R representations of \code{Date}, \code{POSIXct} and \code{nanotime}.
 \details{
 The created (dense or sparse) array will have as many attributes as there
 are columns in the \code{data.frame}.  Each attribute will be a single column.
-For a sparse array, one or more columns have to be designated as dimenions.
+For a sparse array, one or more columns have to be designated as dimensions.
 
 At present, factor variable are converted to character.
 }

--- a/man/fromDataFrame.Rd
+++ b/man/fromDataFrame.Rd
@@ -2,25 +2,29 @@
 % Please edit documentation in R/DataFrame.R
 \name{fromDataFrame}
 \alias{fromDataFrame}
-\title{Create a TileDB Dense Array from a given \code{data.frame} Object}
+\title{Create a TileDB dense or sparse array from a given \code{data.frame} Object}
 \usage{
-fromDataFrame(obj, uri)
+fromDataFrame(obj, uri, sparse = TRUE)
 }
 \arguments{
 \item{obj}{A \code{data.frame} object.}
 
 \item{uri}{A character variable with an Array URI.}
+
+\item{sparse}{A logical switch to select sparse (the default) or dense}
 }
 \value{
 Null, invisibly.
 }
 \description{
 The supplied \code{data.frame} object is (currently) limited to integer,
-numeric, or character columns.
+numeric, or character. In addition, three datetime columns are supported
+with the R representations of \code{Date}, \code{POSIXct} and \code{nanotime}.
 }
 \details{
-The create (Dense) Array will have as many attributes as there are columns in
-the \code{data.frame}.  Each attribute will be a single column.
+The created (dense or sparse) array will have as many attributes as there
+are columns in the \code{data.frame}.  Each attribute will be a single column.
+For a sparse array, one or more columns have to be designated as dimenions.
 
 At present, factor variable are converted to character.
 }
@@ -31,7 +35,7 @@ uri <- tempfile()
 ## turn factor into character
 irisdf <- within(iris, Species <- as.character(Species))
 fromDataFrame(irisdf, uri)
-arr <- tiledb_dense(uri, as.data.frame=TRUE)
+arr <- tiledb_array(uri, as.data.frame=TRUE, sparse=FALSE)
 newdf <- arr[]
 all.equal(iris, newdf)
 }

--- a/man/tiledb_array_schema.Rd
+++ b/man/tiledb_array_schema.Rd
@@ -12,6 +12,7 @@ tiledb_array_schema(
   sparse = FALSE,
   coords_filter_list = NULL,
   offsets_filter_list = NULL,
+  capacity = 10000L,
   ctx = tiledb_get_context()
 )
 }
@@ -29,6 +30,8 @@ tiledb_array_schema(
 \item{coords_filter_list}{(optional)}
 
 \item{offsets_filter_list}{(optional)}
+
+\item{capacity}{(optional)}
 
 \item{ctx}{tiledb_ctx object (optional)}
 }

--- a/src/libtiledb.cpp
+++ b/src/libtiledb.cpp
@@ -2613,8 +2613,8 @@ XPtr<tiledb::Query> libtiledb_query_add_range_with_type(XPtr<tiledb::Query> quer
       query->add_range(uidx, start, end, stride);
     }
   } else if (typestr == "INT64") {
-    int64_t start = static_cast<int64_t>(as<double>(starts));
-    int64_t end = static_cast<int64_t>(as<double>(ends));
+    int64_t start = makeScalarInteger64(as<double>(starts));
+    int64_t end = makeScalarInteger64(as<double>(ends));
     if (strides == R_NilValue) {
       query->add_range(uidx, start, end);
     } else {
@@ -2622,8 +2622,8 @@ XPtr<tiledb::Query> libtiledb_query_add_range_with_type(XPtr<tiledb::Query> quer
       query->add_range(uidx, start, end, stride);
     }
   } else if (typestr == "UINT64") {
-    uint64_t start = static_cast<uint64_t>(as<double>(starts));
-    uint64_t end = static_cast<uint64_t>(as<double>(ends));
+    uint64_t start = static_cast<uint64_t>(makeScalarInteger64(as<double>(starts)));
+    uint64_t end = static_cast<uint64_t>(makeScalarInteger64(as<double>(ends)));
     if (strides == R_NilValue) {
       query->add_range(uidx, start, end);
     } else {


### PR DESCRIPTION
This PR adds more options to the fromDataFrame helper function (including support for sparse matrices, duplicates, cell and tile order, attribute filters, capacity, tile domain ranges and tile extent). 