### PR TITLE
Support Matrix return types

### DIFF
--- a/R/TileDBArray.R
+++ b/R/TileDBArray.R
@@ -81,7 +81,7 @@ setClass("tiledb_array",
 #' @param timestamp optional A POSIXct Datetime value determining where in time the array is
 #' to be openened.
 #' @param as.matrix optional logical switch, defaults to "FALSE"; currently limited to dense
-#' matrices from queries returning one attribute
+#' matrices; in the case of multiple attributes in query lists of matrices are returned
 #' @param ctx tiledb_ctx (optional)
 #' @return tiledb_array object
 #' @export

--- a/R/TileDBArray.R
+++ b/R/TileDBArray.R
@@ -363,8 +363,8 @@ setMethod("[", "tiledb_array",
   attrvarnum <- unname(sapply(attrs, function(a) libtiledb_attribute_get_cell_val_num(a@ptr)))
   attrnullable <- unname(sapply(attrs, function(a) libtiledb_attribute_get_nullable(a@ptr)))
 
-  if (length(x@attrs) != 0) {
-    ind <- match(x@attrs, attrnames)
+  if (length(sel) != 0) {
+    ind <- match(sel, attrnames)
     if (length(ind) == 0) {
       stop("Only non-existing columns selected.", call.=FALSE)
     }

--- a/R/TileDBArray.R
+++ b/R/TileDBArray.R
@@ -583,7 +583,9 @@ setMethod("[", "tiledb_array",
     } else if (ncol(res) > 3) {
       message("case of more than one argument not yet implemented")
     } else if (!is.null(i)) {
-      message("case of row selection not supported for matrix")
+      message("case of row selection not supported for accessing as.matrix")
+    } else if (!is.null(j)) {
+      message("case of column selection not supported for accessing as.matrix")
     } else {
       mat <- matrix(, nrow=max(res[,1]), ncol=max(res[,2]))
       mat[ cbind( res[,1], res[,2] ) ] <- res[,3]

--- a/R/TileDBArray.R
+++ b/R/TileDBArray.R
@@ -580,16 +580,24 @@ setMethod("[", "tiledb_array",
   if (x@as.matrix) {
     if (ncol(res) < 3) {
       message("ignoring as.matrix argument with insufficient result set")
-    } else if (ncol(res) > 3) {
-      message("case of more than one argument not yet implemented")
     } else if (!is.null(i)) {
       message("case of row selection not supported for accessing as.matrix")
     } else if (!is.null(j)) {
       message("case of column selection not supported for accessing as.matrix")
-    } else {
+    } else if (ncol(res) == 3) {
       mat <- matrix(, nrow=max(res[,1]), ncol=max(res[,2]))
       mat[ cbind( res[,1], res[,2] ) ] <- res[,3]
       res <- mat
+    } else {                            # case of ncol > 3
+      k <- ncol(res) - 2
+      lst <- vector(mode = "list", length = k)
+      for (i in seq_len(k)) {
+         mat <- matrix(, nrow=max(res[,1]), ncol=max(res[,2]))
+         mat[ cbind( res[,1], res[,2] ) ] <- res[, 2 + i]
+         lst[[i]] <- mat
+      }
+      names(lst) <- tail(colnames(res), k)
+      res <- lst
     }
   }
 

--- a/R/TileDBArray.R
+++ b/R/TileDBArray.R
@@ -568,8 +568,8 @@ setMethod("[", "tiledb_array",
   res <- data.frame(reslist)[seq_len(resrv),]
   colnames(res) <- allnames
 
-  ## reduce output if extended is false
-  if (!x@extended) {
+  ## reduce output if extended is false, or attrs given
+  if (!x@extended || length(sel) > 0) {
     res <- res[, attrnames]
   }
 

--- a/inst/tinytest/test_dataframe.R
+++ b/inst/tinytest/test_dataframe.R
@@ -33,7 +33,7 @@ expect_equal(irisdf, newdf[,-1])
 arr <- tiledb_array(uri, as.data.frame=TRUE,
                     attrs = c("Petal.Length", "Petal.Width"))
 newdf <- arr[]
-expect_equal(iris[, c("Petal.Length", "Petal.Width")], newdf[,-1])
+expect_equal(iris[, c("Petal.Length", "Petal.Width")], newdf)
 
 
 ## test list

--- a/inst/tinytest/test_tiledbarray.R
+++ b/inst/tinytest/test_tiledbarray.R
@@ -1055,9 +1055,14 @@ df1$vals2 <- df1$vals * 10
 tmp2 <- tempfile()
 fromDataFrame(df1, tmp2)
 
-arr4 <- tiledb_array(tmp2, as.matrix=TRUE)
-expect_true(is.data.frame(suppressMessages(arr4[]))) # will fail if we add list of matrices
-
 ## check selecting matrix out of multiple cols
-arr5 <- tiledb_array(tmp2, attrs=c("rows", "cols", "vals2"), as.matrix=TRUE)
-expect_equal(arr5[], 10*mat)
+arr4 <- tiledb_array(tmp2, attrs=c("rows", "cols", "vals2"), as.matrix=TRUE)
+expect_equal(arr4[], 10*mat)
+arr5 <- tiledb_array(tmp2, attrs=c("rows", "cols", "vals"), as.matrix=TRUE)
+expect_equal(arr5[], mat)
+arr6 <- tiledb_array(tmp2, attrs=c("rows", "cols", "vals", "vals2"), as.matrix=TRUE)
+res <- arr6[]
+expect_true(is.list(res))
+expect_equal(length(res), 2L)
+expect_equal(res$vals, mat)
+expect_equal(res$vals2, 10*mat)

--- a/inst/tinytest/test_tiledbarray.R
+++ b/inst/tinytest/test_tiledbarray.R
@@ -205,7 +205,7 @@ expect_true(length(attrs(arr)) == 0)
 sels <-  c("age", "job", "education", "duration")
 attrs(arr) <- sels
 dat <- arr[]
-expect_equal(colnames(dat), c("__tiledb_rows", sels))
+expect_equal(colnames(dat), sels)
 extended(arr) <- FALSE
 dat <- arr[]
 expect_equal(colnames(dat), sels)
@@ -1057,3 +1057,7 @@ fromDataFrame(df1, tmp2)
 
 arr4 <- tiledb_array(tmp2, as.matrix=TRUE)
 expect_true(is.data.frame(suppressMessages(arr4[]))) # will fail if we add list of matrices
+
+## check selecting matrix out of multiple cols
+arr5 <- tiledb_array(tmp2, attrs=c("rows", "cols", "vals2"), as.matrix=TRUE)
+expect_equal(arr5[], 10*mat)

--- a/man/tiledb_array-class.Rd
+++ b/man/tiledb_array-class.Rd
@@ -35,6 +35,8 @@ describes the (min,max) pair of ranges for dimension i}
 
 \item{\code{timestamp}}{A POSIXct datetime variable}
 
+\item{\code{as.matrix}}{A logical value}
+
 \item{\code{ptr}}{External pointer to the underlying implementation}
 }}
 

--- a/man/tiledb_array.Rd
+++ b/man/tiledb_array.Rd
@@ -16,6 +16,7 @@ tiledb_array(
   datetimes_as_int64 = FALSE,
   encryption_key = character(),
   timestamp = as.POSIXct(double(), origin = "1970-01-01"),
+  as.matrix = FALSE,
   ctx = tiledb_get_context()
 )
 }
@@ -49,6 +50,9 @@ in case the array was written with encryption.}
 
 \item{timestamp}{optional A POSIXct Datetime value determining where in time the array is
 to be openened.}
+
+\item{as.matrix}{optional logical switch, defaults to "FALSE"; currently limited to dense
+matrices from queries returning one attribute}
 
 \item{ctx}{tiledb_ctx (optional)}
 }

--- a/man/tiledb_array.Rd
+++ b/man/tiledb_array.Rd
@@ -52,7 +52,7 @@ in case the array was written with encryption.}
 to be openened.}
 
 \item{as.matrix}{optional logical switch, defaults to "FALSE"; currently limited to dense
-matrices from queries returning one attribute}
+matrices; in the case of multiple attributes in query lists of matrices are returned}
 
 \item{ctx}{tiledb_ctx (optional)}
 }


### PR DESCRIPTION
This PR implements something discussed following #222: for (dense) arrays with row and colum indices, we can optionally return a `Matrix` object (in addition to the existing default of a list of vectors, and the existing `data.frame` option.  

To illustrate, consider the `quickstart_dense` example:

```r
> library(tiledb)
> arr <- tiledb_array("quickstart_dense", as.matrix=TRUE)
> arr[]
     [,1] [,2] [,3] [,4]
[1,]    1    2    3    4
[2,]    5    6    7    8
[3,]    9   10   11   12
[4,]   13   14   15   16
> 
```

In case more than one attribute is returned from a query, a list of matrices is returned.   