### PR TITLE
Warn on incomplete queries

### DIFF
--- a/R/TileDBArray.R
+++ b/R/TileDBArray.R
@@ -638,8 +638,14 @@ setMethod("[", "tiledb_array",
       qryptr <- libtiledb_query_set_condition(qryptr, x@query_condition@ptr)
   }
 
-  ## fire off query and close array
+  ## fire off query
   qryptr <- libtiledb_query_submit(qryptr)
+
+  ## check status
+  status <- libtiledb_query_status(qryptr)
+  if (status != "COMPLETE") warning("Query returned '", status, "'.", call. = FALSE)
+
+  ## close array
   libtiledb_array_close(arrptr)
 
   ## retrieve actual result size (from fixed size element columns)

--- a/inst/tinytest/test_query.R
+++ b/inst/tinytest/test_query.R
@@ -193,3 +193,12 @@ expect_equal(n, 4L)
 expect_equal(rowdat[1:n], rows[4:7])
 expect_equal(valdat[1:n], vals[4:7])
 #})
+
+## check for warning in insufficient memory
+cfg <- tiledb_config()
+cfg["sm.memory_budget"] <- "16"
+cfg["sm.memory_budget_var"] <- "32"
+ctx <- tiledb_ctx(cfg)
+array <- tiledb_array(tmp, as.data.frame=TRUE)
+
+expect_warning(array[])


### PR DESCRIPTION
This PR adds a missing check for query status to the `[` accessor function most commonly used.   This does the right thing for an R user by wrapping `warning()` as local configuration can then be used in both directions: turning warnings into errors (_i.e._ halting) or ignoring warning, or, of course, doing nothing and getting them displayed.