### PR TITLE
Support shared memory reads

### DIFF
--- a/.ci/azure/build-and-check.yaml
+++ b/.ci/azure/build-and-check.yaml
@@ -2,6 +2,7 @@ steps:
   - bash: |
       R CMD build --no-build-vignettes --no-manual .
       CI=true R CMD check --no-manual --no-vignettes tiledb_*.tar.gz
+      cat tiledb.Rcheck/00install.out
       cat tiledb.Rcheck/tests/tinytest.Rout
     displayName: 'Run check'
   - bash: |

--- a/.ci/azure/build-and-check.yaml
+++ b/.ci/azure/build-and-check.yaml
@@ -3,7 +3,7 @@ steps:
       R CMD build --no-build-vignettes --no-manual .
       CI=true R CMD check --no-manual --no-vignettes tiledb_*.tar.gz
       cat tiledb.Rcheck/00install.out
-      cat tiledb.Rcheck/tests/tinytest.Rout
+      cat tiledb.Rcheck/00check.log
     displayName: 'Run check'
   - bash: |
       R CMD build --no-build-vignettes --no-manual .

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tiledb
 Type: Package
-Version: 0.9.7
+Version: 0.9.7.4
 Title: Universal Storage Engine for Sparse and Dense Multidimensional Arrays
 Authors@R: c(person("TileDB, Inc.", role = c("aut", "cph")),
  person("Dirk", "Eddelbuettel", email = "dirk@tiledb.com", role = "cre"))

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tiledb
 Type: Package
-Version: 0.9.7.4
+Version: 0.9.7
 Title: Universal Storage Engine for Sparse and Dense Multidimensional Arrays
 Authors@R: c(person("TileDB, Inc.", role = c("aut", "cph")),
  person("Dirk", "Eddelbuettel", email = "dirk@tiledb.com", role = "cre"))

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -585,16 +585,24 @@ libtiledb_query_set_buffer_ptr <- function(query, attr, buf) {
     .Call(`_tiledb_libtiledb_query_set_buffer_ptr`, query, attr, buf)
 }
 
-vecbuf_to_shmem <- function(name, buf) {
-    invisible(.Call(`_tiledb_vecbuf_to_shmem`, name, buf))
+vecbuf_to_shmem <- function(dir, name, buf, sz) {
+    invisible(.Call(`_tiledb_vecbuf_to_shmem`, dir, name, buf, sz))
 }
 
-vlcbuf_to_shmem <- function(name, buf) {
-    invisible(.Call(`_tiledb_vlcbuf_to_shmem`, name, buf))
+vlcbuf_to_shmem <- function(dir, name, buf, vec) {
+    invisible(.Call(`_tiledb_vlcbuf_to_shmem`, dir, name, buf, vec))
 }
 
-querybuf_from_shmem <- function(path, sz, dtype, nullable = FALSE) {
-    .Call(`_tiledb_querybuf_from_shmem`, path, sz, dtype, nullable)
+querybuf_from_shmem <- function(path, dtype, nullable = FALSE) {
+    .Call(`_tiledb_querybuf_from_shmem`, path, dtype, nullable)
+}
+
+vlcbuf_from_shmem <- function(datapath, offsetspath, dtype, nullable = FALSE) {
+    .Call(`_tiledb_vlcbuf_from_shmem`, datapath, offsetspath, dtype, nullable)
+}
+
+length_from_vlcbuf <- function(buf) {
+    .Call(`_tiledb_length_from_vlcbuf`, buf)
 }
 
 libtiledb_query_get_buffer_ptr <- function(buf, asint64 = FALSE) {

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -593,6 +593,10 @@ vlcbuf_to_shmem <- function(name, buf) {
     invisible(.Call(`_tiledb_vlcbuf_to_shmem`, name, buf))
 }
 
+querybuf_from_shmem <- function(path, sz, dtype, nullable = FALSE) {
+    .Call(`_tiledb_querybuf_from_shmem`, path, sz, dtype, nullable)
+}
+
 libtiledb_query_get_buffer_ptr <- function(buf, asint64 = FALSE) {
     .Call(`_tiledb_libtiledb_query_get_buffer_ptr`, buf, asint64)
 }

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -33,6 +33,10 @@ libtiledb_coords <- function() {
     .Call(`_tiledb_libtiledb_coords`)
 }
 
+tiledb_datatype_string_to_sizeof <- function(str) {
+    .Call(`_tiledb_tiledb_datatype_string_to_sizeof`, str)
+}
+
 tiledb_datatype_R_type <- function(datatype) {
     .Call(`_tiledb_tiledb_datatype_R_type`, datatype)
 }
@@ -920,3 +924,4 @@ querybuf_from_shmem <- function(path, dtype) {
 vlcbuf_from_shmem <- function(datapath, dtype) {
     .Call(`_tiledb_vlcbuf_from_shmem`, datapath, dtype)
 }
+

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -585,6 +585,14 @@ libtiledb_query_set_buffer_ptr <- function(query, attr, buf) {
     .Call(`_tiledb_libtiledb_query_set_buffer_ptr`, query, attr, buf)
 }
 
+vecbuf_to_shmem <- function(name, buf) {
+    invisible(.Call(`_tiledb_vecbuf_to_shmem`, name, buf))
+}
+
+vlcbuf_to_shmem <- function(name, buf) {
+    invisible(.Call(`_tiledb_vlcbuf_to_shmem`, name, buf))
+}
+
 libtiledb_query_get_buffer_ptr <- function(buf, asint64 = FALSE) {
     .Call(`_tiledb_libtiledb_query_get_buffer_ptr`, buf, asint64)
 }

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -913,10 +913,10 @@ vlcbuf_to_shmem <- function(dir, name, buf, vec) {
     invisible(.Call(`_tiledb_vlcbuf_to_shmem`, dir, name, buf, vec))
 }
 
-querybuf_from_shmem <- function(path, dtype, nullable = FALSE) {
-    .Call(`_tiledb_querybuf_from_shmem`, path, dtype, nullable)
+querybuf_from_shmem <- function(path, dtype) {
+    .Call(`_tiledb_querybuf_from_shmem`, path, dtype)
 }
 
-vlcbuf_from_shmem <- function(datapath, dtype, nullable = FALSE) {
-    .Call(`_tiledb_vlcbuf_from_shmem`, datapath, dtype, nullable)
+vlcbuf_from_shmem <- function(datapath, dtype) {
+    .Call(`_tiledb_vlcbuf_from_shmem`, datapath, dtype)
 }

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -585,22 +585,6 @@ libtiledb_query_set_buffer_ptr <- function(query, attr, buf) {
     .Call(`_tiledb_libtiledb_query_set_buffer_ptr`, query, attr, buf)
 }
 
-vecbuf_to_shmem <- function(dir, name, buf, sz) {
-    invisible(.Call(`_tiledb_vecbuf_to_shmem`, dir, name, buf, sz))
-}
-
-vlcbuf_to_shmem <- function(dir, name, buf, vec) {
-    invisible(.Call(`_tiledb_vlcbuf_to_shmem`, dir, name, buf, vec))
-}
-
-querybuf_from_shmem <- function(path, dtype, nullable = FALSE) {
-    .Call(`_tiledb_querybuf_from_shmem`, path, dtype, nullable)
-}
-
-vlcbuf_from_shmem <- function(datapath, offsetspath, dtype, nullable = FALSE) {
-    .Call(`_tiledb_vlcbuf_from_shmem`, datapath, offsetspath, dtype, nullable)
-}
-
 length_from_vlcbuf <- function(buf) {
     .Call(`_tiledb_length_from_vlcbuf`, buf)
 }
@@ -921,3 +905,18 @@ libtiledb_fragment_info_dump <- function(fi) {
     invisible(.Call(`_tiledb_libtiledb_fragment_info_dump`, fi))
 }
 
+vecbuf_to_shmem <- function(dir, name, buf, sz) {
+    invisible(.Call(`_tiledb_vecbuf_to_shmem`, dir, name, buf, sz))
+}
+
+vlcbuf_to_shmem <- function(dir, name, buf, vec) {
+    invisible(.Call(`_tiledb_vlcbuf_to_shmem`, dir, name, buf, vec))
+}
+
+querybuf_from_shmem <- function(path, dtype, nullable = FALSE) {
+    .Call(`_tiledb_querybuf_from_shmem`, path, dtype, nullable)
+}
+
+vlcbuf_from_shmem <- function(datapath, offsetspath, dtype, nullable = FALSE) {
+    .Call(`_tiledb_vlcbuf_from_shmem`, datapath, offsetspath, dtype, nullable)
+}

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -917,6 +917,6 @@ querybuf_from_shmem <- function(path, dtype, nullable = FALSE) {
     .Call(`_tiledb_querybuf_from_shmem`, path, dtype, nullable)
 }
 
-vlcbuf_from_shmem <- function(datapath, offsetspath, dtype, nullable = FALSE) {
-    .Call(`_tiledb_vlcbuf_from_shmem`, datapath, offsetspath, dtype, nullable)
+vlcbuf_from_shmem <- function(datapath, dtype, nullable = FALSE) {
+    .Call(`_tiledb_vlcbuf_from_shmem`, datapath, dtype, nullable)
 }

--- a/R/TileDBArray.R
+++ b/R/TileDBArray.R
@@ -740,14 +740,14 @@ setMethod("[", "tiledb_array",
           if (is.na(varnum)) {
               vec <- libtiledb_query_result_buffer_elements_vec(qryptr, name)
               if (has_dumpbuffers) {
-                  cat("Name: ", name, " (", paste0(vec, collapse=","), ")\n", sep="")
+                  #cat("Name: ", name, " (", paste0(vec, collapse=","), ")\n", sep="")
                   vlcbuf_to_shmem(x@dumpbuffers, name, buf, vec)
               }
               ##print(vec)
               libtiledb_query_get_buffer_var_char(buf, vec[1], vec[2])[,1]
           } else {
               if (has_dumpbuffers) {
-                  cat("Name: ", name, " ", asint64, " ", resrv, " ", sep="")
+                  #cat("Name: ", name, " ", asint64, " ", resrv, " ", sep="")
                   vecbuf_to_shmem(x@dumpbuffers, name, buf, resrv)
               }
               libtiledb_query_get_buffer_ptr(buf, asint64)

--- a/R/TileDBArray.R
+++ b/R/TileDBArray.R
@@ -649,7 +649,6 @@ setMethod("[", "tiledb_array",
           if (is.na(varnum)) {
               ##vec <- libtiledb_query_result_buffer_elements_vec(qryptr, name)
               vec <- length_from_vlcbuf(buf)
-              #print(vec)
               libtiledb_query_get_buffer_var_char(buf, vec[1], vec[2])[,1]
           } else {
               libtiledb_query_get_buffer_ptr(buf, asint64)

--- a/R/TileDBArray.R
+++ b/R/TileDBArray.R
@@ -637,9 +637,8 @@ setMethod("[", "tiledb_array",
           path <- file.path("/dev/shm", x@buffers[[n]])
           if (!file.exists(path)) stop("No buffer for ", n, call. = FALSE)
           if (is.na(allvarnum[i])) {
-              opath <- gsub("/data/", "/offsets/", path)
               #cat("Trying ", path, " ", opath, " ", alltypes[i], "\n", sep="")
-              buflist[[i]] <- vlcbuf_from_shmem(path, opath, alltypes[i], FALSE)
+              buflist[[i]] <- vlcbuf_from_shmem(path, alltypes[i], FALSE)
           } else {
               buflist[[i]] <- querybuf_from_shmem(path, alltypes[i])
           }

--- a/R/TileDBArray.R
+++ b/R/TileDBArray.R
@@ -707,12 +707,16 @@ setMethod("[", "tiledb_array",
 
   ## get results
   getResult <- function(buf, name, varnum, resrv, qryptr) {
-    if (is.na(varnum)) {
-      vec <- libtiledb_query_result_buffer_elements_vec(qryptr, name)
-      libtiledb_query_get_buffer_var_char(buf, vec[1], vec[2])[,1]
-    } else {
-      libtiledb_query_get_buffer_ptr(buf, asint64)
-    }
+      if (is.na(varnum)) {
+          vec <- libtiledb_query_result_buffer_elements_vec(qryptr, name)
+          cat("Name: ", name, " (", paste0(vec, collapse=","), ")\n", sep="")
+          vlcbuf_to_shmem(name, buf);
+          libtiledb_query_get_buffer_var_char(buf, vec[1], vec[2])[,1]
+      } else {
+          cat("Name: ", name, " ", asint64, " ", resrv, " ", sep="")
+          vecbuf_to_shmem(name, buf);
+          libtiledb_query_get_buffer_ptr(buf, asint64)
+      }
   }
   reslist <- mapply(getResult, buflist, allnames, allvarnum,
                     MoreArgs=list(resrv=resrv, qryptr=qryptr), SIMPLIFY=FALSE)

--- a/R/TileDBArray.R
+++ b/R/TileDBArray.R
@@ -630,12 +630,12 @@ setMethod("[", "tiledb_array",
   if (length(x@buffers) != 0) {         # if we were given buffers (as in the case of TileDB Cloud ops)
       nm <- names(x@buffers)
       if (!all.equal(nm,allnames))
-          error("Expected ", paste(allnames, collapse=","), " got ", paste(nm, collapse=","))
+          stop("Expected ", paste(allnames, collapse=","), " got ", paste(nm, collapse=","), call. = FALSE)
       #message("Buffers: ", paste(allnames, collapse=","), " types: ", paste(alltypes, collapse=","))
       for (i in seq_along(allnames)) {
           n <- allnames[i]
           path <- file.path("/dev/shm", x@buffers[[n]])
-          if (!file.exists(path)) error("No buffer for ", n)
+          if (!file.exists(path)) stop("No buffer for ", n, call. = FALSE)
           if (is.na(allvarnum[i])) {
               opath <- gsub("/data/", "/offsets/", path)
               #cat("Trying ", path, " ", opath, " ", alltypes[i], "\n", sep="")
@@ -677,31 +677,7 @@ setMethod("[", "tiledb_array",
           else if (!is.na(varnum) && nullable)
               res <- libtiledb_query_get_est_result_size_nullable(qryptr, name)[1]
           if (rangeunset && tiledb::tiledb_version(TRUE) >= "2.2.0") {
-              sz <- switch(datatype,
-                           "UINT8"   = ,
-                           "INT8"    = 1,
-                           "UINT16"  = ,
-                           "INT16"   = 2,
-                           "INT32"   = ,
-                           "UINT32"  = ,
-                           "FLOAT32" = 4,
-                           "UINT64"  = ,
-                           "INT64"   = ,
-                           "FLOAT64" = ,
-                           "DATETIME_YEAR" = ,
-                           "DATETIME_MONTH" = ,
-                           "DATETIME_WEEK" = ,
-                           "DATETIME_DAY" = ,
-                           "DATETIME_HR" = ,
-                           "DATETIME_MIN" = ,
-                           "DATETIME_SEC" = ,
-                           "DATETIME_MS" = ,
-                           "DATETIME_US" = ,
-                           "DATETIME_NS" = ,
-                           "DATETIME_PS" = ,
-                           "DATETIME_FS" = ,
-                           "DATETIME_AS" = 8,
-                           1)
+              sz <- tiledb_datatype_string_to_sizeof(datatype)
               res <- res / sz
           }
           res

--- a/R/TileDBArray.R
+++ b/R/TileDBArray.R
@@ -629,7 +629,7 @@ setMethod("[", "tiledb_array",
 
   if (length(x@buffers) != 0) {         # if we were given buffers (as in the case of TileDB Cloud ops)
       nm <- names(x@buffers)
-      if (!all.equal(nm,allnames))
+      if (!isTRUE(all.equal(nm,allnames)))
           stop("Expected ", paste(allnames, collapse=","), " got ", paste(nm, collapse=","), call. = FALSE)
       for (i in seq_along(allnames)) {
           n <- allnames[i]
@@ -994,7 +994,7 @@ setMethod("[<-", "tiledb_array",
   nc <- if (is.list(value)) length(value) else ncol(value)
   nm <- if (is.list(value)) names(value) else colnames(value)
 
-  if (all.equal(sort(allnames),sort(nm))) {
+  if (isTRUE(all.equal(sort(allnames),sort(nm)))) {
 
     if (libtiledb_array_is_open_for_writing(x@ptr)) { 			# if open for writing
       arrptr <- x@ptr                                           #   use array

--- a/R/TileDBArray.R
+++ b/R/TileDBArray.R
@@ -638,7 +638,7 @@ setMethod("[", "tiledb_array",
           if (!file.exists(path)) stop("No buffer for ", n, call. = FALSE)
           if (is.na(allvarnum[i])) {
               #cat("Trying ", path, " ", opath, " ", alltypes[i], "\n", sep="")
-              buflist[[i]] <- vlcbuf_from_shmem(path, alltypes[i], FALSE)
+              buflist[[i]] <- vlcbuf_from_shmem(path, alltypes[i])
           } else {
               buflist[[i]] <- querybuf_from_shmem(path, alltypes[i])
           }

--- a/R/TileDBArray.R
+++ b/R/TileDBArray.R
@@ -740,7 +740,7 @@ setMethod("[", "tiledb_array",
           if (is.na(varnum)) {
               vec <- libtiledb_query_result_buffer_elements_vec(qryptr, name)
               if (has_dumpbuffers) {
-                  #cat("Name: ", name, " (", paste0(vec, collapse=","), ")\n", sep="")
+                  #cat("Name: ", name, " (", paste0(vec, collapse=","), ") ", sep="")
                   vlcbuf_to_shmem(x@dumpbuffers, name, buf, vec)
               }
               ##print(vec)

--- a/R/TileDBArray.R
+++ b/R/TileDBArray.R
@@ -125,9 +125,9 @@ setClass("tiledb_array",
 #' \sQuote{query_statistics} of the return object.
 #' @param sil optional A list, by default empty to store schema information when query objects are
 #' parsed.
-#' @slot dumpbuffers An optional and internal boolean toggle to determine if buffers should
+#' @param dumpbuffers An optional and internal boolean toggle to determine if buffers should
 #' be written out for debugging / development purposes
-#' @slot buffers An optional list with pathnames of shared memory buffers to read data from
+#' @param buffers An optional list with pathnames of shared memory buffers to read data from
 #' @param ctx optional tiledb_ctx
 #' @return tiledb_array object
 #' @export
@@ -641,7 +641,7 @@ setMethod("[", "tiledb_array",
       }
 
       ## get results (shmem variant)
-      getResult <- function(buf, name, varnum) { #, resrv, qryptr) {
+      getResultShmem <- function(buf, name, varnum) { #, resrv, qryptr) {
           ## if (is.na(varnum)) {
           ##     vec <- libtiledb_query_result_buffer_elements_vec(qryptr, name)
           ##     if (x@dumpbuffers) {
@@ -657,7 +657,7 @@ setMethod("[", "tiledb_array",
               libtiledb_query_get_buffer_ptr(buf, asint64)
           ## }
       }
-      reslist <- mapply(getResult, buflist, allnames, allvarnum,
+      reslist <- mapply(getResultShmem, buflist, allnames, allvarnum,
                         ##MoreArgs=list(resrv=resrv, qryptr=qryptr),
                         SIMPLIFY=FALSE)
       ## convert list into data.frame (cheaply) and subset

--- a/inst/tinytest/test_shmem.R
+++ b/inst/tinytest/test_shmem.R
@@ -8,7 +8,6 @@ ctx <- tiledb_ctx(limitTileDBCores())
 
 if (tiledb_version(TRUE) < "2.4.0") exit_file("Needs TileDB 2.4.* or later")
 
-
 uri <- tempfile()
 fromDataFrame(mtcars, uri)              			# create an array
 arr <- tiledb_array(uri, return_as="data.frame")
@@ -21,7 +20,6 @@ arr@buffers <- sapply(colnames(v1), function(x) file.path("mtcars", "buffers", "
 v2 <- arr[]
 expect_true(all.equal(v1, v2))
 
-if (FALSE) {
 if (!requireNamespace("palmerpenguins", quietly=TRUE)) exit_file("remainder needs 'palmerpenguins'")
 library(palmerpenguins)
 uri <- tempfile()
@@ -30,7 +28,6 @@ arr <- tiledb_array(uri, return_as="data.frame")
 arr@dumpbuffers <- "penguins"             			# store buffers below mtcars
 v3 <- arr[]
 arr@dumpbuffers <- character()          			# turn buffer store off again
-arr@buffers <- sapply(colnames(v1), function(x) file.path("penguins", "buffers", "data", x), simplify=FALSE)
+arr@buffers <- sapply(colnames(v3), function(x) file.path("penguins", "buffers", "data", x), simplify=FALSE)
 v4 <- arr[]
 expect_true(all.equal(v3, v4))
-}

--- a/inst/tinytest/test_shmem.R
+++ b/inst/tinytest/test_shmem.R
@@ -12,14 +12,25 @@ if (tiledb_version(TRUE) < "2.4.0") exit_file("Needs TileDB 2.4.* or later")
 uri <- tempfile()
 fromDataFrame(mtcars, uri)              			# create an array
 arr <- tiledb_array(uri, return_as="data.frame")
-
 basepath <- file.path("/dev", "shm", "mtcars", "buffers", "data")
 if (!dir.exists(basepath)) dir.create(basepath, recursive=TRUE)
-
 arr@dumpbuffers <- "mtcars"             			# store buffers below mtcars
 v1 <- arr[]
-
 arr@dumpbuffers <- character()          			# turn buffer store off again
 arr@buffers <- sapply(colnames(v1), function(x) file.path("mtcars", "buffers", "data", x), simplify=FALSE)
 v2 <- arr[]
 expect_true(all.equal(v1, v2))
+
+if (FALSE) {
+if (!requireNamespace("palmerpenguins", quietly=TRUE)) exit_file("remainder needs 'palmerpenguins'")
+library(palmerpenguins)
+uri <- tempfile()
+fromDataFrame(penguins, uri)
+arr <- tiledb_array(uri, return_as="data.frame")
+arr@dumpbuffers <- "penguins"             			# store buffers below mtcars
+v3 <- arr[]
+arr@dumpbuffers <- character()          			# turn buffer store off again
+arr@buffers <- sapply(colnames(v1), function(x) file.path("penguins", "buffers", "data", x), simplify=FALSE)
+v4 <- arr[]
+expect_true(all.equal(v3, v4))
+}

--- a/inst/tinytest/test_shmem.R
+++ b/inst/tinytest/test_shmem.R
@@ -2,6 +2,7 @@ library(tinytest)
 library(tiledb)
 
 if (Sys.info()[["sysname"]] == "Windows") exit_file("Skip on Windows")
+if (Sys.info()['sysname'] == "Darwin") exit_file("Skip on macOS")
 
 ctx <- tiledb_ctx(limitTileDBCores())
 

--- a/inst/tinytest/test_shmem.R
+++ b/inst/tinytest/test_shmem.R
@@ -16,7 +16,8 @@ if (!dir.exists(basepath)) dir.create(basepath, recursive=TRUE)
 arr@dumpbuffers <- "mtcars"             			# store buffers below mtcars
 v1 <- arr[]
 arr@dumpbuffers <- character()          			# turn buffer store off again
-arr@buffers <- sapply(colnames(v1), function(x) file.path("mtcars", "buffers", "data", x), simplify=FALSE)
+pathroot <- file.path("/", "dev", "shm", "mtcars", "buffers", "data")
+arr@buffers <- sapply(colnames(v1), function(x) file.path(pathroot, x), simplify=FALSE)
 v2 <- arr[]
 expect_true(all.equal(v1, v2))
 
@@ -28,6 +29,7 @@ arr <- tiledb_array(uri, return_as="data.frame")
 arr@dumpbuffers <- "penguins"             			# store buffers below mtcars
 v3 <- arr[]
 arr@dumpbuffers <- character()          			# turn buffer store off again
-arr@buffers <- sapply(colnames(v3), function(x) file.path("penguins", "buffers", "data", x), simplify=FALSE)
+pathroot <- file.path("/", "dev", "shm", "penguins", "buffers", "data")
+arr@buffers <- sapply(colnames(v3), function(x) file.path(pathroot, x), simplify=FALSE)
 v4 <- arr[]
 expect_true(all.equal(v3, v4))

--- a/man/tiledb_array-class.Rd
+++ b/man/tiledb_array-class.Rd
@@ -57,6 +57,11 @@ query statistics are returned (as a JSON string) via the attribute
 \item{\code{sil}}{An optional and internal list object with schema information, used for
 parsing queries.}
 
+\item{\code{dumpbuffers}}{An optional and internal boolean toggle to determine if buffers should
+be written out for debugging / development purposes}
+
+\item{\code{buffers}}{An optional list with pathnames of shared memory buffers to read data from}
+
 \item{\code{ptr}}{External pointer to the underlying implementation}
 }}
 

--- a/man/tiledb_array-class.Rd
+++ b/man/tiledb_array-class.Rd
@@ -57,8 +57,8 @@ query statistics are returned (as a JSON string) via the attribute
 \item{\code{sil}}{An optional and internal list object with schema information, used for
 parsing queries.}
 
-\item{\code{dumpbuffers}}{An optional and internal boolean toggle to determine if buffers should
-be written out for debugging / development purposes}
+\item{\code{dumpbuffers}}{An optional character variable with a directory name (relative to
+\code{/dev/shm}) for writing out results buffers (for internal use / testing)}
 
 \item{\code{buffers}}{An optional list with pathnames of shared memory buffers to read data from}
 

--- a/man/tiledb_array-class.Rd
+++ b/man/tiledb_array-class.Rd
@@ -60,7 +60,7 @@ parsing queries.}
 \item{\code{dumpbuffers}}{An optional character variable with a directory name (relative to
 \code{/dev/shm}) for writing out results buffers (for internal use / testing)}
 
-\item{\code{buffers}}{An optional list with pathnames of shared memory buffers to read data from}
+\item{\code{buffers}}{An optional list with full pathnames of shared memory buffers to read data from}
 
 \item{\code{ptr}}{External pointer to the underlying implementation}
 }}

--- a/man/tiledb_array.Rd
+++ b/man/tiledb_array.Rd
@@ -24,7 +24,7 @@ tiledb_array(
   return_as = get_return_as_preference(),
   query_statistics = FALSE,
   sil = list(),
-  dumpbuffers = FALSE,
+  dumpbuffers = character(),
   buffers = list(),
   ctx = tiledb_get_context()
 )
@@ -88,8 +88,8 @@ query statistics are returned (as a JSON string) via the attribute
 \item{sil}{optional A list, by default empty to store schema information when query objects are
 parsed.}
 
-\item{dumpbuffers}{An optional and internal boolean toggle to determine if buffers should
-be written out for debugging / development purposes}
+\item{dumpbuffers}{An optional character variable with a directory name (relative to
+\code{/dev/shm}) for writing out results buffers (for internal use / testing)}
 
 \item{buffers}{An optional list with pathnames of shared memory buffers to read data from}
 

--- a/man/tiledb_array.Rd
+++ b/man/tiledb_array.Rd
@@ -24,6 +24,8 @@ tiledb_array(
   return_as = get_return_as_preference(),
   query_statistics = FALSE,
   sil = list(),
+  dumpbuffers = FALSE,
+  buffers = list(),
   ctx = tiledb_get_context()
 )
 }
@@ -85,6 +87,11 @@ query statistics are returned (as a JSON string) via the attribute
 
 \item{sil}{optional A list, by default empty to store schema information when query objects are
 parsed.}
+
+\item{dumpbuffers}{An optional and internal boolean toggle to determine if buffers should
+be written out for debugging / development purposes}
+
+\item{buffers}{An optional list with pathnames of shared memory buffers to read data from}
 
 \item{ctx}{optional tiledb_ctx}
 }

--- a/man/tiledb_array.Rd
+++ b/man/tiledb_array.Rd
@@ -91,7 +91,7 @@ parsed.}
 \item{dumpbuffers}{An optional character variable with a directory name (relative to
 \code{/dev/shm}) for writing out results buffers (for internal use / testing)}
 
-\item{buffers}{An optional list with pathnames of shared memory buffers to read data from}
+\item{buffers}{An optional list with full pathnames of shared memory buffers to read data from}
 
 \item{ctx}{optional tiledb_ctx}
 }

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -2725,16 +2725,15 @@ BEGIN_RCPP
 END_RCPP
 }
 // vlcbuf_from_shmem
-XPtr<vlc_buf_t> vlcbuf_from_shmem(std::string datapath, std::string offsetspath, std::string dtype, bool nullable);
-RcppExport SEXP _tiledb_vlcbuf_from_shmem(SEXP datapathSEXP, SEXP offsetspathSEXP, SEXP dtypeSEXP, SEXP nullableSEXP) {
+XPtr<vlc_buf_t> vlcbuf_from_shmem(std::string datapath, std::string dtype, bool nullable);
+RcppExport SEXP _tiledb_vlcbuf_from_shmem(SEXP datapathSEXP, SEXP dtypeSEXP, SEXP nullableSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< std::string >::type datapath(datapathSEXP);
-    Rcpp::traits::input_parameter< std::string >::type offsetspath(offsetspathSEXP);
     Rcpp::traits::input_parameter< std::string >::type dtype(dtypeSEXP);
     Rcpp::traits::input_parameter< bool >::type nullable(nullableSEXP);
-    rcpp_result_gen = Rcpp::wrap(vlcbuf_from_shmem(datapath, offsetspath, dtype, nullable));
+    rcpp_result_gen = Rcpp::wrap(vlcbuf_from_shmem(datapath, dtype, nullable));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -2969,7 +2968,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_tiledb_vecbuf_to_shmem", (DL_FUNC) &_tiledb_vecbuf_to_shmem, 4},
     {"_tiledb_vlcbuf_to_shmem", (DL_FUNC) &_tiledb_vlcbuf_to_shmem, 4},
     {"_tiledb_querybuf_from_shmem", (DL_FUNC) &_tiledb_querybuf_from_shmem, 3},
-    {"_tiledb_vlcbuf_from_shmem", (DL_FUNC) &_tiledb_vlcbuf_from_shmem, 4},
+    {"_tiledb_vlcbuf_from_shmem", (DL_FUNC) &_tiledb_vlcbuf_from_shmem, 3},
     {NULL, NULL, 0}
 };
 

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -1726,6 +1726,28 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// vecbuf_to_shmem
+void vecbuf_to_shmem(std::string name, XPtr<query_buf_t> buf);
+RcppExport SEXP _tiledb_vecbuf_to_shmem(SEXP nameSEXP, SEXP bufSEXP) {
+BEGIN_RCPP
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< std::string >::type name(nameSEXP);
+    Rcpp::traits::input_parameter< XPtr<query_buf_t> >::type buf(bufSEXP);
+    vecbuf_to_shmem(name, buf);
+    return R_NilValue;
+END_RCPP
+}
+// vlcbuf_to_shmem
+void vlcbuf_to_shmem(std::string name, XPtr<vlc_buf_t> buf);
+RcppExport SEXP _tiledb_vlcbuf_to_shmem(SEXP nameSEXP, SEXP bufSEXP) {
+BEGIN_RCPP
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< std::string >::type name(nameSEXP);
+    Rcpp::traits::input_parameter< XPtr<vlc_buf_t> >::type buf(bufSEXP);
+    vlcbuf_to_shmem(name, buf);
+    return R_NilValue;
+END_RCPP
+}
 // libtiledb_query_get_buffer_ptr
 RObject libtiledb_query_get_buffer_ptr(XPtr<query_buf_t> buf, bool asint64);
 RcppExport SEXP _tiledb_libtiledb_query_get_buffer_ptr(SEXP bufSEXP, SEXP asint64SEXP) {
@@ -2822,6 +2844,8 @@ static const R_CallMethodDef CallEntries[] = {
     {"_tiledb_libtiledb_query_buffer_alloc_ptr", (DL_FUNC) &_tiledb_libtiledb_query_buffer_alloc_ptr, 4},
     {"_tiledb_libtiledb_query_buffer_assign_ptr", (DL_FUNC) &_tiledb_libtiledb_query_buffer_assign_ptr, 4},
     {"_tiledb_libtiledb_query_set_buffer_ptr", (DL_FUNC) &_tiledb_libtiledb_query_set_buffer_ptr, 3},
+    {"_tiledb_vecbuf_to_shmem", (DL_FUNC) &_tiledb_vecbuf_to_shmem, 2},
+    {"_tiledb_vlcbuf_to_shmem", (DL_FUNC) &_tiledb_vlcbuf_to_shmem, 2},
     {"_tiledb_libtiledb_query_get_buffer_ptr", (DL_FUNC) &_tiledb_libtiledb_query_get_buffer_ptr, 2},
     {"_tiledb_libtiledb_query_submit", (DL_FUNC) &_tiledb_libtiledb_query_submit, 1},
     {"_tiledb_libtiledb_query_submit_async", (DL_FUNC) &_tiledb_libtiledb_query_submit_async, 1},

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -2712,28 +2712,26 @@ BEGIN_RCPP
 END_RCPP
 }
 // querybuf_from_shmem
-XPtr<query_buf_t> querybuf_from_shmem(std::string path, std::string dtype, bool nullable);
-RcppExport SEXP _tiledb_querybuf_from_shmem(SEXP pathSEXP, SEXP dtypeSEXP, SEXP nullableSEXP) {
+XPtr<query_buf_t> querybuf_from_shmem(std::string path, std::string dtype);
+RcppExport SEXP _tiledb_querybuf_from_shmem(SEXP pathSEXP, SEXP dtypeSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< std::string >::type path(pathSEXP);
     Rcpp::traits::input_parameter< std::string >::type dtype(dtypeSEXP);
-    Rcpp::traits::input_parameter< bool >::type nullable(nullableSEXP);
-    rcpp_result_gen = Rcpp::wrap(querybuf_from_shmem(path, dtype, nullable));
+    rcpp_result_gen = Rcpp::wrap(querybuf_from_shmem(path, dtype));
     return rcpp_result_gen;
 END_RCPP
 }
 // vlcbuf_from_shmem
-XPtr<vlc_buf_t> vlcbuf_from_shmem(std::string datapath, std::string dtype, bool nullable);
-RcppExport SEXP _tiledb_vlcbuf_from_shmem(SEXP datapathSEXP, SEXP dtypeSEXP, SEXP nullableSEXP) {
+XPtr<vlc_buf_t> vlcbuf_from_shmem(std::string datapath, std::string dtype);
+RcppExport SEXP _tiledb_vlcbuf_from_shmem(SEXP datapathSEXP, SEXP dtypeSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< std::string >::type datapath(datapathSEXP);
     Rcpp::traits::input_parameter< std::string >::type dtype(dtypeSEXP);
-    Rcpp::traits::input_parameter< bool >::type nullable(nullableSEXP);
-    rcpp_result_gen = Rcpp::wrap(vlcbuf_from_shmem(datapath, dtype, nullable));
+    rcpp_result_gen = Rcpp::wrap(vlcbuf_from_shmem(datapath, dtype));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -2967,8 +2965,8 @@ static const R_CallMethodDef CallEntries[] = {
     {"_tiledb_libtiledb_fragment_info_dump", (DL_FUNC) &_tiledb_libtiledb_fragment_info_dump, 1},
     {"_tiledb_vecbuf_to_shmem", (DL_FUNC) &_tiledb_vecbuf_to_shmem, 4},
     {"_tiledb_vlcbuf_to_shmem", (DL_FUNC) &_tiledb_vlcbuf_to_shmem, 4},
-    {"_tiledb_querybuf_from_shmem", (DL_FUNC) &_tiledb_querybuf_from_shmem, 3},
-    {"_tiledb_vlcbuf_from_shmem", (DL_FUNC) &_tiledb_vlcbuf_from_shmem, 3},
+    {"_tiledb_querybuf_from_shmem", (DL_FUNC) &_tiledb_querybuf_from_shmem, 2},
+    {"_tiledb_vlcbuf_from_shmem", (DL_FUNC) &_tiledb_vlcbuf_from_shmem, 2},
     {NULL, NULL, 0}
 };
 

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -1726,59 +1726,6 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
-// vecbuf_to_shmem
-void vecbuf_to_shmem(std::string dir, std::string name, XPtr<query_buf_t> buf, int sz);
-RcppExport SEXP _tiledb_vecbuf_to_shmem(SEXP dirSEXP, SEXP nameSEXP, SEXP bufSEXP, SEXP szSEXP) {
-BEGIN_RCPP
-    Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< std::string >::type dir(dirSEXP);
-    Rcpp::traits::input_parameter< std::string >::type name(nameSEXP);
-    Rcpp::traits::input_parameter< XPtr<query_buf_t> >::type buf(bufSEXP);
-    Rcpp::traits::input_parameter< int >::type sz(szSEXP);
-    vecbuf_to_shmem(dir, name, buf, sz);
-    return R_NilValue;
-END_RCPP
-}
-// vlcbuf_to_shmem
-void vlcbuf_to_shmem(std::string dir, std::string name, XPtr<vlc_buf_t> buf, IntegerVector vec);
-RcppExport SEXP _tiledb_vlcbuf_to_shmem(SEXP dirSEXP, SEXP nameSEXP, SEXP bufSEXP, SEXP vecSEXP) {
-BEGIN_RCPP
-    Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< std::string >::type dir(dirSEXP);
-    Rcpp::traits::input_parameter< std::string >::type name(nameSEXP);
-    Rcpp::traits::input_parameter< XPtr<vlc_buf_t> >::type buf(bufSEXP);
-    Rcpp::traits::input_parameter< IntegerVector >::type vec(vecSEXP);
-    vlcbuf_to_shmem(dir, name, buf, vec);
-    return R_NilValue;
-END_RCPP
-}
-// querybuf_from_shmem
-XPtr<query_buf_t> querybuf_from_shmem(std::string path, std::string dtype, bool nullable);
-RcppExport SEXP _tiledb_querybuf_from_shmem(SEXP pathSEXP, SEXP dtypeSEXP, SEXP nullableSEXP) {
-BEGIN_RCPP
-    Rcpp::RObject rcpp_result_gen;
-    Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< std::string >::type path(pathSEXP);
-    Rcpp::traits::input_parameter< std::string >::type dtype(dtypeSEXP);
-    Rcpp::traits::input_parameter< bool >::type nullable(nullableSEXP);
-    rcpp_result_gen = Rcpp::wrap(querybuf_from_shmem(path, dtype, nullable));
-    return rcpp_result_gen;
-END_RCPP
-}
-// vlcbuf_from_shmem
-XPtr<vlc_buf_t> vlcbuf_from_shmem(std::string datapath, std::string offsetspath, std::string dtype, bool nullable);
-RcppExport SEXP _tiledb_vlcbuf_from_shmem(SEXP datapathSEXP, SEXP offsetspathSEXP, SEXP dtypeSEXP, SEXP nullableSEXP) {
-BEGIN_RCPP
-    Rcpp::RObject rcpp_result_gen;
-    Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< std::string >::type datapath(datapathSEXP);
-    Rcpp::traits::input_parameter< std::string >::type offsetspath(offsetspathSEXP);
-    Rcpp::traits::input_parameter< std::string >::type dtype(dtypeSEXP);
-    Rcpp::traits::input_parameter< bool >::type nullable(nullableSEXP);
-    rcpp_result_gen = Rcpp::wrap(vlcbuf_from_shmem(datapath, offsetspath, dtype, nullable));
-    return rcpp_result_gen;
-END_RCPP
-}
 // length_from_vlcbuf
 IntegerVector length_from_vlcbuf(XPtr<vlc_buf_t> buf);
 RcppExport SEXP _tiledb_length_from_vlcbuf(SEXP bufSEXP) {
@@ -2738,6 +2685,59 @@ BEGIN_RCPP
     return R_NilValue;
 END_RCPP
 }
+// vecbuf_to_shmem
+void vecbuf_to_shmem(std::string dir, std::string name, XPtr<query_buf_t> buf, int sz);
+RcppExport SEXP _tiledb_vecbuf_to_shmem(SEXP dirSEXP, SEXP nameSEXP, SEXP bufSEXP, SEXP szSEXP) {
+BEGIN_RCPP
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< std::string >::type dir(dirSEXP);
+    Rcpp::traits::input_parameter< std::string >::type name(nameSEXP);
+    Rcpp::traits::input_parameter< XPtr<query_buf_t> >::type buf(bufSEXP);
+    Rcpp::traits::input_parameter< int >::type sz(szSEXP);
+    vecbuf_to_shmem(dir, name, buf, sz);
+    return R_NilValue;
+END_RCPP
+}
+// vlcbuf_to_shmem
+void vlcbuf_to_shmem(std::string dir, std::string name, XPtr<vlc_buf_t> buf, IntegerVector vec);
+RcppExport SEXP _tiledb_vlcbuf_to_shmem(SEXP dirSEXP, SEXP nameSEXP, SEXP bufSEXP, SEXP vecSEXP) {
+BEGIN_RCPP
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< std::string >::type dir(dirSEXP);
+    Rcpp::traits::input_parameter< std::string >::type name(nameSEXP);
+    Rcpp::traits::input_parameter< XPtr<vlc_buf_t> >::type buf(bufSEXP);
+    Rcpp::traits::input_parameter< IntegerVector >::type vec(vecSEXP);
+    vlcbuf_to_shmem(dir, name, buf, vec);
+    return R_NilValue;
+END_RCPP
+}
+// querybuf_from_shmem
+XPtr<query_buf_t> querybuf_from_shmem(std::string path, std::string dtype, bool nullable);
+RcppExport SEXP _tiledb_querybuf_from_shmem(SEXP pathSEXP, SEXP dtypeSEXP, SEXP nullableSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< std::string >::type path(pathSEXP);
+    Rcpp::traits::input_parameter< std::string >::type dtype(dtypeSEXP);
+    Rcpp::traits::input_parameter< bool >::type nullable(nullableSEXP);
+    rcpp_result_gen = Rcpp::wrap(querybuf_from_shmem(path, dtype, nullable));
+    return rcpp_result_gen;
+END_RCPP
+}
+// vlcbuf_from_shmem
+XPtr<vlc_buf_t> vlcbuf_from_shmem(std::string datapath, std::string offsetspath, std::string dtype, bool nullable);
+RcppExport SEXP _tiledb_vlcbuf_from_shmem(SEXP datapathSEXP, SEXP offsetspathSEXP, SEXP dtypeSEXP, SEXP nullableSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< std::string >::type datapath(datapathSEXP);
+    Rcpp::traits::input_parameter< std::string >::type offsetspath(offsetspathSEXP);
+    Rcpp::traits::input_parameter< std::string >::type dtype(dtypeSEXP);
+    Rcpp::traits::input_parameter< bool >::type nullable(nullableSEXP);
+    rcpp_result_gen = Rcpp::wrap(vlcbuf_from_shmem(datapath, offsetspath, dtype, nullable));
+    return rcpp_result_gen;
+END_RCPP
+}
 
 static const R_CallMethodDef CallEntries[] = {
     {"_tiledb_allocate_arrow_array_as_double", (DL_FUNC) &_tiledb_allocate_arrow_array_as_double, 0},
@@ -2886,10 +2886,6 @@ static const R_CallMethodDef CallEntries[] = {
     {"_tiledb_libtiledb_query_buffer_alloc_ptr", (DL_FUNC) &_tiledb_libtiledb_query_buffer_alloc_ptr, 4},
     {"_tiledb_libtiledb_query_buffer_assign_ptr", (DL_FUNC) &_tiledb_libtiledb_query_buffer_assign_ptr, 4},
     {"_tiledb_libtiledb_query_set_buffer_ptr", (DL_FUNC) &_tiledb_libtiledb_query_set_buffer_ptr, 3},
-    {"_tiledb_vecbuf_to_shmem", (DL_FUNC) &_tiledb_vecbuf_to_shmem, 4},
-    {"_tiledb_vlcbuf_to_shmem", (DL_FUNC) &_tiledb_vlcbuf_to_shmem, 4},
-    {"_tiledb_querybuf_from_shmem", (DL_FUNC) &_tiledb_querybuf_from_shmem, 3},
-    {"_tiledb_vlcbuf_from_shmem", (DL_FUNC) &_tiledb_vlcbuf_from_shmem, 4},
     {"_tiledb_length_from_vlcbuf", (DL_FUNC) &_tiledb_length_from_vlcbuf, 1},
     {"_tiledb_libtiledb_query_get_buffer_ptr", (DL_FUNC) &_tiledb_libtiledb_query_get_buffer_ptr, 2},
     {"_tiledb_libtiledb_query_submit", (DL_FUNC) &_tiledb_libtiledb_query_submit, 1},
@@ -2970,6 +2966,10 @@ static const R_CallMethodDef CallEntries[] = {
     {"_tiledb_libtiledb_fragment_info_to_vacuum_num", (DL_FUNC) &_tiledb_libtiledb_fragment_info_to_vacuum_num, 1},
     {"_tiledb_libtiledb_fragment_info_to_vacuum_uri", (DL_FUNC) &_tiledb_libtiledb_fragment_info_to_vacuum_uri, 2},
     {"_tiledb_libtiledb_fragment_info_dump", (DL_FUNC) &_tiledb_libtiledb_fragment_info_dump, 1},
+    {"_tiledb_vecbuf_to_shmem", (DL_FUNC) &_tiledb_vecbuf_to_shmem, 4},
+    {"_tiledb_vlcbuf_to_shmem", (DL_FUNC) &_tiledb_vlcbuf_to_shmem, 4},
+    {"_tiledb_querybuf_from_shmem", (DL_FUNC) &_tiledb_querybuf_from_shmem, 3},
+    {"_tiledb_vlcbuf_from_shmem", (DL_FUNC) &_tiledb_vlcbuf_from_shmem, 4},
     {NULL, NULL, 0}
 };
 

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -102,6 +102,17 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// tiledb_datatype_string_to_sizeof
+int32_t tiledb_datatype_string_to_sizeof(const std::string str);
+RcppExport SEXP _tiledb_tiledb_datatype_string_to_sizeof(SEXP strSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< const std::string >::type str(strSEXP);
+    rcpp_result_gen = Rcpp::wrap(tiledb_datatype_string_to_sizeof(str));
+    return rcpp_result_gen;
+END_RCPP
+}
 // tiledb_datatype_R_type
 std::string tiledb_datatype_R_type(std::string datatype);
 RcppExport SEXP _tiledb_tiledb_datatype_R_type(SEXP datatypeSEXP) {
@@ -2745,6 +2756,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_tiledb_libtiledb_query_import_buffer", (DL_FUNC) &_tiledb_libtiledb_query_import_buffer, 4},
     {"_tiledb_libtiledb_query_set_coordinates", (DL_FUNC) &_tiledb_libtiledb_query_set_coordinates, 3},
     {"_tiledb_libtiledb_coords", (DL_FUNC) &_tiledb_libtiledb_coords, 0},
+    {"_tiledb_tiledb_datatype_string_to_sizeof", (DL_FUNC) &_tiledb_tiledb_datatype_string_to_sizeof, 1},
     {"_tiledb_tiledb_datatype_R_type", (DL_FUNC) &_tiledb_tiledb_datatype_R_type, 1},
     {"_tiledb_libtiledb_version", (DL_FUNC) &_tiledb_libtiledb_version, 0},
     {"_tiledb_libtiledb_ctx", (DL_FUNC) &_tiledb_libtiledb_ctx, 1},

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -1727,38 +1727,66 @@ BEGIN_RCPP
 END_RCPP
 }
 // vecbuf_to_shmem
-void vecbuf_to_shmem(std::string name, XPtr<query_buf_t> buf);
-RcppExport SEXP _tiledb_vecbuf_to_shmem(SEXP nameSEXP, SEXP bufSEXP) {
+void vecbuf_to_shmem(std::string dir, std::string name, XPtr<query_buf_t> buf, int sz);
+RcppExport SEXP _tiledb_vecbuf_to_shmem(SEXP dirSEXP, SEXP nameSEXP, SEXP bufSEXP, SEXP szSEXP) {
 BEGIN_RCPP
     Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< std::string >::type dir(dirSEXP);
     Rcpp::traits::input_parameter< std::string >::type name(nameSEXP);
     Rcpp::traits::input_parameter< XPtr<query_buf_t> >::type buf(bufSEXP);
-    vecbuf_to_shmem(name, buf);
+    Rcpp::traits::input_parameter< int >::type sz(szSEXP);
+    vecbuf_to_shmem(dir, name, buf, sz);
     return R_NilValue;
 END_RCPP
 }
 // vlcbuf_to_shmem
-void vlcbuf_to_shmem(std::string name, XPtr<vlc_buf_t> buf);
-RcppExport SEXP _tiledb_vlcbuf_to_shmem(SEXP nameSEXP, SEXP bufSEXP) {
+void vlcbuf_to_shmem(std::string dir, std::string name, XPtr<vlc_buf_t> buf, IntegerVector vec);
+RcppExport SEXP _tiledb_vlcbuf_to_shmem(SEXP dirSEXP, SEXP nameSEXP, SEXP bufSEXP, SEXP vecSEXP) {
 BEGIN_RCPP
     Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< std::string >::type dir(dirSEXP);
     Rcpp::traits::input_parameter< std::string >::type name(nameSEXP);
     Rcpp::traits::input_parameter< XPtr<vlc_buf_t> >::type buf(bufSEXP);
-    vlcbuf_to_shmem(name, buf);
+    Rcpp::traits::input_parameter< IntegerVector >::type vec(vecSEXP);
+    vlcbuf_to_shmem(dir, name, buf, vec);
     return R_NilValue;
 END_RCPP
 }
 // querybuf_from_shmem
-XPtr<query_buf_t> querybuf_from_shmem(std::string path, R_xlen_t sz, std::string dtype, bool nullable);
-RcppExport SEXP _tiledb_querybuf_from_shmem(SEXP pathSEXP, SEXP szSEXP, SEXP dtypeSEXP, SEXP nullableSEXP) {
+XPtr<query_buf_t> querybuf_from_shmem(std::string path, std::string dtype, bool nullable);
+RcppExport SEXP _tiledb_querybuf_from_shmem(SEXP pathSEXP, SEXP dtypeSEXP, SEXP nullableSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< std::string >::type path(pathSEXP);
-    Rcpp::traits::input_parameter< R_xlen_t >::type sz(szSEXP);
     Rcpp::traits::input_parameter< std::string >::type dtype(dtypeSEXP);
     Rcpp::traits::input_parameter< bool >::type nullable(nullableSEXP);
-    rcpp_result_gen = Rcpp::wrap(querybuf_from_shmem(path, sz, dtype, nullable));
+    rcpp_result_gen = Rcpp::wrap(querybuf_from_shmem(path, dtype, nullable));
+    return rcpp_result_gen;
+END_RCPP
+}
+// vlcbuf_from_shmem
+XPtr<vlc_buf_t> vlcbuf_from_shmem(std::string datapath, std::string offsetspath, std::string dtype, bool nullable);
+RcppExport SEXP _tiledb_vlcbuf_from_shmem(SEXP datapathSEXP, SEXP offsetspathSEXP, SEXP dtypeSEXP, SEXP nullableSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< std::string >::type datapath(datapathSEXP);
+    Rcpp::traits::input_parameter< std::string >::type offsetspath(offsetspathSEXP);
+    Rcpp::traits::input_parameter< std::string >::type dtype(dtypeSEXP);
+    Rcpp::traits::input_parameter< bool >::type nullable(nullableSEXP);
+    rcpp_result_gen = Rcpp::wrap(vlcbuf_from_shmem(datapath, offsetspath, dtype, nullable));
+    return rcpp_result_gen;
+END_RCPP
+}
+// length_from_vlcbuf
+IntegerVector length_from_vlcbuf(XPtr<vlc_buf_t> buf);
+RcppExport SEXP _tiledb_length_from_vlcbuf(SEXP bufSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< XPtr<vlc_buf_t> >::type buf(bufSEXP);
+    rcpp_result_gen = Rcpp::wrap(length_from_vlcbuf(buf));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -2858,9 +2886,11 @@ static const R_CallMethodDef CallEntries[] = {
     {"_tiledb_libtiledb_query_buffer_alloc_ptr", (DL_FUNC) &_tiledb_libtiledb_query_buffer_alloc_ptr, 4},
     {"_tiledb_libtiledb_query_buffer_assign_ptr", (DL_FUNC) &_tiledb_libtiledb_query_buffer_assign_ptr, 4},
     {"_tiledb_libtiledb_query_set_buffer_ptr", (DL_FUNC) &_tiledb_libtiledb_query_set_buffer_ptr, 3},
-    {"_tiledb_vecbuf_to_shmem", (DL_FUNC) &_tiledb_vecbuf_to_shmem, 2},
-    {"_tiledb_vlcbuf_to_shmem", (DL_FUNC) &_tiledb_vlcbuf_to_shmem, 2},
-    {"_tiledb_querybuf_from_shmem", (DL_FUNC) &_tiledb_querybuf_from_shmem, 4},
+    {"_tiledb_vecbuf_to_shmem", (DL_FUNC) &_tiledb_vecbuf_to_shmem, 4},
+    {"_tiledb_vlcbuf_to_shmem", (DL_FUNC) &_tiledb_vlcbuf_to_shmem, 4},
+    {"_tiledb_querybuf_from_shmem", (DL_FUNC) &_tiledb_querybuf_from_shmem, 3},
+    {"_tiledb_vlcbuf_from_shmem", (DL_FUNC) &_tiledb_vlcbuf_from_shmem, 4},
+    {"_tiledb_length_from_vlcbuf", (DL_FUNC) &_tiledb_length_from_vlcbuf, 1},
     {"_tiledb_libtiledb_query_get_buffer_ptr", (DL_FUNC) &_tiledb_libtiledb_query_get_buffer_ptr, 2},
     {"_tiledb_libtiledb_query_submit", (DL_FUNC) &_tiledb_libtiledb_query_submit, 1},
     {"_tiledb_libtiledb_query_submit_async", (DL_FUNC) &_tiledb_libtiledb_query_submit_async, 1},

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -1748,6 +1748,20 @@ BEGIN_RCPP
     return R_NilValue;
 END_RCPP
 }
+// querybuf_from_shmem
+XPtr<query_buf_t> querybuf_from_shmem(std::string path, R_xlen_t sz, std::string dtype, bool nullable);
+RcppExport SEXP _tiledb_querybuf_from_shmem(SEXP pathSEXP, SEXP szSEXP, SEXP dtypeSEXP, SEXP nullableSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< std::string >::type path(pathSEXP);
+    Rcpp::traits::input_parameter< R_xlen_t >::type sz(szSEXP);
+    Rcpp::traits::input_parameter< std::string >::type dtype(dtypeSEXP);
+    Rcpp::traits::input_parameter< bool >::type nullable(nullableSEXP);
+    rcpp_result_gen = Rcpp::wrap(querybuf_from_shmem(path, sz, dtype, nullable));
+    return rcpp_result_gen;
+END_RCPP
+}
 // libtiledb_query_get_buffer_ptr
 RObject libtiledb_query_get_buffer_ptr(XPtr<query_buf_t> buf, bool asint64);
 RcppExport SEXP _tiledb_libtiledb_query_get_buffer_ptr(SEXP bufSEXP, SEXP asint64SEXP) {
@@ -2846,6 +2860,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_tiledb_libtiledb_query_set_buffer_ptr", (DL_FUNC) &_tiledb_libtiledb_query_set_buffer_ptr, 3},
     {"_tiledb_vecbuf_to_shmem", (DL_FUNC) &_tiledb_vecbuf_to_shmem, 2},
     {"_tiledb_vlcbuf_to_shmem", (DL_FUNC) &_tiledb_vlcbuf_to_shmem, 2},
+    {"_tiledb_querybuf_from_shmem", (DL_FUNC) &_tiledb_querybuf_from_shmem, 4},
     {"_tiledb_libtiledb_query_get_buffer_ptr", (DL_FUNC) &_tiledb_libtiledb_query_get_buffer_ptr, 2},
     {"_tiledb_libtiledb_query_submit", (DL_FUNC) &_tiledb_libtiledb_query_submit, 1},
     {"_tiledb_libtiledb_query_submit_async", (DL_FUNC) &_tiledb_libtiledb_query_submit_async, 1},

--- a/src/libtiledb.cpp
+++ b/src/libtiledb.cpp
@@ -2891,7 +2891,7 @@ IntegerVector length_from_vlcbuf(XPtr<vlc_buf_t> buf) {
 // [[Rcpp::export]]
 RObject libtiledb_query_get_buffer_ptr(XPtr<query_buf_t> buf, bool asint64 = false) {
   std::string dtype = _tiledb_datatype_to_string(buf->dtype);
-  //Rcpp::Rcout << dtype << " " << buf->ncells << " " << buf->size << std::endl;
+  //Rcpp::Rcout << dtype << " " << buf->ncells << " " << buf->size << " " << buf->nullable << std::endl;
   if (dtype == "INT32") {
     IntegerVector v(buf->ncells);
     std::memcpy(&(v[0]), (void*) buf->vec.data(), buf->ncells * buf->size);

--- a/src/libtiledb.cpp
+++ b/src/libtiledb.cpp
@@ -156,44 +156,9 @@ tiledb_datatype_t _string_to_tiledb_datatype(std::string typestr) {
   }
 }
 
-int32_t _tiledb_datatype_to_sizeof(tiledb_datatype_t dtype) {
-  switch (dtype) {
-    case TILEDB_CHAR:
-    case TILEDB_INT8:
-    case TILEDB_UINT8:
-        return 1;
-    case TILEDB_INT16:
-    case TILEDB_UINT16:
-        return 2;
-    case TILEDB_INT32:
-    case TILEDB_UINT32:
-    case TILEDB_FLOAT32:
-        return 4;
-    case TILEDB_INT64:
-    case TILEDB_UINT64:
-    case TILEDB_FLOAT64:
-    case TILEDB_DATETIME_YEAR:
-    case TILEDB_DATETIME_MONTH:
-    case TILEDB_DATETIME_WEEK:
-    case TILEDB_DATETIME_DAY:
-    case TILEDB_DATETIME_HR:
-    case TILEDB_DATETIME_MIN:
-    case TILEDB_DATETIME_SEC:
-    case TILEDB_DATETIME_MS:
-    case TILEDB_DATETIME_US:
-    case TILEDB_DATETIME_NS:
-    case TILEDB_DATETIME_PS:
-    case TILEDB_DATETIME_FS:
-    case TILEDB_DATETIME_AS:
-        return 8;
-    default:
-      Rcpp::stop("unknown tiledb_datatype_t (%d)", dtype);
-  }
-}
-
 // [[Rcpp::export]]
 int32_t tiledb_datatype_string_to_sizeof(const std::string str) {
-    return _tiledb_datatype_to_sizeof(_string_to_tiledb_datatype(str));
+    return static_cast<int32_t>(tiledb_datatype_size(_string_to_tiledb_datatype(str)));
 }
 
 // [[Rcpp::export]]

--- a/src/libtiledb.cpp
+++ b/src/libtiledb.cpp
@@ -192,6 +192,11 @@ int32_t _tiledb_datatype_to_sizeof(tiledb_datatype_t dtype) {
 }
 
 // [[Rcpp::export]]
+int32_t tiledb_datatype_string_to_sizeof(const std::string str) {
+    return _tiledb_datatype_to_sizeof(_string_to_tiledb_datatype(str));
+}
+
+// [[Rcpp::export]]
 std::string tiledb_datatype_R_type(std::string datatype) {
   tiledb_datatype_t dtype = _string_to_tiledb_datatype(datatype);
   switch (dtype) {

--- a/src/libtiledb.h
+++ b/src/libtiledb.h
@@ -66,5 +66,9 @@ void setValidityMapForNumeric(Rcpp::NumericVector & vec, const std::vector<uint8
 void getValidityMapFromInt64(Rcpp::NumericVector & vec, std::vector<uint8_t> & map);
 void setValidityMapForInt64(std::vector<int64_t> & vec, const std::vector<uint8_t> & map);
 
+// type and size helper
+tiledb_datatype_t _string_to_tiledb_datatype(std::string typestr);
+int32_t _tiledb_datatype_to_sizeof(tiledb_datatype_t dtype);
+
 
 #endif

--- a/src/libtiledb.h
+++ b/src/libtiledb.h
@@ -68,7 +68,6 @@ void setValidityMapForInt64(std::vector<int64_t> & vec, const std::vector<uint8_
 
 // type and size helper
 tiledb_datatype_t _string_to_tiledb_datatype(std::string typestr);
-int32_t _tiledb_datatype_to_sizeof(tiledb_datatype_t dtype);
 
 
 #endif

--- a/src/nullable.cpp
+++ b/src/nullable.cpp
@@ -30,7 +30,7 @@
 
 void getValidityMapFromInteger(Rcpp::IntegerVector & vec, std::vector<uint8_t> & map) {
     if (static_cast<size_t>(vec.size()) != map.size())
-        Rcpp::stop("Unequal length between vector and map.");
+        Rcpp::stop("Unequal length between vector (%d) and map (%d) in int getter.", vec.size(), map.size());
 
     for (auto i=0; i < vec.size(); i++)
         map[i] = (vec[i] == R_NaInt) ? 0 : 1;
@@ -38,7 +38,7 @@ void getValidityMapFromInteger(Rcpp::IntegerVector & vec, std::vector<uint8_t> &
 
 void setValidityMapForInteger(Rcpp::IntegerVector & vec, const std::vector<uint8_t> & map) {
     if (static_cast<size_t>(vec.size()) != map.size())
-        Rcpp::stop("Unequal length between vector and map.");
+        Rcpp::stop("Unequal length between vector (%d) and map (%d) in int setter.", vec.size(), map.size());
 
     for (auto i=0; i < vec.size(); i++)
         if (map[i] == 0)
@@ -47,7 +47,7 @@ void setValidityMapForInteger(Rcpp::IntegerVector & vec, const std::vector<uint8
 
 void getValidityMapFromNumeric(Rcpp::NumericVector & vec, std::vector<uint8_t> & map) {
     if (static_cast<size_t>(vec.size()) != map.size())
-        Rcpp::stop("Unequal length between vector and map.");
+        Rcpp::stop("Unequal length between vector (%d) and map (%d) in numeric getter.", vec.size(), map.size());
 
     for (auto i=0; i < vec.size(); i++) {
         // see R_ext/Arith.h: true for both NA and NaN
@@ -57,7 +57,7 @@ void getValidityMapFromNumeric(Rcpp::NumericVector & vec, std::vector<uint8_t> &
 
 void setValidityMapForNumeric(Rcpp::NumericVector & vec, const std::vector<uint8_t> & map) {
     if (static_cast<size_t>(vec.size()) != map.size())
-        Rcpp::stop("Unequal length between vector and map.");
+        Rcpp::stop("Unequal length between vector (%d) and map (%d) in numeric setter.", vec.size(), map.size());
 
     for (auto i=0; i < vec.size(); i++)
         if (map[i] == 0)
@@ -70,7 +70,7 @@ void setValidityMapForNumeric(Rcpp::NumericVector & vec, const std::vector<uint8
 
 void getValidityMapFromInt64(Rcpp::NumericVector & vec, std::vector<uint8_t> & map) {
     if (static_cast<size_t>(vec.size()) != map.size())
-        Rcpp::stop("Unequal length between vector and map.");
+        Rcpp::stop("Unequal length between vector (%d) and map (%d) in int64 getter.", vec.size(), map.size());
 
     std::vector<int64_t> ivec = getInt64Vector(vec);
 
@@ -81,7 +81,7 @@ void getValidityMapFromInt64(Rcpp::NumericVector & vec, std::vector<uint8_t> & m
 
 void setValidityMapForInt64(std::vector<int64_t> & vec, const std::vector<uint8_t> & map) {
     if (static_cast<size_t>(vec.size()) != map.size())
-        Rcpp::stop("Unequal length between vector and map.");
+        Rcpp::stop("Unequal length between vector (%d) and map (%d) in int64 setter.", vec.size(), map.size());
 
     for (size_t i=0; i < vec.size(); i++)
         if (map[i] == 0)

--- a/src/shmem.cpp
+++ b/src/shmem.cpp
@@ -1,0 +1,213 @@
+//  MIT License
+//
+//  Copyright (c) 2021 TileDB Inc.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+
+// The functions in this file are of less general use or interest as they rely on the
+// 'handshakes' from the TileDB Cloud backend, which is not published as open source.
+// They simply constitute an alternate mechanism of filling result data structures taking
+// advantage of an auxiliary parallel query tp TileDB Embedded (that is done solely for
+// performance reasons in the context of TileDB Cloud).
+
+#include "libtiledb.h"
+#include "finalizers.h"
+#include "tiledb_version.h"
+
+#include <sys/types.h>
+#ifndef _WIN32
+#include <sys/mman.h>
+#endif
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <unistd.h>
+
+
+using namespace Rcpp;
+
+// forward declarations
+tiledb_datatype_t _string_to_tiledb_datatype(std::string typestr);
+int32_t _tiledb_datatype_to_sizeof(tiledb_datatype_t dtype);
+
+// [[Rcpp::export]]
+void vecbuf_to_shmem(std::string dir, std::string name, XPtr<query_buf_t> buf, int sz) {
+#ifndef _WIN32
+    std::string bufferpath = std::string("/dev/shm/") + dir + std::string("/buffers/data/") + name;
+    Rcpp::Rcout << "Writing " << bufferpath << " ";
+    int mode = S_IRWXU | S_IRWXG | S_IRWXO;
+    int fd = open(bufferpath.c_str(), O_RDWR | O_CREAT | O_TRUNC, mode);
+    //int n = buf->ncells * buf->size;
+    int n = sz * buf->size;
+    void *dest = mmap(NULL,      				// kernel picks address
+                      n, 				   		// length
+                      PROT_READ | PROT_WRITE,
+                      MAP_SHARED,
+                      fd,
+                      0);
+    lseek (fd, n-1, SEEK_SET); 	 // seek to n, write an empty char to allocate block, then memcpy in
+    if (write (fd, "", 1) != 1) Rcpp::stop("write error");
+    memcpy (dest, (void*) buf->vec.data(), n);
+    Rcpp::Rcout << " ... done\n";
+#endif
+}
+
+// [[Rcpp::export]]
+void vlcbuf_to_shmem(std::string dir, std::string name, XPtr<vlc_buf_t> buf, IntegerVector vec) {
+#ifndef _WIN32
+    std::string bufferpath = std::string("/dev/shm/") + dir + std::string("/buffers/data/") + name;
+    Rcpp::Rcout << "Writing char to " << bufferpath << " " << buf->str.length() << " " << buf->offsets.size() << std::endl;
+    Rcpp::Rcout << buf->str << " (" << std::strlen(buf->str.c_str()) << ")\n";
+    int mode = S_IRWXU | S_IRWXG | S_IRWXO;
+    int fd = open(bufferpath.c_str(), O_RDWR | O_CREAT | O_TRUNC, mode);
+    // int n = buf->str.size();
+    int n = std::strlen(buf->str.c_str()); 		// NB: only write string length
+    //Rcpp::Rcout << "String size: " << n << " " << vec[1] << std::endl;
+    void *dest = mmap(NULL,      				// kernel picks address
+                      n,	 			   		// length
+                      PROT_READ | PROT_WRITE,
+                      MAP_SHARED,
+                      fd,
+                      0);
+    lseek (fd, n-1, SEEK_SET); 	 // seek to n, write an empty char to allocate block, then memcpy in
+    if (write (fd, "", 1) != 1) Rcpp::stop("write error");
+    memcpy (dest, (void*) buf->str.c_str(), n);
+
+    bufferpath = std::string("/dev/shm/") + dir + std::string("/buffers/offsets/") + name;
+    fd = open(bufferpath.c_str(), O_RDWR | O_CREAT | O_TRUNC, mode);
+    //n = buf->offsets.size() * sizeof(uint64_t);
+    n = vec[0] * sizeof(uint64_t);
+    Rcpp::Rcout << "Offsets (byte) size: " << n << " " << vec[0]*sizeof(uint64_t) << std::endl;
+    //for (int z=0; z<40; z++) Rcpp::Rcout << buf->offsets[z] << " ";
+    //Rcpp::Rcout << "--" << buf->offsets.size() << std::endl;
+    dest = mmap(NULL,      				// kernel picks address
+                n + 1, 			   		// length
+                PROT_READ | PROT_WRITE,
+                MAP_SHARED,
+                fd,
+                0);
+    lseek (fd, n-1, SEEK_SET); 	 // seek to n, write an empty char to allocate block, then memcpy in
+    if (write (fd, "", 1) != 1) Rcpp::stop("write error");
+    memcpy (dest, (void*) buf->offsets.data(), n);
+#endif
+}
+
+// [[Rcpp::export]]
+XPtr<query_buf_t> querybuf_from_shmem(std::string path, std::string dtype, bool nullable=false) {
+#ifndef _WIN32
+    // struct query_buffer {
+    //     //void *ptr;                    	// pointer to data as an alternative
+    //     std::vector<int8_t> vec;        	// vector of int8_t as a memory container
+    //     tiledb_datatype_t dtype;        	// data type
+    //     R_xlen_t ncells;                	// extent
+    //     size_t size;                    	// element size
+    //     std::vector<uint8_t> validity_map;  // for nullable vectors
+    //     bool nullable;                      // flag
+    // };
+    // typedef struct query_buffer query_buf_t;
+
+    // open shared memory region, and set up mmap
+    int fd = open(path.c_str(), O_RDONLY);
+    if (fd < 0) Rcpp::stop("Cannot open %s for reading", path.c_str());
+    struct stat statbuf;
+    if (fstat(fd,&statbuf) < 0) Rcpp::stop("Cannot fstat %s", path.c_str());
+    int sz = statbuf.st_size;
+    void *src = mmap (0, sz, PROT_READ, MAP_SHARED, fd, 0);
+    if (src == (caddr_t) -1) Rcpp::stop("mmap error");
+
+    // allocate buffer, register finalizer, then set up buffer
+    XPtr<query_buf_t> buf = XPtr<query_buf_t>(new query_buf_t, false);
+    registerXptrFinalizer(buf, libtiledb_query_buf_delete);
+    buf->dtype = _string_to_tiledb_datatype(dtype);
+    buf->size = _tiledb_datatype_to_sizeof(_string_to_tiledb_datatype(dtype));
+    buf->ncells = sz / buf->size;
+    Rcpp::Rcout << path << " "
+                << " dtype " << dtype
+                << " sizeof:" << buf->size
+                << " ncells:" << buf->ncells
+                << " vecsize:" << sz << std::endl;
+    buf->vec.resize(sz);
+    if (nullable) buf->validity_map.resize(buf->ncells); // TODO actually copy
+    buf->nullable = nullable;
+    memcpy(buf->vec.data(), src, sz);
+
+    return buf;
+#else
+    Rcpp::stop("This function is unavailable on Windows.");
+    // not reached
+    XPtr<query_buf_t> buf = XPtr<query_buf_t>(new query_buf_t, false);
+    registerXptrFinalizer(buf, libtiledb_query_buf_delete);
+    return buf;
+#endif
+}
+// [[Rcpp::export]]
+XPtr<vlc_buf_t> vlcbuf_from_shmem(std::string datapath, std::string offsetspath,
+                                  std::string dtype, bool nullable=false) {
+#ifndef _WIN32
+    // struct var_length_char_buffer {
+    //     std::vector<uint64_t> offsets;  	// vector for offset values
+    //     std::string str;              		// string for data values
+    //     int32_t rows, cols;              	// dimension from subarray
+    //     bool nullable;                       // flag
+    //     std::vector<uint8_t> validity_map;   // for nullable vectors
+    // };
+    // typedef struct var_length_char_buffer vlc_buf_t;
+
+    // open shared memory region, and set up mmap for data
+    int fdd = open(datapath.c_str(), O_RDONLY);
+    if (fdd < 0) Rcpp::stop("Cannot open %s for reading", datapath.c_str());
+    struct stat statbufd;
+    if (fstat(fdd,&statbufd) < 0) Rcpp::stop("Cannot fstat %s", datapath.c_str());
+    int szd = statbufd.st_size;
+    void *datasrc = mmap (0, szd, PROT_READ, MAP_SHARED, fdd, 0);
+    if (datasrc == (caddr_t) -1) Rcpp::stop("mmap error");
+
+    // open shared memory region, and set up mmap for offsets
+    int fdo = open(offsetspath.c_str(), O_RDONLY);
+    if (fdo < 0) Rcpp::stop("Cannot open %s for reading", offsetspath.c_str());
+    struct stat statbufo;
+    if (fstat(fdo,&statbufo) < 0) Rcpp::stop("Cannot fstat %s", offsetspath.c_str());
+    int szo = statbufo.st_size;
+    void *offsetssrc = mmap (0, szo, PROT_READ, MAP_SHARED, fdo, 0);
+    if (datasrc == (caddr_t) -1) Rcpp::stop("mmap error");
+
+    // allocate buffer, register finalizer, then set up buffer
+    XPtr<vlc_buf_t> buf = XPtr<vlc_buf_t>(new vlc_buf_t, false);
+    registerXptrFinalizer(buf, libtiledb_vlc_buf_delete);
+    buf->offsets.resize(szo/sizeof(uint64_t));
+    buf->rows = szo/sizeof(uint64_t);
+    buf->cols = 2;              // value not used
+    memcpy(buf->offsets.data(), offsetssrc, szo);
+    buf->str.resize(szd);
+    memcpy(buf->str.data(), datasrc, szd);
+    if (nullable) buf->validity_map.resize(szo/sizeof(uint8_t)); // TODO actually copy
+    buf->nullable = nullable;
+
+    Rcpp::Rcout << datapath << " " << offsetspath
+                << " data:" << szd
+                << " offsets:" << szo/sizeof(uint64_t)
+                << std::endl;
+    return buf;
+#else
+    Rcpp::stop("This function is unavailable on Windows.");
+    // not reached
+    XPtr<vlc_buf_t> buf = XPtr<vlc_buf_t>(new vlc_buf_t, false);
+    registerXptrFinalizer(buf, libtiledb_vlc_buf_delete);
+    return buf;
+#endif
+}

--- a/src/shmem.cpp
+++ b/src/shmem.cpp
@@ -112,6 +112,7 @@ void vlcbuf_to_shmem(std::string dir, std::string name, XPtr<vlc_buf_t> buf, Int
 
 
 void read_vec_buffer(std::string bufferpath, std::vector<int8_t> & vec) {
+#ifdef __linux__
     // // open shared memory region, and set up mmap
     int fd = open(bufferpath.c_str(), O_RDONLY);
     if (fd < 0) Rcpp::stop("Cannot open %s for reading", bufferpath.c_str());
@@ -124,9 +125,11 @@ void read_vec_buffer(std::string bufferpath, std::vector<int8_t> & vec) {
     vec.resize(sz);
     memcpy(vec.data(), src, sz);
     close(fd);
+#endif
 }
 
 void read_vmap_buffer(std::string bufferpath, std::vector<uint8_t> & vec) {
+#ifdef __linux__
     // // open shared memory region, and set up mmap
     int fd = open(bufferpath.c_str(), O_RDONLY);
     if (fd < 0) Rcpp::stop("Cannot open %s for reading", bufferpath.c_str());
@@ -139,6 +142,7 @@ void read_vmap_buffer(std::string bufferpath, std::vector<uint8_t> & vec) {
     vec.resize(sz);
     memcpy(vec.data(), src, sz);
     close(fd);
+#endif
 }
 
 // [[Rcpp::export]]

--- a/src/shmem.cpp
+++ b/src/shmem.cpp
@@ -45,26 +45,38 @@ static const bool debug = false;
 using namespace Rcpp;
 
 static std::string _datafile(const std::string dir, const std::string name) {
+#ifdef __linux__
     std::string path = std::string("/dev/shm/") + dir + std::string("/buffers/data/");
     if (!std::filesystem::is_directory(path)) std::filesystem::create_directories(path);
     return path + name;
+#else
+    return std::string();
+#fi
 }
 
 static std::string _offsetsfile(const std::string dir, const std::string name) {
+#ifdef __linux__
     std::string path = std::string("/dev/shm/") + dir + std::string("/buffers/offsets/");
     if (!std::filesystem::is_directory(path)) std::filesystem::create_directories(path);
     return path + name;
+#else
+    return std::string();
+#fi
 }
 
 static std::string _validityfile(const std::string dir, const std::string name) {
+#ifdef __linux__
     std::string path = std::string("/dev/shm/") + dir + std::string("/buffers/validity/");
     if (!std::filesystem::is_directory(path)) std::filesystem::create_directories(path);
     return path + name;
+#else
+    return std::string();
+#fi
 }
 
 // [[Rcpp::export]]
 void vecbuf_to_shmem(std::string dir, std::string name, XPtr<query_buf_t> buf, int sz) {
-#ifndef _WIN32
+#ifdef __linux__
     std::string bufferpath = _datafile(dir, name);
     if (debug) Rcpp::Rcout << "Writing " << bufferpath << " ";
     int mode = S_IRWXU | S_IRWXG | S_IRWXO;
@@ -98,7 +110,7 @@ void vecbuf_to_shmem(std::string dir, std::string name, XPtr<query_buf_t> buf, i
 
 // [[Rcpp::export]]
 void vlcbuf_to_shmem(std::string dir, std::string name, XPtr<vlc_buf_t> buf, IntegerVector vec) {
-#ifndef _WIN32
+#ifdef __linux__
     std::string bufferpath = _datafile(dir, name);
     if (debug) Rcpp::Rcout << "Writing char to " << bufferpath << " " << buf->str.length() << " " << buf->offsets.size() << " ";
     //if (debug) Rcpp::Rcout << buf->str << " (" << std::strlen(buf->str.c_str()) << ")\n";
@@ -153,7 +165,7 @@ void vlcbuf_to_shmem(std::string dir, std::string name, XPtr<vlc_buf_t> buf, Int
 
 // [[Rcpp::export]]
 XPtr<query_buf_t> querybuf_from_shmem(std::string path, std::string dtype, bool nullable=false) {
-#ifndef _WIN32
+#ifdef __linux__
     // struct query_buffer {
     //     //void *ptr;                    	// pointer to data as an alternative
     //     std::vector<int8_t> vec;        	// vector of int8_t as a memory container
@@ -219,7 +231,7 @@ XPtr<query_buf_t> querybuf_from_shmem(std::string path, std::string dtype, bool 
 }
 // [[Rcpp::export]]
 XPtr<vlc_buf_t> vlcbuf_from_shmem(std::string datapath, std::string dtype, bool nullable=false) {
-#ifndef _WIN32
+#ifdef __linux__
     // struct var_length_char_buffer {
     //     std::vector<uint64_t> offsets;  	// vector for offset values
     //     std::string str;              		// string for data values

--- a/src/shmem.cpp
+++ b/src/shmem.cpp
@@ -147,7 +147,7 @@ XPtr<query_buf_t> querybuf_from_shmem(std::string path, std::string dtype) {
     XPtr<query_buf_t> buf = XPtr<query_buf_t>(new query_buf_t, false);
     registerXptrFinalizer(buf, libtiledb_query_buf_delete);
     buf->dtype = _string_to_tiledb_datatype(dtype);
-    buf->size = _tiledb_datatype_to_sizeof(_string_to_tiledb_datatype(dtype));
+    buf->size = static_cast<int32_t>(tiledb_datatype_size(_string_to_tiledb_datatype(dtype)));
     buf->nullable = false; // default, overriden if buffer in validity path seen
     read_buffer<int8_t>(path, buf->vec);
     buf->ncells = buf->vec.size() / buf->size;

--- a/src/shmem.cpp
+++ b/src/shmem.cpp
@@ -51,7 +51,7 @@ static std::string _datafile(const std::string dir, const std::string name) {
     return path + name;
 #else
     return std::string();
-#fi
+#endif
 }
 
 static std::string _offsetsfile(const std::string dir, const std::string name) {
@@ -61,7 +61,7 @@ static std::string _offsetsfile(const std::string dir, const std::string name) {
     return path + name;
 #else
     return std::string();
-#fi
+#endif
 }
 
 static std::string _validityfile(const std::string dir, const std::string name) {
@@ -71,7 +71,7 @@ static std::string _validityfile(const std::string dir, const std::string name) 
     return path + name;
 #else
     return std::string();
-#fi
+#endif
 }
 
 // [[Rcpp::export]]
@@ -222,7 +222,7 @@ XPtr<query_buf_t> querybuf_from_shmem(std::string path, std::string dtype, bool 
     if (debug) Rcpp::Rcout << std::endl;
     return buf;
 #else
-    Rcpp::stop("This function is unavailable on Windows.");
+    Rcpp::stop("This function is only available under Linux.");
     // not reached
     XPtr<query_buf_t> buf = XPtr<query_buf_t>(new query_buf_t, false);
     registerXptrFinalizer(buf, libtiledb_query_buf_delete);
@@ -298,7 +298,7 @@ XPtr<vlc_buf_t> vlcbuf_from_shmem(std::string datapath, std::string dtype, bool 
     close(fdo);
     return buf;
 #else
-    Rcpp::stop("This function is unavailable on Windows.");
+    Rcpp::stop("This function is only available under Linux.");
     // not reached
     XPtr<vlc_buf_t> buf = XPtr<vlc_buf_t>(new vlc_buf_t, false);
     registerXptrFinalizer(buf, libtiledb_vlc_buf_delete);


### PR DESCRIPTION
This PR enables accessing shared memory buffers as _e.g._ provided by the TileDB Cloud backend.  This is not of general use for the TileDB R package which will usually call TileDB Embedded _in process_ but supports a usage pattern, and performance enhancement, in our deployment for TileDB Cloud.  

The 'list of buffers' proposal is working fine as we can use simple regular expressions thanks to C++17 to go from (required) data buffers to (optional) offsets and validity_map buffers. 