### PR TITLE
Upgrade TileDB Embedded to 2.2.7

### DIFF
--- a/tools/tiledbVersion.txt
+++ b/tools/tiledbVersion.txt
@@ -1,2 +1,2 @@
-version: 2.2.6
-sha: b6926bc
+version: 2.2.7
+sha: a788ce5


### PR DESCRIPTION
As before, uses the config file to switch to release 2.2.7 for the builds involving downloads to pre-made artifacts.