### PR TITLE
Do not finalize read queries

### DIFF
--- a/R/TileDBArray.R
+++ b/R/TileDBArray.R
@@ -688,9 +688,6 @@ setMethod("[", "tiledb_array",
   status <- libtiledb_query_status(qryptr)
   if (status != "COMPLETE") warning("Query returned '", status, "'.", call. = FALSE)
 
-  ## finalize query
-  qryptr <- libtiledb_query_finalize(qryptr)
-
   ## close array
   libtiledb_array_close(arrptr)
 


### PR DESCRIPTION
The one-line change below is the difference between whether an identical query sent to one of
- s3://genomic-datasets/biological-databases/data/tables/gtex-analysis-rnaseqc-gene-tpm
- tiledb://TileDB-Inc/gtex-analysis-rnaseqc-gene-tpm

succeeds in both cases.  Without the change it will _not_ work for the second uri.

A simple test script follows,  Calling with any one of `b` or `bad` or `tile` will show the issues---by failing to retrieve data---unless the change in the PR is made.

```r
#!/usr/bin/Rscript

library(tiledb)
argv <- commandArgs(TRUE)

## good
uri <- "s3://genomic-datasets/biological-databases/data/tables/gtex-analysis-rnaseqc-gene-tpm"

## bad
if (length(argv) > 0 && is.finite(match(argv, c("b", "bad", "tile"))))
    uri <- "tiledb://TileDB-Inc/gtex-analysis-rnaseqc-gene-tpm"

cat("Using uri", uri, "\n")
gtex_array <- tiledb_array(uri = uri, is.sparse = TRUE, attrs = "tpm", return_as = "tibble")
res <- gtex_array["ENSG00000199405.1", ]
print(res)
```
    