### PR TITLE
Upgrade TileDB Embedded to release 2.2.6

### DIFF
--- a/tools/tiledbVersion.txt
+++ b/tools/tiledbVersion.txt
@@ -1,2 +1,2 @@
-version: 2.2.5
-sha: f1b05c8
+version: 2.2.6
+sha: b6926bc


### PR DESCRIPTION
As before, uses the config file to switch to release 2.2.6 for the builds involving downloads to pre-made artifacts.

