### PR TITLE
Release 0.9.0 

### DIFF
--- a/inst/NEWS.md
+++ b/inst/NEWS.md
@@ -58,7 +58,9 @@
 
 * Support for Nullable vectors has been added (#211)
 
-* Support for the default TileDB Embedded library has been set to 2.2.4 (#206, #209)
+* Support for the default TileDB Embedded library has been set to 2.2.4 (#212)
+
+* Small tweaks to timezone and factor settings in unit tests (#213, #214)
 
 
 # 0.8.2

--- a/inst/tinytest/test_dataframe.R
+++ b/inst/tinytest/test_dataframe.R
@@ -146,7 +146,7 @@ suppressMessages({
   library(bit64)
 })
 
-if (getRversion() < '4.0.0') Sys.setenv(TZ="")
+Sys.setenv(TZ="")
 df <- data.frame(time=round(Sys.time(), "secs") + trunc(cumsum(runif(nobs)*3600)),
                  double_range=seq(-1000, 1000, length=nobs),
                  int_vals=sort(as.integer(runif(nobs)*1e9)),


### PR DESCRIPTION
This PR, along with the main one #213 preceding it, constitutes release 0.9.0.  In accomodating the changes at Azure one TZ setting in a test file was made conditional, this corrects it -- and also updated the NEWS.Rd file one more time.

