### PR TITLE
Update to recent TileDB Embedded changes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,5 +27,5 @@ LinkingTo: Rcpp
 Suggests: tinytest, rmarkdown, knitr, minidown, curl, bit64, Matrix, palmerpenguins, nycflights13, data.table, tibble
 VignetteBuilder: knitr
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.1
+RoxygenNote: 7.1.2
 Encoding: UTF-8

--- a/R/DataFrame.R
+++ b/R/DataFrame.R
@@ -40,7 +40,7 @@
 ##' @param col_index An optional column index, either numeric with a column index,
 ##' or character with a column name, designating an index column; default is NULL
 ##' implying an index column is added when the array is created
-##' @param sparse A logical switch to select sparse or dense (the default)
+##' @param sparse A logical switch to select sparse (the default) or dense
 ##' @param allows_dups A logical switch to select if duplicate values
 ##' are allowed or not, default is the same value as \sQuote{sparse}.
 ##' @param cell_order A character variable with one of the TileDB cell order values,
@@ -71,7 +71,7 @@
 ##' all.equal(iris, newdf)
 ##' }
 ##' @export
-fromDataFrame <- function(obj, uri, col_index=NULL, sparse=FALSE, allows_dups=sparse,
+fromDataFrame <- function(obj, uri, col_index=NULL, sparse=TRUE, allows_dups=sparse,
                           cell_order = "COL_MAJOR", tile_order = "COL_MAJOR", filter="ZSTD",
                           capacity = 10000L, tile_domain = NULL, tile_extent = NULL, debug = FALSE) {
 

--- a/inst/tinytest/test_arrowio.R
+++ b/inst/tinytest/test_arrowio.R
@@ -52,7 +52,7 @@ sch <- tiledb_array_schema(dom,
                                      tiledb_attr("int64",  type="INT64"),
                                      tiledb_attr("uint64", type="UINT64"),
                                      tiledb_attr("float64",type="FLOAT64")),
-                           sparse = FALSE)
+                           sparse = TRUE)
 tiledb_array_create(tmp, sch)
 
 arr <- tiledb_array(tmp)
@@ -126,7 +126,7 @@ sch <- tiledb_array_schema(dom,
                                      tiledb_attr("int64",  type="INT64"),
                                      tiledb_attr("uint64", type="UINT64"),
                                      tiledb_attr("float64",type="FLOAT64")),
-                           sparse = FALSE)
+                           sparse = TRUE)
 tiledb_array_create(tmp, sch)
 
 ## create an arrow 'record batch' with a number of (correcsponding) columns

--- a/inst/tinytest/test_dataframe.R
+++ b/inst/tinytest/test_dataframe.R
@@ -37,7 +37,7 @@ expect_equivalent(iris[, c("Petal.Length", "Petal.Width")], newdf) # skip attrib
 
 
 ## test list
-arr <- tiledb_array(uri)
+arr <- tiledb_array(uri, return_as="asis")
 res <- arr[]
 expect_equal(class(res), "list")
 expect_equal(length(res), 6)            # plus one for 'rows'

--- a/inst/tinytest/test_dataframe.R
+++ b/inst/tinytest/test_dataframe.R
@@ -266,3 +266,14 @@ arr <- tiledb_array(uri, as.data.frame=TRUE)
 chk <- arr[]
 if (getRversion() <  '4.0.0') chk$char <- as.character(chk$char)
 expect_equivalent(df, chk)              # skip attribute
+
+## explicit dense data.frame
+df <- data.frame(aa=1:26,
+                 bb=26:1,
+                 cc=letters,
+                 dd=LETTERS)
+uri <- tempfile()
+fromDataFrame(df, uri, sparse=FALSE)
+arr <- tiledb_array(uri, return_as="data.frame", extended=FALSE)  # skip row index on return
+res <- arr[]
+expect_equivalent(df, arr[])

--- a/inst/tinytest/test_dataframe.R
+++ b/inst/tinytest/test_dataframe.R
@@ -276,4 +276,8 @@ uri <- tempfile()
 fromDataFrame(df, uri, sparse=FALSE)
 arr <- tiledb_array(uri, return_as="data.frame", extended=FALSE)  # skip row index on return
 res <- arr[]
-expect_equivalent(df, arr[])
+if (getRversion() < '4.0.0') {
+    res$cc <- as.character(res$cc)
+    res$dd <- as.character(res$dd)
+}
+expect_equivalent(df, res)

--- a/inst/tinytest/test_query.R
+++ b/inst/tinytest/test_query.R
@@ -158,7 +158,7 @@ dom <- tiledb_domain(dims = tiledb_dim("rows", c(1L, 10L), 1L, type = "INT32"))
 schema <- tiledb_array_schema(dom,
                               attrs = c(tiledb_attr("vals", type = "INT32"),
                                         tiledb_attr("keys", type = "INT32", nullable = TRUE)),
-                              sparse=FALSE)
+                              sparse=TRUE)
 tiledb_array_create(tmp, schema)
 arr <- tiledb_array(tmp)
 qry <- tiledb_query(arr, "WRITE")

--- a/inst/tinytest/test_tiledbarray.R
+++ b/inst/tinytest/test_tiledbarray.R
@@ -586,7 +586,7 @@ if (requireNamespace("bit64", quietly=TRUE)) {
   ## The array will be 4x4 with dimensions "rows" and "cols", with domain [1,4]
   dom <- tiledb_domain(dims = c(tiledb_dim("rows", c(1L,4L), 4L, "INT8"),
                                 tiledb_dim("cols", c(1L,4L), 4L, "INT8")))
-  schema <- tiledb_array_schema(dom, attrs = c(tiledb_attr("a", type = "INT32")), sparse=FALSE)
+  schema <- tiledb_array_schema(dom, attrs = c(tiledb_attr("a", type = "INT32")), sparse=TRUE)
   tiledb_array_create(uri = tmp, schema)
   #print(schema)
   A <- tiledb_array(uri = tmp)
@@ -617,7 +617,7 @@ if (requireNamespace("bit64", quietly=TRUE)) {
   ## The array will be 4x4 with dimensions "rows" and "cols", with domain [1,4]
   dom <- tiledb_domain(dims = c(tiledb_dim("rows", c(1L,4L), 4L, "UINT8"),
                                 tiledb_dim("cols", c(1L,4L), 4L, "UINT8")))
-  schema <- tiledb_array_schema(dom, attrs = c(tiledb_attr("a", type = "INT32")), sparse=FALSE)
+  schema <- tiledb_array_schema(dom, attrs = c(tiledb_attr("a", type = "INT32")), sparse=TRUE)
   tiledb_array_create(uri = tmp, schema)
   #print(schema)
   A <- tiledb_array(uri = tmp)
@@ -648,7 +648,7 @@ if (requireNamespace("bit64", quietly=TRUE)) {
   ## The array will be 4x4 with dimensions "rows" and "cols", with domain [1,4]
   dom <- tiledb_domain(dims = c(tiledb_dim("rows", c(1L,4L), 4L, "INT16"),
                                 tiledb_dim("cols", c(1L,4L), 4L, "INT16")))
-  schema <- tiledb_array_schema(dom, attrs = c(tiledb_attr("a", type = "INT32")), sparse=FALSE)
+  schema <- tiledb_array_schema(dom, attrs = c(tiledb_attr("a", type = "INT32")), sparse=TRUE)
   tiledb_array_create(uri = tmp, schema)
   #print(schema)
   A <- tiledb_array(uri = tmp)
@@ -679,7 +679,7 @@ if (requireNamespace("bit64", quietly=TRUE)) {
   ## The array will be 4x4 with dimensions "rows" and "cols", with domain [1,4]
   dom <- tiledb_domain(dims = c(tiledb_dim("rows", c(1L,4L), 4L, "UINT16"),
                                 tiledb_dim("cols", c(1L,4L), 4L, "UINT16")))
-  schema <- tiledb_array_schema(dom, attrs = c(tiledb_attr("a", type = "INT32")), sparse=FALSE)
+  schema <- tiledb_array_schema(dom, attrs = c(tiledb_attr("a", type = "INT32")), sparse=TRUE)
   tiledb_array_create(uri = tmp, schema)
   #print(schema)
   A <- tiledb_array(uri = tmp)
@@ -710,7 +710,7 @@ if (requireNamespace("bit64", quietly=TRUE)) {
   ## The array will be 4x4 with dimensions "rows" and "cols", with domain [1,4]
   dom <- tiledb_domain(dims = c(tiledb_dim("rows", c(1L,4L), 4L, "INT32"),
                                 tiledb_dim("cols", c(1L,4L), 4L, "INT32")))
-  schema <- tiledb_array_schema(dom, attrs = c(tiledb_attr("a", type = "INT32")), sparse=FALSE)
+  schema <- tiledb_array_schema(dom, attrs = c(tiledb_attr("a", type = "INT32")), sparse=TRUE)
   tiledb_array_create(uri = tmp, schema)
   #print(schema)
   A <- tiledb_array(uri = tmp)
@@ -741,7 +741,7 @@ if (requireNamespace("bit64", quietly=TRUE)) {
   ## The array will be 4x4 with dimensions "rows" and "cols", with domain [1,4]
   dom <- tiledb_domain(dims = c(tiledb_dim("rows", c(1L,4L), 4L, "UINT32"),
                                 tiledb_dim("cols", c(1L,4L), 4L, "UINT32")))
-  schema <- tiledb_array_schema(dom, attrs = c(tiledb_attr("a", type = "INT32")), sparse=FALSE)
+  schema <- tiledb_array_schema(dom, attrs = c(tiledb_attr("a", type = "INT32")), sparse=TRUE)
   tiledb_array_create(uri = tmp, schema)
   #print(schema)
   A <- tiledb_array(uri = tmp)
@@ -772,7 +772,7 @@ if (requireNamespace("bit64", quietly=TRUE)) {
   ## The array will be 4x4 with dimensions "rows" and "cols", with domain [1,4]
   dom <- tiledb_domain(dims = c(tiledb_dim("rows", as.integer64(c(1,4)), as.integer64(4), "INT64"),
                                 tiledb_dim("cols", as.integer64(c(1,4)), as.integer64(4), "INT64")))
-  schema <- tiledb_array_schema(dom, attrs = c(tiledb_attr("a", type = "INT32")), sparse=FALSE)
+  schema <- tiledb_array_schema(dom, attrs = c(tiledb_attr("a", type = "INT32")), sparse=TRUE)
   tiledb_array_create(uri = tmp, schema)
   #print(schema)
   A <- tiledb_array(uri = tmp)
@@ -804,7 +804,7 @@ if (requireNamespace("bit64", quietly=TRUE)) {
   ## The array will be 4x4 with dimensions "rows" and "cols", with domain [1,4]
   dom <- tiledb_domain(dims = c(tiledb_dim("rows", as.integer64(c(1,4)), as.integer64(4), "UINT64"),
                                 tiledb_dim("cols", as.integer64(c(1,4)), as.integer64(4), "UINT64")))
-  schema <- tiledb_array_schema(dom, attrs = c(tiledb_attr("a", type = "INT32")), sparse=FALSE)
+  schema <- tiledb_array_schema(dom, attrs = c(tiledb_attr("a", type = "INT32")), sparse=TRUE)
   tiledb_array_create(uri = tmp, schema)
   #print(schema)
   A <- tiledb_array(uri = tmp)
@@ -846,7 +846,7 @@ if (requireNamespace("bit64", quietly=TRUE)) {
                                           tiledb_attr("a7", type = "INT64"),
                                           tiledb_attr("a8", type = "UINT64")
                                           ),
-                                sparse=FALSE)
+                                sparse=TRUE)
   tiledb_array_create(uri = tmp, schema)
   #print(schema)
   A <- tiledb_array(uri = tmp)

--- a/man/fromDataFrame.Rd
+++ b/man/fromDataFrame.Rd
@@ -8,7 +8,7 @@ fromDataFrame(
   obj,
   uri,
   col_index = NULL,
-  sparse = FALSE,
+  sparse = TRUE,
   allows_dups = sparse,
   cell_order = "COL_MAJOR",
   tile_order = "COL_MAJOR",
@@ -28,7 +28,7 @@ fromDataFrame(
 or character with a column name, designating an index column; default is NULL
 implying an index column is added when the array is created}
 
-\item{sparse}{A logical switch to select sparse or dense (the default)}
+\item{sparse}{A logical switch to select sparse (the default) or dense}
 
 \item{allows_dups}{A logical switch to select if duplicate values
 are allowed or not, default is the same value as \sQuote{sparse}.}


### PR DESCRIPTION
This PR changes a few tests to default to sparse arrays to accomodate a recent library change.  It also switches the default format for `fromDataFrame()` to sparse.