### PR TITLE
Support dense subarray writes via [ assignment 

### DIFF
--- a/inst/tinytest/test_tiledbarray.R
+++ b/inst/tinytest/test_tiledbarray.R
@@ -1170,3 +1170,29 @@ selected_ranges(arr) <- list(species=matrix(c("Fred", "Fred",
 res2 <- arr[]
 expect_equal(nrow(res2), 2)
 expect_equal(res1, res2)
+
+
+
+## issue 255
+uri <- tempfile()
+## Generate a matrix
+n <- 5L
+k <- 4L
+mat <- matrix(1:(n*k) * 0.12345, nrow=n, ncol=k)
+dom <- tiledb_domain(dims = c(tiledb_dim("rows", c(1L, n), n, "INT32"),
+                              tiledb_dim("cols", c(1L, k), k, "INT32")))
+schema <- tiledb_array_schema(dom, attrs=tiledb_attr("vals", type="FLOAT64"))
+tiledb_array_create(uri, schema)
+arr <- tiledb_array(uri, is.sparse=FALSE)
+I <- c(1:3)
+J <- c(3:4)
+arr[I, J] <- mat[I, J]
+I <- 4:5
+J <- 1:4
+arr[I,J] <- mat[I, J]
+arr2 <- tiledb_array(uri, as.matrix=TRUE)
+res <- arr2[]
+expect_equal(dim(res), c(5,4))
+expect_equal(sum(is.na(res[1:3,1:2])), 6) # arr[1:3,1:2] all NA
+expect_equal(res[1:3,3:4], mat[1:3,3:4])
+expect_equal(res[4:5,1:4], mat[4:5,1:4])


### PR DESCRIPTION
This PR completes the support for assignments to dense arrays opened via `tiledb_array` when subarray indices are supplied, and addresses issue #255 filed earlier today.  A new unit test was added as well.  Everything passes as usual (took a moment for the 2nd CI platform to come to town...).