### PR TITLE
Additional time-travel support

### DIFF
--- a/R/TileDBArray.R
+++ b/R/TileDBArray.R
@@ -38,7 +38,7 @@
 #' @slot query_layout An optional character value
 #' @slot datetimes_as_int64 A logical value
 #' @slot encryption_key A character value
-#' @slot timestamp A POSIXct datimetime variable
+#' @slot timestamp A POSIXct datetime variable
 #' @slot ptr External pointer to the underlying implementation
 #' @exportClass tiledb_array
 setClass("tiledb_array",
@@ -76,7 +76,7 @@ setClass("tiledb_array",
 #' \code{POSIXct} or \code{nanotime} objects.
 #' @param encryption_key optional A character value with an AES-256 encryption key
 #' in case the array was written with encryption.
-#' @param timestamp optional A Datetime value determining where in time the array is
+#' @param timestamp optional A POSIXct Datetime value determining where in time the array is
 #' to be openened.
 #' @param ctx tiledb_ctx (optional)
 #' @return tiledb_array object

--- a/R/TileDBArray.R
+++ b/R/TileDBArray.R
@@ -38,6 +38,7 @@
 #' @slot query_layout An optional character value
 #' @slot datetimes_as_int64 A logical value
 #' @slot encryption_key A character value
+#' @slot timestamp A POSIXct datimetime variable
 #' @slot ptr External pointer to the underlying implementation
 #' @exportClass tiledb_array
 setClass("tiledb_array",
@@ -51,6 +52,7 @@ setClass("tiledb_array",
                       query_layout = "character",
                       datetimes_as_int64 = "logical",
                       encryption_key = "character",
+                      timestamp = "POSIXct",
                       ptr = "externalptr"))
 
 #' Constructs a tiledb_array object backed by a persisted tiledb array uri
@@ -74,6 +76,8 @@ setClass("tiledb_array",
 #' \code{POSIXct} or \code{nanotime} objects.
 #' @param encryption_key optional A character value with an AES-256 encryption key
 #' in case the array was written with encryption.
+#' @param timestamp optional A Datetime value determining where in time the array is
+#' to be openened.
 #' @param ctx tiledb_ctx (optional)
 #' @return tiledb_array object
 #' @export
@@ -87,6 +91,7 @@ tiledb_array <- function(uri,
                          query_layout = character(),
                          datetimes_as_int64 = FALSE,
                          encryption_key = character(),
+                         timestamp = as.POSIXct(double()),
                          ctx = tiledb_get_context()) {
   query_type = match.arg(query_type)
   if (!is(ctx, "tiledb_ctx"))
@@ -97,9 +102,18 @@ tiledb_array <- function(uri,
   if (length(encryption_key) > 0) {
     if (!is.character(encryption_key))
       stop("if used, argument aes_key must be character", call. = FALSE)
-    array_xptr <- libtiledb_array_open_with_key(ctx@ptr, uri, query_type, encryption_key)
+    if (length(timestamp) > 0) {
+      array_xptr <- libtiledb_array_open_at_with_key(ctx@ptr, uri, query_type,
+                                                     encryption_key, timestamp)
+    } else {
+      array_xptr <- libtiledb_array_open_with_key(ctx@ptr, uri, query_type, encryption_key)
+    }
   } else {
-    array_xptr <- libtiledb_array_open(ctx@ptr, uri, query_type)
+    if (length(timestamp) > 0) {
+      array_xptr <- libtiledb_array_open_at(ctx@ptr, uri, query_type, timestamp)
+    } else {
+      array_xptr <- libtiledb_array_open(ctx@ptr, uri, query_type)
+    }
   }
   schema_xptr <- libtiledb_array_get_schema(array_xptr)
   is_sparse_status <- libtiledb_array_schema_sparse(schema_xptr)
@@ -120,6 +134,7 @@ tiledb_array <- function(uri,
       query_layout = query_layout,
       datetimes_as_int64 = datetimes_as_int64,
       encryption_key = encryption_key,
+      timestamp = timestamp,
       ptr = array_xptr)
 }
 
@@ -179,6 +194,7 @@ setMethod("show", signature = "tiledb_array",
      ,"  query_layout       = ", if (length(object@query_layout) == 0) "(none)" else object@query_layout, "\n"
      ,"  datetimes_as_int64 = ", if (object@datetimes_as_int64) "TRUE" else "FALSE", "\n"
      ,"  encryption_key     = ", if (length(object@encryption_key) == 0) "(none)" else "(set)", "\n"
+     ,"  timestamp          = ", if (length(object@timestamp) == 0) "(none)" else format(object@timestamp), "\n"
      ,sep="")
 })
 
@@ -249,6 +265,11 @@ setValidity("tiledb_array", function(object) {
     msg <- c(msg, "The 'encryption_key' slot does not contain a character vector.")
   }
 
+  if (!inherits(object@timestamp, "POSIXct")) {
+    valid <- FALSE
+    msg <- c(msg, "The 'timestamp' slot does not contain a POSIXct value.")
+  }
+
   if (!is(object@ptr, "externalptr")) {
     valid <- FALSE
     msg <- c(msg, "The 'ptr' slot does not contain an external pointer.")
@@ -293,11 +314,20 @@ setMethod("[", "tiledb_array",
   layout <- x@query_layout
   asint64 <- x@datetimes_as_int64
   enckey <- x@encryption_key
+  tstamp <- x@timestamp
 
   if (length(enckey) > 0) {
-    libtiledb_array_open_with_key(ctx@ptr, uri, "READ", enckey)
+    if (length(tstamp) > 0) {
+      libtiledb_array_open_at_with_key(ctx@ptr, uri, "READ", enckey, tstamp)
+    } else {
+      libtiledb_array_open_with_key(ctx@ptr, uri, "READ", enckey)
+    }
   } else {
-    libtiledb_array_open_with_ptr(x@ptr, "READ")
+    if (length(tstamp) > 0) {
+      libtiledb_array_open_at(ctx@ptr, uri, "READ", tstamp)
+    } else {
+      libtiledb_array_open(ctx@ptr, uri, "READ")
+    }
   }
   on.exit(libtiledb_array_close(x@ptr))
 
@@ -327,9 +357,17 @@ setMethod("[", "tiledb_array",
 
 
   if (length(enckey) > 0) {
-    arrptr <- libtiledb_array_open_with_key(ctx@ptr, uri, "READ", enckey)
+    if (length(tstamp) > 0) {
+      arrptr <- libtiledb_array_open_at_with_key(ctx@ptr, uri, "READ", enckey, tstamp)
+    } else {
+      arrptr <- libtiledb_array_open_with_key(ctx@ptr, uri, "READ", enckey)
+    }
   } else {
-    arrptr <- libtiledb_array_open(ctx@ptr, uri, "READ")
+    if (length(tstamp) > 0) {
+      arrptr <- libtiledb_array_open_at(ctx@ptr, uri, "READ", tstamp)
+    } else {
+      arrptr <- libtiledb_array_open(ctx@ptr, uri, "READ")
+    }
   }
 
   ## helper function to sweep over names and types of domain
@@ -527,6 +565,7 @@ setMethod("[<-", "tiledb_array",
   layout <- x@query_layout
   asint64 <- x@datetimes_as_int64
   enckey <- x@encryption_key
+  tstamp <- x@timestamp
 
   sparse <- libtiledb_array_schema_sparse(sch@ptr)
 
@@ -614,10 +653,20 @@ setMethod("[<-", "tiledb_array",
   if (all.equal(sort(allnames),sort(nm))) {
 
     if (length(enckey) > 0) {
-      arrptr <- libtiledb_array_open_with_key(ctx@ptr, uri, "WRITE", enckey)
+      if (length(tstamp) > 0) {
+        arrptr <- libtiledb_array_open_at_with_key(ctx@ptr, uri, "WRITE", enckey, tstamp)
+      } else {
+        arrptr <- libtiledb_array_open_with_key(ctx@ptr, uri, "WRITE", enckey)
+      }
     } else {
-      arrptr <- libtiledb_array_open(ctx@ptr, uri, "WRITE")
+      if (length(tstamp) > 0) {
+        arrptr <- libtiledb_array_open_at(ctx@ptr, uri, "WRITE", tstamp)
+      } else {
+        arrptr <- libtiledb_array_open(ctx@ptr, uri, "WRITE")
+      }
     }
+
+
     qryptr <- libtiledb_query(ctx@ptr, arrptr, "WRITE")
     qryptr <- libtiledb_query_set_layout(qryptr,
                                          if (length(layout) > 0) layout

--- a/R/TileDBArray.R
+++ b/R/TileDBArray.R
@@ -318,15 +318,15 @@ setMethod("[", "tiledb_array",
 
   if (length(enckey) > 0) {
     if (length(tstamp) > 0) {
-      libtiledb_array_open_at_with_key(ctx@ptr, uri, "READ", enckey, tstamp)
+      x@ptr <- libtiledb_array_open_at_with_key(ctx@ptr, uri, "READ", enckey, tstamp)
     } else {
-      libtiledb_array_open_with_key(ctx@ptr, uri, "READ", enckey)
+      x@ptr <- libtiledb_array_open_with_key(ctx@ptr, uri, "READ", enckey)
     }
   } else {
     if (length(tstamp) > 0) {
-      libtiledb_array_open_at(ctx@ptr, uri, "READ", tstamp)
+      x@ptr <- libtiledb_array_open_at(ctx@ptr, uri, "READ", tstamp)
     } else {
-      libtiledb_array_open_with_ptr(x@ptr, "READ")
+      x@ptr <- libtiledb_array_open(ctx@ptr, uri, "READ")
     }
   }
   on.exit(libtiledb_array_close(x@ptr))

--- a/R/TileDBArray.R
+++ b/R/TileDBArray.R
@@ -326,7 +326,7 @@ setMethod("[", "tiledb_array",
     if (length(tstamp) > 0) {
       libtiledb_array_open_at(ctx@ptr, uri, "READ", tstamp)
     } else {
-      libtiledb_array_open(ctx@ptr, uri, "READ")
+      libtiledb_array_open_with_ptr(x@ptr, "READ")
     }
   }
   on.exit(libtiledb_array_close(x@ptr))

--- a/inst/examples/quickstart_sparse.R
+++ b/inst/examples/quickstart_sparse.R
@@ -52,7 +52,7 @@ create_array <- function(array_name) {
                                   tiledb_dim("cols", c(1L, 4L), 4L, "INT32")))
 
    # The array will be dense with a single attribute "a" so each (i,j) cell can store an integer.
-    schema = tiledb_array_schema(dom, attrs=c(tiledb_attr("a", type = "INT32")), sparse = TRUE)
+    schema <- tiledb_array_schema(dom, attrs=c(tiledb_attr("a", type = "INT32")), sparse = TRUE)
 
     # Create the (empty) array on disk.
     invisible( tiledb_array_create(array_name, schema) )

--- a/inst/examples/quickstart_sparse_async.R
+++ b/inst/examples/quickstart_sparse_async.R
@@ -52,7 +52,7 @@ create_array <- function(array_name) {
                                   tiledb_dim("cols", c(1L, 4L), 4L, "INT32")))
 
    # The array will be dense with a single attribute "a" so each (i,j) cell can store an integer.
-    schema = tiledb_array_schema(dom, attrs=c(tiledb_attr("a", type = "INT32")), sparse = TRUE)
+    schema <- tiledb_array_schema(dom, attrs=c(tiledb_attr("a", type = "INT32")), sparse = TRUE)
 
     # Create the (empty) array on disk.
     invisible( tiledb_array_create(array_name, schema) )

--- a/inst/tinytest/test_tiledbarray.R
+++ b/inst/tinytest/test_tiledbarray.R
@@ -989,3 +989,37 @@ expect_equal(schema, schema2)
 schema3 <- schema(arr)
 expect_true(is(schema3, "tiledb_array_schema"))
 expect_equal(schema, schema3)
+
+
+## time travel
+tmp <- tempfile()
+dir.create(tmp)
+dom <- tiledb_domain(dims = c(tiledb_dim("rows", c(1L, 10L), 5L, "INT32"),
+                              tiledb_dim("cols", c(1L, 10L), 5L, "INT32")))
+schema <- tiledb_array_schema(dom, attrs=c(tiledb_attr("a", type = "INT32")), sparse = TRUE)
+invisible( tiledb_array_create(tmp, schema) )
+
+I <- c(1, 2, 2)
+J <- c(1, 4, 3)
+data <- c(1L, 2L, 3L)
+now1 <- Sys.time()
+A <- tiledb_array(uri = tmp, timestamp=now1)
+A[I, J] <- data
+
+Sys.sleep(1)
+
+now2 <- Sys.time()
+I <- c(8, 6, 9)
+J <- c(5, 7, 8)
+data <- c(11L, 22L, 33L)
+A <- tiledb_array(uri = tmp, timestamp=now2)
+A[I, J] <- data
+
+A <- tiledb_array(uri = tmp, as.data.frame=TRUE, timestamp=now1 - 0.5)
+expect_equal(nrow(A[]), 0)
+A <- tiledb_array(uri = tmp, as.data.frame=TRUE, timestamp=now1 + 0.5)
+expect_equal(nrow(A[]), 3)
+A <- tiledb_array(uri = tmp, as.data.frame=TRUE, timestamp=now2 - 0.5)
+expect_equal(nrow(A[]), 3)
+A <- tiledb_array(uri = tmp, as.data.frame=TRUE, timestamp=now2 + 0.5)
+expect_equal(nrow(A[]), 6)

--- a/man/tiledb_array-class.Rd
+++ b/man/tiledb_array-class.Rd
@@ -33,7 +33,7 @@ describes the (min,max) pair of ranges for dimension i}
 
 \item{\code{encryption_key}}{A character value}
 
-\item{\code{timestamp}}{A POSIXct datimetime variable}
+\item{\code{timestamp}}{A POSIXct datetime variable}
 
 \item{\code{ptr}}{External pointer to the underlying implementation}
 }}

--- a/man/tiledb_array-class.Rd
+++ b/man/tiledb_array-class.Rd
@@ -33,6 +33,8 @@ describes the (min,max) pair of ranges for dimension i}
 
 \item{\code{encryption_key}}{A character value}
 
+\item{\code{timestamp}}{A POSIXct datimetime variable}
+
 \item{\code{ptr}}{External pointer to the underlying implementation}
 }}
 

--- a/man/tiledb_array.Rd
+++ b/man/tiledb_array.Rd
@@ -47,7 +47,7 @@ representation as \sQuote{raw} \code{integer64} and not as \code{Date},
 \item{encryption_key}{optional A character value with an AES-256 encryption key
 in case the array was written with encryption.}
 
-\item{timestamp}{optional A Datetime value determining where in time the array is
+\item{timestamp}{optional A POSIXct Datetime value determining where in time the array is
 to be openened.}
 
 \item{ctx}{tiledb_ctx (optional)}

--- a/man/tiledb_array.Rd
+++ b/man/tiledb_array.Rd
@@ -15,6 +15,7 @@ tiledb_array(
   query_layout = character(),
   datetimes_as_int64 = FALSE,
   encryption_key = character(),
+  timestamp = as.POSIXct(double()),
   ctx = tiledb_get_context()
 )
 }
@@ -45,6 +46,9 @@ representation as \sQuote{raw} \code{integer64} and not as \code{Date},
 
 \item{encryption_key}{optional A character value with an AES-256 encryption key
 in case the array was written with encryption.}
+
+\item{timestamp}{optional A Datetime value determining where in time the array is
+to be openened.}
 
 \item{ctx}{tiledb_ctx (optional)}
 }


### PR DESCRIPTION
This PR adds high-level support for timestamps at the `tiledb_array` level.   A simple illustration is included as well (and the basis of added unit tests):  we open an array, write three rows at a recording timestamp, sleep a little and write three more rows.   The expected reads before first, after first, before second and after second time stamp are the expected 0, 3, 3, and 6 rows.

```r
$ Rscript inst/examples/quickstart_sparse_timetravel.R
Array already exists, removing to create new one.
Writing first record at 2020-12-28 17:35:05.074403 
(...sleeping 1s ...)
Writing second record at 2020-12-28 17:35:06.104814 

Reading everything:
  rows cols  a
1    1    1  1
2    2    3  3
3    2    4  2
4    6    7 22
5    8    5 11
6    9    8 33

Opening / reading 0.5s before first tstamp
[1] rows cols a   
<0 rows> (or 0-length row.names)
Opening / reading 0.5s after first tstamp
  rows cols a
1    1    1 1
2    2    3 3
3    2    4 2
Opening / reading 0.5s before second tstamp
  rows cols a
1    1    1 1
2    2    3 3
3    2    4 2
Opening / reading 0.5s after second tstamp
  rows cols  a
1    1    1  1
2    2    3  3
3    2    4  2
4    6    7 22
5    8    5 11
6    9    8 33
$ 
```