### PR TITLE
correct domain getter for uint32, uint64, int64 cases

### DIFF
--- a/src/libtiledb.cpp
+++ b/src/libtiledb.cpp
@@ -836,34 +836,34 @@ SEXP libtiledb_dim_get_domain(XPtr<tiledb::Dimension> dim) {
       using DataType = tiledb::impl::tiledb_to_type<TILEDB_UINT32>::type;
       auto d1 = dim->domain<DataType>().first;
       auto d2 = dim->domain<DataType>().second;
-      if (d1 > std::numeric_limits<int32_t>::max() ||
-          d2 > std::numeric_limits<int32_t>::max()) {
-        Rcpp::stop("tiledb_dim domain UINT32 value not representable as an R integer");
+      if (d1 > std::numeric_limits<int64_t>::max() ||
+          d2 > std::numeric_limits<int64_t>::max()) {
+        Rcpp::stop("tiledb_dim domain UINT32 value not representable as an R integer64 type");
       }
-      return IntegerVector({static_cast<int32_t>(d1),
-                            static_cast<int32_t>(d2)});
+      std::vector<int64_t> v = { static_cast<int64_t>(d1), static_cast<int64_t>(d2) };
+      return makeInteger64(v);
     }
     case TILEDB_INT64: {
       using DataType = tiledb::impl::tiledb_to_type<TILEDB_INT64>::type;
       auto d1 = dim->domain<DataType>().first;
       auto d2 = dim->domain<DataType>().second;
-      if (d1 <= R_NaInt || d1 > std::numeric_limits<int32_t>::max() ||
-          d2 <= R_NaInt || d2 > std::numeric_limits<int32_t>::max()) {
-        Rcpp::stop("tiledb_dim domain INT64 value not representable as an R integer");
+      if (d1 <= R_NaInt || d1 > std::numeric_limits<int64_t>::max() ||
+          d2 <= R_NaInt || d2 > std::numeric_limits<int64_t>::max()) {
+        Rcpp::stop("tiledb_dim domain INT64 value not representable as an R integer64 type");
       }
-      return IntegerVector({static_cast<int32_t>(d1),
-                            static_cast<int32_t>(d2)});
+      std::vector<int64_t> v = { d1, d2 };
+      return makeInteger64(v);
     }
     case TILEDB_UINT64: {
       using DataType = tiledb::impl::tiledb_to_type<TILEDB_UINT64>::type;
       auto d1 = dim->domain<DataType>().first;
       auto d2 = dim->domain<DataType>().second;
-      if (d1 > std::numeric_limits<int32_t>::max() ||
-          d2 > std::numeric_limits<int32_t>::max()) {
-        Rcpp::stop("tiledb_dim domain UINT64 value not representable as an R integer");
+      if (d1 > std::numeric_limits<int64_t>::max() ||
+          d2 > std::numeric_limits<int64_t>::max()) {
+          Rcpp::stop("tiledb_dim domain UINT64 value not representable as an R integer64 type");
       }
-      return IntegerVector({static_cast<int32_t>(d1),
-                            static_cast<int32_t>(d2)});
+      std::vector<int64_t> v = { static_cast<int64_t>(d1), static_cast<int64_t>(d2) };
+      return makeInteger64(v);
     }
     case TILEDB_DATETIME_YEAR:
     case TILEDB_DATETIME_MONTH:


### PR DESCRIPTION
This PR addresses an issue highlighted by @aaronwolen with a VCF example having `uint32_t` indices (with values in excess of `INT_MAX`) which were not queried correctly from a higher-level getter in the package.  This now works for `uint32_t`, `uint64_t` and `int64_t` by updating some remaining legacy code and switching to `integer64` return values.

For the array in question:

```r
> library(tiledb)
TileDB R 0.9.4 with TileDB Embedded 2.4.0. See https://tiledb.com for more information.
> vcf <- tiledb::tiledb_array("tiledb://TileDB-Inc/vcf-1kg-phase3-data")
> tiledb::domain(tiledb::dimensions(tiledb::schema(vcf))[[2]])
integer64
[1] 0          4294967294
> 
```