### PR TITLE
Switch to C++17 compilation and declare C++17 as a requirement

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,11 +17,12 @@ Copyright: TileDB, Inc.
 License: MIT + file LICENSE
 URL: https://github.com/TileDB-Inc/TileDB-R
 BugReports: https://github.com/TileDB-Inc/TileDB-R/issues
-SystemRequirements: cmake (only when TileDB source build selected),
- git (only when TileDB source build selected); on x86_64 platforms
- pre-built TileDB Embedded libraries are available at GitHub and
- are used if no TileDB installation is detected, and no other
- option to build or download was specified by the user.
+SystemRequirements: A C++17 compiler is required. Optionally cmake
+ (only when TileDB source build selected), git (only when TileDB
+ source build selected); on x86_64 platforms pre-built TileDB
+ Embedded libraries are available at GitHub and are used if no
+ TileDB installation is detected, and no other option to build
+ or download was specified by the user.
 Imports: methods, Rcpp, nanotime
 LinkingTo: Rcpp
 Suggests: tinytest, rmarkdown, knitr, minidown, curl, bit64, Matrix, palmerpenguins, nycflights13, data.table, tibble

--- a/src/Makevars.in
+++ b/src/Makevars.in
@@ -1,5 +1,5 @@
-## We need C++11 to use TileDB's C++ API
-CXX_STD = CXX11
+## We need C++17 to use TileDB's C++ API
+CXX_STD = CXX17
 
 ## We need the TileDB Headers
 PKG_CPPFLAGS =	-I../inst/include/ @TILEDB_INCLUDE@


### PR DESCRIPTION
This PR turns the C++ language standard used to build the package to C++17 and, per _Writing R Extensions_ guidelines, declares the requirement in the updated SystemRequirements: field in the `DESCRIPTION` file.