### PR TITLE
Update TileDB to 2.1.4

### DIFF
--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,5 +1,5 @@
 CXX_STD = CXX11
-VERSION = 2.1.3
+VERSION = 2.1.4
 RWINLIB=../windows/tiledb-$(VERSION)
 
 PKG_CPPFLAGS = -I../inst/include -I$(RWINLIB)/include -DTILEDB_STATIC_DEFINE

--- a/tools/fetchTileDBLib.R
+++ b/tools/fetchTileDBLib.R
@@ -17,8 +17,8 @@ if (osarg == "url" && length(argv) <= 1) {
 }
 urlarg <- argv[2]
 
-ver <- "2.1.3"
-sha <- "47bee7c"
+ver <- "2.1.4"
+sha <- "b397864"
 baseurl <- "https://github.com/TileDB-Inc/TileDB/releases/download"
 dlurl <- switch(osarg,
                 linux = file.path(baseurl,sprintf("%s/tiledb-linux-%s-%s-full.tar.gz", ver, ver, sha)),

--- a/tools/fetchTileDBSrc.R
+++ b/tools/fetchTileDBSrc.R
@@ -1,7 +1,7 @@
 #!/usr/bin/Rscript
 
 ## by default we download the source from a given release
-url <- "https://github.com/TileDB-Inc/TileDB/archive/2.1.3.tar.gz"
+url <- "https://github.com/TileDB-Inc/TileDB/archive/2.1.4.tar.gz"
 
 cat("Downloading ", url, "\n")
 op <- options()


### PR DESCRIPTION
Windows binary artifacts for 2.1.4 and now being used as well following https://github.com/rwinlib/tiledb/pull/2 and https://github.com/r-windows/rtools-packages/pull/172