### PR TITLE
Support row and column names when saving / retrieving sparse matrices

### DIFF
--- a/R/Metadata.R
+++ b/R/Metadata.R
@@ -99,22 +99,13 @@ tiledb_get_metadata <- function(arr, key) {
 ##'
 ##' @param arr A TileDB Array object, or a character URI describing one
 ##' @param key A character value describing a metadata key
-##' @param val An object to be store
+##' @param val An object to be stored
 ##' @return A boolean value indicating success
 ##' @export
 tiledb_put_metadata <- function(arr, key, val) {
-  if (!.isArray(arr)) {
-    stop("Argument must be a (dense or sparse) TileDB array.", call.=FALSE)
-  }
-
-  ## Now deal with (default) case of an array object
-  ## Check for 'is it open' ?
-  if (!libtiledb_array_is_open_for_writing(arr@ptr)) {
-    stop("Array is not open for writing, cannot access metadata.", call.=FALSE)
-  }
-
-  ## Run query
-  return(libtiledb_array_put_metadata(arr@ptr, key, val))
+    stopifnot(`Argument must be a (dense or sparse) TileDB array.` = .isArray(arr),
+              `Array is not open for writing.` = libtiledb_array_is_open_for_writing(arr@ptr))
+    libtiledb_array_put_metadata(arr@ptr, key, val)
 }
 
 

--- a/R/SparseMatrix.R
+++ b/R/SparseMatrix.R
@@ -66,7 +66,6 @@ fromSparseMatrix <- function(obj,
               `uri must character` = is.character(uri))
 
     dimnm <- dimnames(obj)
-
     classIn <- "dgTMatrix"
     if (class(obj)[1] != classIn) {
         classIn <- class(obj)[1]
@@ -89,30 +88,24 @@ fromSparseMatrix <- function(obj,
     else
         stop("Currently unsupported type: ", cl)
 
-
     filterlist <- tiledb_filter_list(sapply(filter, tiledb_filter))
 
-    hasRownames <- !is.null(dimnm[[1]])
-    hasColnames <- !is.null(dimnm[[2]])
-
     attx <- tiledb_attr(name="x", type = tp, ncells = 1, filter_list = filterlist)
-    if (hasRownames) attr <- tiledb_attr(name="rownames__", type = "ASCII", ncells = 1, filter_list = filterlist)
-
     schema <- tiledb_array_schema(dom,
-                                  attrs = if (hasRownames) c(attx, attr) else attx,
+                                  attrs = attx,
                                   cell_order = cell_order,
                                   tile_order = tile_order,
                                   sparse = TRUE,
                                   capacity=capacity)
     tiledb_array_create(uri, schema)
     arr <- tiledb_array(uri)
+    arr[] <- data.frame(i = obj@i, j = obj@j, x = obj@x)
 
-    if (hasRownames)
-        arr[] <- data.frame(i = obj@i, j = obj@j, x = obj@x, rownames__ = dimnm[[1]])
-    else
-        arr[] <- data.frame(i = obj@i, j = obj@j, x = obj@x)
-
-    if (hasColnames) tiledb_put_metadata(arr, "colnames", dput(dimnm[[2]]))
+    if (!is.null(dimnm[[1]]) || !is.null(dimnm[[2]])) {
+        tiledb_array_open(arr, "WRITE")
+        tiledb_put_metadata(arr, "dimnames", rawToChar(serialize(dimnm, NULL, ascii = TRUE)))
+        tiledb_array_close(arr)
+    }
 
     invisible(NULL)
 }

--- a/R/SparseMatrix.R
+++ b/R/SparseMatrix.R
@@ -117,9 +117,16 @@ toSparseMatrix <- function(uri) {
     arr <- tiledb_array(uri, as.data.frame=TRUE, query_layout="UNORDERED")
     obj <- arr[]
 
+    dimnm <- list(NULL, NULL)        # by default no dimnames
+    tiledb_array_open(arr, "READ")
+    if (tiledb_has_metadata(arr, "dimnames")) {
+        dimnm <- unserialize(charToRaw(tiledb_get_metadata(arr, "dimnames")))
+    }
+    tiledb_array_close(arr)
+
     dims <- dimensions(domain(schema(uri)))
-    d1 <- domain(dims[[1]]) #tiledb:::libtiledb_dim_get_domain(dims[[1]]@ptr) + 1
-    d2 <- domain(dims[[2]]) #tiledb:::libtiledb_dim_get_domain(dims[[2]]@ptr) + 2
+    d1 <- domain(dims[[1]])
+    d2 <- domain(dims[[2]])
     stopifnot(`No column i in data`=!is.na(match("i", colnames(obj))),
               `No column j in data`=!is.na(match("j", colnames(obj))),
               `No column x in data`=!is.na(match("x", colnames(obj))),
@@ -129,6 +136,7 @@ toSparseMatrix <- function(uri) {
                                j = obj$j + 1,
                                x = obj$x,
                                dims = c(d1[2] + 1, d2[2] + 1),
+                               dimnames = dimnm,
                                repr = "T")
 
     sp

--- a/inst/tinytest/test_sparsematrix.R
+++ b/inst/tinytest/test_sparsematrix.R
@@ -1,4 +1,3 @@
-
 library(tinytest)
 library(tiledb)
 
@@ -10,6 +9,7 @@ ctx <- tiledb_ctx(limitTileDBCores())
 if (!requireNamespace("Matrix", quietly=TRUE)) exit_file("Need the 'Matrix' package")
 library(Matrix)
 if (packageVersion("Matrix") < "1.3.0") exit_file("Old 'Matrix' package?")
+if (Sys.getenv("ALLTESTS", "no") == "yes") {
 
 set.seed(123)                           # just to fix it
 n <- 60
@@ -24,9 +24,27 @@ spmat <- as(mat, "dgTMatrix")
 uri <- tempfile()
 if (dir.exists(uri)) unlink(uri, recursive=TRUE)
 fromSparseMatrix(spmat, uri)
-
 chk <- toSparseMatrix(uri)
 expect_true(is(chk, "sparseMatrix"))
 expect_true(inherits(chk, "dgTMatrix"))
-expect_true(all.equal(spmat, chk))
 expect_equivalent(spmat, chk)
+
+
+set.seed(123)                           # just to fix it
+n <- 25
+k <- 15
+mat <- matrix(0, nrow=n, ncol=k, dimnames=list(LETTERS[1:n], letters[1:k]))
+nelem <- 0.2 * n * k
+mat[sample(seq_len(n*k), nelem)] <- seq(1, nelem)
+## Convert dense matrix to sparse matrix
+spmat <- as(mat, "dgTMatrix")
+uri <- tempfile()
+if (dir.exists(uri)) unlink(uri, recursive=TRUE)
+fromSparseMatrix(spmat, uri)
+chk <- toSparseMatrix(uri)
+expect_true(is(chk, "sparseMatrix"))
+expect_true(inherits(chk, "dgTMatrix"))
+expect_equivalent(spmat, chk)
+expect_equal(rownames(spmat), rownames(chk))
+expect_equal(colnames(spmat), colnames(chk))
+}

--- a/inst/tinytest/test_sparsematrix.R
+++ b/inst/tinytest/test_sparsematrix.R
@@ -9,7 +9,6 @@ ctx <- tiledb_ctx(limitTileDBCores())
 if (!requireNamespace("Matrix", quietly=TRUE)) exit_file("Need the 'Matrix' package")
 library(Matrix)
 if (packageVersion("Matrix") < "1.3.0") exit_file("Old 'Matrix' package?")
-if (Sys.getenv("ALLTESTS", "no") == "yes") {
 
 set.seed(123)                           # just to fix it
 n <- 60
@@ -47,4 +46,3 @@ expect_true(inherits(chk, "dgTMatrix"))
 expect_equivalent(spmat, chk)
 expect_equal(rownames(spmat), rownames(chk))
 expect_equal(colnames(spmat), colnames(chk))
-}

--- a/src/libtiledb.cpp
+++ b/src/libtiledb.cpp
@@ -3675,7 +3675,8 @@ std::string libtiledb_vfs_create_dir(XPtr<tiledb::VFS> vfs, std::string uri) {
 
 // [[Rcpp::export]]
 bool libtiledb_vfs_is_dir(XPtr<tiledb::VFS> vfs, std::string uri) {
-  return vfs->is_dir(uri);
+    auto ptr = vfs.get();
+    return ptr->is_dir(uri);
 }
 
 // [[Rcpp::export]]


### PR DESCRIPTION
This PR extends support for sparse matrices by also write row and column names, if present, in separate arrays.