### PR TITLE
Add Date support to fromDataFrame

### DIFF
--- a/R/DataFrame.R
+++ b/R/DataFrame.R
@@ -122,6 +122,9 @@ fromDataFrame <- function(obj, uri, col_index=NULL, sparse=FALSE, allows_dups=sp
             if (inherits(idxcol, "POSIXt")) {
                 dtype <- "DATETIME_US"
                 col_domain <- as.numeric(col_domain) * 1e6 	# int64 used
+            } else if (inherits(idxcol, "Date")) {
+                dtype <- "DATETIME_DAY"
+                col_extent <- as.numeric(col_extent) # to not trigger INT32 test
             } else if (inherits(idxcol, "numeric")) {
                 dtype <- "FLOAT64"
                 col_extent <- as.numeric(col_extent)
@@ -177,6 +180,9 @@ fromDataFrame <- function(obj, uri, col_index=NULL, sparse=FALSE, allows_dups=sp
             tp <- "INT64"
         else
             stop("Currently unsupported type: ", cl)
+        if (debug) {
+            cat(sprintf("Setting attribute name %s type %s\n", colnames(obj)[ind], tp))
+        }
         tiledb_attr(colnames(obj)[ind],
                     type = tp,
                     ncells = ifelse(tp=="CHAR",NA_integer_,1),

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -32,7 +32,9 @@
 }
 
 .onAttach <- function(libname, pkgName) {
-    packageStartupMessage("TileDB R ", packageVersion("tiledb"),
-                          " with TileDB Embedded ", format(tiledb_version(TRUE)),
-                          ". See https://tiledb.com for more information.")
+    if (interactive()) {
+        packageStartupMessage("TileDB R ", packageVersion("tiledb"),
+                              " with TileDB Embedded ", format(tiledb_version(TRUE)),
+                              ". See https://tiledb.com for more information.")
+    }
 }


### PR DESCRIPTION
This PR covers Date types when auto-generating schemas in fromDataFrame.   It also makes the recently added version display conditional on `interactive()` being true.  While small, the PR rounds things out and should probably go in before we roll up 0.9.1.