### PR TITLE
Re-enable Windows UCRT tests

### DIFF
--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -12,8 +12,8 @@ jobs:
       matrix:
         include: [
           { windows: windows-2019, r: release    },
-          { windows: windows-2022, r: devel      }#,
-          #{ windows: windows-2022, r: devel-ucrt }
+          { windows: windows-2022, r: devel      },
+          { windows: windows-2022, r: devel-ucrt }
         ]
     steps:
       - run: git config --global core.autocrlf false

--- a/tools/fetchTileDBLib.R
+++ b/tools/fetchTileDBLib.R
@@ -31,7 +31,7 @@ ver <- dcf[[1, "version"]]
 sha <- dcf[[1, "sha"]]
 
 ## on linux, we need to consider AVX2 vs non-AVX2 capabilities on the build machine
-avx2 <- if (arch == "linux" && any(grepl("avx2", readLines("/proc/cpuinfo")))) "" else "-noavx2"
+avx2 <- if (osarg == "linux" && any(grepl("avx2", readLines("/proc/cpuinfo")))) "" else "-noavx2"
 
 ## downloads are from GitHub releases
 baseurl <- "https://github.com/TileDB-Inc/TileDB/releases/download"


### PR DESCRIPTION
This simple PR reactivates tests on Windows using the newer / alternate UCRT setup.  These had been suspended when the (required) `nanotime` package was unavailable as a binary and the test setup seemingly failed to flip back to source.  

@jeroen pointed me to [alternate / newer actions](https://github.com/r-lib/gert/blob/main/.github/workflows/R-CMD-check.yaml#L41-L45) we could use too,