### PR TITLE
Update query parser to infer strings as ascii

### DIFF
--- a/R/QueryCondition.R
+++ b/R/QueryCondition.R
@@ -107,7 +107,7 @@ tiledb_query_condition_combine <- function(lhs, rhs, op) {
 parse_query_condition <- function(expr, debug=FALSE) {
     .isComparisonOperator <- function(x) as.character(x) %in% c(">", ">=", "<", "<=", "==", "!=")
     .isBooleanOperator <- function(x) as.character(x) %in% c("&&", "||", "!")
-    .isAscii <- function(x) grepl("[a-zA-Z_]", x)
+    .isAscii <- function(x) grepl("[[:alpha:]]", x)
     .isInteger <- function(x) as.character(as.integer(x)) == x
     .isDouble <- function(x) as.character(as.numeric(x)) == x && grepl("[\\.]", as.character(x))
     .getType <- function(x) {

--- a/R/QueryCondition.R
+++ b/R/QueryCondition.R
@@ -107,6 +107,7 @@ tiledb_query_condition_combine <- function(lhs, rhs, op) {
 parse_query_condition <- function(expr, debug=FALSE) {
     .isComparisonOperator <- function(x) as.character(x) %in% c(">", ">=", "<", "<=", "==", "!=")
     .isBooleanOperator <- function(x) as.character(x) %in% c("&&", "||", "!")
+    .isAscii <- function(x) grepl("^[[:alnum:]_]+$", x)
     .isInteger <- function(x) grepl("^[[:digit:]]+$", as.character(x))
     .isDouble <- function(x) grepl("^[[:digit:]\\.]+$", as.character(x)) && length(grepRaw(".", as.character(x), fixed = TRUE, all = TRUE)) == 1
     .getType <- function(x) {

--- a/R/QueryCondition.R
+++ b/R/QueryCondition.R
@@ -107,7 +107,7 @@ tiledb_query_condition_combine <- function(lhs, rhs, op) {
 parse_query_condition <- function(expr, debug=FALSE) {
     .isComparisonOperator <- function(x) as.character(x) %in% c(">", ">=", "<", "<=", "==", "!=")
     .isBooleanOperator <- function(x) as.character(x) %in% c("&&", "||", "!")
-    .isAscii <- function(x) grepl("^[a-zA-Z_]*$", x)
+    .isAscii <- function(x) grepl("[a-zA-Z_]", x)
     .isInteger <- function(x) as.character(as.integer(x)) == x
     .isDouble <- function(x) as.character(as.numeric(x)) == x && grepl("[\\.]", as.character(x))
     .getType <- function(x) {

--- a/R/QueryCondition.R
+++ b/R/QueryCondition.R
@@ -107,13 +107,12 @@ tiledb_query_condition_combine <- function(lhs, rhs, op) {
 parse_query_condition <- function(expr, debug=FALSE) {
     .isComparisonOperator <- function(x) as.character(x) %in% c(">", ">=", "<", "<=", "==", "!=")
     .isBooleanOperator <- function(x) as.character(x) %in% c("&&", "||", "!")
-    .isAscii <- function(x) grepl("[[:alpha:]_]", x)
-    .isInteger <- function(x) as.character(as.integer(x)) == x
-    .isDouble <- function(x) as.character(as.numeric(x)) == x && grepl("[\\.]", as.character(x))
+    .isInteger <- function(x) grepl("^[[:digit:]]+$", as.character(x))
+    .isDouble <- function(x) grepl("^[[:digit:]\\.]+$", as.character(x)) && length(grepRaw(".", as.character(x), fixed = TRUE, all = TRUE)) == 1
     .getType <- function(x) {
-        if (.isAscii(as.character(x))) "ASCII"
-        else if (.isDouble(as.character(x))) "FLOAT64"
-        else "INT32"
+        if (isTRUE(.isInteger(x))) "INT32"
+        else if (isTRUE(.isDouble(x))) "FLOAT64"
+        else "ASCII"
     }
     .mapOpToCharacter <- function(x) switch(x,
                                             `>`  = "GT",

--- a/R/QueryCondition.R
+++ b/R/QueryCondition.R
@@ -107,7 +107,7 @@ tiledb_query_condition_combine <- function(lhs, rhs, op) {
 parse_query_condition <- function(expr, debug=FALSE) {
     .isComparisonOperator <- function(x) as.character(x) %in% c(">", ">=", "<", "<=", "==", "!=")
     .isBooleanOperator <- function(x) as.character(x) %in% c("&&", "||", "!")
-    .isAscii <- function(x) grepl("[[:alpha:]]", x)
+    .isAscii <- function(x) grepl("[[:alpha:]_]", x)
     .isInteger <- function(x) as.character(as.integer(x)) == x
     .isDouble <- function(x) as.character(as.numeric(x)) == x && grepl("[\\.]", as.character(x))
     .getType <- function(x) {

--- a/inst/tinytest/test_querycondition.R
+++ b/inst/tinytest/test_querycondition.R
@@ -204,4 +204,4 @@ fromDataFrame(edgecases, uri, sparse=TRUE)
 qcx1 <- tiledb::parse_query_condition(x1 == "a1")
 arrx1 <- tiledb_array(uri, as.data.frame=TRUE, query_condition=qcx1)
 res <- arrx1[]
-expect_true(res$x1, "a1")
+expect_equal(res$x1, "a1")

--- a/inst/tinytest/test_querycondition.R
+++ b/inst/tinytest/test_querycondition.R
@@ -196,7 +196,7 @@ expect_equal(NROW(res), 165L)
 expect_true(all(res$sex != "male"))
 
 ## check type inference for edge cases
-edgecases <- data.frame(x1 = "a1", x2 = 1L, x3 = "_1")
+edgecases <- data.frame(x1 = "a1", x2 = 1L, x3 = "_1", x4 = "1.1.1")
 
 uri <- tempfile()
 fromDataFrame(edgecases, uri, sparse=TRUE)
@@ -214,3 +214,7 @@ expect_equal(res$x2, 1L)
 qcx3 <- tiledb::parse_query_condition(x3 == "_1")
 arrx3 <- tiledb_array(uri, as.data.frame=TRUE, query_condition=qcx3)
 expect_equal(arrx3[]$x3, "_1")
+
+qcx4 <- tiledb::parse_query_condition(x4 == "1.1.1")
+arrx4 <- tiledb_array(uri, as.data.frame=TRUE, query_condition=qcx4)
+expect_equal(arrx4[]$x4, "1.1.1")

--- a/inst/tinytest/test_querycondition.R
+++ b/inst/tinytest/test_querycondition.R
@@ -196,7 +196,7 @@ expect_equal(NROW(res), 165L)
 expect_true(all(res$sex != "male"))
 
 ## check type inference for edge cases
-edgecases <- data.frame(x1 = "a1", x2 = 1L)
+edgecases <- data.frame(x1 = "a1", x2 = 1L, x3 = "_1")
 
 uri <- tempfile()
 fromDataFrame(edgecases, uri, sparse=TRUE)
@@ -210,3 +210,7 @@ qcx2 <- tiledb::parse_query_condition(x2 == 1L)
 arrx2 <- tiledb_array(uri, as.data.frame=TRUE, query_condition=qcx2)
 res <- arrx2[]
 expect_equal(res$x2, 1L)
+
+qcx3 <- tiledb::parse_query_condition(x3 == "_1")
+arrx3 <- tiledb_array(uri, as.data.frame=TRUE, query_condition=qcx3)
+expect_equal(arrx3[]$x3, "_1")

--- a/inst/tinytest/test_querycondition.R
+++ b/inst/tinytest/test_querycondition.R
@@ -194,3 +194,14 @@ arrwithqc <- tiledb_array(uri, as.data.frame=TRUE, query_condition=qc)
 res <- arrwithqc[]
 expect_equal(NROW(res), 165L)
 expect_true(all(res$sex != "male"))
+
+## check type inference for edge cases
+edgecases <- data.frame(x1 = "a1")
+
+uri <- tempfile()
+fromDataFrame(edgecases, uri, sparse=TRUE)
+
+qcx1 <- tiledb::parse_query_condition(x1 == "a1")
+arrx1 <- tiledb_array(uri, as.data.frame=TRUE, query_condition=qcx1)
+res <- arrx1[]
+expect_true(res$x1, "a1")

--- a/inst/tinytest/test_querycondition.R
+++ b/inst/tinytest/test_querycondition.R
@@ -196,7 +196,7 @@ expect_equal(NROW(res), 165L)
 expect_true(all(res$sex != "male"))
 
 ## check type inference for edge cases
-edgecases <- data.frame(x1 = "a1")
+edgecases <- data.frame(x1 = "a1", x2 = 1L)
 
 uri <- tempfile()
 fromDataFrame(edgecases, uri, sparse=TRUE)
@@ -205,3 +205,8 @@ qcx1 <- tiledb::parse_query_condition(x1 == "a1")
 arrx1 <- tiledb_array(uri, as.data.frame=TRUE, query_condition=qcx1)
 res <- arrx1[]
 expect_equal(res$x1, "a1")
+
+qcx2 <- tiledb::parse_query_condition(x2 == 1L)
+arrx2 <- tiledb_array(uri, as.data.frame=TRUE, query_condition=qcx2)
+res <- arrx2[]
+expect_equal(res$x2, 1L)


### PR DESCRIPTION
Drops the anchors from `.isAscii`'s regex pattern to look for alpha characters anywhere in the value. Also adds a new test section where we can start checking for more type inference edge cases.