### PR TITLE
Add devel-ucrt to CI matrix

### DIFF
--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -6,19 +6,27 @@ name: windows
 
 jobs:
   windows:
-    name: (Windows/mingw-w64)
-    runs-on: windows-latest
+    runs-on: ${{ matrix.windows }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include: [
+          { windows: windows-2019, r: release },
+          { windows: windows-2022, r: devel },
+          { windows: windows-2022, r: devel-ucrt }
+        ]
     steps:
       - run: git config --global core.autocrlf false
       - uses: actions/checkout@v2
-      - uses: r-lib/actions/setup-r@master
-      - uses: r-lib/actions/setup-pandoc@master
+      - uses: r-lib/actions/setup-r@v1
+        with:
+          r-version: ${{ matrix.r }}
+      - uses: r-lib/actions/setup-pandoc@v1
       - name: Install dependencies
         run: |
-          setRepositories(ind = 1:2)
           install.packages(c("remotes", "rcmdcheck"))
           remotes::install_deps(dependencies = NA)
-          install.packages(c("Matrix", "palmerpenguins", "nycflights13", "tibble", "data.table"))
+          install.packages(c("palmerpenguins", "nycflights13", "tibble", "data.table"))
         shell: Rscript {0}
         env:
           R_REMOTES_NO_ERRORS_FROM_WARNINGS: true


### PR DESCRIPTION
This may be useful to ensure that your rwinlib tiledb binaries are working as expected also for ucrt.

The R-devel-ucrt installer from Tomas currently has special built-in repos, so I had to remove the line where you override this. And also I had to remove Matrix because this is a recommended package, which is apparently not in the ucrt repo.