### PR TITLE
Let result size fall back to estimated size 

### DIFF
--- a/R/TileDBArray.R
+++ b/R/TileDBArray.R
@@ -526,7 +526,11 @@ setMethod("[", "tiledb_array",
       libtiledb_query_result_buffer_elements(qryptr, name)
   }
   estsz <- mapply(getResultSize, allnames, allvarnum, MoreArgs=list(qryptr=qryptr), SIMPLIFY=TRUE)
-  resrv <- max(estsz, na.rm=TRUE)
+  if (any(!is.na(estsz))) {
+      resrv <- max(estsz, na.rm=TRUE)
+  } else {
+      resrv <- resrv/8                  # character case where bytesize of offset vector was used
+  }
 
   ## get results
   getResult <- function(buf, name, varnum, resrv, qryptr) {

--- a/inst/NEWS.md
+++ b/inst/NEWS.md
@@ -8,6 +8,7 @@
 
 * Two tests with datetime comparisons which fail only on one macOS system are now conditional (#216)
 
+* Result sets with all-character column now fall back to estimated result sizes (#217)
 
 
 # 0.9.0

--- a/inst/tinytest/test_dataframe.R
+++ b/inst/tinytest/test_dataframe.R
@@ -70,7 +70,6 @@ expect_equal(df, newdf[,-1])
 
 
 ## test dense with non-default index columm
-#exit_file("not finished")
 uri <- tempfile()
 set.seed(42)
 rows <- 50L
@@ -233,3 +232,17 @@ if (getRversion() < '4.0.0') {
     val$B <- as.character(val$B)
 }
 expect_equal(dat, val)
+
+## array with char only columns in dimension and attribute, used to error before #217
+N <- 20
+D <- data.frame(sample=paste(LETTERS[1:N], as.character(sort(trunc(runif(N, 100, 200)))), sep=""),
+                header=paste(LETTERS[1:N], as.character(sort(trunc(runif(N, 10000, 20000)))), sep=""),
+                stringsAsFactors=FALSE)
+uri <- tempfile()
+fromDataFrame(D, uri, col_index=1, sparse=TRUE)
+chk <- tiledb_array(uri, as.data.frame=TRUE)
+if (getRversion() < '4.0.0') {
+    chk$sample <- as.character(chk$sample)
+    chk$header <- as.character(chk$header)
+}
+expect_equal(D, chk[])


### PR DESCRIPTION
This PR covers a corner case seem in an example provided last week when dimension and attribute are of type character.