### PR TITLE
Support array opening at start / end timestamps

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -489,6 +489,22 @@ libtiledb_array_delete_metadata <- function(array, key) {
     invisible(.Call(`_tiledb_libtiledb_array_delete_metadata`, array, key))
 }
 
+libtiledb_array_set_open_timestamp_start <- function(array, tstamp) {
+    invisible(.Call(`_tiledb_libtiledb_array_set_open_timestamp_start`, array, tstamp))
+}
+
+libtiledb_array_open_timestamp_start <- function(array) {
+    .Call(`_tiledb_libtiledb_array_open_timestamp_start`, array)
+}
+
+libtiledb_array_set_open_timestamp_end <- function(array, tstamp) {
+    invisible(.Call(`_tiledb_libtiledb_array_set_open_timestamp_end`, array, tstamp))
+}
+
+libtiledb_array_open_timestamp_end <- function(array) {
+    .Call(`_tiledb_libtiledb_array_open_timestamp_end`, array)
+}
+
 libtiledb_query <- function(ctx, array, type) {
     .Call(`_tiledb_libtiledb_query`, ctx, array, type)
 }

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -490,7 +490,7 @@ libtiledb_array_delete_metadata <- function(array, key) {
 }
 
 libtiledb_array_set_open_timestamp_start <- function(array, tstamp) {
-    invisible(.Call(`_tiledb_libtiledb_array_set_open_timestamp_start`, array, tstamp))
+    .Call(`_tiledb_libtiledb_array_set_open_timestamp_start`, array, tstamp)
 }
 
 libtiledb_array_open_timestamp_start <- function(array) {
@@ -498,7 +498,7 @@ libtiledb_array_open_timestamp_start <- function(array) {
 }
 
 libtiledb_array_set_open_timestamp_end <- function(array, tstamp) {
-    invisible(.Call(`_tiledb_libtiledb_array_set_open_timestamp_end`, array, tstamp))
+    .Call(`_tiledb_libtiledb_array_set_open_timestamp_end`, array, tstamp)
 }
 
 libtiledb_array_open_timestamp_end <- function(array) {

--- a/R/TileDBArray.R
+++ b/R/TileDBArray.R
@@ -38,10 +38,12 @@
 #' @slot query_layout An optional character value
 #' @slot datetimes_as_int64 A logical value
 #' @slot encryption_key A character value
-#' @slot timestamp A POSIXct datetime variable
+#' @slot timestamp A POSIXct datetime variable (deprecated, use timestamp_start)
 #' @slot as.matrix A logical value
 #' @slot as.array A logical value
 #' @slot query_condition A Query Condition object
+#' @slot timestamp_start A POSIXct datetime variable for the inclusive interval start
+#' @slot timestamp_end A POSIXct datetime variable for the inclusive interval start
 #' @slot ptr External pointer to the underlying implementation
 #' @exportClass tiledb_array
 setClass("tiledb_array",
@@ -59,6 +61,8 @@ setClass("tiledb_array",
                       as.matrix = "logical",
                       as.array = "logical",
                       query_condition = "tiledb_query_condition",
+                      timestamp_start = "POSIXct",
+                      timestamp_end = "POSIXct",
                       ptr = "externalptr"))
 
 #' Constructs a tiledb_array object backed by a persisted tiledb array uri
@@ -83,13 +87,17 @@ setClass("tiledb_array",
 #' @param encryption_key optional A character value with an AES-256 encryption key
 #' in case the array was written with encryption.
 #' @param timestamp optional A POSIXct Datetime value determining where in time the array is
-#' to be openened.
+#' to be openened. Deprecated, use \sQuote{timestamp_start} instead
 #' @param as.matrix optional logical switch, defaults to "FALSE"; currently limited to dense
 #' matrices; in the case of multiple attributes in query a list of matrices is returned
 #' @param as.array optional logical switch, defaults to "FALSE"; in the case of multiple
 #' attributes in query a list of arrays is returned
 #' @param query_condition optional \code{tiledb_query_condition} object, by default uninitialized
 #' without a condition; this functionality requires TileDB 2.3.0 or later
+#' @param timestamp_start optional A POSIXct Datetime value determining the inclusive time point
+#' at which the array is to be openened. No fragments written earlier will be considered.
+#' @param timestamp_end optional A POSIXct Datetime value determining the inclusive time point
+#' until which the array is to be openened. No fragments written earlier later be considered.
 #' @param ctx tiledb_ctx (optional)
 #' @return tiledb_array object
 #' @export
@@ -107,6 +115,8 @@ tiledb_array <- function(uri,
                          as.matrix = FALSE,
                          as.array = FALSE,
                          query_condition = new("tiledb_query_condition"),
+                         timestamp_start = as.POSIXct(double(), origin="1970-01-01"),
+                         timestamp_end = as.POSIXct(double(), origin="1970-01-01"),
                          ctx = tiledb_get_context()) {
   query_type = match.arg(query_type)
   if (!is(ctx, "tiledb_ctx"))
@@ -134,6 +144,14 @@ tiledb_array <- function(uri,
       array_xptr <- libtiledb_array_open(ctx@ptr, uri, query_type)
     }
   }
+
+  if (length(timestamp) > 0)
+      .Deprecated(msg="Use 'timestamp_start' (or possibly 'timestamp_end') instead of 'timestamp'.")
+  if (length(timestamp_start) > 0)
+      libtiledb_array_open(array_xptr, timestamp_start)
+  if (length(timestamp_end) > 0)
+      libtiledb_array_open(array_xptr, timestamp_end)
+
   schema_xptr <- libtiledb_array_get_schema(array_xptr)
   is_sparse_status <- libtiledb_array_schema_sparse(schema_xptr)
   if (!is.na(is.sparse) && is.sparse != is_sparse_status) {
@@ -161,6 +179,8 @@ tiledb_array <- function(uri,
       as.matrix = as.matrix,
       as.array = as.array,
       query_condition = query_condition,
+      timestamp_start = timestamp_start,
+      timestamp_end = timestamp_end,
       ptr = array_xptr)
 }
 

--- a/R/TileDBArray.R
+++ b/R/TileDBArray.R
@@ -146,7 +146,7 @@ tiledb_array <- function(uri,
   }
 
   if (length(timestamp) > 0)
-      .Deprecated(msg="Use 'timestamp_start' (or possibly 'timestamp_end') instead of 'timestamp'.")
+      .Deprecated(msg="Use 'timestamp_start' (and maybe 'timestamp_end') instead of 'timestamp'.")
   if (length(timestamp_start) > 0) {
       libtiledb_array_set_open_timestamp_start(array_xptr, timestamp_start)
   }

--- a/man/tiledb_array-class.Rd
+++ b/man/tiledb_array-class.Rd
@@ -33,13 +33,17 @@ describes the (min,max) pair of ranges for dimension i}
 
 \item{\code{encryption_key}}{A character value}
 
-\item{\code{timestamp}}{A POSIXct datetime variable}
+\item{\code{timestamp}}{A POSIXct datetime variable (deprecated, use timestamp_start)}
 
 \item{\code{as.matrix}}{A logical value}
 
 \item{\code{as.array}}{A logical value}
 
 \item{\code{query_condition}}{A Query Condition object}
+
+\item{\code{timestamp_start}}{A POSIXct datetime variable for the inclusive interval start}
+
+\item{\code{timestamp_end}}{A POSIXct datetime variable for the inclusive interval start}
 
 \item{\code{ptr}}{External pointer to the underlying implementation}
 }}

--- a/man/tiledb_array.Rd
+++ b/man/tiledb_array.Rd
@@ -19,6 +19,8 @@ tiledb_array(
   as.matrix = FALSE,
   as.array = FALSE,
   query_condition = new("tiledb_query_condition"),
+  timestamp_start = as.POSIXct(double(), origin = "1970-01-01"),
+  timestamp_end = as.POSIXct(double(), origin = "1970-01-01"),
   ctx = tiledb_get_context()
 )
 }
@@ -51,7 +53,7 @@ representation as \sQuote{raw} \code{integer64} and not as \code{Date},
 in case the array was written with encryption.}
 
 \item{timestamp}{optional A POSIXct Datetime value determining where in time the array is
-to be openened.}
+to be openened. Deprecated, use \sQuote{timestamp_start} instead}
 
 \item{as.matrix}{optional logical switch, defaults to "FALSE"; currently limited to dense
 matrices; in the case of multiple attributes in query a list of matrices is returned}
@@ -61,6 +63,12 @@ attributes in query a list of arrays is returned}
 
 \item{query_condition}{optional \code{tiledb_query_condition} object, by default uninitialized
 without a condition; this functionality requires TileDB 2.3.0 or later}
+
+\item{timestamp_start}{optional A POSIXct Datetime value determining the inclusive time point
+at which the array is to be openened. No fragments written earlier will be considered.}
+
+\item{timestamp_end}{optional A POSIXct Datetime value determining the inclusive time point
+until which the array is to be openened. No fragments written earlier later be considered.}
 
 \item{ctx}{tiledb_ctx (optional)}
 }

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -1439,6 +1439,50 @@ BEGIN_RCPP
     return R_NilValue;
 END_RCPP
 }
+// libtiledb_array_set_open_timestamp_start
+void libtiledb_array_set_open_timestamp_start(XPtr<tiledb::Array> array, Rcpp::Datetime tstamp);
+RcppExport SEXP _tiledb_libtiledb_array_set_open_timestamp_start(SEXP arraySEXP, SEXP tstampSEXP) {
+BEGIN_RCPP
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< XPtr<tiledb::Array> >::type array(arraySEXP);
+    Rcpp::traits::input_parameter< Rcpp::Datetime >::type tstamp(tstampSEXP);
+    libtiledb_array_set_open_timestamp_start(array, tstamp);
+    return R_NilValue;
+END_RCPP
+}
+// libtiledb_array_open_timestamp_start
+Rcpp::Datetime libtiledb_array_open_timestamp_start(XPtr<tiledb::Array> array);
+RcppExport SEXP _tiledb_libtiledb_array_open_timestamp_start(SEXP arraySEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< XPtr<tiledb::Array> >::type array(arraySEXP);
+    rcpp_result_gen = Rcpp::wrap(libtiledb_array_open_timestamp_start(array));
+    return rcpp_result_gen;
+END_RCPP
+}
+// libtiledb_array_set_open_timestamp_end
+void libtiledb_array_set_open_timestamp_end(XPtr<tiledb::Array> array, Rcpp::Datetime tstamp);
+RcppExport SEXP _tiledb_libtiledb_array_set_open_timestamp_end(SEXP arraySEXP, SEXP tstampSEXP) {
+BEGIN_RCPP
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< XPtr<tiledb::Array> >::type array(arraySEXP);
+    Rcpp::traits::input_parameter< Rcpp::Datetime >::type tstamp(tstampSEXP);
+    libtiledb_array_set_open_timestamp_end(array, tstamp);
+    return R_NilValue;
+END_RCPP
+}
+// libtiledb_array_open_timestamp_end
+Rcpp::Datetime libtiledb_array_open_timestamp_end(XPtr<tiledb::Array> array);
+RcppExport SEXP _tiledb_libtiledb_array_open_timestamp_end(SEXP arraySEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< XPtr<tiledb::Array> >::type array(arraySEXP);
+    rcpp_result_gen = Rcpp::wrap(libtiledb_array_open_timestamp_end(array));
+    return rcpp_result_gen;
+END_RCPP
+}
 // libtiledb_query
 XPtr<tiledb::Query> libtiledb_query(XPtr<tiledb::Context> ctx, XPtr<tiledb::Array> array, std::string type);
 RcppExport SEXP _tiledb_libtiledb_query(SEXP ctxSEXP, SEXP arraySEXP, SEXP typeSEXP) {
@@ -2473,6 +2517,10 @@ static const R_CallMethodDef CallEntries[] = {
     {"_tiledb_libtiledb_array_get_metadata_from_index", (DL_FUNC) &_tiledb_libtiledb_array_get_metadata_from_index, 2},
     {"_tiledb_libtiledb_array_get_metadata_list", (DL_FUNC) &_tiledb_libtiledb_array_get_metadata_list, 1},
     {"_tiledb_libtiledb_array_delete_metadata", (DL_FUNC) &_tiledb_libtiledb_array_delete_metadata, 2},
+    {"_tiledb_libtiledb_array_set_open_timestamp_start", (DL_FUNC) &_tiledb_libtiledb_array_set_open_timestamp_start, 2},
+    {"_tiledb_libtiledb_array_open_timestamp_start", (DL_FUNC) &_tiledb_libtiledb_array_open_timestamp_start, 1},
+    {"_tiledb_libtiledb_array_set_open_timestamp_end", (DL_FUNC) &_tiledb_libtiledb_array_set_open_timestamp_end, 2},
+    {"_tiledb_libtiledb_array_open_timestamp_end", (DL_FUNC) &_tiledb_libtiledb_array_open_timestamp_end, 1},
     {"_tiledb_libtiledb_query", (DL_FUNC) &_tiledb_libtiledb_query, 3},
     {"_tiledb_libtiledb_query_type", (DL_FUNC) &_tiledb_libtiledb_query_type, 1},
     {"_tiledb_libtiledb_query_set_layout", (DL_FUNC) &_tiledb_libtiledb_query_set_layout, 2},

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -1440,14 +1440,15 @@ BEGIN_RCPP
 END_RCPP
 }
 // libtiledb_array_set_open_timestamp_start
-void libtiledb_array_set_open_timestamp_start(XPtr<tiledb::Array> array, Rcpp::Datetime tstamp);
+XPtr<tiledb::Array> libtiledb_array_set_open_timestamp_start(XPtr<tiledb::Array> array, Rcpp::Datetime tstamp);
 RcppExport SEXP _tiledb_libtiledb_array_set_open_timestamp_start(SEXP arraySEXP, SEXP tstampSEXP) {
 BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< XPtr<tiledb::Array> >::type array(arraySEXP);
     Rcpp::traits::input_parameter< Rcpp::Datetime >::type tstamp(tstampSEXP);
-    libtiledb_array_set_open_timestamp_start(array, tstamp);
-    return R_NilValue;
+    rcpp_result_gen = Rcpp::wrap(libtiledb_array_set_open_timestamp_start(array, tstamp));
+    return rcpp_result_gen;
 END_RCPP
 }
 // libtiledb_array_open_timestamp_start
@@ -1462,14 +1463,15 @@ BEGIN_RCPP
 END_RCPP
 }
 // libtiledb_array_set_open_timestamp_end
-void libtiledb_array_set_open_timestamp_end(XPtr<tiledb::Array> array, Rcpp::Datetime tstamp);
+XPtr<tiledb::Array> libtiledb_array_set_open_timestamp_end(XPtr<tiledb::Array> array, Rcpp::Datetime tstamp);
 RcppExport SEXP _tiledb_libtiledb_array_set_open_timestamp_end(SEXP arraySEXP, SEXP tstampSEXP) {
 BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< XPtr<tiledb::Array> >::type array(arraySEXP);
     Rcpp::traits::input_parameter< Rcpp::Datetime >::type tstamp(tstampSEXP);
-    libtiledb_array_set_open_timestamp_end(array, tstamp);
-    return R_NilValue;
+    rcpp_result_gen = Rcpp::wrap(libtiledb_array_set_open_timestamp_end(array, tstamp));
+    return rcpp_result_gen;
 END_RCPP
 }
 // libtiledb_array_open_timestamp_end

--- a/src/libtiledb.cpp
+++ b/src/libtiledb.cpp
@@ -2184,9 +2184,10 @@ void libtiledb_array_delete_metadata(XPtr<tiledb::Array> array, std::string key)
 }
 
 // [[Rcpp::export]]
-void libtiledb_array_set_open_timestamp_start(XPtr<tiledb::Array> array, Rcpp::Datetime tstamp) {
+XPtr<tiledb::Array> libtiledb_array_set_open_timestamp_start(XPtr<tiledb::Array> array, Rcpp::Datetime tstamp) {
     uint64_t ts_ms = static_cast<uint64_t>(std::round(tstamp.getFractionalTimestamp() * 1000));
     array->set_open_timestamp_start(ts_ms);
+    return array;
 }
 
 // [[Rcpp::export]]
@@ -2197,9 +2198,10 @@ Rcpp::Datetime libtiledb_array_open_timestamp_start(XPtr<tiledb::Array> array) {
 }
 
 // [[Rcpp::export]]
-void libtiledb_array_set_open_timestamp_end(XPtr<tiledb::Array> array, Rcpp::Datetime tstamp) {
+XPtr<tiledb::Array> libtiledb_array_set_open_timestamp_end(XPtr<tiledb::Array> array, Rcpp::Datetime tstamp) {
     uint64_t ts_ms = static_cast<uint64_t>(std::round(tstamp.getFractionalTimestamp() * 1000));
     array->set_open_timestamp_end(ts_ms);
+    return array;
 }
 
 // [[Rcpp::export]]

--- a/src/libtiledb.cpp
+++ b/src/libtiledb.cpp
@@ -2183,6 +2183,32 @@ void libtiledb_array_delete_metadata(XPtr<tiledb::Array> array, std::string key)
   array->delete_metadata(key.c_str());
 }
 
+// [[Rcpp::export]]
+void libtiledb_array_set_open_timestamp_start(XPtr<tiledb::Array> array, Rcpp::Datetime tstamp) {
+    uint64_t ts_ms = static_cast<uint64_t>(std::round(tstamp.getFractionalTimestamp() * 1000));
+    array->set_open_timestamp_start(ts_ms);
+}
+
+// [[Rcpp::export]]
+Rcpp::Datetime libtiledb_array_open_timestamp_start(XPtr<tiledb::Array> array) {
+    uint64_t ts_ms = array->open_timestamp_start();
+    double ts = ts_ms / 1000.0;
+    return(Rcpp::Datetime(ts));
+}
+
+// [[Rcpp::export]]
+void libtiledb_array_set_open_timestamp_end(XPtr<tiledb::Array> array, Rcpp::Datetime tstamp) {
+    uint64_t ts_ms = static_cast<uint64_t>(std::round(tstamp.getFractionalTimestamp() * 1000));
+    array->set_open_timestamp_end(ts_ms);
+}
+
+// [[Rcpp::export]]
+Rcpp::Datetime libtiledb_array_open_timestamp_end(XPtr<tiledb::Array> array) {
+    uint64_t ts_ms = array->open_timestamp_end();
+    double ts = ts_ms / 1000.0;
+    return(Rcpp::Datetime(ts));
+}
+
 /**
  * Query
  */


### PR DESCRIPTION
This PR support the extended timestamp format for arrays:
- adds dedicated setter and getter and start and end timestamp
- updates `tiledb_array` interface with start and end timestamp support
- continues (but marked as 'deprecated') support for the older 'timestamp' argument
- adds new tests, old test code runs as is (until deprecated function removed), 
- old tests also recast in new arguments