### PR TITLE
Use tiledb 2.4.3

### DIFF
--- a/tools/tiledbVersion.txt
+++ b/tools/tiledbVersion.txt
@@ -1,2 +1,2 @@
-version: 2.4.2
-sha: 81a0286
+version: 2.4.3
+sha: 5cb0824


### PR DESCRIPTION
This enables TileDB Embedded release 2.4.3 made earlier today.  There is current fail on Linux at Azure where macOS passed (an unusual combination) that I will dig into so consider this a draft for now.