### PR TITLE
Display a startup message with tiledb version numbers

### DIFF
--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,6 +1,6 @@
 #  MIT License
 #
-#  Copyright (c) 2017-2020 TileDB Inc.
+#  Copyright (c) 2017-2021 TileDB Inc.
 #
 #  Permission is hereby granted, free of charge, to any person obtaining a copy
 #  of this software and associated documentation files (the "Software"), to deal
@@ -29,4 +29,10 @@
 
   ## similarly, use a slot for the vfs object
   .pkgenv[["vfs"]] <- NULL
+}
+
+.onAttach <- function(libname, pkgName) {
+    packageStartupMessage("TileDB R ", packageVersion("tiledb"),
+                          " with TileDB Embedded ", format(tiledb_version(TRUE)),
+                          ". See https://tiledb.com for more information.")
 }


### PR DESCRIPTION
This PR adds a suppressable message to the startup showing both the R package version and the version of the embedded TileDB C++ library. 