### PR TITLE
Refine optional dimension drop for given attribute selection or matrix case (fixes #244)

### DIFF
--- a/R/TileDBArray.R
+++ b/R/TileDBArray.R
@@ -604,8 +604,10 @@ setMethod("[", "tiledb_array",
   colnames(res) <- allnames
 
   ## reduce output if extended is false, or attrs given
-  if (!x@extended || length(sel) > 0) {
-      res <- res[, if (sparse) allnames else attrnames]
+  if (!x@extended) {
+      if (length(sel) > 0) {
+          res <- res[, if (sparse) allnames else attrnames]
+      }
       k <- match("__tiledb_rows", colnames(res))
       if (is.finite(k)) {
           res <- res[, -k]
@@ -617,6 +619,10 @@ setMethod("[", "tiledb_array",
   }
 
   if (x@as.matrix) {
+    k <- match("__tiledb_rows", colnames(res))
+    if (is.finite(k)) {
+       res <- res[, -k]
+    }
     if (ncol(res) < 3) {
       message("ignoring as.matrix argument with insufficient result set")
     } else if (!is.null(i)) {

--- a/inst/examples/ex_1.R
+++ b/inst/examples/ex_1.R
@@ -28,9 +28,9 @@ create_array <- function(uri) {
 
 
 write_array <- function(uri) {
-  data <- list(array(seq(1:50), dim = c(10,5)),
-               array(as.double(seq(101,by=0.5,length=50)), dim = c(10,5)),
-               array(c(letters[1:26], "brown", "fox", LETTERS[1:22]), dim = c(10,5)))
+  data <- list(a=array(seq(1:50), dim = c(10,5)),
+               b=array(as.double(seq(101,by=0.5,length=50)), dim = c(10,5)),
+               c=array(c(letters[1:26], "brown", "fox", LETTERS[1:22]), dim = c(10,5)))
   ## Open the array and write to it.
   A <- tiledb_array(uri = uri)
   A[] <- data

--- a/inst/tinytest/test_dataframe.R
+++ b/inst/tinytest/test_dataframe.R
@@ -30,7 +30,7 @@ expect_equal(irisdf, newdf[,-1])
 
 
 ## test attrs subselection
-arr <- tiledb_array(uri, as.data.frame=TRUE,
+arr <- tiledb_array(uri, as.data.frame=TRUE, extended=FALSE,
                     attrs = c("Petal.Length", "Petal.Width"))
 newdf <- arr[]
 expect_equal(iris[, c("Petal.Length", "Petal.Width")], newdf)

--- a/inst/tinytest/test_tiledbarray.R
+++ b/inst/tinytest/test_tiledbarray.R
@@ -199,7 +199,7 @@ dat <- readRDS(system.file("sampledata", "bankSample.rds", package="tiledb"))
 dir.create(tmpuri <- tempfile())
 fromDataFrame(dat[,-1], tmpuri)
 
-arr <- tiledb_array(tmpuri, as.data.frame=TRUE)
+arr <- tiledb_array(tmpuri, as.data.frame=TRUE, extended=FALSE)
 expect_true(length(attrs(arr)) == 0)
 
 sels <-  c("age", "job", "education", "duration")


### PR DESCRIPTION
This PR refines when dimensions are dropped (or kept) when attributes are selected (and in the matrix case). Implicit use of the `extended` argument did not correctly cover all cases.  The change addresses the issue ticket #244 filed by @LTLA last evening, and leads to two minor agument changes in tests.  