### PR TITLE
Remove remaining max buffer elements calls

### DIFF
--- a/R/DenseArray.R
+++ b/R/DenseArray.R
@@ -213,8 +213,7 @@ attribute_buffers <- function(array, sch, dom, sub, selected) {
 
   # first alloc coordinate buffer if we are returning a data.frame
   if(array@as.data.frame) {
-    ncells_coords <- libtiledb_array_max_buffer_elements_with_type(array@ptr, sub,
-                                                                   libtiledb_coords(), domaintype)
+    ncells_coords <- 2*ncells
     if (is.integral(dom)) {
       attributes[["coords"]] <- integer(length = ncells_coords)
     } else {
@@ -234,10 +233,6 @@ attribute_buffers <- function(array, sch, dom, sub, selected) {
     type <- tiledb_datatype_R_type(dtype)
     datatype <- libtiledb_attribute_get_type(attr@ptr)
     #cat("dtype:", dtype, " type:", type, " datatype:", datatype, "\n", sep="")
-    ## If getting it as a dataframe we need to use max buffer elements to get proper buffer size
-    if (array@as.data.frame) {
-      ncells <- libtiledb_array_max_buffer_elements_with_type(array@ptr, sub, aname, domaintype)
-    }
     if (type %in% c("integer", "double")) {
       buff <- vector(mode = type, length = ncells)
     } else if (dtype %in% c("CHAR")) {  # TODO: add other char and date types

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -33,18 +33,6 @@ libtiledb_coords <- function() {
     .Call(`_tiledb_libtiledb_coords`)
 }
 
-libtiledb_array_max_buffer_elements_with_type <- function(array, subarray, attribute, typestr) {
-    .Call(`_tiledb_libtiledb_array_max_buffer_elements_with_type`, array, subarray, attribute, typestr)
-}
-
-libtiledb_array_max_buffer_elements <- function(array, subarray, attribute) {
-    .Call(`_tiledb_libtiledb_array_max_buffer_elements`, array, subarray, attribute)
-}
-
-libtiledb_array_max_buffer_elements_vec <- function(array, subarray, attribute) {
-    .Call(`_tiledb_libtiledb_array_max_buffer_elements_vec`, array, subarray, attribute)
-}
-
 tiledb_datatype_R_type <- function(datatype) {
     .Call(`_tiledb_tiledb_datatype_R_type`, datatype)
 }

--- a/R/SparseArray.R
+++ b/R/SparseArray.R
@@ -96,7 +96,7 @@ setMethod("schema", "tiledb_sparse", function(object, ...) {
   return(tiledb_array_schema.from_ptr(schema_xptr))
 })
 
-sparse_attribute_buffers <- function(array, sch, dom, sub, selected) {
+sparse_attribute_buffers <- function(array, sch, dom, sub, selected, ncells=1000) {
   stopifnot(is(sch, "tiledb_array_schema"))
   stopifnot(is(dom, "tiledb_domain"))
   #domaintype <- libtiledb_domain_get_type(dom@ptr)
@@ -105,8 +105,8 @@ sparse_attribute_buffers <- function(array, sch, dom, sub, selected) {
   attributes <- list()
   # first alloc coordinate buffer
   #print(domaintype)
-  ncells <- libtiledb_array_max_buffer_elements_with_type(array@ptr, sub,
-                                                          libtiledb_coords(), domaintype[1])
+  #ncells <- libtiledb_array_max_buffer_elements_with_type(array@ptr, sub,
+  #                                                        libtiledb_coords(), domaintype[1])
   attributes[["coords"]] <- libtiledb_query_buffer_alloc_ptr(array@ptr, domaintype[1], ncells)
   attrs <- tiledb::attrs(sch)
   if (length(selected) == 0) {          # no selection given -> use all
@@ -122,7 +122,7 @@ sparse_attribute_buffers <- function(array, sch, dom, sub, selected) {
     type <- tiledb_datatype_R_type(dtype)
     datatype <- libtiledb_attribute_get_type(attr@ptr)
     #cat("dtype:", dtype, " type:", type, " datatype:", datatype, "\n", sep="")
-    ncells <- libtiledb_array_max_buffer_elements_with_type(array@ptr, sub, aname, domaintype[1])
+    #ncells <- libtiledb_array_max_buffer_elements_with_type(array@ptr, sub, aname, domaintype[1])
     if (dtype %in% c("CHAR")) {  # TODO: add other char and date types
       #buff <- libtiledb_query_buffer_var_char_alloc(array@ptr, sub, aname)
       buff <- libtiledb_query_buffer_var_char_alloc_direct(ncells, ncells*8, FALSE, sub[4]-sub[3]+1)

--- a/R/SparseArray.R
+++ b/R/SparseArray.R
@@ -1,6 +1,6 @@
 #  MIT License
 #
-#  Copyright (c) 2017-2020 TileDB Inc.
+#  Copyright (c) 2017-2021 TileDB Inc.
 #
 #  Permission is hereby granted, free of charge, to any person obtaining a copy
 #  of this software and associated documentation files (the "Software"), to deal
@@ -104,9 +104,6 @@ sparse_attribute_buffers <- function(array, sch, dom, sub, selected, ncells=1000
                        libtiledb_dim_get_datatype)
   attributes <- list()
   # first alloc coordinate buffer
-  #print(domaintype)
-  #ncells <- libtiledb_array_max_buffer_elements_with_type(array@ptr, sub,
-  #                                                        libtiledb_coords(), domaintype[1])
   attributes[["coords"]] <- libtiledb_query_buffer_alloc_ptr(array@ptr, domaintype[1], ncells)
   attrs <- tiledb::attrs(sch)
   if (length(selected) == 0) {          # no selection given -> use all
@@ -121,10 +118,7 @@ sparse_attribute_buffers <- function(array, sch, dom, sub, selected, ncells=1000
     dtype <- tiledb::datatype(attr)
     type <- tiledb_datatype_R_type(dtype)
     datatype <- libtiledb_attribute_get_type(attr@ptr)
-    #cat("dtype:", dtype, " type:", type, " datatype:", datatype, "\n", sep="")
-    #ncells <- libtiledb_array_max_buffer_elements_with_type(array@ptr, sub, aname, domaintype[1])
     if (dtype %in% c("CHAR")) {  # TODO: add other char and date types
-      #buff <- libtiledb_query_buffer_var_char_alloc(array@ptr, sub, aname)
       buff <- libtiledb_query_buffer_var_char_alloc_direct(ncells, ncells*8, FALSE, sub[4]-sub[3]+1)
     } else if (datatype %in% c("DATETIME_DAY", "DATETIME_SEC", "DATETIME_MS",
                                "DATETIME_US", "DATETIME_NS")) {

--- a/inst/tinytest/test_fragmentinfo.R
+++ b/inst/tinytest/test_fragmentinfo.R
@@ -5,6 +5,7 @@ if (tiledb_version(TRUE) < "2.2.0") exit_file("Needs TileDB 2.2.* or later")
 
 isOldWindows <- Sys.info()[["sysname"]] == "Windows" && grepl('Windows Server 2008', osVersion)
 if (isOldWindows) exit_file("skip this file on old Windows releases")
+isMacOS <- (Sys.info()['sysname'] == "Darwin")
 
 ctx <- tiledb_ctx(limitTileDBCores())
 
@@ -47,7 +48,7 @@ rng <- tiledb_fragment_info_get_timestamp_range(fraginf, 0)
 expect_true(inherits(rng, "POSIXt"))
 expect_equal(length(rng), 2)
 expect_equal(as.Date(rng[1]), as.Date(as.POSIXlt(Sys.time(), tz="UTC")))  # very coarse :)
-expect_true(as.numeric(difftime(Sys.time(), rng[1], "secs")) < 0.5) # at most 0.5 sec after array creation
+expect_true(as.numeric(difftime(Sys.time(), rng[1], "secs")) < 0.5 + 1.0*isMacOS) # at most 0.5 sec after array creation (plus extra for maxOS which failed here randomly)
 expect_equal(tiledb_fragment_info_get_cell_num(fraginf, 0), 10)
 
 expect_true(tiledb_fragment_info_get_version(fraginf, 0) > 5) # we may test with older core libs

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -102,46 +102,6 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
-// libtiledb_array_max_buffer_elements_with_type
-R_xlen_t libtiledb_array_max_buffer_elements_with_type(XPtr<tiledb::Array> array, SEXP subarray, std::string attribute, std::string typestr);
-RcppExport SEXP _tiledb_libtiledb_array_max_buffer_elements_with_type(SEXP arraySEXP, SEXP subarraySEXP, SEXP attributeSEXP, SEXP typestrSEXP) {
-BEGIN_RCPP
-    Rcpp::RObject rcpp_result_gen;
-    Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< XPtr<tiledb::Array> >::type array(arraySEXP);
-    Rcpp::traits::input_parameter< SEXP >::type subarray(subarraySEXP);
-    Rcpp::traits::input_parameter< std::string >::type attribute(attributeSEXP);
-    Rcpp::traits::input_parameter< std::string >::type typestr(typestrSEXP);
-    rcpp_result_gen = Rcpp::wrap(libtiledb_array_max_buffer_elements_with_type(array, subarray, attribute, typestr));
-    return rcpp_result_gen;
-END_RCPP
-}
-// libtiledb_array_max_buffer_elements
-R_xlen_t libtiledb_array_max_buffer_elements(XPtr<tiledb::Array> array, SEXP subarray, std::string attribute);
-RcppExport SEXP _tiledb_libtiledb_array_max_buffer_elements(SEXP arraySEXP, SEXP subarraySEXP, SEXP attributeSEXP) {
-BEGIN_RCPP
-    Rcpp::RObject rcpp_result_gen;
-    Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< XPtr<tiledb::Array> >::type array(arraySEXP);
-    Rcpp::traits::input_parameter< SEXP >::type subarray(subarraySEXP);
-    Rcpp::traits::input_parameter< std::string >::type attribute(attributeSEXP);
-    rcpp_result_gen = Rcpp::wrap(libtiledb_array_max_buffer_elements(array, subarray, attribute));
-    return rcpp_result_gen;
-END_RCPP
-}
-// libtiledb_array_max_buffer_elements_vec
-NumericVector libtiledb_array_max_buffer_elements_vec(XPtr<tiledb::Array> array, SEXP subarray, std::string attribute);
-RcppExport SEXP _tiledb_libtiledb_array_max_buffer_elements_vec(SEXP arraySEXP, SEXP subarraySEXP, SEXP attributeSEXP) {
-BEGIN_RCPP
-    Rcpp::RObject rcpp_result_gen;
-    Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< XPtr<tiledb::Array> >::type array(arraySEXP);
-    Rcpp::traits::input_parameter< SEXP >::type subarray(subarraySEXP);
-    Rcpp::traits::input_parameter< std::string >::type attribute(attributeSEXP);
-    rcpp_result_gen = Rcpp::wrap(libtiledb_array_max_buffer_elements_vec(array, subarray, attribute));
-    return rcpp_result_gen;
-END_RCPP
-}
 // tiledb_datatype_R_type
 std::string tiledb_datatype_R_type(std::string datatype);
 RcppExport SEXP _tiledb_tiledb_datatype_R_type(SEXP datatypeSEXP) {
@@ -2724,9 +2684,6 @@ static const R_CallMethodDef CallEntries[] = {
     {"_tiledb_libtiledb_query_import_buffer", (DL_FUNC) &_tiledb_libtiledb_query_import_buffer, 4},
     {"_tiledb_libtiledb_query_set_coordinates", (DL_FUNC) &_tiledb_libtiledb_query_set_coordinates, 3},
     {"_tiledb_libtiledb_coords", (DL_FUNC) &_tiledb_libtiledb_coords, 0},
-    {"_tiledb_libtiledb_array_max_buffer_elements_with_type", (DL_FUNC) &_tiledb_libtiledb_array_max_buffer_elements_with_type, 4},
-    {"_tiledb_libtiledb_array_max_buffer_elements", (DL_FUNC) &_tiledb_libtiledb_array_max_buffer_elements, 3},
-    {"_tiledb_libtiledb_array_max_buffer_elements_vec", (DL_FUNC) &_tiledb_libtiledb_array_max_buffer_elements_vec, 3},
     {"_tiledb_tiledb_datatype_R_type", (DL_FUNC) &_tiledb_tiledb_datatype_R_type, 1},
     {"_tiledb_libtiledb_version", (DL_FUNC) &_tiledb_libtiledb_version, 0},
     {"_tiledb_libtiledb_ctx", (DL_FUNC) &_tiledb_libtiledb_ctx, 1},

--- a/src/deprecation.cpp
+++ b/src/deprecation.cpp
@@ -34,17 +34,6 @@
 
 using namespace Rcpp;
 
-// [[Rcpp::plugins(cpp11)]]
-
-
-// declarations needed
-XPtr<tiledb::ArraySchema> libtiledb_array_get_schema(XPtr<tiledb::Array> array);
-XPtr<tiledb::Domain> libtiledb_array_schema_get_domain(XPtr<tiledb::ArraySchema> schema);
-XPtr<tiledb::Attribute> libtiledb_array_schema_get_attribute_from_name(XPtr<tiledb::ArraySchema> schema, std::string name);
-std::string libtiledb_attribute_get_type(XPtr<tiledb::Attribute> attr);
-
-
-
 // [[Rcpp::export]]
 XPtr<tiledb::Query> libtiledb_query_set_coordinates(XPtr<tiledb::Query> query,
                                                     SEXP coords,
@@ -77,78 +66,4 @@ XPtr<tiledb::Query> libtiledb_query_set_coordinates(XPtr<tiledb::Query> query,
 // [[Rcpp::export]]
 std::string libtiledb_coords() {
   return tiledb_coords();
-}
-
-
-// using domain type information
-// [[Rcpp::export]]
-R_xlen_t libtiledb_array_max_buffer_elements_with_type(XPtr<tiledb::Array> array,
-                                                       SEXP subarray,
-                                                       std::string attribute,
-                                                       std::string typestr) {
-  if (typestr == "INT32") {
-    auto sub = as<std::vector<int32_t>>(subarray);
-    auto max_elements = array->max_buffer_elements(sub);
-    return max_elements[attribute].second;
-  } else if (typestr == "FLOAT64") {
-    auto sub = as<std::vector<double>>(subarray);
-    auto max_elements = array->max_buffer_elements(sub);
-    return max_elements[attribute].second;
-  } else if (typestr == "INT64" ||
-             typestr == "UINT64" ||
-             typestr == "UINT32" ||
-             typestr == "DATETIME_DAY" ||
-             typestr == "DATETIME_HR"  ||
-             typestr == "DATETIME_MIN" ||
-             typestr == "DATETIME_SEC" ||
-             typestr == "DATETIME_MS" ||
-             typestr == "DATETIME_US" ||
-             typestr == "DATETIME_NS") {
-    NumericVector svec(subarray);
-    std::vector<int64_t> v(svec.size());
-    for (int i=0; i<svec.size(); i++) {
-      v[i] = static_cast<int64_t>(svec[i]);
-    }
-    auto max_elements = array->max_buffer_elements(v);
-    return max_elements[attribute].second;
-  } else {
-    Rcpp::stop("Invalid subarray buffer type '%s' for domain: '%s'",
-               typestr.c_str(), Rcpp::type2name(subarray));
-  }
-}
-
-
-// [[Rcpp::export]]
-R_xlen_t libtiledb_array_max_buffer_elements(XPtr<tiledb::Array> array,
-                                             SEXP subarray,
-                                             std::string attribute) {
-  if (TYPEOF(subarray) == INTSXP) {
-    auto sub = as<std::vector<int32_t>>(subarray);
-    auto max_elements = array->max_buffer_elements(sub);
-    return max_elements[attribute].second;
-  } else if (TYPEOF(subarray) == REALSXP) {
-    auto sub = as<std::vector<double>>(subarray);
-    auto max_elements = array->max_buffer_elements(sub);
-    return max_elements[attribute].second;
-  } else {
-    Rcpp::stop("Invalid subarray buffer type for domain: '%s'", Rcpp::type2name(subarray));
-  }
-}
-
-
-// [[Rcpp::export]]
-NumericVector libtiledb_array_max_buffer_elements_vec(XPtr<tiledb::Array> array,
-                                                      SEXP subarray,
-                                                      std::string attribute) {
-  if (TYPEOF(subarray) == INTSXP) {
-    auto sub = as<std::vector<int32_t>>(subarray);
-    auto max_elements = array->max_buffer_elements(sub);
-    return NumericVector::create(max_elements[attribute].first, max_elements[attribute].second);
-  } else if (TYPEOF(subarray) == REALSXP) {
-    auto sub = as<std::vector<double>>(subarray);
-    auto max_elements = array->max_buffer_elements(sub);
-    return NumericVector::create(max_elements[attribute].first, max_elements[attribute].second);
-  } else {
-    Rcpp::stop("Invalid subarray buffer type for domain %s", Rcpp::type2name(subarray));
-  }
 }

--- a/tools/tiledbVersion.txt
+++ b/tools/tiledbVersion.txt
@@ -1,2 +1,2 @@
-version: 2.4.3
-sha: 5cb0824
+version: 2.5.0-rc0
+sha: 08cca1a

--- a/tools/tiledbVersion.txt
+++ b/tools/tiledbVersion.txt
@@ -1,2 +1,2 @@
-version: 2.5.0-rc0
-sha: 08cca1a
+version: 2.4.3
+sha: 5cb0824


### PR DESCRIPTION
This follows #317 and removes all instances of `max_buffer_elements` which has been removed from TileDB Embedded.