### PR TITLE
Set library version and sha centrally

### DIFF
--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,7 +1,5 @@
 CXX_STD = CXX11
-VERSION = 2.2.2
-#RWINLIB=../windows/tiledb-$(VERSION)
-RWINLIB=../windows/rwinlib-tiledb-$(VERSION)
+RWINLIB = ../windows/rwinlib-tiledb
 
 PKG_CPPFLAGS = -I../inst/include -I$(RWINLIB)/include -DTILEDB_STATIC_DEFINE
 PKG_LIBS = \
@@ -14,7 +12,7 @@ PKG_LIBS = \
 all: clean winlibs
 
 winlibs:
-	"$(R_HOME)/bin$(R_ARCH_BIN)/Rscript.exe" "../tools/winlibs.R" $(VERSION)
+	"$(R_HOME)/bin$(R_ARCH_BIN)/Rscript.exe" "../tools/winlibs.R"
 
 clean:
 	rm -f $(SHLIB) $(OBJECTS)

--- a/tools/fetchTileDBLib.R
+++ b/tools/fetchTileDBLib.R
@@ -17,8 +17,15 @@ if (osarg == "url" && length(argv) <= 1) {
 }
 urlarg <- argv[2]
 
-ver <- "2.2.2"
-sha <- "220dd9e"
+dcffile <- "../tools/tiledbVersion.txt"
+if (!file.exists(dcffile)) {
+    message("TileDB Version file not found.")
+    q()
+}
+dcf <- read.dcf(dcffile)
+ver <- dcf[[1, "version"]]
+sha <- dcf[[1, "sha"]]
+
 baseurl <- "https://github.com/TileDB-Inc/TileDB/releases/download"
 dlurl <- switch(osarg,
                 linux = file.path(baseurl,sprintf("%s/tiledb-linux-%s-%s-full.tar.gz", ver, ver, sha)),

--- a/tools/fetchTileDBSrc.R
+++ b/tools/fetchTileDBSrc.R
@@ -1,7 +1,15 @@
 #!/usr/bin/Rscript
 
-## by default we download the source from a given release
-url <- "https://github.com/TileDB-Inc/TileDB/archive/2.2.2.tar.gz"
+dcffile <- "../tools/tiledbVersion.txt"
+if (!file.exists(dcffile)) {
+    message("TileDB Version file not found.")
+    q()
+}
+dcf <- read.dcf(dcffile)
+ver <- dcf[[1, "version"]]
+
+## by default we download the source from the given release
+url <- paste0("https://github.com/TileDB-Inc/TileDB/archive/", ver, ".tar.gz")
 
 cat("Downloading ", url, "\n")
 op <- options()

--- a/tools/rhubTest.r
+++ b/tools/rhubTest.r
@@ -1,0 +1,14 @@
+#!/usr/bin/env Rscript
+##
+## also see bulkTestOnRHub.r
+
+library(rhub)
+
+argv <- commandArgs(trailingOnly=TRUE)
+tgt <- if (length(argv) > 0) argv[1] else "."
+
+selected <- c("debian-gcc-release",
+              "macos-highsierra-release",
+              "windows-x86_64-release")
+
+check(tgt, platform = selected, email = getOption("email", "edd@debian.org"))

--- a/tools/tiledbVersion.txt
+++ b/tools/tiledbVersion.txt
@@ -1,0 +1,2 @@
+version: 2.2.2
+sha: 220dd9e

--- a/tools/winlibs.R
+++ b/tools/winlibs.R
@@ -1,13 +1,18 @@
-# Build against static libraries from rwinlib
-VERSION <- commandArgs(TRUE)
-if (!file.exists(sprintf("../windows/tiledb-%s/include/tiledb/tiledb.h", VERSION))) {
-  if (getRversion() < "4") stop("This package requires Rtools40 or newer")
-  op <- options()
-  options(timeout=60)
-  ## download.file(sprintf("https://github.com/rwinlib/tiledb/archive/v%s.zip", VERSION), "lib.zip", quiet = TRUE)
-  download.file(sprintf("https://github.com/TileDB-Inc/rwinlib-tiledb/archive/v%s.zip", VERSION), "lib.zip", quiet = TRUE)
-  options(op)
-  dir.create("../windows", showWarnings = FALSE)
-  unzip("lib.zip", exdir = "../windows")
-  unlink("lib.zip")
+# Build against static libraries from rwinlib or rwinlib-tiledb
+
+dcffile <- "../tools/tiledbVersion.txt"
+if (!file.exists(dcffile)) stop("TileDB Version file not found.")
+dcf <- read.dcf(dcffile)
+ver <- dcf[[1, "version"]]
+
+if (!file.exists("../windows/rwinlib-tiledb/include/tiledb/tiledb.h")) {
+    if (getRversion() < "4") stop("This package requires Rtools40 or newer")
+    op <- options()
+    options(timeout=60)                 # CRAN request to have patient download settings
+    download.file(sprintf("https://github.com/TileDB-Inc/rwinlib-tiledb/archive/v%s.zip", ver), "lib.zip", quiet = TRUE)
+    options(op)
+    dir.create("../windows", showWarnings = FALSE)
+    unzip("lib.zip", exdir = "../windows")
+    file.rename(sprintf("../windows/rwinlib-tiledb-%s", ver), "../windows/rwinlib-tiledb")
+    unlink("lib.zip")
 }


### PR DESCRIPTION
This PR simplifies where and how we set the version (and sha) of the TileDB Embedded release used for building the R package (in case no system installation is found, or other configuration is supplied aka "the most common case").  

Previously two scripts in `tools/` needs to be updated as well as the `src/Makevars.win` snippet.   That is errorprone and mixes code and configuration.  Given that R can natively read [Debian Control Files](https://www.debian.org/doc/debian-policy/ch-controlfields.html) (as for example each `DESCRIPTION` file of each R package use it) we now use a very simple key-value file `tools/tiledbVersion.txt` to specify the version and the sha of the release --- which are then picked up in the three helper files that need it.   This required one small logic change on the Windows build in the sense that we now make the installed directory not contain the version string to not have to pass the version info to `make` simplifying things further (and users will not likely have several versions of our headers and static lib _in their R build directory_).

Name and location of `tools/tiledbVersion.txt` can be changed.  We can even add the two lines to the `DESCRIPTION` file of the package itself (though we should then prefix them as, say, `TileDB-version` and `TileDB-sha`.