### PR TITLE
Update TileDB to 2.1.3

### DIFF
--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,5 +1,5 @@
 CXX_STD = CXX11
-VERSION = 2.1.1
+VERSION = 2.1.3
 RWINLIB=../windows/tiledb-$(VERSION)
 
 PKG_CPPFLAGS = -I../inst/include -I$(RWINLIB)/include -DTILEDB_STATIC_DEFINE

--- a/tools/fetchTileDBLib.R
+++ b/tools/fetchTileDBLib.R
@@ -17,8 +17,8 @@ if (osarg == "url" && length(argv) <= 1) {
 }
 urlarg <- argv[2]
 
-ver <- "2.1.2"
-sha <- "4d3be6b"
+ver <- "2.1.3"
+sha <- "47bee7c"
 baseurl <- "https://github.com/TileDB-Inc/TileDB/releases/download"
 dlurl <- switch(osarg,
                 linux = file.path(baseurl,sprintf("%s/tiledb-linux-%s-%s-full.tar.gz", ver, ver, sha)),

--- a/tools/fetchTileDBSrc.R
+++ b/tools/fetchTileDBSrc.R
@@ -1,7 +1,7 @@
 #!/usr/bin/Rscript
 
 ## by default we download the source from a given release
-url <- "https://github.com/TileDB-Inc/TileDB/archive/2.1.2.tar.gz"
+url <- "https://github.com/TileDB-Inc/TileDB/archive/2.1.3.tar.gz"
 
 cat("Downloading ", url, "\n")
 op <- options()


### PR DESCRIPTION
Updating script to use TileDB 2.1.3 source artifacts as well as a the Windows build.

While 2.1.4 is released we still wait for an updated Windows binary [here](https://github.com/rwinlib/tiledb) (based on the already updated [PKGBUILD](https://github.com/r-windows/rtools-packages/pull/172)).  