### PR TITLE
Additional TileDB 2.2.* conditioning

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,18 @@
+# Ongoing development
+
+* This release of the R package builds against [TileDB 2.3.3](https://github.com/TileDB-Inc/TileDB/releases/tag/2.3.3), but has also been tested against previous releases and the development version.
+
+## Improvements
+
+* When retrieving results via the `[` operator, incomplete queries generate a warning (#283)
+
+* The interface to query element size of queries was extended (#282)
+
+## Bug Fixes
+
+* One cast statement was corrected so a warning is no longer triggered from `clang` (#281)
+
+
 # tiledb 0.9.5
 
 * This release of the R package builds against [TileDB 2.3.3](https://github.com/TileDB-Inc/TileDB/releases/tag/2.3.3), but has also been tested against previous releases and the development version.

--- a/inst/tinytest/test_query.R
+++ b/inst/tinytest/test_query.R
@@ -208,6 +208,8 @@ expect_equal(keydat[1:n], keys[4:7])
 n2 <- tiledb:::libtiledb_query_result_buffer_elements(qry@ptr, "rows", 0)
 expect_equal(n2, 0)                     # first element can be requested, is zero for fixed-sized
 
+if (tiledb_version(TRUE) < "2.2.0") exit_file("Remaining tests require TileDB 2.2.* or later")
+
 ## not as streamlined as it could, may need a wrapper for schema-from-query
 arrschptr <- tiledb:::libtiledb_query_get_schema(qry@ptr, tiledb_get_context()@ptr)
 sch <- tiledb:::tiledb_array_schema.from_ptr(arrschptr)

--- a/src/libtiledb.cpp
+++ b/src/libtiledb.cpp
@@ -2922,6 +2922,7 @@ R_xlen_t libtiledb_query_result_buffer_elements(XPtr<tiledb::Query> query,
 NumericVector libtiledb_query_result_buffer_elements_vec(XPtr<tiledb::Query> query,
                                                          std::string attribute,
                                                          bool nullable = false) {
+#if TILEDB_VERSION >= TileDB_Version(2,2,0)
     if (nullable) {
         auto nelem = query->result_buffer_elements_nullable()[attribute];
         auto vec = NumericVector( {
@@ -2934,6 +2935,10 @@ NumericVector libtiledb_query_result_buffer_elements_vec(XPtr<tiledb::Query> que
         auto nelem = query->result_buffer_elements()[attribute];
         return NumericVector( { static_cast<double>(nelem.first), static_cast<double>(nelem.second) });
     }
+#else
+    auto nelem = query->result_buffer_elements()[attribute];
+    return NumericVector( { static_cast<double>(nelem.first), static_cast<double>(nelem.second) });
+#endif
 }
 
 // [[Rcpp::export]]
@@ -3231,16 +3236,24 @@ XPtr<tiledb::Query> libtiledb_query_set_condition(XPtr<tiledb::Query> query,
 //
 // [[Rcpp::export]]
 XPtr<tiledb::Array> libtiledb_query_get_array(XPtr<tiledb::Query> query, XPtr<tiledb::Context> ctx) {
+#if TILEDB_VERSION >= TileDB_Version(2,2,0)
     auto arr = query->array();
     auto cptr = arr.ptr().get();
     return XPtr<tiledb::Array>(new tiledb::Array(*ctx.get(), cptr, false));
+#else
+    return XPtr<tiledb::Array>(R_NilValue);
+#endif
 }
 
 // [[Rcpp::export]]
 XPtr<tiledb::ArraySchema> libtiledb_query_get_schema(XPtr<tiledb::Query> query,
                                                      XPtr<tiledb::Context> ctx) {
+#if TILEDB_VERSION >= TileDB_Version(2,2,0)
     auto arr = query->array();
     return libtiledb_array_schema_load(ctx, arr.uri()); // returns an XPtr<tiledb::ArraySchema>
+#else
+    return XPtr<tiledb::ArraySchema>(R_NilValue);
+#endif
 }
 
 /**


### PR DESCRIPTION
The additions in #282 did not properly account for requirement of TileDB 2.2.0 or later in parts of the code which this small PR corrects.  It also updates the NEWS files for the few PRs since 0.9.5 was released.