### PR TITLE
Reorder selected_ranges to dimension order if in different order

### DIFF
--- a/R/TileDBArray.R
+++ b/R/TileDBArray.R
@@ -467,6 +467,13 @@ setMethod("[", "tiledb_array",
       x@selected_ranges <- fulllist
   }
 
+  ## selected_ranges may be in different order than dimnames, so reorder if need be
+  if ((length(x@selected_ranges) == length(dimnames))
+      && (!is.null(names(x@selected_ranges)))
+      && (!identical(names(x@selected_ranges), dimnames))) {
+      x@selected_ranges <- x@selected_ranges[dimnames]
+  }
+
   ## if selected_ranges is still an empty list, make it an explicit one
   if (length(x@selected_ranges) == 0) {
       x@selected_ranges <- vector(mode="list", length=length(dimnames))

--- a/inst/tinytest/test_tiledbarray.R
+++ b/inst/tinytest/test_tiledbarray.R
@@ -1137,7 +1137,7 @@ uri <- tempfile()
 fromDataFrame(penguins, uri, sparse = TRUE,
               col_index = c("species", "year"),
               tile_domain=list(year=c(1966L, 2021L)))
-arr <- tiledb_array(uri)
+arr <- tiledb_array(uri, as.data.frame=TRUE)
 ## new data
 newdf <- penguins[1:2,]
 newdf$species <- c("Fred", "Ginger")
@@ -1155,3 +1155,18 @@ expect_true("Fred" %in% res$species)
 expect_true("Ginger" %in% res$species)
 expect_equal(nrow(penguins) + 2, nrow(res))
 expect_equal(ncol(penguins), ncol(res))
+
+## test for both possible orders of selected_ranges
+selected_ranges(arr) <- list(year=cbind(1966L, 1999L),
+                             species=matrix(c("Fred", "Fred",
+                                              "Ginger", "Ginger"),
+                                            2, 2, byrow=TRUE))
+res1 <- arr[]
+expect_equal(nrow(res1), 2)
+selected_ranges(arr) <- list(species=matrix(c("Fred", "Fred",
+                                              "Ginger", "Ginger"),
+                                            2, 2, byrow=TRUE),
+                             year=cbind(1966L, 1999L))
+res2 <- arr[]
+expect_equal(nrow(res2), 2)
+expect_equal(res1, res2)


### PR DESCRIPTION
This PR addresses an issue a user reported:  when (several) dimensions were selected (via `selected_ranges(array)`), and the number of selected dimensions was equal to the actual number of dimensions in the array, we were implicitly requiring that the order of selected dimensions was identical to the order of dimensions in the array.  

This PR removes this constraint and allows any order of dimensions.   A unit test has been added as well.