### PR TITLE
Use COL_MAJOR as default query layout

### DIFF
--- a/R/DataFrame.R
+++ b/R/DataFrame.R
@@ -72,7 +72,7 @@
 ##' }
 ##' @export
 fromDataFrame <- function(obj, uri, col_index=NULL, sparse=FALSE, allows_dups=sparse,
-                          cell_order = "ROW_MAJOR", tile_order = "ROW_MAJOR", filter="ZSTD",
+                          cell_order = "COL_MAJOR", tile_order = "COL_MAJOR", filter="ZSTD",
                           capacity = 10000L, tile_domain = NULL, tile_extent = NULL, debug = FALSE) {
 
     if (!inherits(obj, "data.frame")) stop("Argument 'obj' should be a 'data.frame' (or a related object).", call. = FALSE)

--- a/R/Query.R
+++ b/R/Query.R
@@ -58,10 +58,10 @@ tiledb_query_type <- function(query) {
 #'
 #' @param query A TileDB Query object
 #' @param layout A character variable with the layout; must be one of
-#'   "ROW_MAJOR", "COL_MAJOR", "GLOBAL_ORDER", "UNORDERED")
+#'   "COL_MAJOR", "ROW_MAJOR", "GLOBAL_ORDER", "UNORDERED")
 #' @return The modified query object, invisibly
 #' @export
-tiledb_query_set_layout <- function(query, layout=c("ROW_MAJOR", "COL_MAJOR",
+tiledb_query_set_layout <- function(query, layout=c("COL_MAJOR", "ROW_MAJOR",
                                                     "GLOBAL_ORDER", "UNORDERED")) {
   layout <- match.arg(layout)
   stopifnot(query_object=is(query, "tiledb_query"))

--- a/R/Query.R
+++ b/R/Query.R
@@ -58,11 +58,11 @@ tiledb_query_type <- function(query) {
 #'
 #' @param query A TileDB Query object
 #' @param layout A character variable with the layout; must be one of
-#'   "COL_MAJOR", "ROW_MAJOR", "GLOBAL_ORDER", "UNORDERED", "HILBERT")
+#'   "COL_MAJOR", "ROW_MAJOR", "GLOBAL_ORDER", "UNORDERED")
 #' @return The modified query object, invisibly
 #' @export
 tiledb_query_set_layout <- function(query, layout=c("COL_MAJOR", "ROW_MAJOR",
-                                                    "GLOBAL_ORDER", "UNORDERED", "HILBERT")) {
+                                                    "GLOBAL_ORDER", "UNORDERED")) {
   layout <- match.arg(layout)
   stopifnot(query_object=is(query, "tiledb_query"))
   libtiledb_query_set_layout(query@ptr, layout)

--- a/R/Query.R
+++ b/R/Query.R
@@ -58,11 +58,11 @@ tiledb_query_type <- function(query) {
 #'
 #' @param query A TileDB Query object
 #' @param layout A character variable with the layout; must be one of
-#'   "COL_MAJOR", "ROW_MAJOR", "GLOBAL_ORDER", "UNORDERED")
+#'   "COL_MAJOR", "ROW_MAJOR", "GLOBAL_ORDER", "UNORDERED", "HILBERT")
 #' @return The modified query object, invisibly
 #' @export
 tiledb_query_set_layout <- function(query, layout=c("COL_MAJOR", "ROW_MAJOR",
-                                                    "GLOBAL_ORDER", "UNORDERED")) {
+                                                    "GLOBAL_ORDER", "UNORDERED", "HILBERT")) {
   layout <- match.arg(layout)
   stopifnot(query_object=is(query, "tiledb_query"))
   libtiledb_query_set_layout(query@ptr, layout)

--- a/inst/tinytest/test_query.R
+++ b/inst/tinytest/test_query.R
@@ -52,7 +52,9 @@ expect_equal(tiledb_query_get_layout(tiledb_query_set_layout(query, "ROW_MAJOR")
 expect_equal(tiledb_query_get_layout(tiledb_query_set_layout(query, "COL_MAJOR")), "COL_MAJOR")
 expect_equal(tiledb_query_get_layout(tiledb_query_set_layout(query, "GLOBAL_ORDER")), "GLOBAL_ORDER")
 expect_equal(tiledb_query_get_layout(tiledb_query_set_layout(query, "UNORDERED")), "UNORDERED")
-
+if (tiledb_version(TRUE) >= "2.2.0") {
+    expect_equal(tiledb_query_get_layout(tiledb_query_set_layout(query, "HILBERT")), "HILBERT")
+}
 unlink(tmp, recursive=TRUE)
 #})
 

--- a/inst/tinytest/test_query.R
+++ b/inst/tinytest/test_query.R
@@ -52,9 +52,6 @@ expect_equal(tiledb_query_get_layout(tiledb_query_set_layout(query, "ROW_MAJOR")
 expect_equal(tiledb_query_get_layout(tiledb_query_set_layout(query, "COL_MAJOR")), "COL_MAJOR")
 expect_equal(tiledb_query_get_layout(tiledb_query_set_layout(query, "GLOBAL_ORDER")), "GLOBAL_ORDER")
 expect_equal(tiledb_query_get_layout(tiledb_query_set_layout(query, "UNORDERED")), "UNORDERED")
-if (tiledb_version(TRUE) >= "2.2.0") {
-    expect_equal(tiledb_query_get_layout(tiledb_query_set_layout(query, "HILBERT")), "HILBERT")
-}
 unlink(tmp, recursive=TRUE)
 #})
 

--- a/man/fromDataFrame.Rd
+++ b/man/fromDataFrame.Rd
@@ -10,8 +10,8 @@ fromDataFrame(
   col_index = NULL,
   sparse = FALSE,
   allows_dups = sparse,
-  cell_order = "ROW_MAJOR",
-  tile_order = "ROW_MAJOR",
+  cell_order = "COL_MAJOR",
+  tile_order = "COL_MAJOR",
   filter = "ZSTD",
   capacity = 10000L,
   tile_domain = NULL,
@@ -44,8 +44,10 @@ one or more filters to be applied to each attribute;}
 
 \item{capacity}{A integer value with the schema capacity, default is 10000.}
 
-\item{tile_domain}{An integer vector of size two specifying the integer domain of the row
-dimension; if \code{NULL} the row dimension of the \code{obj} is used.}
+\item{tile_domain}{An integer vector or list or \code{NULL}. If an integer vector
+of size two it specifies the integer domain of the row dimension; if a list then a named
+element is used for the dimension of the same name; or if \code{NULL} the row
+dimension of the \code{obj} is used.}
 
 \item{tile_extent}{An integer value for the tile extent of the row dimensions;
 if \code{NULL} the row dimension of the \code{obj} is used. Note that the \code{tile_extent}

--- a/man/tiledb_query_set_layout.Rd
+++ b/man/tiledb_query_set_layout.Rd
@@ -6,14 +6,14 @@
 \usage{
 tiledb_query_set_layout(
   query,
-  layout = c("ROW_MAJOR", "COL_MAJOR", "GLOBAL_ORDER", "UNORDERED")
+  layout = c("COL_MAJOR", "ROW_MAJOR", "GLOBAL_ORDER", "UNORDERED")
 )
 }
 \arguments{
 \item{query}{A TileDB Query object}
 
 \item{layout}{A character variable with the layout; must be one of
-"ROW_MAJOR", "COL_MAJOR", "GLOBAL_ORDER", "UNORDERED")}
+"COL_MAJOR", "ROW_MAJOR", "GLOBAL_ORDER", "UNORDERED")}
 }
 \value{
 The modified query object, invisibly

--- a/man/tiledb_query_set_layout.Rd
+++ b/man/tiledb_query_set_layout.Rd
@@ -6,14 +6,14 @@
 \usage{
 tiledb_query_set_layout(
   query,
-  layout = c("COL_MAJOR", "ROW_MAJOR", "GLOBAL_ORDER", "UNORDERED")
+  layout = c("COL_MAJOR", "ROW_MAJOR", "GLOBAL_ORDER", "UNORDERED", "HILBERT")
 )
 }
 \arguments{
 \item{query}{A TileDB Query object}
 
 \item{layout}{A character variable with the layout; must be one of
-"COL_MAJOR", "ROW_MAJOR", "GLOBAL_ORDER", "UNORDERED")}
+"COL_MAJOR", "ROW_MAJOR", "GLOBAL_ORDER", "UNORDERED", "HILBERT")}
 }
 \value{
 The modified query object, invisibly

--- a/man/tiledb_query_set_layout.Rd
+++ b/man/tiledb_query_set_layout.Rd
@@ -6,14 +6,14 @@
 \usage{
 tiledb_query_set_layout(
   query,
-  layout = c("COL_MAJOR", "ROW_MAJOR", "GLOBAL_ORDER", "UNORDERED", "HILBERT")
+  layout = c("COL_MAJOR", "ROW_MAJOR", "GLOBAL_ORDER", "UNORDERED")
 )
 }
 \arguments{
 \item{query}{A TileDB Query object}
 
 \item{layout}{A character variable with the layout; must be one of
-"COL_MAJOR", "ROW_MAJOR", "GLOBAL_ORDER", "UNORDERED", "HILBERT")}
+"COL_MAJOR", "ROW_MAJOR", "GLOBAL_ORDER", "UNORDERED")}
 }
 \value{
 The modified query object, invisibly

--- a/vignettes/documentation.Rmd
+++ b/vignettes/documentation.Rmd
@@ -233,10 +233,10 @@ schema <- tiledb_array_schema(dom, c(attr1, attr2), sparse = FALSE)
 # ... create domain dom
 # ... create attributes attr1, attr2
 
-# The tile and order can be "ROW_MAJOR" or "COL_MAJOR"
+# The tile and order can be "COL_MAJOR" or "ROW_MAJOR"
 schema <- tiledb_array_schema(dom, c(attr1, attr2),
                               cell_order = "COL_MAJOR",
-                              tile_order = "ROW_MAJOR")
+                              tile_order = "COL_MAJOR")
 ```
 
 #### Setting the Data Tile Capacity
@@ -452,7 +452,7 @@ subarr <- c(1L,4L, 1L,4L)
 
 qryptr <- tiledb:::libtiledb_query(ctx@ptr, arrptr, "WRITE")
 qryptr <- tiledb:::libtiledb_query_set_subarray(qryptr, subarr)
-qryptr <- tiledb:::libtiledb_query_set_layout(qryptr, "ROW_MAJOR")
+qryptr <- tiledb:::libtiledb_query_set_layout(qryptr, "COL_MAJOR")
 qryptr <- tiledb:::libtiledb_query_set_buffer(qryptr, "a", vec)
 qryptr <- tiledb:::libtiledb_query_submit(qryptr)
 res <- tiledb:::libtiledb_array_close(arrptr)
@@ -518,7 +518,7 @@ subarr <- c(1L,4L, 1L,4L)
 
 qryptr <- tiledb:::libtiledb_query(ctx@ptr, arrptr, "WRITE")
 qryptr <- tiledb:::libtiledb_query_set_subarray(qryptr, subarr)
-qryptr <- tiledb:::libtiledb_query_set_layout(qryptr, "ROW_MAJOR")
+qryptr <- tiledb:::libtiledb_query_set_layout(qryptr, "COL_MAJOR")
 qryptr <- tiledb:::libtiledb_query_set_buffer(qryptr, "a", vec)
 qryptr <- tiledb:::libtiledb_query_submit(qryptr)
 res <- tiledb:::libtiledb_array_close(arrptr)
@@ -544,8 +544,8 @@ tiledb:::libtiledb_attribute_set_cell_val_num(attr@ptr, NA)
 ctx <- tiledb_ctx()
 schptr <- tiledb:::libtiledb_array_schema_create(ctx@ptr, "DENSE")
 tiledb:::libtiledb_array_schema_set_domain(schptr, dom@ptr)
-tiledb:::libtiledb_array_schema_set_cell_order(schptr, "ROW_MAJOR")
-tiledb:::libtiledb_array_schema_set_tile_order(schptr, "ROW_MAJOR")
+tiledb:::libtiledb_array_schema_set_cell_order(schptr, "COL_MAJOR")
+tiledb:::libtiledb_array_schema_set_tile_order(schptr, "COL_MAJOR")
 tiledb:::libtiledb_array_schema_add_attribute(schptr, attr@ptr)
 
 
@@ -559,7 +559,7 @@ offsets <- c(0L, 1L, 3L, 6L, 8L, 11L, 12L, 13L, 16L, 17L, 20L, 22L, 23L, 24L, 25
 ctx <- tiledb_ctx()
 arrptr <- tiledb:::libtiledb_array_open(ctx@ptr, uridensevar, "WRITE")
 qryptr <- tiledb:::libtiledb_query(ctx@ptr, arrptr, "WRITE")
-qryptr <- tiledb:::libtiledb_query_set_layout(qryptr, "ROW_MAJOR")
+qryptr <- tiledb:::libtiledb_query_set_layout(qryptr, "COL_MAJOR")
 
 bufptr <- tiledb:::libtiledb_query_buffer_var_char_create(offsets, data)
 qryptr <- tiledb:::libtiledb_query_set_buffer_var_char(qryptr, "a1", bufptr)
@@ -803,7 +803,7 @@ subarr <- c(1L,2L, 2L,4L)
 
 qryptr <- tiledb:::libtiledb_query(ctx@ptr, arrptr, "READ")
 qryptr <- tiledb:::libtiledb_query_set_subarray(qryptr, subarr)
-qryptr <- tiledb:::libtiledb_query_set_layout(qryptr, "ROW_MAJOR")
+qryptr <- tiledb:::libtiledb_query_set_layout(qryptr, "COL_MAJOR")
 v <- integer(6)  # reserve space
 qryptr <- tiledb:::libtiledb_query_set_buffer(qryptr, "a", v)
 qryptr <- tiledb:::libtiledb_query_submit(qryptr)
@@ -822,7 +822,7 @@ bufptr <- tiledb:::libtiledb_query_buffer_var_char_alloc(arrptr, subarr, "a1", 1
 
 qryptr <- tiledb:::libtiledb_query(ctx@ptr, arrptr, "READ")
 qryptr <- tiledb:::libtiledb_query_set_subarray(qryptr, subarr)
-qryptr <- tiledb:::libtiledb_query_set_layout(qryptr, "ROW_MAJOR")
+qryptr <- tiledb:::libtiledb_query_set_layout(qryptr, "COL_MAJOR")
 
 qryptr <- tiledb:::libtiledb_query_set_buffer_var_char(qryptr, "a1", bufptr)
 qryptr <- tiledb:::libtiledb_query_submit(qryptr)
@@ -944,7 +944,7 @@ arrptr <- tiledb:::libtiledb_array_open_at(ctx@ptr, uridense, "READ", tstamp)
 subarr <- c(1L,2L, 2L,4L)
 qryptr <- tiledb:::libtiledb_query(ctx@ptr, arrptr, "READ")
 qryptr <- tiledb:::libtiledb_query_set_subarray(qryptr, subarr)
-qryptr <- tiledb:::libtiledb_query_set_layout(qryptr, "ROW_MAJOR")
+qryptr <- tiledb:::libtiledb_query_set_layout(qryptr, "COL_MAJOR")
 a <- integer(6)  # reserve space
 qryptr <- tiledb:::libtiledb_query_set_buffer(qryptr, "a", a)
 qryptr <- tiledb:::libtiledb_query_submit(qryptr)


### PR DESCRIPTION
This PR defaults the cell and tile order to column major when creating arrays from a data.frame. It also updates the API documentation vignette to show COL_MAJOR as default.