### PR TITLE
Upgrade TileDB Embedded to release 2.2.8

### DIFF
--- a/tools/tiledbVersion.txt
+++ b/tools/tiledbVersion.txt
@@ -1,2 +1,2 @@
-version: 2.2.7
-sha: a788ce5
+version: 2.2.8
+sha: 6e7a5a2


### PR DESCRIPTION
As before, uses the config file to switch to release 2.2.8 for the builds involving downloads to pre-made artifacts.