### PR TITLE
Make data.frame creation more robust

### DIFF
--- a/R/DataFrame.R
+++ b/R/DataFrame.R
@@ -115,7 +115,7 @@ fromDataFrame <- function(obj, uri, col_index=NULL, sparse=FALSE, allows_dups=sp
             col_domain <- if (is.null(tile_domain)) c(min(idxcol), max(idxcol)) else tile_domain
             col_extent <- if (is.null(tile_extent)) dims[1] else tile_extent
             if (!inherits(idxcol, "character")) {
-                dom_range <- diff(range(col_domain)) + 1
+                dom_range <- diff(as.numeric(range(col_domain))) + 1
                 col_extent <- min(dom_range, col_extent)
             }
             dtype <- "INT32"                # default

--- a/R/DataFrame.R
+++ b/R/DataFrame.R
@@ -106,12 +106,18 @@ fromDataFrame <- function(obj, uri, col_index=NULL, sparse=FALSE, allows_dups=sp
         atrobj <- obj[, -col_index, drop=FALSE]
         useobj <- cbind(dimobj, atrobj)
 
+        if (any(is.na(dimobj)))
+            stop("Nullable columns are not supported as dimension columns.", call. = FALSE)
+
         makeDim <- function(ind) {
             idxcol <- dimobj[,ind]
             idxnam <- colnames(dimobj)[ind]
-            if (debug) cat("Looking at col_index =", ind, ":", idxnam, "\n")
             col_domain <- if (is.null(tile_domain)) c(min(idxcol), max(idxcol)) else tile_domain
             col_extent <- if (is.null(tile_extent)) dims[1] else tile_extent
+            if (!inherits(idxcol, "character")) {
+                dom_range <- diff(range(col_domain)) + 1
+                col_extent <- min(dom_range, col_extent)
+            }
             dtype <- "INT32"                # default
             if (inherits(idxcol, "POSIXt")) {
                 dtype <- "DATETIME_US"
@@ -129,8 +135,16 @@ fromDataFrame <- function(obj, uri, col_index=NULL, sparse=FALSE, allows_dups=sp
                 dtype <- "ASCII"
                 col_extent <- NULL
                 col_domain <- c(NULL, NULL)
+            } else if (dtype == "INT32") {
+                col_extent <- as.integer(col_extent)
             }
 
+            if (debug) {
+                cat(sprintf("Setting domain name %s type %s domain (%s,%s) extent %s\n", idxnam, dtype,
+                            ifelse(is.null(col_domain[1]), "null", format(col_domain[1])),
+                            ifelse(is.null(col_domain[2]), "null", format(col_domain[2])),
+                            ifelse(is.null(col_extent), "null", format(col_extent))))
+            }
             tiledb_dim(name = idxnam,
                        domain = col_domain,
                        tile = col_extent,
@@ -176,7 +190,6 @@ fromDataFrame <- function(obj, uri, col_index=NULL, sparse=FALSE, allows_dups=sp
     schema <- tiledb_array_schema(dom, attrs = attributes,
                                   cell_order = cell_order, tile_order = tile_order,
                                   sparse=sparse, capacity=capacity)
-    if (debug) print(schema)
     allows_dups(schema) <- allows_dups
     tiledb_array_create(uri, schema)
 


### PR DESCRIPTION
This PR makes the behaviour in `fromDataFrame()` more robust to _e.g._ `Datetime` columns. The extent calculation uses a `diff()` over a `range()` of the column values.  When these are `Datetime`, R dispatch to `difftime()` which does not return a single value as desired.  The injected `as.numeric` does that.   

The net effect is that we can now create dimension columns from `Datetime` as well as in this example using the NYC Flights data where `time_hour` is of type `Datetime`:

```r
    fromDataFrame(flights,
                  uri,
                  col_index = c("carrier", "origin", "dest", "time_hour"),
                  sparse=TRUE) # we want a sparse array (and this implies allows dupes)
```

We also added a test for missing values as columns containing those cannot be used as dimensions.