### PR TITLE
Correct one cast to suppress warning when checking size

### DIFF
--- a/src/libtiledb.cpp
+++ b/src/libtiledb.cpp
@@ -836,8 +836,8 @@ SEXP libtiledb_dim_get_domain(XPtr<tiledb::Dimension> dim) {
       using DataType = tiledb::impl::tiledb_to_type<TILEDB_UINT32>::type;
       auto d1 = dim->domain<DataType>().first;
       auto d2 = dim->domain<DataType>().second;
-      if (d1 > std::numeric_limits<int64_t>::max() ||
-          d2 > std::numeric_limits<int64_t>::max()) {
+      if (d1 > std::numeric_limits<uint32_t>::max() ||
+          d2 > std::numeric_limits<uint32_t>::max()) {
         Rcpp::stop("tiledb_dim domain UINT32 value not representable as an R integer64 type");
       }
       std::vector<int64_t> v = { static_cast<int64_t>(d1), static_cast<int64_t>(d2) };


### PR DESCRIPTION
This PR suppresses a two-line warning when the size of a `uint32_t` is checked, and we accidentally compared to a `int64_t`.  It is being triggered now at CRAN following the 0.9.5 upload as seen at [the results page](https://cran.r-project.org/web/checks/check_results_tiledb.html).
