### PR TITLE
Update TileDB Embedded to version 2.2.4

### DIFF
--- a/tools/tiledbVersion.txt
+++ b/tools/tiledbVersion.txt
@@ -1,2 +1,2 @@
-version: 2.2.3
-sha: dbaf5ff
+version: 2.2.4
+sha: 2f138f9


### PR DESCRIPTION
As before, uses the config file to switch to release 2.2.4 for the builds involving downloads to pre-made artifacts.