### PR TITLE
Small usability enhancements to schema creation

### DIFF
--- a/R/ArraySchema.R
+++ b/R/ArraySchema.R
@@ -44,6 +44,7 @@ tiledb_array_schema.from_ptr <- function(ptr) {
 #' @param coords_filter_list (optional)
 #' @param offsets_filter_list (optional)
 #' @param capacity (optional)
+#' @param allows_dups (optional, requires \sQuote{spars} to be TRUE)
 #' @param ctx tiledb_ctx object (optional)
 #' @examples
 #' \dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
@@ -66,6 +67,7 @@ tiledb_array_schema <- function(domain,
                                 coords_filter_list = NULL,
                                 offsets_filter_list = NULL,
                                 capacity = 10000L,
+                                allows_dups = FALSE,
                                 ctx = tiledb_get_context()) {
   if (!is(ctx, "tiledb_ctx")) {
     stop("ctx argument must be a tiledb_ctx")
@@ -95,6 +97,12 @@ tiledb_array_schema <- function(domain,
   if (!is.logical(sparse)) {
     stop("sparse argument must be a logical TRUE or FALSE")
   }
+  if (!is.logical(allows_dups)) {
+    stop("allows_dups argument must be a logical TRUE or FALSE")
+  }
+  if (allows_dups && !sparse) {
+    stop("allows_dups argument requires sparse argument")
+  }
   attr_ptrs <- lapply(attrs, function(obj) slot(obj, "ptr"))
   coords_filter_list_ptr <- NULL
   if (!is.null(coords_filter_list)) {
@@ -107,6 +115,9 @@ tiledb_array_schema <- function(domain,
   ptr <- libtiledb_array_schema(ctx@ptr, domain@ptr, attr_ptrs, cell_order, tile_order,
                                 coords_filter_list_ptr, offsets_filter_list_ptr, sparse)
   libtiledb_array_schema_set_capacity(ptr, capacity)
+  if (allows_dups) {
+      libtiledb_array_schema_set_allows_dups(ptr, TRUE)
+  }
   return(new("tiledb_array_schema", ptr = ptr))
 }
 

--- a/R/TileDBArray.R
+++ b/R/TileDBArray.R
@@ -653,6 +653,7 @@ setMethod("[<-", "tiledb_array",
       return(x)
     }
   }
+  if (is.null(names(value))) stop("No column names supplied", call. = FALSE)
 
   ## add defaults
   if (missing(i)) i <- NULL

--- a/man/sub-tiledb_array-ANY-method.Rd
+++ b/man/sub-tiledb_array-ANY-method.Rd
@@ -26,7 +26,7 @@ ranges.}
 \item{drop}{Optional logical switch to drop dimensions, default FALSE, currently unused.}
 }
 \value{
-An element from the sparse array
+The resulting elements in the selected format
 }
 \description{
 Heterogenous domains are supported, including timestamps and characters.

--- a/man/tiledb_array_schema.Rd
+++ b/man/tiledb_array_schema.Rd
@@ -13,6 +13,7 @@ tiledb_array_schema(
   coords_filter_list = NULL,
   offsets_filter_list = NULL,
   capacity = 10000L,
+  allows_dups = FALSE,
   ctx = tiledb_get_context()
 )
 }
@@ -32,6 +33,8 @@ tiledb_array_schema(
 \item{offsets_filter_list}{(optional)}
 
 \item{capacity}{(optional)}
+
+\item{allows_dups}{(optional, requires \sQuote{spars} to be TRUE)}
 
 \item{ctx}{tiledb_ctx object (optional)}
 }

--- a/src/libtiledb.cpp
+++ b/src/libtiledb.cpp
@@ -1277,7 +1277,7 @@ XPtr<tiledb::Attribute> libtiledb_attribute(XPtr<tiledb::Context> ctx,
     } else if (attr_dtype == TILEDB_FLOAT32) {
         using DType = tiledb::impl::tiledb_to_type<TILEDB_FLOAT32>::type;
         attr = XPtr<tiledb::Attribute>(new tiledb::Attribute(tiledb::Attribute::create<DType>(*ctx.get(), name)), false);
-    } else if (attr_dtype == TILEDB_CHAR) {
+    } else if (attr_dtype == TILEDB_CHAR || attr_dtype == TILEDB_STRING_ASCII) {
         using DType = tiledb::impl::tiledb_to_type<TILEDB_CHAR>::type;
         attr = XPtr<tiledb::Attribute>(new tiledb::Attribute(tiledb::Attribute::create<DType>(*ctx.get(), name)), false);
         uint64_t num = static_cast<uint64_t>(ncells);
@@ -1311,7 +1311,7 @@ XPtr<tiledb::Attribute> libtiledb_attribute(XPtr<tiledb::Context> ctx,
         Rcpp::Rcout << type << std::endl;
         Rcpp::stop("Only integer ((U)INT{8,16,32,64}), logical (INT32), real (FLOAT{32,64}), "
                    "Date (DATEIME_DAY), Datetime (DATETIME_{SEC,MS,US}), "
-                   "nanotime (DATETIME_NS) and character (CHAR) attributes "
+                   "nanotime (DATETIME_NS) and character (CHAR,ASCII) attributes "
                    "are supported");
     }
     attr->set_filter_list(*filter_list);


### PR DESCRIPTION
While working on a data.frame example I came across three distinct little fixes now regrouped here:
- setting duplicates should also be possible in the schema creation ~key~ step
- we should allow for TILEDB_STRING_ASCII alongside TILEDB_CHAR
- we may as well check for omitted column names in the `[<-` assignment

No other actual code changes.