### PR TITLE
Correct buffer size for all-string arrays under query conditions

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -605,8 +605,8 @@ libtiledb_query_status <- function(query) {
     .Call(`_tiledb_libtiledb_query_status`, query)
 }
 
-libtiledb_query_result_buffer_elements <- function(query, attribute) {
-    .Call(`_tiledb_libtiledb_query_result_buffer_elements`, query, attribute)
+libtiledb_query_result_buffer_elements <- function(query, attribute, which = 1L) {
+    .Call(`_tiledb_libtiledb_query_result_buffer_elements`, query, attribute, which)
 }
 
 libtiledb_query_get_fragment_num <- function(query) {

--- a/R/TileDBArray.R
+++ b/R/TileDBArray.R
@@ -670,7 +670,8 @@ setMethod("[", "tiledb_array",
   ## retrieve actual result size (from fixed size element columns)
   getResultSize <- function(name, varnum, qryptr) {
     if (is.na(varnum))                  # symbols come up with higher count
-      varnum
+      #varnum
+      libtiledb_query_result_buffer_elements(qryptr, name, 0)
     else
       libtiledb_query_result_buffer_elements(qryptr, name)
   }
@@ -684,15 +685,15 @@ setMethod("[", "tiledb_array",
   ## get results
   getResult <- function(buf, name, varnum, resrv, qryptr) {
     if (is.na(varnum)) {
-      sz <- libtiledb_query_result_buffer_elements(qryptr, name)
-      libtiledb_query_get_buffer_var_char(buf, resrv, sz)[,1]
+      sz <- libtiledb_query_result_buffer_elements(qryptr, name, 0)
+      len <- libtiledb_query_result_buffer_elements(qryptr, name, 1)
+      libtiledb_query_get_buffer_var_char(buf, sz, len)[,1]
     } else {
       libtiledb_query_get_buffer_ptr(buf, asint64)
     }
   }
   reslist <- mapply(getResult, buflist, allnames, allvarnum,
                     MoreArgs=list(resrv=resrv, qryptr=qryptr), SIMPLIFY=FALSE)
-
   ## convert list into data.frame (cheaply) and subset
   res <- data.frame(reslist)[seq_len(resrv),]
   colnames(res) <- allnames

--- a/R/TileDBArray.R
+++ b/R/TileDBArray.R
@@ -670,7 +670,6 @@ setMethod("[", "tiledb_array",
   ## retrieve actual result size (from fixed size element columns)
   getResultSize <- function(name, varnum, qryptr) {
     if (is.na(varnum))                  # symbols come up with higher count
-      #varnum
       libtiledb_query_result_buffer_elements(qryptr, name, 0)
     else
       libtiledb_query_result_buffer_elements(qryptr, name)

--- a/inst/tinytest/test_querycondition.R
+++ b/inst/tinytest/test_querycondition.R
@@ -218,3 +218,16 @@ expect_equal(arrx3[]$x3, "_1")
 qcx4 <- tiledb::parse_query_condition(x4 == "1.1.1")
 arrx4 <- tiledb_array(uri, as.data.frame=TRUE, query_condition=qcx4)
 expect_equal(arrx4[]$x4, "1.1.1")
+
+
+## edge case of text only array
+df <- data.frame(abb = state.abb,		# builtin-data
+                 region = state.region,	# idem
+                 name = state.name)     # idem
+uri <- tempfile()
+fromDataFrame(df, uri, col_index="abb", sparse=TRUE)
+fullarr <- tiledb_array(uri, as.data.frame=TRUE)[]
+expect_equal(dim(fullarr), c(50,3))
+subarr <- tiledb_array(uri, as.data.frame=TRUE,
+                       query_condition=parse_query_condition(region == "Northeast"))[]
+expect_equal(dim(subarr), c(9,3))

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -1794,14 +1794,15 @@ BEGIN_RCPP
 END_RCPP
 }
 // libtiledb_query_result_buffer_elements
-R_xlen_t libtiledb_query_result_buffer_elements(XPtr<tiledb::Query> query, std::string attribute);
-RcppExport SEXP _tiledb_libtiledb_query_result_buffer_elements(SEXP querySEXP, SEXP attributeSEXP) {
+R_xlen_t libtiledb_query_result_buffer_elements(XPtr<tiledb::Query> query, std::string attribute, int32_t which);
+RcppExport SEXP _tiledb_libtiledb_query_result_buffer_elements(SEXP querySEXP, SEXP attributeSEXP, SEXP whichSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< XPtr<tiledb::Query> >::type query(querySEXP);
     Rcpp::traits::input_parameter< std::string >::type attribute(attributeSEXP);
-    rcpp_result_gen = Rcpp::wrap(libtiledb_query_result_buffer_elements(query, attribute));
+    Rcpp::traits::input_parameter< int32_t >::type which(whichSEXP);
+    rcpp_result_gen = Rcpp::wrap(libtiledb_query_result_buffer_elements(query, attribute, which));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -2572,7 +2573,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_tiledb_libtiledb_query_submit_async", (DL_FUNC) &_tiledb_libtiledb_query_submit_async, 1},
     {"_tiledb_libtiledb_query_finalize", (DL_FUNC) &_tiledb_libtiledb_query_finalize, 1},
     {"_tiledb_libtiledb_query_status", (DL_FUNC) &_tiledb_libtiledb_query_status, 1},
-    {"_tiledb_libtiledb_query_result_buffer_elements", (DL_FUNC) &_tiledb_libtiledb_query_result_buffer_elements, 2},
+    {"_tiledb_libtiledb_query_result_buffer_elements", (DL_FUNC) &_tiledb_libtiledb_query_result_buffer_elements, 3},
     {"_tiledb_libtiledb_query_get_fragment_num", (DL_FUNC) &_tiledb_libtiledb_query_get_fragment_num, 1},
     {"_tiledb_libtiledb_query_get_fragment_uri", (DL_FUNC) &_tiledb_libtiledb_query_get_fragment_uri, 2},
     {"_tiledb_libtiledb_query_get_fragment_timestamp_range", (DL_FUNC) &_tiledb_libtiledb_query_get_fragment_timestamp_range, 2},

--- a/src/libtiledb.cpp
+++ b/src/libtiledb.cpp
@@ -2910,9 +2910,12 @@ std::string libtiledb_query_status(XPtr<tiledb::Query> query) {
 }
 
 // [[Rcpp::export]]
-R_xlen_t libtiledb_query_result_buffer_elements(XPtr<tiledb::Query> query, std::string attribute) {
-  R_xlen_t nelem = query->result_buffer_elements()[attribute].second;
-  return nelem;
+R_xlen_t libtiledb_query_result_buffer_elements(XPtr<tiledb::Query> query,
+                                                std::string attribute,
+                                                int32_t which=1) {
+    auto nelements = query->result_buffer_elements()[attribute];
+    R_xlen_t nelem = (which == 0 ? nelements.first : nelements.second);
+    return nelem;
 }
 
 // [[Rcpp::export]]


### PR DESCRIPTION
This PR corrects the issue identified by @aaronwolen wherein an all string-ascii array would not query properly if a query condition was supplied.   A new test has been added as well.