### PR TITLE
Extended fromDataFrame support

### DIFF
--- a/R/DataFrame.R
+++ b/R/DataFrame.R
@@ -82,18 +82,20 @@ fromDataFrame <- function(obj, uri, col_index=NULL, sparse=FALSE, allows_dups=sp
                                                domain = tile_domain,
                                                tile = tile_extent,
                                                type = "INT32"))
+
     } else {
         if (length(col_index) > 1) {
             warning("Currently only one index column supported")
             col_index <- col_index[1]
         }
-        #cat("Looking at col_index =", col_index, "\n")
         if (is.character(col_index)) col_index <- match(col_index, colnames(obj))
         idxcol <- obj[, col_index]
         idxnam <- colnames(obj)[col_index]
         #cat("Looking at col_index =", col_index, ":", idxnam, "\n")
-
-
+        if (col_index != 1) {
+            obj <- cbind(obj[,col_index,drop=FALSE], obj[, -col_index,drop=FALSE])
+            col_index <- 1
+        }
         if (missing(tile_domain)) tile_domain <- c(min(idxcol), max(idxcol))
         if (missing(tile_extent)) tile_extent <- dims[1]
 

--- a/R/DataFrame.R
+++ b/R/DataFrame.R
@@ -108,11 +108,10 @@ fromDataFrame <- function(obj, uri, col_index=NULL, sparse=FALSE, allows_dups=sp
             tile_extent <- as.numeric(tile_extent)
         } else if (inherits(idxcol, "nanotime")) {
             dtype <- "DATETIME_NS"
-            tile_domain <- c(min(idxcol) - 1e9, max(idxcol) + 1e9)
-            #tile_extent <- as.integer64(tile_extent)
+            tile_domain <- c(min(idxcol) - 1e10, max(idxcol) + 1e10)
         } else if (inherits(idxcol, "integer64")) {
             dtype <- "INT64"
-            tile_extent <- as.integer64(tile_extent)
+            tile_extent <- bit64::as.integer64(tile_extent)
         }
 
         dom <- tiledb_domain(dims = tiledb_dim(name = idxnam,

--- a/R/DataFrame.R
+++ b/R/DataFrame.R
@@ -95,7 +95,7 @@ fromDataFrame <- function(obj, uri, col_index=NULL, sparse=FALSE, allows_dups=sp
 
 
         if (missing(tile_domain)) tile_domain <- c(min(idxcol), max(idxcol))
-        if (missing(tile_extent)) tile_extent <- diff(range(idxcol)) + 1L
+        if (missing(tile_extent)) tile_extent <- dims[1]
 
         dom <- tiledb_domain(dims = tiledb_dim(name = idxnam,
                                                domain = tile_domain,
@@ -148,6 +148,8 @@ fromDataFrame <- function(obj, uri, col_index=NULL, sparse=FALSE, allows_dups=sp
     allows_dups(schema) <- allows_dups
 
     df <- tiledb_array(uri)
+    ## when setting an index when likely want 'sparse write to dense array
+    if (!is.null(col_index) && !sparse) query_layout(df) <- "UNORDERED"
     if (sparse) obj <- cbind(data.frame(`__tiledb_rows`=seq(1,dims[1])), obj)
     df[] <- obj
     invisible(NULL)

--- a/R/DataFrame.R
+++ b/R/DataFrame.R
@@ -112,6 +112,10 @@ fromDataFrame <- function(obj, uri, col_index=NULL, sparse=FALSE, allows_dups=sp
         } else if (inherits(idxcol, "integer64")) {
             dtype <- "INT64"
             tile_extent <- bit64::as.integer64(tile_extent)
+        } else if (inherits(idxcol, "character")) {
+            dtype <- "ASCII"
+            tile_extent <- NULL
+            tile_domain <- c(NULL, NULL)
         }
 
         dom <- tiledb_domain(dims = tiledb_dim(name = idxnam,

--- a/R/DataFrame.R
+++ b/R/DataFrame.R
@@ -99,10 +99,15 @@ fromDataFrame <- function(obj, uri, col_index=NULL, sparse=FALSE, allows_dups=sp
         if (missing(tile_domain)) tile_domain <- c(min(idxcol), max(idxcol))
         if (missing(tile_extent)) tile_extent <- dims[1]
         dtype <- "INT32"                # default
+
         if (inherits(idxcol, "POSIXt")) {
             dtype <- "DATETIME_US"
             tile_domain <- as.numeric(tile_domain) * 1e6 	# int64 used
+        } else if (inherits(idxcol, "numeric")) {
+            dtype <- "FLOAT64"
+            tile_extent <- as.numeric(tile_extent)
         }
+
 
         dom <- tiledb_domain(dims = tiledb_dim(name = idxnam,
                                                domain = tile_domain,

--- a/R/DataFrame.R
+++ b/R/DataFrame.R
@@ -47,7 +47,7 @@
 ##' default is \dQuote{COL_MAJOR}.
 ##' @param tile_order A character variable with one of the TileDB tile order values,
 ##' default is \dQuote{COL_MAJOR}.
-##' @param filter A character variable vectoe, defaults to \sQuote{ZSTD}, for
+##' @param filter A character variable vector, defaults to \sQuote{ZSTD}, for
 ##' one or more filters to be applied to each attribute;
 ##' @param capacity A integer value with the schema capacity, default is 1000.
 ##' @param tile_domain An integer vector of size two specifying the integer domain of the row
@@ -152,7 +152,7 @@ fromDataFrame <- function(obj, uri, col_index=NULL, sparse=FALSE, allows_dups=sp
     df <- tiledb_array(uri)
     ## when setting an index when likely want 'sparse write to dense array
     if (!is.null(col_index) && !sparse) query_layout(df) <- "UNORDERED"
-    if (sparse) obj <- cbind(data.frame(`__tiledb_rows`=seq(1,dims[1])), obj)
+    if (sparse) obj <- cbind(data.frame(`__tiledb_rows`=seq(1,dims[1]), check.names=FALSE), obj)
     df[] <- obj
     invisible(NULL)
 }

--- a/R/DataFrame.R
+++ b/R/DataFrame.R
@@ -106,8 +106,14 @@ fromDataFrame <- function(obj, uri, col_index=NULL, sparse=FALSE, allows_dups=sp
         } else if (inherits(idxcol, "numeric")) {
             dtype <- "FLOAT64"
             tile_extent <- as.numeric(tile_extent)
+        } else if (inherits(idxcol, "nanotime")) {
+            dtype <- "DATETIME_NS"
+            tile_domain <- c(min(idxcol) - 1e9, max(idxcol) + 1e9)
+            #tile_extent <- as.integer64(tile_extent)
+        } else if (inherits(idxcol, "integer64")) {
+            dtype <- "INT64"
+            tile_extent <- as.integer64(tile_extent)
         }
-
 
         dom <- tiledb_domain(dims = tiledb_dim(name = idxnam,
                                                domain = tile_domain,
@@ -141,6 +147,8 @@ fromDataFrame <- function(obj, uri, col_index=NULL, sparse=FALSE, allows_dups=sp
             tp <- "DATETIME_MS"
         else if (cl == "nanotime")
             tp <- "DATETIME_NS"
+        else if (cl == "integer64")
+            tp <- "INT64"
         else
             stop("Currently unsupported type: ", cl)
         tiledb_attr(colnames(obj)[ind],

--- a/R/Dim.R
+++ b/R/Dim.R
@@ -70,7 +70,7 @@ tiledb_dim <- function(name, domain, tile, type, ctx = tiledb_get_context()) {
                           "DATETIME_MS", "DATETIME_US", "DATETIME_NS",
                           "DATETIME_PS", "DATETIME_FS", "DATETIME_AS",
                           "ASCII")) {
-    stop("type argument must be '(U)INT{8,16,32,64}' or 'FLOAT{32,64}' or a supported 'DATETIME_*' type.", call.=FALSE)
+    stop("type argument must be '(U)INT{8,16,32,64}', 'FLOAT{32,64}', 'ASCII', or a supported 'DATETIME_*' type.", call.=FALSE)
   }
   if (!type %in% c("ASCII")) {
     if ((typeof(domain) != "integer" && typeof(domain) != "double") || (length(domain) != 2)) {

--- a/R/TileDBArray.R
+++ b/R/TileDBArray.R
@@ -673,19 +673,23 @@ setMethod("[<-", "tiledb_array",
                                          else { if (sparse) "UNORDERED" else "ROW_MAJOR" })
 
     buflist <- vector(mode="list", length=nc)
-    for (i in 1:nc) {
+
+    for (colnam in allnames) {
+      ## when an index column is use this may be unordered to remap to position in 'nm' names
+      i <- match(colnam, nm)
       if (alltypes[i] %in% c("CHAR", "ASCII")) { # variable length
         txtvec <- as.character(value[[i]])
         offsets <- c(0L, cumsum(nchar(txtvec[-length(txtvec)])))
         data <- paste(txtvec, collapse="")
         buflist[[i]] <- libtiledb_query_buffer_var_char_create(offsets, data)
-        qryptr <- libtiledb_query_set_buffer_var_char(qryptr, allnames[i], buflist[[i]])
+        qryptr <- libtiledb_query_set_buffer_var_char(qryptr, colnam, buflist[[i]])
       } else {
         nr <- NROW(value[[i]])
         buflist[[i]] <- libtiledb_query_buffer_alloc_ptr(arrptr, alltypes[i], nr)
         buflist[[i]] <- libtiledb_query_buffer_assign_ptr(buflist[[i]], alltypes[i],
                                                           value[[i]], asint64)
-        qryptr <- libtiledb_query_set_buffer_ptr(qryptr, allnames[i], buflist[[i]])
+        qryptr <- libtiledb_query_set_buffer_ptr(qryptr, colnam, buflist[[i]])
+        #cat("Set buffer", i, "for", colnam, ":", alltypes[i], "nr:", nr, "\n")
       }
     }
 

--- a/R/TileDBArray.R
+++ b/R/TileDBArray.R
@@ -683,6 +683,7 @@ setMethod("[<-", "tiledb_array",
         data <- paste(txtvec, collapse="")
         buflist[[i]] <- libtiledb_query_buffer_var_char_create(offsets, data)
         qryptr <- libtiledb_query_set_buffer_var_char(qryptr, colnam, buflist[[i]])
+        #cat("Set char buffer", i, "for", colnam, ":", alltypes[i], "nr:", nr, "\n")
       } else {
         nr <- NROW(value[[i]])
         buflist[[i]] <- libtiledb_query_buffer_alloc_ptr(arrptr, alltypes[i], nr)

--- a/R/TileDBArray.R
+++ b/R/TileDBArray.R
@@ -681,16 +681,16 @@ setMethod("[<-", "tiledb_array",
         txtvec <- as.character(value[[i]])
         offsets <- c(0L, cumsum(nchar(txtvec[-length(txtvec)])))
         data <- paste(txtvec, collapse="")
+        #cat("Alloc char buffer", i, "for", colnam, ":", alltypes[i], "\n")
         buflist[[i]] <- libtiledb_query_buffer_var_char_create(offsets, data)
         qryptr <- libtiledb_query_set_buffer_var_char(qryptr, colnam, buflist[[i]])
-        #cat("Set char buffer", i, "for", colnam, ":", alltypes[i], "nr:", nr, "\n")
       } else {
         nr <- NROW(value[[i]])
+        #cat("Alloc buffer", i, "for", colnam, ":", alltypes[i], "nr:", nr, "\n")
         buflist[[i]] <- libtiledb_query_buffer_alloc_ptr(arrptr, alltypes[i], nr)
         buflist[[i]] <- libtiledb_query_buffer_assign_ptr(buflist[[i]], alltypes[i],
                                                           value[[i]], asint64)
         qryptr <- libtiledb_query_set_buffer_ptr(qryptr, colnam, buflist[[i]])
-        #cat("Set buffer", i, "for", colnam, ":", alltypes[i], "nr:", nr, "\n")
       }
     }
 

--- a/inst/tinytest/test_dataframe.R
+++ b/inst/tinytest/test_dataframe.R
@@ -126,9 +126,16 @@ uri <- tempfile()
 set.seed(42)
 nobs <- 50L
 
+#if (!requireNamespace("bit64", quietly=TRUE)) exit_file("Remainder needs 'bit64'.")
+#suppressMessages(library(bit64))
+if (!requireNamespace("nanotime", quietly=TRUE)) exit_file("Remainder needs 'nanotime'.")
+suppressMessages(library(nanotime))
+
 df <- data.frame(time=round(Sys.time(), "secs") + trunc(cumsum(runif(nobs)*3600)),
                  double_range=seq(-1000, 1000, length=nobs),
-                 int_vals=sort(as.integer(runif(nobs)*1e9)))
+                 int_vals=sort(as.integer(runif(nobs)*1e9)),
+                 #int64_vals=sort(as.integer64(runif(nobs)*1e9)),  ## TODO: return int64
+                 nanotime=as.nanotime(Sys.time() + cumsum(runif(nobs)*3600)))
 
 if (dir.exists(uri)) unlink(uri, recursive=TRUE)
 fromDataFrame(df, uri, sparse=TRUE)

--- a/inst/tinytest/test_dataframe.R
+++ b/inst/tinytest/test_dataframe.R
@@ -64,3 +64,56 @@ newdf <- within(newdf, char <- as.character(char))
 
 expect_equal(df, newdf[,-1])
 #})
+
+
+## test dense with non-default columm
+#exit_file("not finished")
+uri <- tempfile()
+set.seed(42)
+rows <- 50L
+
+df <- data.frame(index=sort(sample(1:1000, rows)),
+                 chars=sample(LETTERS, rows, replace=TRUE),
+                 vals=rnorm(rows) * 100)
+fromDataFrame(df, uri)
+arr <- tiledb_array(uri, as.data.frame=TRUE)
+chk <- arr[]
+expect_equal(df, chk[,-1])              # omit first col which is added
+
+if (dir.exists(uri)) unlink(uri, recursive=TRUE)
+fromDataFrame(df, uri, col_index=1)
+arr <- tiledb_array(uri, as.data.frame=TRUE)
+chk <- arr[]
+expect_equal(df[,2], na.omit(chk)[,2])  # compare column by column
+expect_equal(df[,3], na.omit(chk)[,3])
+
+if (dir.exists(uri)) unlink(uri, recursive=TRUE)
+fromDataFrame(df, uri, col_index="index")
+arr <- tiledb_array(uri, as.data.frame=TRUE)
+chk <- arr[]
+expect_equal(df[,2], na.omit(chk)[,2])  # compare column by column
+expect_equal(df[,3], na.omit(chk)[,3])
+
+olddf <- df
+df <- data.frame(chars=olddf$chars,
+                 index=olddf$index,     # index not in first column
+                 val=olddf$vals)
+if (dir.exists(uri)) unlink(uri, recursive=TRUE)
+fromDataFrame(df, uri)
+arr <- tiledb_array(uri, as.data.frame=TRUE)
+chk <- arr[]
+expect_equal(df, chk[,-1])              # omit first col which is added
+
+if (dir.exists(uri)) unlink(uri, recursive=TRUE)
+fromDataFrame(df, uri, col_index=2)
+arr <- tiledb_array(uri, as.data.frame=TRUE)
+chk <- arr[]
+expect_equal(df[,1], na.omit(chk)[,2])  # compare column by column
+expect_equal(df[,3], na.omit(chk)[,3])
+
+if (dir.exists(uri)) unlink(uri, recursive=TRUE)
+fromDataFrame(df, uri, col_index="index")
+arr <- tiledb_array(uri, as.data.frame=TRUE)
+chk <- arr[]
+expect_equal(df[,1], na.omit(chk)[,2])  # compare column by column
+expect_equal(df[,3], na.omit(chk)[,3])

--- a/inst/tinytest/test_dataframe.R
+++ b/inst/tinytest/test_dataframe.R
@@ -66,7 +66,7 @@ expect_equal(df, newdf[,-1])
 #})
 
 
-## test dense with non-default columm
+## test dense with non-default index columm
 #exit_file("not finished")
 uri <- tempfile()
 set.seed(42)
@@ -117,3 +117,28 @@ arr <- tiledb_array(uri, as.data.frame=TRUE)
 chk <- arr[]
 expect_equal(df[,1], na.omit(chk)[,2])  # compare column by column
 expect_equal(df[,3], na.omit(chk)[,3])
+
+
+
+## test sparse with non-default index columm
+#exit_file("not finished")
+uri <- tempfile()
+set.seed(42)
+nobs <- 50L
+
+df <- data.frame(time=round(Sys.time(), "secs") + trunc(cumsum(runif(nobs)*3600)),
+                 double_range=seq(-1000, 1000, length=nobs),
+                 int_vals=sort(as.integer(runif(nobs)*1e9)))
+
+if (dir.exists(uri)) unlink(uri, recursive=TRUE)
+fromDataFrame(df, uri, sparse=TRUE)
+
+chk <- tiledb_array(uri, as.data.frame=TRUE, extended=FALSE)
+expect_equal(df, chk[])
+
+for (i in seq_len(dim(df)[2])) {
+    if (dir.exists(uri)) unlink(uri, recursive=TRUE)
+    fromDataFrame(df, uri, sparse=TRUE, col_index=i)
+    chk <- tiledb_array(uri, as.data.frame=TRUE)
+    expect_equal(df, chk[][,colnames(df)]) 		# index col comes first so need re-order
+}

--- a/inst/tinytest/test_query.R
+++ b/inst/tinytest/test_query.R
@@ -155,10 +155,11 @@ if (requireNamespace("nanotime", quietly=TRUE)) {
 tmp <- tempfile()
 dir.create(tmp)
 
-dom <- tiledb_domain(dims = c(tiledb_dim("rows", c(1L, 10L), 1L, type = "INT32")))
-schema <- tiledb_array_schema(dom, attrs = c(tiledb_attr("vals", type = "INT32")), sparse=FALSE)
+dom <- tiledb_domain(dims = tiledb_dim("rows", c(1L, 10L), 1L, type = "INT32"))
+schema <- tiledb_array_schema(dom,
+                              attrs = tiledb_attr("vals", type = "INT32"),
+                              sparse=FALSE)
 tiledb_array_create(tmp, schema)
-
 arr <- tiledb_array(tmp)
 qry <- tiledb_query(arr, "WRITE")
 qry <- tiledb_query_set_layout(qry, "ROW_MAJOR")

--- a/inst/tinytest/test_tiledbarray.R
+++ b/inst/tinytest/test_tiledbarray.R
@@ -205,7 +205,7 @@ expect_true(length(attrs(arr)) == 0)
 sels <-  c("age", "job", "education", "duration")
 attrs(arr) <- sels
 dat <- arr[]
-expect_equal(colnames(dat), c("rows", sels))
+expect_equal(colnames(dat), c("__tiledb_rows", sels))
 extended(arr) <- FALSE
 dat <- arr[]
 expect_equal(colnames(dat), sels)

--- a/man/fromDataFrame.Rd
+++ b/man/fromDataFrame.Rd
@@ -7,12 +7,13 @@
 fromDataFrame(
   obj,
   uri,
-  sparse = TRUE,
-  allows_dups = TRUE,
-  cell_order = "COL_MAJOR",
-  tile_order = "COL_MAJOR",
-  filter = "NONE",
-  capacity = 1000L,
+  col_index = NULL,
+  sparse = FALSE,
+  allows_dups = sparse,
+  cell_order = "ROW_MAJOR",
+  tile_order = "ROW_MAJOR",
+  filter = "ZSTD",
+  capacity = 10000L,
   tile_domain,
   tile_extent
 )
@@ -22,10 +23,14 @@ fromDataFrame(
 
 \item{uri}{A character variable with an Array URI.}
 
-\item{sparse}{A logical switch to select sparse (the default) or dense}
+\item{col_index}{An optional column index, either numeric with a column index,
+or character with a column name, designating an index column; default is NULL
+implying an index column is added when the array is created}
+
+\item{sparse}{A logical switch to select sparse or dense (the default)}
 
 \item{allows_dups}{A logical switch to select if duplicate values
-are allowed or not, default is \sQuote{TRUE}.}
+are allowed or not, default is the same value as \sQuote{sparse}.}
 
 \item{cell_order}{A character variable with one of the TileDB cell order values,
 default is \dQuote{COL_MAJOR}.}

--- a/man/fromDataFrame.Rd
+++ b/man/fromDataFrame.Rd
@@ -38,8 +38,8 @@ default is \dQuote{COL_MAJOR}.}
 \item{tile_order}{A character variable with one of the TileDB tile order values,
 default is \dQuote{COL_MAJOR}.}
 
-\item{filter}{A character variable, defaults to \sQuote{NONE}, for a
-filter to be applied to each attribute.}
+\item{filter}{A character variable vectoe, defaults to \sQuote{ZSTD}, for
+one or more filters to be applied to each attribute;}
 
 \item{capacity}{A integer value with the schema capacity, default is 1000.}
 

--- a/man/fromDataFrame.Rd
+++ b/man/fromDataFrame.Rd
@@ -14,8 +14,9 @@ fromDataFrame(
   tile_order = "ROW_MAJOR",
   filter = "ZSTD",
   capacity = 10000L,
-  tile_domain,
-  tile_extent
+  tile_domain = NULL,
+  tile_extent = NULL,
+  debug = FALSE
 )
 }
 \arguments{
@@ -38,17 +39,19 @@ default is \dQuote{COL_MAJOR}.}
 \item{tile_order}{A character variable with one of the TileDB tile order values,
 default is \dQuote{COL_MAJOR}.}
 
-\item{filter}{A character variable vectoe, defaults to \sQuote{ZSTD}, for
+\item{filter}{A character variable vector, defaults to \sQuote{ZSTD}, for
 one or more filters to be applied to each attribute;}
 
 \item{capacity}{A integer value with the schema capacity, default is 1000.}
 
 \item{tile_domain}{An integer vector of size two specifying the integer domain of the row
-dimension; if missing the row dimension of the \code{obj} is used.}
+dimension; if \code{NULL} the row dimension of the \code{obj} is used.}
 
 \item{tile_extent}{An integer value for the tile extent of the row dimensions;
-if missing the row dimension of the \code{obj} is used. Note that the \code{tile_extent}
+if \code{NULL} the row dimension of the \code{obj} is used. Note that the \code{tile_extent}
 cannot exceed the tile domain.}
+
+\item{debug}{Logical flag to select additional output}
 }
 \value{
 Null, invisibly.

--- a/src/libtiledb.cpp
+++ b/src/libtiledb.cpp
@@ -576,7 +576,7 @@ XPtr<tiledb::Dimension> libtiledb_dim(XPtr<tiledb::Context> ctx,
   if (dtype == TILEDB_INT32 && (TYPEOF(domain) != INTSXP || TYPEOF(tile_extent) != INTSXP)) {
     Rcpp::stop("domain or tile_extent does not match dimension type");
   } else if (dtype == TILEDB_FLOAT64 && (TYPEOF(domain) != REALSXP || TYPEOF(tile_extent) != REALSXP)) {
-    Rcpp::stop("domain or tile_extent does not match dimenson type");
+    Rcpp::stop("domain or tile_extent does not match dimension type");
   }
   if (dtype == TILEDB_INT32) {
     using Dtype = tiledb::impl::tiledb_to_type<TILEDB_INT32>::type;


### PR DESCRIPTION
This PR extends the existing `fromDataFrame` function to support arbitrary index columns indicated by position and/or name.