### PR TITLE
Support incremental array writing from data frame object

### DIFF
--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -2,10 +2,10 @@ on:
   push:
   pull_request:
 
-name: R-CMD-check
+name: windows
 
 jobs:
-  R-CMD-check:
+  windows:
     name: (Windows/mingw-w64)
     runs-on: windows-latest
     steps:

--- a/R/TileDBArray.R
+++ b/R/TileDBArray.R
@@ -745,13 +745,14 @@ setMethod("[<-", "tiledb_array",
 
   ## Case 1
   if (length(colnames(value)) == length(allnames)) {
-    ## same length is good
-    if (length(intersect(colnames(value), allnames)) == length(allnames)) {
-      ## all good, proceed
-      #message("Yay all columns found")
-    } else {
-      stop("Assigned data.frame does not contain all required attribute and dimension columns.")
-    }
+      ## same length is good
+      if (length(intersect(colnames(value), allnames)) == length(allnames)) {
+          ## all good, proceed
+          #message("Yay all columns found")
+          value <- value[, allnames]    # reordering helps with append case
+      } else {
+          stop("Assigned data.frame does not contain all required attribute and dimension columns.")
+      }
   }
 
   ## Case 2

--- a/R/VFS.R
+++ b/R/VFS.R
@@ -222,7 +222,7 @@ tiledb_vfs_remove_dir <- function(uri, vfs = tiledb_get_vfs()) {
   }
   stopifnot(vfs_argument=is(vfs, "tiledb_vfs"),
             uri_argument=is.character(uri))
-  libtiledb_vfs_remove_dir(vfs@ptr, uri)
+  invisible(libtiledb_vfs_remove_dir(vfs@ptr, uri))
 }
 
 #' Test for VFS File

--- a/inst/tinytest/test_tiledbarray.R
+++ b/inst/tinytest/test_tiledbarray.R
@@ -1132,7 +1132,7 @@ expect_equal(chk[], M)
 
 ## test for data.frame append
 if (!requireNamespace("palmerpenguins", quietly=TRUE)) exit_file("remainder needs 'palmerpenguins'")
-data(penguins, package="palmerpenguins")
+library(palmerpenguins)
 uri <- tempfile()
 fromDataFrame(penguins, uri, sparse = TRUE,
               col_index = c("species", "year"),

--- a/inst/tinytest/test_tiledbarray.R
+++ b/inst/tinytest/test_tiledbarray.R
@@ -1128,3 +1128,30 @@ M <- matrix(runif(N*K), N, K)
 obj[] <- M                              # prior to #246 this write had a write data type
 chk <- tiledb_array(uri, as.matrix=TRUE)
 expect_equal(chk[], M)
+
+
+## test for data.frame append
+if (!requireNamespace("palmerpenguins", quietly=TRUE)) exit_file("remainder needs 'palmerpenguins'")
+data(penguins, package="palmerpenguins")
+uri <- tempfile()
+fromDataFrame(penguins, uri, sparse = TRUE,
+              col_index = c("species", "year"),
+              tile_domain=list(year=c(1966L, 2021L)))
+arr <- tiledb_array(uri)
+## new data
+newdf <- penguins[1:2,]
+newdf$species <- c("Fred", "Ginger")
+newdf$island <- c("Manhattan", "Staten Island")
+newdf$year <- c(1966L, 1969L)                     # int is important
+arr[] <- newdf
+## check it
+chk <- tiledb_array("/tmp/tiledb/penguinsTest", as.data.frame=TRUE)
+res <- chk[]
+expect_true(1966L %in% res$year)
+expect_true(1969L %in% res$year)
+expect_true("Manhattan" %in% res$island)
+expect_true("Staten Island" %in% res$island)
+expect_true("Fred" %in% res$species)
+expect_true("Ginger" %in% res$species)
+expect_equal(nrow(penguins) + 2, nrow(res))
+expect_equal(ncol(penguins), ncol(res))

--- a/inst/tinytest/test_tiledbarray.R
+++ b/inst/tinytest/test_tiledbarray.R
@@ -1145,7 +1145,7 @@ newdf$island <- c("Manhattan", "Staten Island")
 newdf$year <- c(1966L, 1969L)                     # int is important
 arr[] <- newdf
 ## check it
-chk <- tiledb_array("/tmp/tiledb/penguinsTest", as.data.frame=TRUE)
+chk <- tiledb_array(uri, as.data.frame=TRUE)
 res <- chk[]
 expect_true(1966L %in% res$year)
 expect_true(1969L %in% res$year)


### PR DESCRIPTION
This PR supports writing larger-than-memory arrays incrementally.  To do so, it permits to set dimension domain ranges as a new optional argument to `fromDataFrame()`.  This allows _e.g._ years to be set to [1970, 2021], say, rather than to the range in submitted chunk.  (String dimensions already have null so no issue there.)  Additionally, we ensure that the to-be-appended data.frame is re-ordered such that dimensions precede attributes after which the existing writing code "just works".

A new unit tests has been added as well.

(The tests were all fine at GH but some timed out when Azure Pipes had the flu earlier today leading to the temporary red marks.  They will pass on re-run, and we can wait if need be.)