### PR TITLE
Release 0.9.6

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tiledb
 Type: Package
-Version: 0.9.5
+Version: 0.9.6
 Title: Sparse and Dense Multidimensional Array Storage Engine for Data Science
 Authors@R: c(person("TileDB, Inc.", role = c("aut", "cph")),
  person("Dirk", "Eddelbuettel", email = "dirk@tiledb.com", role = "cre"))


### PR DESCRIPTION
Processing of release 0.9.6 at CRAN involded a manual inspection given the compiler warning from clang-12 resulting in a NOTE (which is fixed in 0.9.6) so once accepted the previous PR was merged before the version number was committed and pushed. 

This PR rectifies this.