### PR TITLE
Update to TileDB 2.2.2

### DIFF
--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,5 +1,5 @@
 CXX_STD = CXX11
-VERSION = 2.2.1
+VERSION = 2.2.2
 #RWINLIB=../windows/tiledb-$(VERSION)
 RWINLIB=../windows/rwinlib-tiledb-$(VERSION)
 

--- a/tools/fetchTileDBLib.R
+++ b/tools/fetchTileDBLib.R
@@ -17,8 +17,8 @@ if (osarg == "url" && length(argv) <= 1) {
 }
 urlarg <- argv[2]
 
-ver <- "2.2.1"
-sha <- "4744a3f"
+ver <- "2.2.2"
+sha <- "220dd9e"
 baseurl <- "https://github.com/TileDB-Inc/TileDB/releases/download"
 dlurl <- switch(osarg,
                 linux = file.path(baseurl,sprintf("%s/tiledb-linux-%s-%s-full.tar.gz", ver, ver, sha)),

--- a/tools/fetchTileDBSrc.R
+++ b/tools/fetchTileDBSrc.R
@@ -1,7 +1,7 @@
 #!/usr/bin/Rscript
 
 ## by default we download the source from a given release
-url <- "https://github.com/TileDB-Inc/TileDB/archive/2.2.1.tar.gz"
+url <- "https://github.com/TileDB-Inc/TileDB/archive/2.2.2.tar.gz"
 
 cat("Downloading ", url, "\n")
 op <- options()


### PR DESCRIPTION
This updates the build to 2.2.2 used via an updated Windows release along with updated linux and macOS archives.