### PR TITLE
Set UNORDERED layout for tests with sparse writes to dense matrices

### DIFF
--- a/inst/tinytest/test_arrowio.R
+++ b/inst/tinytest/test_arrowio.R
@@ -35,7 +35,6 @@ tiledb:::.delete_arrow_schema_from_double(as)
 tiledb:::.delete_arrow_array_from_double(aa)
 
 
-
 ## round-turn test 1: write tiledb first, create arrow object via zero-copy
 suppressMessages(library(bit64))
 n <- 10L
@@ -69,6 +68,7 @@ for (col in c("int8", "uint8", "int16", "uint16", "int32", "uint32", "int64", "u
     attrlst[[col]] <- tiledb_query_create_buffer_ptr(qry, toupper(col), vals)
     qry <- tiledb_query_set_buffer_ptr(qry, col, attrlst[[col]])
 }
+tiledb_query_set_layout(qry, "UNORDERED")
 tiledb_query_submit(qry)
 tiledb_query_finalize(qry)
 
@@ -157,6 +157,7 @@ for (nam in nms) {
 
     lst[[nam]] <- list(aa=aa, as=as)
 }
+tiledb_query_set_layout(qry, "UNORDERED")
 tiledb_query_submit(qry)
 tiledb_query_finalize(qry)
 

--- a/inst/tinytest/test_query.R
+++ b/inst/tinytest/test_query.R
@@ -170,6 +170,7 @@ qry <- tiledb_query_set_buffer(qry, "rows", rows)
 vals <- seq(101,110)
 qry <- tiledb_query_set_buffer(qry, "vals", vals)
 
+tiledb_query_set_layout(qry, "UNORDERED")
 tiledb_query_submit(qry)
 tiledb_query_finalize(qry)
 expect_equal(tiledb_query_status(qry), "COMPLETE")

--- a/inst/tinytest/test_tiledbarray.R
+++ b/inst/tinytest/test_tiledbarray.R
@@ -585,7 +585,7 @@ if (requireNamespace("bit64", quietly=TRUE)) {
   tiledb_array_create(uri = tmp, schema)
   #print(schema)
   A <- tiledb_array(uri = tmp)
-  query_layout(A) <- "ROW_MAJOR"      # as in issue #222, before PR #226 changed to "COL_MAJOR"
+  query_layout(A) <- "UNORDERED"
 
   data <- 1:16
   ## can write as data.frame
@@ -616,7 +616,7 @@ if (requireNamespace("bit64", quietly=TRUE)) {
   tiledb_array_create(uri = tmp, schema)
   #print(schema)
   A <- tiledb_array(uri = tmp)
-  query_layout(A) <- "ROW_MAJOR"      # as in issue #222, before PR #226 changed to "COL_MAJOR"
+  query_layout(A) <- "UNORDERED"
 
   data <- 1:16
   ## can write as data.frame
@@ -647,7 +647,7 @@ if (requireNamespace("bit64", quietly=TRUE)) {
   tiledb_array_create(uri = tmp, schema)
   #print(schema)
   A <- tiledb_array(uri = tmp)
-  query_layout(A) <- "ROW_MAJOR"      # as in issue #222, before PR #226 changed to "COL_MAJOR"
+  query_layout(A) <- "UNORDERED"
 
   data <- 1:16
   ## can write as data.frame
@@ -678,7 +678,7 @@ if (requireNamespace("bit64", quietly=TRUE)) {
   tiledb_array_create(uri = tmp, schema)
   #print(schema)
   A <- tiledb_array(uri = tmp)
-  query_layout(A) <- "ROW_MAJOR"      # as in issue #222, before PR #226 changed to "COL_MAJOR"
+  query_layout(A) <- "UNORDERED"
 
   data <- 1:16
   ## can write as data.frame
@@ -709,7 +709,7 @@ if (requireNamespace("bit64", quietly=TRUE)) {
   tiledb_array_create(uri = tmp, schema)
   #print(schema)
   A <- tiledb_array(uri = tmp)
-  query_layout(A) <- "ROW_MAJOR"      # as in issue #222, before PR #226 changed to "COL_MAJOR"
+  query_layout(A) <- "UNORDERED"
 
   data <- 1:16
   ## can write as data.frame
@@ -740,7 +740,7 @@ if (requireNamespace("bit64", quietly=TRUE)) {
   tiledb_array_create(uri = tmp, schema)
   #print(schema)
   A <- tiledb_array(uri = tmp)
-  query_layout(A) <- "ROW_MAJOR"      # as in issue #222, before PR #226 changed to "COL_MAJOR"
+  query_layout(A) <- "UNORDERED"
 
   data <- 1:16
   ## can write as data.frame
@@ -771,7 +771,7 @@ if (requireNamespace("bit64", quietly=TRUE)) {
   tiledb_array_create(uri = tmp, schema)
   #print(schema)
   A <- tiledb_array(uri = tmp)
-  query_layout(A) <- "ROW_MAJOR"      # as in issue #222, before PR #226 changed to "COL_MAJOR"
+  query_layout(A) <- "UNORDERED"
 
   data <- 1:16
   ## can write as data.frame
@@ -803,7 +803,7 @@ if (requireNamespace("bit64", quietly=TRUE)) {
   tiledb_array_create(uri = tmp, schema)
   #print(schema)
   A <- tiledb_array(uri = tmp)
-  query_layout(A) <- "ROW_MAJOR"      # as in issue #222, before PR #226 changed to "COL_MAJOR"
+  query_layout(A) <- "UNORDERED"
 
   data <- 1:16
   ## can write as data.frame
@@ -845,7 +845,7 @@ if (requireNamespace("bit64", quietly=TRUE)) {
   tiledb_array_create(uri = tmp, schema)
   #print(schema)
   A <- tiledb_array(uri = tmp)
-  query_layout(A) <- "ROW_MAJOR"      # as in issue #222, before PR #226 changed to "COL_MAJOR"
+  query_layout(A) <- "UNORDERED"
 
   data <- data.frame(a1=1:16,
                      a2=1:16,


### PR DESCRIPTION
This small PR updates three unit-tests file which fail under the most current TileDB Embedded version as sparse write to dense matrices are detected under row- or col-major layout -- which we now update to unordered.

No changes to any R or C++ package code.