### PR TITLE
Use TileDB 2.5.0

### DIFF
--- a/.ci/azure/build-and-check.yaml
+++ b/.ci/azure/build-and-check.yaml
@@ -3,7 +3,6 @@ steps:
       R CMD build --no-build-vignettes --no-manual .
       CI=true MACOSX_DEPLOYMENT_TARGET=10.13 R CMD check --no-manual --no-vignettes tiledb_*.tar.gz
       cat tiledb.Rcheck/00install.out
-      cat tiledb.Rcheck/tests/tinytest.Rout
     displayName: 'Run check'
   - bash: |
       R CMD build --no-build-vignettes --no-manual .

--- a/.ci/azure/build-and-check.yaml
+++ b/.ci/azure/build-and-check.yaml
@@ -1,13 +1,13 @@
 steps:
   - bash: |
       R CMD build --no-build-vignettes --no-manual .
-      CI=true MACOSX_DEPLOYMENT_TARGET=10.13 R CMD check --no-manual --no-vignettes tiledb_*.tar.gz
+      CI=true R CMD check --no-manual --no-vignettes tiledb_*.tar.gz
       cat tiledb.Rcheck/00install.out
     displayName: 'Run check'
-  - bash: |
-      R CMD build --no-build-vignettes --no-manual .
-      TILEDB_USE_REFACTORED_READERS=true MACOSX_DEPLOYMENT_TARGET=10.13 R CMD check --no-manual --no-vignettes tiledb_*.tar.gz
-    displayName: 'Run refactored check'
+#  - bash: |
+#      R CMD build --no-build-vignettes --no-manual .
+#      TILEDB_USE_REFACTORED_READERS=true R CMD check --no-manual --no-vignettes tiledb_*.tar.gz
+#    displayName: 'Run refactored check'
 
 ## -- use this to display installation log
 ## test -f /*/*/work/1/s/tiledb.Rcheck/00install.out && cat /*/*/work/1/s/tiledb.Rcheck/00install.out

--- a/.ci/azure/build-and-check.yaml
+++ b/.ci/azure/build-and-check.yaml
@@ -1,13 +1,13 @@
 steps:
   - bash: |
       R CMD build --no-build-vignettes --no-manual .
-      CI=true R CMD check --no-manual --no-vignettes tiledb_*.tar.gz
+      CI=true MACOSX_DEPLOYMENT_TARGET=10.13 R CMD check --no-manual --no-vignettes tiledb_*.tar.gz
       cat tiledb.Rcheck/00install.out
-      cat tiledb.Rcheck/00check.log
+      cat tiledb.Rcheck/tests/tinytest.Rout
     displayName: 'Run check'
   - bash: |
       R CMD build --no-build-vignettes --no-manual .
-      TILEDB_USE_REFACTORED_READERS=true R CMD check --no-manual --no-vignettes tiledb_*.tar.gz
+      TILEDB_USE_REFACTORED_READERS=true MACOSX_DEPLOYMENT_TARGET=10.13 R CMD check --no-manual --no-vignettes tiledb_*.tar.gz
     displayName: 'Run refactored check'
 
 ## -- use this to display installation log

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,12 +17,13 @@ Copyright: TileDB, Inc.
 License: MIT + file LICENSE
 URL: https://github.com/TileDB-Inc/TileDB-R
 BugReports: https://github.com/TileDB-Inc/TileDB-R/issues
-SystemRequirements: A C++17 compiler is required. Optionally cmake
+SystemRequirements: A C++17 compiler is required, and on macOS
+ compilation for version 11.14 is required. Optionally cmake
  (only when TileDB source build selected), git (only when TileDB
- source build selected); on x86_64 platforms pre-built TileDB
- Embedded libraries are available at GitHub and are used if no
- TileDB installation is detected, and no other option to build
- or download was specified by the user.
+ source build selected); on x86_64 and M1 platforms pre-built
+ TileDB Embedded libraries are available at GitHub and are used
+ if no TileDB installation is detected, and no other option to
+ build or download was specified by the user.
 Imports: methods, Rcpp, nanotime
 LinkingTo: Rcpp
 Suggests: tinytest, rmarkdown, knitr, minidown, curl, bit64, Matrix, palmerpenguins, nycflights13, data.table, tibble

--- a/configure
+++ b/configure
@@ -620,6 +620,7 @@ ac_includes_default="\
 
 ac_subst_vars='LTLIBOBJS
 LIBOBJS
+CXX17_MACOS
 have_git
 have_cmake
 EGREP
@@ -2960,8 +2961,8 @@ fi
 
 ## If yes, also check for whether pkg-config knows tiledb
 if test x"${have_pkg_config}" != x"no"; then
-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking pkg-config knows TileDB" >&5
-$as_echo_n "checking pkg-config knows TileDB... " >&6; }
+    { $as_echo "$as_me:${as_lineno-$LINENO}: checking if pkg-config knows TileDB" >&5
+$as_echo_n "checking if pkg-config knows TileDB... " >&6; }
     if pkg-config --exists tiledb; then
         { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
 $as_echo "yes" >&6; }
@@ -2993,8 +2994,8 @@ fi
 
 ## If we have pkg-config, use it to test minimal version
 if test x"${have_pkg_config}" != x"no"; then
-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking pkg-config checking TileDB version" >&5
-$as_echo_n "checking pkg-config checking TileDB version... " >&6; }
+    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for pkg-config checking TileDB version" >&5
+$as_echo_n "checking for pkg-config checking TileDB version... " >&6; }
     if pkg-config --atleast-version=2.0.0 tiledb; then
         { $as_echo "$as_me:${as_lineno-$LINENO}: result: >= 2.0.0" >&5
 $as_echo ">= 2.0.0" >&6; }
@@ -3072,6 +3073,14 @@ origCPPFLAGS="${CPPFLAGS}"
 origLDFLAGS="${LDFLAGS}"
 CPPFLAGS="${origCPPFLAGS} ${TILEDB_INCLUDE}"
 LDFLAGS="${origLDFLAGS} ${TILEDB_LIBS} ${TILEDB_RPATH}"
+if test x"${uname}" = x"Darwin"; then
+    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for Darwin minimum version override" >&5
+$as_echo_n "checking for Darwin minimum version override... " >&6; }
+    CXX17_MACOS="-mmacosx-version-min=10.14"
+    { $as_echo "$as_me:${as_lineno-$LINENO}: result: ${CXX17_MACOS}" >&5
+$as_echo "${CXX17_MACOS}" >&6; }
+fi
+
 
 ## -- Part 3: Check for TileDB --------------------------------------------------
 ##
@@ -3517,7 +3526,7 @@ $as_echo "installing TileDB for ${osrel}..." >&6; }
     { $as_echo "$as_me:${as_lineno-$LINENO}: result: using inst/tiledb/{lib,include}" >&5
 $as_echo "using inst/tiledb/{lib,include}" >&6; }
     RPATH=" -Wl,-rpath,'\$\$ORIGIN/../tiledb/lib'"
-    TILEDB_INCLUDE="-I../inst/tiledb/include"
+    TILEDB_INCLUDE="-I../inst/tiledb/include ${CXX17_MACOS}"
 
     TILEDB_LIBS="-ltiledb -L../inst/tiledb/lib"
 
@@ -3528,6 +3537,8 @@ $as_echo "using inst/tiledb/{lib,include}" >&6; }
     LDFLAGS="${origLDFLAGS} ${TILEDB_LIBS} ${TILEDB_RPATH}"
 
 fi
+
+
 
 ac_config_files="$ac_config_files src/Makevars"
 

--- a/configure
+++ b/configure
@@ -3079,9 +3079,11 @@ origCPPFLAGS="${CPPFLAGS}"
 origLDFLAGS="${LDFLAGS}"
 CPPFLAGS="${origCPPFLAGS} ${TILEDB_INCLUDE}"
 LDFLAGS="${origLDFLAGS} ${TILEDB_LIBS} ${TILEDB_RPATH}"
-if test x"${uname}" = x"Darwin"; then
-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for Darwin minimum version override" >&5
-$as_echo_n "checking for Darwin minimum version override... " >&6; }
+
+## Take care of 10.14 requirement for Intel macOS
+if test x"${uname}" = x"Darwin" -a x"${machine}" = x"x86_64"; then
+    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for Darwin x86_64 use minimum version override" >&5
+$as_echo_n "checking for Darwin x86_64 use minimum version override... " >&6; }
     CXX17_MACOS="-mmacosx-version-min=10.14"
     { $as_echo "$as_me:${as_lineno-$LINENO}: result: ${CXX17_MACOS}" >&5
 $as_echo "${CXX17_MACOS}" >&6; }

--- a/configure
+++ b/configure
@@ -2008,8 +2008,14 @@ if test -z "${R_HOME}"; then
     exit 1
 fi
 
-CXXFLAGS=`"${R_HOME}/bin/R" CMD config CXX11FLAGS`
+CXX=`"${R_HOME}/bin/R" CMD config CXX`
+if test -z "${CXX}"; then
+    as_fn_error $? "No C++ compiler available" "$LINENO" 5
+fi
+CXXFLAGS=`"${R_HOME}/bin/R" CMD config CXXFLAGS`
 CPPFLAGS=`"${R_HOME}/bin/R" CMD config CPPFLAGS`
+CXX11FLAGS=`"${R_HOME}/bin/R" CMD config CXX11FLAGS`
+CXX17FLAGS=`"${R_HOME}/bin/R" CMD config CXX17FLAGS`
 ac_ext=cpp
 ac_cpp='$CXXCPP $CPPFLAGS'
 ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'

--- a/configure.ac
+++ b/configure.ac
@@ -35,8 +35,14 @@ if test -z "${R_HOME}"; then
     exit 1
 fi
 
-CXXFLAGS=`"${R_HOME}/bin/R" CMD config CXX11FLAGS`
+CXX=`"${R_HOME}/bin/R" CMD config CXX`
+if test -z "${CXX}"; then
+    AC_MSG_ERROR([No C++ compiler available])
+fi
+CXXFLAGS=`"${R_HOME}/bin/R" CMD config CXXFLAGS`
 CPPFLAGS=`"${R_HOME}/bin/R" CMD config CPPFLAGS`
+CXX11FLAGS=`"${R_HOME}/bin/R" CMD config CXX11FLAGS`
+CXX17FLAGS=`"${R_HOME}/bin/R" CMD config CXX17FLAGS`
 AC_LANG(C++)
 AC_REQUIRE_CPP
 AC_PROG_CXX

--- a/configure.ac
+++ b/configure.ac
@@ -45,7 +45,7 @@ AC_PROG_CXX
 AC_PATH_PROG(have_pkg_config, pkg-config, no)
 ## If yes, also check for whether pkg-config knows tiledb
 if test x"${have_pkg_config}" != x"no"; then
-    AC_MSG_CHECKING([pkg-config knows TileDB])
+    AC_MSG_CHECKING([if pkg-config knows TileDB])
     if pkg-config --exists tiledb; then
         AC_MSG_RESULT([yes])
         tiledb_include=$(pkg-config --cflags tiledb)
@@ -69,7 +69,7 @@ fi
 
 ## If we have pkg-config, use it to test minimal version
 if test x"${have_pkg_config}" != x"no"; then
-    AC_MSG_CHECKING([pkg-config checking TileDB version])
+    AC_MSG_CHECKING([for pkg-config checking TileDB version])
     if pkg-config --atleast-version=2.0.0 tiledb; then
         AC_MSG_RESULT([>= 2.0.0])
     else
@@ -137,6 +137,12 @@ origCPPFLAGS="${CPPFLAGS}"
 origLDFLAGS="${LDFLAGS}"
 CPPFLAGS="${origCPPFLAGS} ${TILEDB_INCLUDE}"
 LDFLAGS="${origLDFLAGS} ${TILEDB_LIBS} ${TILEDB_RPATH}"
+if test x"${uname}" = x"Darwin"; then
+    AC_MSG_CHECKING([for Darwin minimum version override])
+    CXX17_MACOS="-mmacosx-version-min=10.14"
+    AC_MSG_RESULT([${CXX17_MACOS}])
+fi
+
 
 ## -- Part 3: Check for TileDB --------------------------------------------------
 ##
@@ -220,7 +226,7 @@ if test x"${have_tiledb}" = x"no"; then
     #AC_SUBST([TILEDB_INCLUDE], "-Itiledb-inst/include")
     AC_MSG_RESULT([using inst/tiledb/{lib,include}])
     RPATH=" -Wl,-rpath,'\$\$ORIGIN/../tiledb/lib'"
-    AC_SUBST([TILEDB_INCLUDE], "-I../inst/tiledb/include")
+    AC_SUBST([TILEDB_INCLUDE], "-I../inst/tiledb/include ${CXX17_MACOS}")
     AC_SUBST([TILEDB_LIBS], "-ltiledb -L../inst/tiledb/lib")
     AC_SUBST([TILEDB_RPATH], "${RPATH}")
 
@@ -228,6 +234,8 @@ if test x"${have_tiledb}" = x"no"; then
     LDFLAGS="${origLDFLAGS} ${TILEDB_LIBS} ${TILEDB_RPATH}"
 
 fi
+
+AC_SUBST([CXX17_MACOS])
 
 AC_CONFIG_FILES([src/Makevars])
 AC_OUTPUT

--- a/configure.ac
+++ b/configure.ac
@@ -143,8 +143,10 @@ origCPPFLAGS="${CPPFLAGS}"
 origLDFLAGS="${LDFLAGS}"
 CPPFLAGS="${origCPPFLAGS} ${TILEDB_INCLUDE}"
 LDFLAGS="${origLDFLAGS} ${TILEDB_LIBS} ${TILEDB_RPATH}"
-if test x"${uname}" = x"Darwin"; then
-    AC_MSG_CHECKING([for Darwin minimum version override])
+
+## Take care of 10.14 requirement for Intel macOS
+if test x"${uname}" = x"Darwin" -a x"${machine}" = x"x86_64"; then
+    AC_MSG_CHECKING([for Darwin x86_64 use minimum version override])
     CXX17_MACOS="-mmacosx-version-min=10.14"
     AC_MSG_RESULT([${CXX17_MACOS}])
 fi

--- a/src/Makevars.in
+++ b/src/Makevars.in
@@ -1,11 +1,14 @@
 ## We need C++17 to use TileDB's C++ API
 CXX_STD = CXX17
 
+## For macOS aka Darwin need to set minimum version 10.14 for macOS
+PKG_CXX17FLAGS = @CXX17_MACOS@
+
 ## We need the TileDB Headers
-PKG_CPPFLAGS =	-I../inst/include/ @TILEDB_INCLUDE@
+PKG_CPPFLAGS = -I../inst/include/ @TILEDB_INCLUDE@
 
 ## We also need the TileDB library
-PKG_LIBS = @TILEDB_LIBS@ @TILEDB_RPATH@
+PKG_LIBS = @CXX17_MACOS@ @TILEDB_LIBS@ @TILEDB_RPATH@
 
 all: $(SHLIB)
         # if we are

--- a/src/Makevars.ucrt
+++ b/src/Makevars.ucrt
@@ -1,2 +1,3 @@
 CRT=-ucrt
+CXX_STD = CXX17
 include Makevars.win

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,4 +1,4 @@
-CXX_STD = CXX11
+CXX_STD = CXX17
 RWINLIB = ../windows/rwinlib-tiledb
 
 PKG_CPPFLAGS = -I../inst/include -I$(RWINLIB)/include -DTILEDB_STATIC_DEFINE

--- a/src/shmem.cpp
+++ b/src/shmem.cpp
@@ -24,16 +24,16 @@
 // 'handshakes' from the TileDB Cloud backend, which is not published as open source.
 // They simply constitute an alternate mechanism of filling result data structures taking
 // advantage of an auxiliary parallel query tp TileDB Embedded (that is done solely for
-// performance reasons in the context of TileDB Cloud).
+// performance reasons in the context of TileDB Cloud). They are also made conditional
+// on building on Linux as the shared memory inter-process communication is only use there.
 
 #include "libtiledb.h"
 #include "finalizers.h"
 #include "tiledb_version.h"
 
+#ifdef __linux__
 #include <sys/types.h>
-#ifndef _WIN32
 #include <sys/mman.h>
-#endif
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <unistd.h>
@@ -42,9 +42,6 @@
 
 static const bool debug = false;
 
-using namespace Rcpp;
-
-#ifdef __linux__
 static std::string _datafile(const std::string dir, const std::string name) {
     std::string path = std::string("/dev/shm/") + dir + std::string("/buffers/data/");
     if (!std::filesystem::is_directory(path)) std::filesystem::create_directories(path);

--- a/tools/tiledbVersion.txt
+++ b/tools/tiledbVersion.txt
@@ -1,2 +1,2 @@
-version: 2.5.0-rc1
-sha: ded43f7
+version: 2.5.0
+sha: d11292d

--- a/tools/tiledbVersion.txt
+++ b/tools/tiledbVersion.txt
@@ -1,2 +1,2 @@
-version: 2.4.3
-sha: 5cb0824
+version: 2.5.0-rc0
+sha: 9a8fbc1

--- a/tools/tiledbVersion.txt
+++ b/tools/tiledbVersion.txt
@@ -1,2 +1,2 @@
-version: 2.5.0-rc0
-sha: 9a8fbc1
+version: 2.5.0-rc1
+sha: ded43f7


### PR DESCRIPTION
This ~(for now in draft)~ PR will turn on TileDB 2.5.0 when released. It currently tests fine on Linux and macOS against 2.5.0-rc0, tested fine against 2.5.0-rc1 earlier today and is now running with 2.5.0.