### PR TITLE
Default dense data.frame writes to column major layout

### DIFF
--- a/R/TileDBArray.R
+++ b/R/TileDBArray.R
@@ -769,7 +769,7 @@ setMethod("[<-", "tiledb_array",
     qryptr <- libtiledb_query(ctx@ptr, arrptr, "WRITE")
     qryptr <- libtiledb_query_set_layout(qryptr,
                                          if (length(layout) > 0) layout
-                                         else { if (sparse) "UNORDERED" else "ROW_MAJOR" })
+                                         else { if (sparse) "UNORDERED" else "COL_MAJOR" })
 
     buflist <- vector(mode="list", length=nc)
 

--- a/inst/tinytest/test_tiledbarray.R
+++ b/inst/tinytest/test_tiledbarray.R
@@ -585,6 +585,7 @@ if (requireNamespace("bit64", quietly=TRUE)) {
   tiledb_array_create(uri = tmp, schema)
   #print(schema)
   A <- tiledb_array(uri = tmp)
+  query_layout(A) <- "ROW_MAJOR"      # as in issue #222, before PR #226 changed to "COL_MAJOR"
 
   data <- 1:16
   ## can write as data.frame
@@ -615,6 +616,7 @@ if (requireNamespace("bit64", quietly=TRUE)) {
   tiledb_array_create(uri = tmp, schema)
   #print(schema)
   A <- tiledb_array(uri = tmp)
+  query_layout(A) <- "ROW_MAJOR"      # as in issue #222, before PR #226 changed to "COL_MAJOR"
 
   data <- 1:16
   ## can write as data.frame
@@ -645,6 +647,7 @@ if (requireNamespace("bit64", quietly=TRUE)) {
   tiledb_array_create(uri = tmp, schema)
   #print(schema)
   A <- tiledb_array(uri = tmp)
+  query_layout(A) <- "ROW_MAJOR"      # as in issue #222, before PR #226 changed to "COL_MAJOR"
 
   data <- 1:16
   ## can write as data.frame
@@ -675,6 +678,7 @@ if (requireNamespace("bit64", quietly=TRUE)) {
   tiledb_array_create(uri = tmp, schema)
   #print(schema)
   A <- tiledb_array(uri = tmp)
+  query_layout(A) <- "ROW_MAJOR"      # as in issue #222, before PR #226 changed to "COL_MAJOR"
 
   data <- 1:16
   ## can write as data.frame
@@ -705,6 +709,7 @@ if (requireNamespace("bit64", quietly=TRUE)) {
   tiledb_array_create(uri = tmp, schema)
   #print(schema)
   A <- tiledb_array(uri = tmp)
+  query_layout(A) <- "ROW_MAJOR"      # as in issue #222, before PR #226 changed to "COL_MAJOR"
 
   data <- 1:16
   ## can write as data.frame
@@ -735,6 +740,7 @@ if (requireNamespace("bit64", quietly=TRUE)) {
   tiledb_array_create(uri = tmp, schema)
   #print(schema)
   A <- tiledb_array(uri = tmp)
+  query_layout(A) <- "ROW_MAJOR"      # as in issue #222, before PR #226 changed to "COL_MAJOR"
 
   data <- 1:16
   ## can write as data.frame
@@ -765,6 +771,7 @@ if (requireNamespace("bit64", quietly=TRUE)) {
   tiledb_array_create(uri = tmp, schema)
   #print(schema)
   A <- tiledb_array(uri = tmp)
+  query_layout(A) <- "ROW_MAJOR"      # as in issue #222, before PR #226 changed to "COL_MAJOR"
 
   data <- 1:16
   ## can write as data.frame
@@ -796,6 +803,7 @@ if (requireNamespace("bit64", quietly=TRUE)) {
   tiledb_array_create(uri = tmp, schema)
   #print(schema)
   A <- tiledb_array(uri = tmp)
+  query_layout(A) <- "ROW_MAJOR"      # as in issue #222, before PR #226 changed to "COL_MAJOR"
 
   data <- 1:16
   ## can write as data.frame
@@ -837,6 +845,7 @@ if (requireNamespace("bit64", quietly=TRUE)) {
   tiledb_array_create(uri = tmp, schema)
   #print(schema)
   A <- tiledb_array(uri = tmp)
+  query_layout(A) <- "ROW_MAJOR"      # as in issue #222, before PR #226 changed to "COL_MAJOR"
 
   data <- data.frame(a1=1:16,
                      a2=1:16,


### PR DESCRIPTION
As seen in issue #222, dense arrays written from a `data.frame` object defaulted to row-major layout.  As column-major is more natural for R, the PR reverts this from row-major to column-major.   

The only other changes was to account for the change in a number of unit tests.