### PR TITLE
Use TileDB 2.4.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # Ongoing development
 
+* This release of the R package builds against [TileDB 2.4.0](https://github.com/TileDB-Inc/TileDB/releases/tag/2.4.0), but has been tested against previous releases and the development version.
+
+
+# tiledb 0.9.6
+
 * This release of the R package builds against [TileDB 2.3.4](https://github.com/TileDB-Inc/TileDB/releases/tag/2.3.4), but has been tested against previous releases and the development version.
 
 ## Improvements

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -5,7 +5,7 @@ PKG_CPPFLAGS = -I../inst/include -I$(RWINLIB)/include -DTILEDB_STATIC_DEFINE
 PKG_LIBS = \
 	-L$(RWINLIB)/lib$(subst gcc,,$(COMPILED_BY))$(R_ARCH) \
 	-L$(RWINLIB)/lib$(R_ARCH)$(CRT) \
-	-ltiledbstatic -lbz2 -lzstd -llz4 -lz \
+	-ltiledbstatic -lbz2 -lzstd -llz4 -lz -lspdlog \
 	-laws-cpp-sdk-identity-management -laws-cpp-sdk-cognito-identity -laws-cpp-sdk-sts -laws-cpp-sdk-s3 -laws-cpp-sdk-core -laws-c-event-stream -laws-checksums -laws-c-common \
 	-lShlwapi -lBcrypt -lRpcrt4 -lWininet -lWinhttp -lws2_32 -lVersion -lUserenv
 

--- a/tools/tiledbVersion.txt
+++ b/tools/tiledbVersion.txt
@@ -1,2 +1,2 @@
-version: 2.3.4
-sha: e19855e
+version: 2.4.0
+sha: baf64e1


### PR DESCRIPTION
Standard upgrade to next TileDB Embedded release using artifacts where available.