### PR TITLE
Update use of set_buffer to set_{data,validity,offset}

### DIFF
--- a/src/libtiledb.cpp
+++ b/src/libtiledb.cpp
@@ -448,8 +448,10 @@ bool libtiledb_ctx_is_supported_fs(XPtr<tiledb::Context> ctx, std::string scheme
     return ctx->is_supported_fs(TILEDB_AZURE);
   } else if (scheme == "gcs") {
     return ctx->is_supported_fs(TILEDB_GCS);
+#if TILEDB_VERSION >= TileDB_Version(2,2,0)
   } else if (scheme == "memory") {
     return ctx->is_supported_fs(TILEDB_MEMFS);
+#endif
   } else {
     Rcpp::stop("Unknown TileDB fs scheme: '%s'", scheme.c_str());
   }
@@ -2405,15 +2407,15 @@ XPtr<tiledb::Query> libtiledb_query_set_buffer(XPtr<tiledb::Query> query,
                                                SEXP buffer) {
   if (TYPEOF(buffer) == INTSXP) {
     IntegerVector vec(buffer);
-    query->set_buffer(attr, vec.begin(), vec.length());
+    query->set_data_buffer(attr, vec.begin(), vec.length());
     return query;
   } else if (TYPEOF(buffer) == REALSXP) {
     NumericVector vec(buffer);
-    query->set_buffer(attr, vec.begin(), vec.length());
+    query->set_data_buffer(attr, vec.begin(), vec.length());
     return query;
   } else if (TYPEOF(buffer) == LGLSXP) {
     LogicalVector vec(buffer);
-    query->set_buffer(attr, vec.begin(), vec.length());
+    query->set_data_buffer(attr, vec.begin(), vec.length());
     return query;
   } else {
     Rcpp::stop("Invalid attribute buffer type for attribute '%s': %s",

--- a/src/libtiledb.cpp
+++ b/src/libtiledb.cpp
@@ -2506,15 +2506,12 @@ XPtr<tiledb::Query> libtiledb_query_set_buffer_var_char(XPtr<tiledb::Query> quer
 
 #if TILEDB_VERSION >= TileDB_Version(2,2,4)
     if (bufptr->nullable) {
-        query->set_buffer_nullable(attr, bufptr->offsets, bufptr->str, bufptr->validity_map);
-    } else {
-        query->set_buffer(attr, bufptr->offsets, bufptr->str);
+        query->set_validity_buffer(attr, bufptr->validity_map);
     }
-    return query;
-#else
-    query->set_buffer(attr, bufptr->offsets, bufptr->str);
-    return query;
 #endif
+    query->set_data_buffer(attr, bufptr->str);
+    query->set_offsets_buffer(attr, bufptr->offsets);
+    return query;
 }
 
 // 'len' is the length of the query result set, i.e. buffer elements for standard columns

--- a/src/libtiledb.cpp
+++ b/src/libtiledb.cpp
@@ -2801,17 +2801,11 @@ XPtr<tiledb::Query> libtiledb_query_set_buffer_ptr(XPtr<tiledb::Query> query,
                                                    XPtr<query_buf_t> buf) {
 #if TILEDB_VERSION >= TileDB_Version(2,2,0)
     if (buf->nullable) {
-        query->set_buffer_nullable(attr, static_cast<void*>(buf->vec.data()), buf->ncells,
-                                   buf->validity_map.data(),
-                                   static_cast<uint64_t>(buf->validity_map.size()));
-    } else {
-        query->set_buffer(attr, static_cast<void*>(buf->vec.data()), buf->ncells);
+        query->set_validity_buffer(attr, buf->validity_map);
     }
-    return query;
-#else
-    query->set_buffer(attr, static_cast<void*>(buf->vec.data()), buf->ncells);
-    return query;
 #endif
+    query->set_data_buffer(attr, static_cast<void*>(buf->vec.data()), buf->ncells);
+    return query;
 }
 
 

--- a/src/libtiledb.cpp
+++ b/src/libtiledb.cpp
@@ -2576,11 +2576,13 @@ XPtr<vlv_buf_t> libtiledb_query_buffer_var_vec_create(IntegerVector intoffsets, 
 XPtr<tiledb::Query> libtiledb_query_set_buffer_var_vec(XPtr<tiledb::Query> query,
                                                        std::string attr, XPtr<vlv_buf_t> buf) {
   if (buf->dtype == TILEDB_INT32) {
-    query->set_buffer(attr, buf->offsets, buf->idata);
+      query->set_data_buffer(attr, buf->idata);
+      query->set_offsets_buffer(attr, buf->offsets);
   } else if (buf->dtype == TILEDB_FLOAT64) {
-    query->set_buffer(attr, buf->offsets, buf->ddata);
+      query->set_data_buffer(attr, buf->ddata);
+      query->set_offsets_buffer(attr, buf->offsets);
   } else {
-    Rcpp::stop("Unsupported type '%s' for buffer", _tiledb_datatype_to_string(buf->dtype));
+      Rcpp::stop("Unsupported type '%s' for buffer", _tiledb_datatype_to_string(buf->dtype));
   }
   return query;
 }


### PR DESCRIPTION
This PR catches up to the updated buffer setting interfaces.  

No functional changes, no test changes, just a few retirements of now-deprecated calls.