### PR TITLE
Update TileDB to 2.1.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The most recent released version can be installed from
     > library(tiledb)
     > tiledb_version()
     major minor patch
-        2     0     8
+        2     1     5
     > help(package=tiledb)
 
 If the TileDB library is installed in a custom location, you need to pass the explicit path:
@@ -48,7 +48,7 @@ If the TileDB library is installed in a custom location, you need to pass the ex
     > remotes::install_github("TileDB-Inc/TileDB-R",
           args="--configure-args='--with-tiledb=/path/to/tiledb'")
 
-Note that the TileDB R package is developed and tested against the latest stable (`v2.0.x`) version
+Note that the TileDB R package is developed and tested against the latest stable (`v2.1.x`) version
 of TileDB, but should also build against the newest development version.
 
 ## Quick Links

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,5 +1,5 @@
 CXX_STD = CXX11
-VERSION = 2.1.4
+VERSION = 2.1.5
 RWINLIB=../windows/tiledb-$(VERSION)
 
 PKG_CPPFLAGS = -I../inst/include -I$(RWINLIB)/include -DTILEDB_STATIC_DEFINE

--- a/tools/fetchTileDBLib.R
+++ b/tools/fetchTileDBLib.R
@@ -17,8 +17,8 @@ if (osarg == "url" && length(argv) <= 1) {
 }
 urlarg <- argv[2]
 
-ver <- "2.1.4"
-sha <- "b397864"
+ver <- "2.1.5"
+sha <- "46aec45"
 baseurl <- "https://github.com/TileDB-Inc/TileDB/releases/download"
 dlurl <- switch(osarg,
                 linux = file.path(baseurl,sprintf("%s/tiledb-linux-%s-%s-full.tar.gz", ver, ver, sha)),

--- a/tools/fetchTileDBSrc.R
+++ b/tools/fetchTileDBSrc.R
@@ -1,7 +1,7 @@
 #!/usr/bin/Rscript
 
 ## by default we download the source from a given release
-url <- "https://github.com/TileDB-Inc/TileDB/archive/2.1.4.tar.gz"
+url <- "https://github.com/TileDB-Inc/TileDB/archive/2.1.5.tar.gz"
 
 cat("Downloading ", url, "\n")
 op <- options()


### PR DESCRIPTION
This PR switches to the source and Linux/macOS artifacts for 2.1.5, as well as to the Windows components available following the PRs https://github.com/r-windows/rtools-packages/pull/173 and https://github.com/rwinlib/tiledb/pull/3.