### PR TITLE
Fix for duplicate values in sparse array index

### DIFF
--- a/R/DataFrame.R
+++ b/R/DataFrame.R
@@ -177,9 +177,8 @@ fromDataFrame <- function(obj, uri, col_index=NULL, sparse=FALSE, allows_dups=sp
                                   cell_order = cell_order, tile_order = tile_order,
                                   sparse=sparse, capacity=capacity)
     if (debug) print(schema)
-    tiledb_array_create(uri, schema)
-
     allows_dups(schema) <- allows_dups
+    tiledb_array_create(uri, schema)
 
     df <- tiledb_array(uri)
     ## when setting an index when likely want 'sparse write to dense array

--- a/inst/tinytest/test_dataframe.R
+++ b/inst/tinytest/test_dataframe.R
@@ -247,3 +247,24 @@ if (getRversion() < '4.0.0') {
     chk$header <- as.character(chk$header)
 }
 expect_equal(D, chk[])
+
+## sparse array can have duplicate values in index column
+df <- data.frame(
+  index = c(1, 1, 3),
+  char = c("a", "a", "c"),
+  stringsAsFactors = FALSE
+)
+
+uri <- tempfile()
+expect_error(
+    fromDataFrame(df, uri, col_index=1, sparse=TRUE, allows_dups=FALSE)
+)
+
+uri <- tempfile()
+expect_silent(
+    arr <- fromDataFrame(df, uri, col_index=1, sparse=TRUE, allows_dups=TRUE)
+)
+
+arr <- tiledb_array(uri, as.data.frame=TRUE)
+chk <- arr[]
+expect_equal(df, chk)


### PR DESCRIPTION
`fromDataFrame()` was ignoring the `allows_dups` argument.