### PR TITLE
Condition parts of one test file on use of TileDB 2.1.0 or later

### DIFF
--- a/inst/examples/ex_S3_unload.R
+++ b/inst/examples/ex_S3_unload.R
@@ -1,0 +1,26 @@
+
+library(tiledb)
+
+## replace this URI with one for a public s3 bucket,
+## or one accessible under your aws access key
+array_name <- "s3://tiledb-public-us-west-1/test-array-4x4"
+
+cfg <- tiledb_config()
+cfg["vfs.s3.region"] <- "us-west-1"
+ctx <- tiledb_ctx(cfg)
+## ctx object is now updated globally
+
+## access the s3 bucket, here simply querying the type
+tiledb_object_type(array_name)
+
+## check if it is a bucket
+tiledb_vfs_is_bucket(array_name)
+
+## check if it is an empty bucket
+tiledb_vfs_is_empty_bucket(array_name)
+
+detach("package:tiledb")
+
+gc()
+
+cat("All done\n")

--- a/inst/tinytest/test_dataframe.R
+++ b/inst/tinytest/test_dataframe.R
@@ -80,6 +80,8 @@ arr <- tiledb_array(uri, as.data.frame=TRUE)
 chk <- arr[]
 expect_equal(df, chk[,-1])              # omit first col which is added
 
+if (tiledb_version(TRUE) < "2.1.0") exit_file("Remaining tests required TileDB 2.1.0 or later")
+
 if (dir.exists(uri)) unlink(uri, recursive=TRUE)
 fromDataFrame(df, uri, col_index=1)
 arr <- tiledb_array(uri, as.data.frame=TRUE)
@@ -125,12 +127,11 @@ uri <- tempfile()
 set.seed(42)
 nobs <- 50L
 
-#if (!requireNamespace("bit64", quietly=TRUE)) exit_file("Remainder needs 'bit64'.")
-#suppressMessages(library(bit64))
-if (!requireNamespace("nanotime", quietly=TRUE)) exit_file("Remainder needs 'nanotime'.")
-suppressMessages(library(nanotime))
-if (!requireNamespace("bit64", quietly=TRUE)) exit_file("Remainder needs 'bit64'.")
-suppressMessages(library(bit64))
+## datetimes test (cf ex_aggdatetimes)
+suppressMessages({
+  library(nanotime)
+  library(bit64)
+})
 
 df <- data.frame(time=round(Sys.time(), "secs") + trunc(cumsum(runif(nobs)*3600)),
                  double_range=seq(-1000, 1000, length=nobs),


### PR DESCRIPTION
This is a microcospic PR refining the previous PR #204 as one testfile displayed a minor issue under the older TileDB 2.0.*.  It also adds a small example file which shows how to unload the R package after s3 use.