### PR TITLE
Add small tweaks to make tests pass with R 3.6.3

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# tiledb 'under development'
+
+## Bug Fixes
+
+* Unit tests of character columns in data frames accomodate R versions prior to R 4.0.0 in all cases (#243)
+
+
 # tiledb 0.9.1
 
 * This release of the R package builds against [TileDB 2.2.9](https://github.com/TileDB-Inc/TileDB/releases/tag/2.2.9), but has also been tested against previous releases as well as the development version.

--- a/inst/tinytest/test_dataframe.R
+++ b/inst/tinytest/test_dataframe.R
@@ -241,12 +241,13 @@ D <- data.frame(sample=paste(LETTERS[1:N], as.character(sort(trunc(runif(N, 100,
                 stringsAsFactors=FALSE)
 uri <- tempfile()
 fromDataFrame(D, uri, col_index=1, sparse=TRUE)
-chk <- tiledb_array(uri, as.data.frame=TRUE)
+arr <- tiledb_array(uri, as.data.frame=TRUE)
+chk <- arr[]
 if (getRversion() < '4.0.0') {
     chk$sample <- as.character(chk$sample)
     chk$header <- as.character(chk$header)
 }
-expect_equal(D, chk[])
+expect_equal(D, chk)
 
 ## sparse array can have duplicate values in index column
 df <- data.frame(
@@ -256,15 +257,12 @@ df <- data.frame(
 )
 
 uri <- tempfile()
-expect_error(
-    fromDataFrame(df, uri, col_index=1, sparse=TRUE, allows_dups=FALSE)
-)
+expect_error(fromDataFrame(df, uri, col_index=1, sparse=TRUE, allows_dups=FALSE))
 
 uri <- tempfile()
-expect_silent(
-    arr <- fromDataFrame(df, uri, col_index=1, sparse=TRUE, allows_dups=TRUE)
-)
+expect_silent(arr <- fromDataFrame(df, uri, col_index=1, sparse=TRUE, allows_dups=TRUE))
 
 arr <- tiledb_array(uri, as.data.frame=TRUE)
 chk <- arr[]
+if (getRversion() <  '4.0.0') chk$char <- as.character(chk$char)
 expect_equal(df, chk)

--- a/inst/tinytest/test_dim.R
+++ b/inst/tinytest/test_dim.R
@@ -194,11 +194,12 @@ for (dtype in dimtypes) {
                    "DATETIME_AS"  = as.nanotime("1970-01-01T00:00:00.000000001+00:00") + (0:4)*1e9
                    )
     avec <- 10^(1:5)
-    data <- data.frame(row = dvec, attr = avec)
+    data <- data.frame(row = dvec, attr = avec, stringsAsFactors=FALSE)
     arr[] <- data
 
     arr2 <- tiledb_array(uri, as.data.frame=TRUE)
     readdata <- arr2[]
+    if (dtype == "ASCII" && getRversion() < '4.0.0') readdata$row <- as.character(readdata$row)
     if (dtype == "UINT64") readdata[,1] <- as.integer64(readdata[,1])  # return doubles here
     expect_equal(data, readdata)
     if (grepl("^DATETIME", dtype)) {
@@ -252,6 +253,7 @@ for (dtype in dimtypes) {
         selected_ranges(arr3) <- list(cbind(data[2, "row"], data[4, "row"]))
     }
     readdata <- arr3[]
+    if (dtype == "ASCII" && getRversion() < '4.0.0') readdata$row <- as.character(readdata$row)
     if (dtype == "UINT64") readdata[,1] <- as.integer64(readdata[,1])  # return doubles here
     expect_equivalent(data[2:4,], readdata, info=dtype) # equivalent as not type consistent (int <-> numeric)
     expect_equal(NROW(readdata), 3L)


### PR DESCRIPTION
This PR addresses the issue that some tests failed under R 3.6.* (having to do with the fact that the default behavior for stringsAsFactors switched from pre-R 4.0.0 to R 4.0.0).  For character columns, our code always treats them as character and never as factors (just as R now does) but in two or three spots the tests did not account for that and now do a (conditional on R < 4.0.0) conversion.