### PR TITLE
Condition raw stats on TileDB 2.0.3 or greater, update NEWS

### DIFF
--- a/R/Stats.R
+++ b/R/Stats.R
@@ -69,32 +69,39 @@ tiledb_stats_print <- function() {
 
 #' Dumps internal TileDB statistics as JSON to file
 #'
+#' This function requires TileDB Embedded 2.0.3 or later.
 #' @param path Character variable with path to stats file;
 #' if the empty string is passed then the result is displayed on stdout.
 #' @examples
 #' \dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
-#' pth <- tempfile()
-#' tiledb_stats_raw_dump(pth)
-#' cat(readLines(pth)[1:10], sep = "\n")
-#'
+#' if (tiledb_version(TRUE) >= "2.0.3") {
+#'   pth <- tempfile()
+#'   tiledb_stats_raw_dump(pth)
+#'   cat(readLines(pth)[1:10], sep = "\n")
+#' }
 #' @export
 tiledb_stats_raw_dump <- function(path) {
+  if (tiledb_version(TRUE) < "2.0.3") warning("Raw statistics are available with TileDB Embedded verion 2.0.3 or later")
   libtiledb_stats_raw_dump(path)
 }
 
 #' Print internal TileDB statistics as JSON
 #'
 #' This function is a convenience wrapper for \code{tiledb_stats_raw_dump}.
+#' It required TileDB Embedded 2.0.3 or later.
 #' @export
 tiledb_stats_raw_print <- function() {
+  if (tiledb_version(TRUE) < "2.0.3") stop("Raw statistics are available with TileDB Embedded verion 2.0.3 or later")
   libtiledb_stats_raw_dump("")
 }
 
 #' Gets internal TileDB statistics as JSON string
 #'
 #' This function is a convenience wrapper for \code{tiledb_stats_raw_dump}
-#' and returns the result as a JSON string
+#' and returns the result as a JSON string.
+#' It required TileDB Embedded 2.0.3 or later.
 #' @export
 tiledb_stats_raw_get <- function() {
+  if (tiledb_version(TRUE) < "2.0.3") stop("Raw statistics are available with TileDB Embedded verion 2.0.3 or later")
   libtiledb_stats_raw_get()
 }

--- a/R/Stats.R
+++ b/R/Stats.R
@@ -81,7 +81,7 @@ tiledb_stats_print <- function() {
 #' }
 #' @export
 tiledb_stats_raw_dump <- function(path) {
-  if (tiledb_version(TRUE) < "2.0.3") warning("Raw statistics are available with TileDB Embedded verion 2.0.3 or later")
+  if (tiledb_version(TRUE) < "2.0.3") stop("Raw statistics are available with TileDB Embedded verion 2.0.3 or later")
   libtiledb_stats_raw_dump(path)
 }
 

--- a/inst/NEWS.md
+++ b/inst/NEWS.md
@@ -6,6 +6,14 @@
 
 * Updated the underlying TileDB library to use TileDB 2.1.2 on macOS and Linux (when no system library is found) (#181)
 
+* There is extended support for array creation directly from DataFrame objects. (#182)
+
+* Internal TileDB performance statistics can now be exported 'raw' in JSON format. (#183)
+
+* The vignette was updated with respect to the preferred used of `tiledb_array`. (#184)
+
+* The Hilbert cell layout added recently to TileDB Embbeded is supported. (#185)
+
 
 # 0.8.2
 

--- a/man/tiledb_array-class.Rd
+++ b/man/tiledb_array-class.Rd
@@ -27,7 +27,7 @@ based on refactored implementation utilising newer TileDB features.
 \item{\code{selected_ranges}}{An optional list with matrices where each matrix i
 describes the (min,max) pair of ranges for dimension i}
 
-\item{\code{query_layout}}{A optional character value}
+\item{\code{query_layout}}{An optional character value}
 
 \item{\code{ptr}}{External pointer to the underlying implementation}
 }}

--- a/man/tiledb_stats_raw_dump.Rd
+++ b/man/tiledb_stats_raw_dump.Rd
@@ -11,12 +11,13 @@ tiledb_stats_raw_dump(path)
 if the empty string is passed then the result is displayed on stdout.}
 }
 \description{
-Dumps internal TileDB statistics as JSON to file
+This function requires TileDB Embedded 2.0.3 or later.
 }
 \examples{
 \dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
-pth <- tempfile()
-tiledb_stats_raw_dump(pth)
-cat(readLines(pth)[1:10], sep = "\n")
-
+if (tiledb_version(TRUE) >= "2.0.3") {
+  pth <- tempfile()
+  tiledb_stats_raw_dump(pth)
+  cat(readLines(pth)[1:10], sep = "\n")
+}
 }

--- a/man/tiledb_stats_raw_get.Rd
+++ b/man/tiledb_stats_raw_get.Rd
@@ -8,5 +8,6 @@ tiledb_stats_raw_get()
 }
 \description{
 This function is a convenience wrapper for \code{tiledb_stats_raw_dump}
-and returns the result as a JSON string
+and returns the result as a JSON string.
+It required TileDB Embedded 2.0.3 or later.
 }

--- a/man/tiledb_stats_raw_print.Rd
+++ b/man/tiledb_stats_raw_print.Rd
@@ -8,4 +8,5 @@ tiledb_stats_raw_print()
 }
 \description{
 This function is a convenience wrapper for \code{tiledb_stats_raw_dump}.
+It required TileDB Embedded 2.0.3 or later.
 }

--- a/src/libtiledb.cpp
+++ b/src/libtiledb.cpp
@@ -2990,6 +2990,9 @@ void libtiledb_stats_dump(std::string path = "") {
 
 // [[Rcpp::export]]
 void libtiledb_stats_raw_dump(std::string path = "") {
+#if TILEDB_VERSION < TileDB_Version(2,0,3)
+  Rcpp::stop("This function requires TileDB Embedded 2.0.3 or later.");
+#else
   if (path == "") {
     tiledb::Stats::raw_dump();
   } else {
@@ -3001,11 +3004,17 @@ void libtiledb_stats_raw_dump(std::string path = "") {
     tiledb::Stats::raw_dump(fptr);
     fclose(fptr);
   }
+#endif
 }
 
 // [[Rcpp::export]]
 std::string libtiledb_stats_raw_get() {
+#if TILEDB_VERSION < TileDB_Version(2,0,3)
+  Rcpp::stop("This function requires TileDB Embedded 2.0.3 or later.");
+  return(std::string());//not reached
+#else
   std::string result;
   tiledb::Stats::raw_dump(&result);
   return result;
+#endif
 }


### PR DESCRIPTION
Small cleanup PR to condition use of 'raw' stats on TileDB Embedded 2.0.3 or later, and an update to NEWS.Rd.