### PR TITLE
Correct attribute type assignment for one-column attribute selection with row and col dimensions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,10 @@
 
 * Unit tests of character columns in data frames accomodate R versions prior to R 4.0.0 in all cases (#243)
 
+* Dimension reduction for attribute-selected columns was incorrect in some cases (#245)
+
+* Attribute-selected columns were using dimenion data types in some cases (#246)
+
 
 # tiledb 0.9.1
 

--- a/R/TileDBArray.R
+++ b/R/TileDBArray.R
@@ -773,6 +773,8 @@ setMethod("[<-", "tiledb_array",
       value <- data.frame(x=as.matrix(value)[seq(1, d[1]*d[2])])
       colnames(value) <- attrnames
       allnames <- attrnames
+      alltypes <- attrtypes
+      allnullable <- attrnullable
     }
 
   ## Case 4: dense, list on RHS e.g. the ex_1.R example

--- a/inst/tinytest/test_tiledbarray.R
+++ b/inst/tinytest/test_tiledbarray.R
@@ -1076,3 +1076,44 @@ expect_true(is.list(res))
 expect_equal(length(res), 2L)
 expect_equal(res$vals, mat)
 expect_equal(res$vals2, 10*mat)
+
+## PR #245 (variant of examples/ex_1.R)
+uri <- tempfile()
+dom <- tiledb_domain(dims = c(tiledb_dim("rows", c(1L, 10L), 10L, "INT32"),
+                              tiledb_dim("cols", c(1L, 5L), 5L, "INT32")))
+schema <- tiledb_array_schema(dom,
+                              attrs = c(tiledb_attr("a", type = "INT32"),
+                                        tiledb_attr("b", type = "FLOAT64"),
+                                        tiledb_attr("c", type = "CHAR", ncells=NA_integer_)),
+                              cell_order = "ROW_MAJOR", tile_order = "ROW_MAJOR")
+tiledb_array_create(uri, schema)
+data <- list(a=array(seq(1:50), dim = c(10,5)),
+             b=array(as.double(seq(101,by=0.5,length=50)), dim = c(10,5)),
+             c=array(c(letters[1:26], "brown", "fox", LETTERS[1:22]), dim = c(10,5)))
+A <- tiledb_array(uri)
+A[] <- data
+obj <- tiledb_array(uri, attrs="a", as.data.frame=TRUE)
+res <- obj[]
+expect_equal(colnames(res), c("rows", "cols", "a")) 	# this was the PR issues
+obj <- tiledb_array(uri, attrs="a", as.matrix=TRUE)     # this is the preferred accessor here
+expect_equal(obj[], data[["a"]])
+obj <- tiledb_array(uri, as.matrix=TRUE)     			# test all three matrices
+res <- obj[]
+expect_equal(res[["a"]], data[["a"]])
+expect_equal(res[["b"]], data[["b"]])
+expect_equal(res[["c"]], data[["c"]])
+
+## PR #246
+N <- 25L
+K <- 4L
+uri <- tempfile()
+schema <- tiledb_array_schema(tiledb_domain(dims=c(tiledb_dim("d1", c(1L, N), tile=N, type="INT32"),
+                                                   tiledb_dim("d2", c(1L, K), tile=K, type="INT32"))),
+                              sparse=FALSE,
+                              attrs=tiledb_attr("x", type="FLOAT64"))
+tiledb_array_create(uri, schema)
+obj <- tiledb_array(uri, attrs="x", query_type="WRITE")
+M <- matrix(runif(N*K), N, K)
+obj[] <- M                              # prior to #246 this write had a write data type
+chk <- tiledb_array(uri, as.matrix=TRUE)
+expect_equal(chk[], M)


### PR DESCRIPTION
This PR corrects a bug kindly reported vy @LTLA in [this gist](https://gist.github.com/LTLA/47c0a1abb9efb6979d003b98bb5830a0).  In short, in the (common and key to his use) case of two (integer) dimensions and one (selected, or total) double attribute, when writing the data the buffer allocation used the wrong variable type. It was using the dimension type and not accounting for the attribute type.  The change is simple and similar to what is done in other code paths.  Some more detail is in [CH 7493](https://app.clubhouse.io/tiledb-inc/story/7493/buffer-allocation-error-in-r-example-as-reported-by-aaron-lun).