### PR TITLE
Update stopifnot() assertions

### DIFF
--- a/R/Array.R
+++ b/R/Array.R
@@ -39,8 +39,8 @@
 #'
 #' @export
 tiledb_array_create <- function(uri, schema, encryption_key) {
-    stopifnot(`argument 'uri' must be a string scalar` = !missing(uri) && is.scalar(uri, "character"),
-              `argument 'schema' must a tiledb_array_schema object` = !missing(schema) && is(schema, "tiledb_array_schema"))
+    stopifnot(`The 'uri' argument must be a string scalar` = !missing(uri) && is.scalar(uri, "character"),
+              `The 'schema' argument must a tiledb_array_schema object` = !missing(schema) && is(schema, "tiledb_array_schema"))
     if (missing(encryption_key)) {
         return(libtiledb_array_create(uri, schema@ptr))
     } else {
@@ -56,7 +56,7 @@ tiledb_array_create <- function(uri, schema, encryption_key) {
 ##' @importFrom methods .hasSlot
 ##' @export
 tiledb_array_open <- function(arr, type=c("READ","WRITE")) {
-  stopifnot(`argument 'arr' must be a tiledb_array object` = is(arr, "tiledb_array") || is(arr, "tiledb_sparse") || is(arr, "tiledb_dense"))
+  stopifnot(`The 'arr' argument must be a tiledb_array object` = is(arr, "tiledb_array") || is(arr, "tiledb_sparse") || is(arr, "tiledb_dense"))
   type <- match.arg(type)
 
   if (.hasSlot(arr, "encryption_key") && length(arr@encryption_key) > 0) {
@@ -76,8 +76,8 @@ tiledb_array_open <- function(arr, type=c("READ","WRITE")) {
 ##' @return The TileDB Array object but opened for reading or writing
 ##' @export
 tiledb_array_open_at <- function(arr, type=c("READ","WRITE"), timestamp) {
-  stopifnot(`argument 'arr' must be a tiledb_array object` = is(arr, "tiledb_array") || is(arr, "tiledb_sparse") || is(arr, "tiledb_dense"),
-            `argument 'timestamp' must a time object` = inherits(timestamp, "POSIXct"))
+  stopifnot(`The 'arr' argument must be a tiledb_array object` = is(arr, "tiledb_array") || is(arr, "tiledb_sparse") || is(arr, "tiledb_dense"),
+            `The 'timestamp' argument must a time object` = inherits(timestamp, "POSIXct"))
   type <- match.arg(type)
   ctx <- tiledb_get_context()
   if (.hasSlot(arr, "encryption_key") && length(arr@encryption_key) > 0) {
@@ -95,7 +95,7 @@ tiledb_array_open_at <- function(arr, type=c("READ","WRITE"), timestamp) {
 ##' @return The TileDB Array object but closed
 ##' @export
 tiledb_array_close <- function(arr) {
-  stopifnot(`argument 'arr' must be a tiledb_array object` = is(arr, "tiledb_array") || is(arr, "tiledb_sparse") || is(arr, "tiledb_dense"))
+  stopifnot(`The 'arr' argument must be a tiledb_array object` = is(arr, "tiledb_array") || is(arr, "tiledb_sparse") || is(arr, "tiledb_dense"))
   libtiledb_array_close(arr@ptr)
   arr
 }
@@ -106,7 +106,7 @@ tiledb_array_close <- function(arr) {
 ##' @return A boolean indicating if the array has homogeneous domains
 ##' @export
 tiledb_array_is_homogeneous <- function(arr) {
-  stopifnot(`argument 'arr' must be a tiledb_array object` = is(arr, "tiledb_array") || is(arr, "tiledb_sparse") || is(arr, "tiledb_dense"))
+  stopifnot(`The argument 'arr' must be a tiledb_array object` = is(arr, "tiledb_array") || is(arr, "tiledb_sparse") || is(arr, "tiledb_dense"))
   ## there is a non-exported call at the C level we could use instead
   sch <- schema(arr)
   dom <- domain(sch)
@@ -122,7 +122,7 @@ tiledb_array_is_homogeneous <- function(arr) {
 ##' @return A boolean indicating if the array has heterogenous domains
 ##' @export
 tiledb_array_is_heterogeneous <- function(arr) {
-  stopifnot(`argument 'arr' must be a tiledb_array object` = is(arr, "tiledb_array") || is(arr, "tiledb_sparse") || is(arr, "tiledb_dense"))
+  stopifnot(`The 'arr' argument must be a tiledb_array object` = is(arr, "tiledb_array") || is(arr, "tiledb_sparse") || is(arr, "tiledb_dense"))
   ## there is a non-exported call at the C level we could use instead
   sch <- schema(arr)
   dom <- domain(sch)

--- a/R/Array.R
+++ b/R/Array.R
@@ -1,6 +1,6 @@
 #  MIT License
 #
-#  Copyright (c) 2017-2020 TileDB Inc.
+#  Copyright (c) 2017-2021 TileDB Inc.
 #
 #  Permission is hereby granted, free of charge, to any person obtaining a copy
 #  of this software and associated documentation files (the "Software"), to deal
@@ -39,16 +39,13 @@
 #'
 #' @export
 tiledb_array_create <- function(uri, schema, encryption_key) {
-  if (missing(uri) || !is.scalar(uri, "character")) {
-    stop("argument uri must be a string scalar")
-  } else if (missing(schema) || !is(schema, "tiledb_array_schema")) {
-    stop("argument schema must a tiledb_array_schema")
-  }
-  if (missing(encryption_key)) {
-    return(libtiledb_array_create(uri, schema@ptr))
-  } else {
-    return(libtiledb_array_create_with_key(uri, schema@ptr, encryption_key))
-  }
+    stopifnot(`argument 'uri' must be a string scalar` = !missing(uri) && is.scalar(uri, "character"),
+              `argument 'schema' must a tiledb_array_schema object` = !missing(schema) && is(schema, "tiledb_array_schema"))
+    if (missing(encryption_key)) {
+        return(libtiledb_array_create(uri, schema@ptr))
+    } else {
+        return(libtiledb_array_create_with_key(uri, schema@ptr, encryption_key))
+    }
 }
 
 ##' Open a TileDB Array
@@ -59,6 +56,7 @@ tiledb_array_create <- function(uri, schema, encryption_key) {
 ##' @importFrom methods .hasSlot
 ##' @export
 tiledb_array_open <- function(arr, type=c("READ","WRITE")) {
+  stopifnot(`argument 'arr' must be a tiledb_array object` = is(arr, "tiledb_array") || is(arr, "tiledb_sparse") || is(arr, "tiledb_dense"))
   type <- match.arg(type)
 
   if (.hasSlot(arr, "encryption_key") && length(arr@encryption_key) > 0) {
@@ -78,7 +76,8 @@ tiledb_array_open <- function(arr, type=c("READ","WRITE")) {
 ##' @return The TileDB Array object but opened for reading or writing
 ##' @export
 tiledb_array_open_at <- function(arr, type=c("READ","WRITE"), timestamp) {
-  stopifnot(timestamp_argument=inherits(timestamp, "POSIXct"))
+  stopifnot(`argument 'arr' must be a tiledb_array object` = is(arr, "tiledb_array") || is(arr, "tiledb_sparse") || is(arr, "tiledb_dense"),
+            `argument 'timestamp' must a time object` = inherits(timestamp, "POSIXct"))
   type <- match.arg(type)
   ctx <- tiledb_get_context()
   if (.hasSlot(arr, "encryption_key") && length(arr@encryption_key) > 0) {
@@ -96,6 +95,7 @@ tiledb_array_open_at <- function(arr, type=c("READ","WRITE"), timestamp) {
 ##' @return The TileDB Array object but closed
 ##' @export
 tiledb_array_close <- function(arr) {
+  stopifnot(`argument 'arr' must be a tiledb_array object` = is(arr, "tiledb_array") || is(arr, "tiledb_sparse") || is(arr, "tiledb_dense"))
   libtiledb_array_close(arr@ptr)
   arr
 }
@@ -106,6 +106,7 @@ tiledb_array_close <- function(arr) {
 ##' @return A boolean indicating if the array has homogeneous domains
 ##' @export
 tiledb_array_is_homogeneous <- function(arr) {
+  stopifnot(`argument 'arr' must be a tiledb_array object` = is(arr, "tiledb_array") || is(arr, "tiledb_sparse") || is(arr, "tiledb_dense"))
   ## there is a non-exported call at the C level we could use instead
   sch <- schema(arr)
   dom <- domain(sch)
@@ -121,6 +122,7 @@ tiledb_array_is_homogeneous <- function(arr) {
 ##' @return A boolean indicating if the array has heterogenous domains
 ##' @export
 tiledb_array_is_heterogeneous <- function(arr) {
+  stopifnot(`argument 'arr' must be a tiledb_array object` = is(arr, "tiledb_array") || is(arr, "tiledb_sparse") || is(arr, "tiledb_dense"))
   ## there is a non-exported call at the C level we could use instead
   sch <- schema(arr)
   dom <- domain(sch)

--- a/R/ArraySchema.R
+++ b/R/ArraySchema.R
@@ -28,7 +28,7 @@ setClass("tiledb_array_schema",
          slots = list(ptr = "externalptr"))
 
 tiledb_array_schema.from_ptr <- function(ptr) {
-  stopifnot(`The 'ptr' argument must be a non NULL externalptr to a tiledb_array_schema instance` = { !missing(ptr), typeof(ptr) == "externalptr", !is.null(ptr) })
+  stopifnot(`The 'ptr' argument must be a non NULL externalptr to a tiledb_array_schema instance` = !missing(ptr) && typeof(ptr) == "externalptr" && !is.null(ptr) )
   new("tiledb_array_schema", ptr = ptr)
 }
 
@@ -433,7 +433,7 @@ setMethod("allows_dups", signature = "tiledb_array_schema", function(x) {
 #' @return the logical value
 #' @export
 tiledb_array_schema_get_allows_dups <- function(x) {
-  stopifnot(`The 'x' argument must be a tiledb_array object` = is(x, "tiledb_array") || is(x, "tiledb_sparse"))
+  stopifnot(`The 'x' argument must be a tiledb_array_schema object` = is(x, "tiledb_array_schema"))
   libtiledb_array_schema_get_allows_dups(x@ptr)
 }
 

--- a/R/ArraySchema.R
+++ b/R/ArraySchema.R
@@ -28,7 +28,7 @@ setClass("tiledb_array_schema",
          slots = list(ptr = "externalptr"))
 
 tiledb_array_schema.from_ptr <- function(ptr) {
-  stopifnot(`The 'ptr' argument must be a non NULL externalptr to a tiledb_array_schema instance` = !missing(ptr) && typeof(ptr) == "externalptr" && !is.null(ptr) )
+  stopifnot(`The 'ptr' argument must be a non NULL externalptr to a tiledb_array_schema instance` = !missing(ptr) && is(ptr, "externalptr") && !is.null(ptr) )
   new("tiledb_array_schema", ptr = ptr)
 }
 

--- a/R/ArraySchema.R
+++ b/R/ArraySchema.R
@@ -28,9 +28,7 @@ setClass("tiledb_array_schema",
          slots = list(ptr = "externalptr"))
 
 tiledb_array_schema.from_ptr <- function(ptr) {
-  if (missing(ptr) || typeof(ptr) != "externalptr" || is.null(ptr)) {
-    stop("ptr argument must be a non NULL externalptr to a tiledb_array_schema instance")
-  }
+  stopifnot(`The 'ptr' argument must be a non NULL externalptr to a tiledb_array_schema instance` = { !missing(ptr), typeof(ptr) == "externalptr", !is.null(ptr) })
   new("tiledb_array_schema", ptr = ptr)
 }
 
@@ -122,11 +120,8 @@ tiledb_array_schema <- function(domain,
 }
 
 tiledb_array_schema.from_array <- function(x, ctx = tiledb_get_context()) {
-  if (!is(ctx, "tiledb_ctx")) {
-    stop("ctx argument must be a tiledb_ctx")
-  } else if (missing(x) || !is.array(x)) {
-    stop("x argument must be a valid array object")
-  }
+  stopifnot(`The 'ctx' argument must be a tiledb_ctx object` = is(ctx, "tiledb_ctx"),
+            `The 'x' argument must be a valid array object` = !missing(x) && is.array(x))
   xdim <- dim(x)
   dims <- lapply(seq_len(xdim), function(i) {
     tiledb_dim(c(1L, xdim[i]), type = "INT32", ctx)
@@ -339,6 +334,8 @@ setMethod("filter_list", "tiledb_array_schema", function(object) {
 #' @return The modified Array Schema object
 #' @export
 tiledb_array_schema_set_coords_filter_list <- function(sch, fl) {
+  stopifnot(`The 'sch' argument must be a tiledb_array_schema object` = is(sch, "tiledb_array_schema"),
+            `The 'fl' argument must be a tiledb_filter_list object` = is(fl, "tiledb_filter_list"))
   sch@ptr <- libtiledb_array_schema_set_coords_filter_list(sch@ptr, fl@ptr)
   sch
 }
@@ -350,6 +347,8 @@ tiledb_array_schema_set_coords_filter_list <- function(sch, fl) {
 #' @return The modified Array Schema object
 #' @export
 tiledb_array_schema_set_offsets_filter_list <- function(sch, fl) {
+  stopifnot(`The 'sch' argument must be a tiledb_array_schema object` = is(sch, "tiledb_array_schema"),
+            `The 'fl' argument must be a tiledb_filter_list object` = is(fl, "tiledb_filter_list"))
   sch@ptr <- libtiledb_array_schema_set_offsets_filter_list(sch@ptr, fl@ptr)
   sch
 }
@@ -434,6 +433,7 @@ setMethod("allows_dups", signature = "tiledb_array_schema", function(x) {
 #' @return the logical value
 #' @export
 tiledb_array_schema_get_allows_dups <- function(x) {
+  stopifnot(`The 'x' argument must be a tiledb_array object` = is(x, "tiledb_array") || is(x, "tiledb_sparse"))
   libtiledb_array_schema_get_allows_dups(x@ptr)
 }
 
@@ -456,6 +456,8 @@ setMethod("allows_dups<-", signature = "tiledb_array_schema", function(x, value)
 #' @return the tiledb_array_schema object
 #' @export
 tiledb_array_schema_set_allows_dups <- function(x, value) {
+  stopifnot(`The 'x' argument must be a tiledb_array_schema object` = is(x, "tiledb_array_schema"),
+            `The 'value' argument must be a boolean` = is.logical(value))
   libtiledb_array_schema_set_allows_dups(x@ptr, value)
 }
 
@@ -465,7 +467,7 @@ tiledb_array_schema_set_allows_dups <- function(x, value) {
 ##' @return A character vector of dimension and attribute names
 ##' @export
 tiledb_schema_get_names <- function(sch) {
-  stopifnot(`Argument must be a schema` = is(sch, "tiledb_array_schema"))
+  stopifnot(`The 'sch' argument must be a schema` = is(sch, "tiledb_array_schema"))
   dom <- tiledb::domain(sch)
   dims <- tiledb::dimensions(dom)
   ndims <- length(dims)
@@ -483,7 +485,7 @@ tiledb_schema_get_names <- function(sch) {
 ##' @return A character vector of dimension and attribute data types
 ##' @export
 tiledb_schema_get_types <- function(sch) {
-  stopifnot(`Argument must be a schema` = is(sch, "tiledb_array_schema"))
+  stopifnot(`The 'sch' argument must be a schema` = is(sch, "tiledb_array_schema"))
   dom <- tiledb::domain(sch)
   dims <- tiledb::dimensions(dom)
   ndims <- length(dims)
@@ -503,7 +505,7 @@ tiledb_schema_get_types <- function(sch) {
 ##' @return An integer vector where each element corresponds to a schema entry,
 ##' and a value of one signals dimension and a value of two an attribute.
 tiledb_schema_get_dim_attr_status <- function(sch) {
-  stopifnot(`Argument must be a schema` = is(sch, "tiledb_array_schema"))
+  stopifnot(`The 'sch' argument must be a schema` = is(sch, "tiledb_array_schema"))
   dom <- tiledb::domain(sch)
   dims <- tiledb::dimensions(dom)
   attrs <- tiledb::attrs(sch)
@@ -541,6 +543,7 @@ setReplaceMethod("capacity", signature = "tiledb_array_schema", function(x, valu
 #' @return The tile capacity value
 #' @export
 tiledb_array_schema_get_capacity <- function(object) {
+  stopifnot(`The argument must be a tiledb_array_schema object` = is(object, "tiledb_array_schema"))
   libtiledb_array_schema_get_capacity(object@ptr)
 }
 
@@ -552,6 +555,8 @@ tiledb_array_schema_get_capacity <- function(object) {
 #' @return The modified \code{array_schema} object
 #' @export
 tiledb_array_schema_set_capacity <- function(x, value) {
+  stopifnot(`The first argument must be a tiledb_array_schema object` = is(x, "tiledb_array_schema"),
+            `The second argumebt must a int or numeric value` = is.numeric(value))
   libtiledb_array_schema_set_capacity(x@ptr, value)
   x
 }
@@ -579,6 +584,7 @@ setMethod("check", signature = "tiledb_array_schema", function(object) {
 #' schema; for an incorrect schema an error condition is triggered.
 #' @export
 tiledb_array_schema_check <- function(object) {
+  stopifnot(`The argument must be a tiledb_array_schema object` = is(object, "tiledb_array_schema"))
   libtiledb_array_schema_check(object@ptr)
 }
 
@@ -592,7 +598,7 @@ tiledb_array_schema_check <- function(object) {
 #' @return A boolean value indicating if the attribute exists in the schema
 #' @export
 has_attribute <- function(schema, attr) {
-  stopifnot(schema_argument=is(schema, "tiledb_array_schema"),
-            attr_argument=is.character(attr))
+  stopifnot(`The 'schema' argument must be an array schema` = is(schema, "tiledb_array_schema"),
+            `The 'attr' argument must be a character` = is.character(attr))
   libtiledb_array_schema_has_attribute(schema@ptr, attr)
 }

--- a/R/ArrowIO.R
+++ b/R/ArrowIO.R
@@ -31,8 +31,8 @@
 ##' pointers to the Arrow array and schema
 ##' @export
 tiledb_query_export_buffer <- function(query, name, ctx = tiledb_get_context()) {
-    stopifnot(`query argument`=is(query, "tiledb_query"),
-              `name argument`=is.character(name))
+    stopifnot(`The 'query' argument must be a tiledb query` = is(query, "tiledb_query"),
+              `The 'name' argument must be character` = is.character(name))
     res <- libtiledb_query_export_buffer(ctx@ptr, query@ptr, name)
     res
 }
@@ -49,10 +49,9 @@ tiledb_query_export_buffer <- function(query, name, ctx = tiledb_get_context()) 
 ##' @return The update Query external pointer is returned
 ##' @export
 tiledb_query_import_buffer <- function(query, name, arrowpointers, ctx = tiledb_get_context()) {
-    stopifnot(`query argument` = is(query, "tiledb_query"),
-              `name argument` = is.character(name),
-              `arrow pointers` = is.numeric(arrowpointers),
-              `length of arrow pointers vectors` = length(arrowpointers)==2)
+    stopifnot(`The 'query' argument must be a tiledb query` = is(query, "tiledb_query"),
+              `The 'name' argument must be character` = is.character(name),
+              `The 'arrowpointers' argument must be length-2 vector` = is.numeric(arrowpointers) && is.vector(arrowpointers) && length(arrowpointers)==2)
     query@ptr <- libtiledb_query_import_buffer(ctx@ptr, query@ptr, name, arrowpointers)
     query
 }

--- a/R/Attribute.R
+++ b/R/Attribute.R
@@ -28,9 +28,9 @@ setClass("tiledb_attr",
          slots = list(ptr = "externalptr"))
 
 tiledb_attr.from_ptr <- function(ptr) {
-   if (typeof(ptr) != "externalptr" || is.null(ptr)) {
-    stop("ptr argument must be a non NULL externalptr to a tiledb::Attribute instance")
-  }
+  stopifnot(`The 'ptr' argument must be a non-NULL external pointer to an Attribute instance` =
+                typeof(ptr) == "externalptr" && !is.null(ptr))
+
   new("tiledb_attr", ptr = ptr)
 }
 
@@ -61,19 +61,11 @@ tiledb_attr <- function(name,
                         nullable = FALSE,
                         ctx = tiledb_get_context()
                         ) {
-    if (missing(name)) {
-        name <- ""
-    }
-    if (missing(type)) {
-        stop("The 'type' argument for tiledb_attr() is mandatory")
-    }
-    if (!is(ctx, "tiledb_ctx")) {
-        stop("ctx argument must be a tiledb_ctx")
-    } else if (!is.scalar(name, "character")) {
-        stop("name argument must be a scalar string")
-    } else if(!is(filter_list, "tiledb_filter_list")) {
-        stop("filter_list argument must be a tiledb_filter_list instance")
-    }
+    if (missing(name)) name <- ""
+    stopifnot(`The 'type' argument for is mandatory` = !missing(type),
+              `The 'ctx' argument must be a tiledb_ctx` = is(ctx, "tiledb_ctx"),
+              `The 'name' argument must be a scalar string` = is.scalar(name, "character"),
+              `The 'filter_list' argument must be a tiledb_filter_list instance` = is(filter_list, "tiledb_filter_list"))
     ptr <- libtiledb_attribute(ctx@ptr, name, type, filter_list@ptr, ncells, nullable)
     new("tiledb_attr", ptr = ptr)
 }
@@ -251,8 +243,8 @@ tiledb_attribute_get_fill_value <- function(attr) {
 #' @return \code{NULL} is returned invisibly
 #' @export
 tiledb_attribute_set_fill_value <- function(attr, value) {
-  stopifnot(attr_object=is(attr, "tiledb_attr"),
-            value_type=is.integer(value) || is.numeric(value) || is.character(value))
+  stopifnot(`The first argument must be an attribute` = is(attr, "tiledb_attr"),
+            `The second argument must be int, numeric or char` = is.integer(value) || is.numeric(value) || is.character(value))
   libtiledb_attribute_set_fill_value(attr@ptr, value)
   invisible()
 }
@@ -263,7 +255,7 @@ tiledb_attribute_set_fill_value <- function(attr, value) {
 #' @return A boolean value indicating variable-size or not
 #' @export
 tiledb_attribute_is_variable_sized <- function(attr) {
-  stopifnot(attr_object=is(attr, "tiledb_attr"))
+  stopifnot(`The argument must be an attribute` = is(attr, "tiledb_attr"))
   libtiledb_attribute_is_variable_sized(attr@ptr)
 }
 
@@ -273,7 +265,7 @@ tiledb_attribute_is_variable_sized <- function(attr) {
 #' @return A numeric value with the cell size
 #' @export
 tiledb_attribute_get_cell_size <- function(attr) {
-  stopifnot(attr_object=is(attr, "tiledb_attr"))
+  stopifnot(`The argument must be an attribute` = is(attr, "tiledb_attr"))
   libtiledb_attribute_get_cell_size(attr@ptr)
 }
 
@@ -284,9 +276,9 @@ tiledb_attribute_get_cell_size <- function(attr) {
 #' @return Nothing is returned
 #' @export
 tiledb_attribute_set_nullable <- function(attr, flag) {
-    stopifnot(attr_object=is(attr, "tiledb_attr"),
-              flag_boolean_not_na=is.logical(flag) & !is.na(flag))
-    libtiledb_attribute_set_nullable(attr@ptr, flag)
+  stopifnot(`The first argument must be an attribute` = is(attr, "tiledb_attr"),
+            `The second argument must be a logical` = is.logical(flag) && !is.na(flag))
+  libtiledb_attribute_set_nullable(attr@ptr, flag)
 }
 
 #' Get the TileDB Attribute Nullable flag value
@@ -295,6 +287,6 @@ tiledb_attribute_set_nullable <- function(attr, flag) {
 #' @return A boolean value with the \sQuote{Nullable} status
 #' @export
 tiledb_attribute_get_nullable <- function(attr) {
-    stopifnot(attr_object=is(attr, "tiledb_attr"))
+    stopifnot(`The argument must be an attribute` = is(attr, "tiledb_attr"))
     libtiledb_attribute_get_nullable(attr@ptr)
 }

--- a/R/Attribute.R
+++ b/R/Attribute.R
@@ -29,8 +29,7 @@ setClass("tiledb_attr",
 
 tiledb_attr.from_ptr <- function(ptr) {
   stopifnot(`The 'ptr' argument must be a non-NULL external pointer to an Attribute instance` =
-                typeof(ptr) == "externalptr" && !is.null(ptr))
-
+                !missing(ptr) && is(ptr, "externalptr") && !is.null(ptr))
   new("tiledb_attr", ptr = ptr)
 }
 

--- a/R/Config.R
+++ b/R/Config.R
@@ -29,7 +29,7 @@ setClass("tiledb_config",
 
 #' @importFrom methods new
 tiledb_config.from_ptr <- function(ptr) {
-    stopifnot(`ptr must be a non-NULL externalptr to a tiledb_config instance` = typeof(ptr) == "externalptr" && !is.null(ptr))
+    stopifnot(`ptr must be a non-NULL externalptr to a tiledb_config instance` = !missing(ptr) && is(ptr, "externalptr") && !is.null(ptr))
     new("tiledb_config", ptr = ptr)
 }
 

--- a/R/Config.R
+++ b/R/Config.R
@@ -1,6 +1,6 @@
 #  MIT License
 #
-#  Copyright (c) 2017-2020 TileDB Inc.
+#  Copyright (c) 2017-2021 TileDB Inc.
 #
 #  Permission is hereby granted, free of charge, to any person obtaining a copy
 #  of this software and associated documentation files (the "Software"), to deal
@@ -29,10 +29,8 @@ setClass("tiledb_config",
 
 #' @importFrom methods new
 tiledb_config.from_ptr <- function(ptr) {
-  if (typeof(ptr) != "externalptr" || is.null(ptr)) {
-    stop("ptr must be a non NULL externalptr to a tiledb_config instance")
-  }
-  new("tiledb_config", ptr = ptr)
+    stopifnot(`ptr must be a non-NULL externalptr to a tiledb_config instance` = typeof(ptr) == "externalptr" && !is.null(ptr))
+    new("tiledb_config", ptr = ptr)
 }
 
 #' Creates a `tiledb_config` object
@@ -58,9 +56,7 @@ tiledb_config.from_ptr <- function(ptr) {
 #' @export tiledb_config
 tiledb_config <- function(config = NA_character_) {
   if (!is.na(config)) {
-    if (typeof(config) != "character" || is.null(names(config))) {
-      stop("config argument must be a name, value character vector")
-    }
+    stopifnot(`If given, the 'config' argument must be a name, value character vector` = is.character(config) && !is.null(names(config)))
     ptr <- libtiledb_config(config)
   } else {
     ptr <- libtiledb_config()
@@ -86,12 +82,8 @@ tiledb_config <- function(config = NA_character_) {
 #' @aliases [,tiledb_config,ANY,tiledb_config-method
 #' @aliases [,tiledb_config,ANY,ANY,tiledb_config-method
 setMethod("[", "tiledb_config", function(x, i, j, ..., drop=FALSE) {
-  if (!is.character(i)) {
-    stop("tiledb_config subscript must be of type 'character'")
-  }
-  if (!missing(j)) {
-    stop("incorrect number of subscripts")
-  }
+  stopifnot(`The first subscript in tiledb_config subscript must be of type 'character'` = is.character(i),
+            `The second subscript is currently unused` = missing(j))
   tryCatch(libtiledb_config_get(x@ptr, i), error = function(e) NA)
 })
 
@@ -116,18 +108,13 @@ setMethod("[", "tiledb_config", function(x, i, j, ..., drop=FALSE) {
 #' @aliases [<-,tiledb_config,ANY,tiledb_config-method
 #' @aliases [<-,tiledb_config,ANY,ANY,tiledb_config-method
 setMethod("[<-", "tiledb_config", function(x, i, j, value) {
-  if (!is.character(i)) {
-    stop("tiledb_config subscript must be of type 'character'")
-  } else if (!missing(j)) {
-    stop("incorrect number of subscripts")
-  } else if (!is.character(value)) {
-    if (is.double(value) || is.integer(value)) {
-      value <- as.character(value)
-    } else if (is.logical(value)) {
-      value <- if (isTRUE(value)) "true" else "false"
-    } else {
-      stop("tiledb_config parameter value must be a 'character', 'double', 'integer' or 'logical'")
-    }
+  stopifnot(`The first subscript in tiledb_config subscript must be of type 'character'` = is.character(i),
+            `The second subscript is currently unused` = missing(j),
+            `The value argument must be be int, numeric, character or logical` = is.logical(value) || is.character(value) || is.numeric(value))
+  if (is.logical(value)) {
+    value <- if (isTRUE(value)) "true" else "false"
+  } else {
+    value <- as.character(value)
   }
   libtiledb_config_set(x@ptr, i, value)
   x
@@ -160,8 +147,8 @@ setMethod("show", signature(object = "tiledb_config"), function(object) {
 #'
 #' @export
 tiledb_config_save <- function(config, path) {
-  stopifnot(class(config) == "tiledb_config")
-  stopifnot(typeof(path) == "character")
+  stopifnot(`The 'config' argument must be a tiledb_config object` = is(config, "tiledb_config"),
+            `The 'path' argument must be of type character` = is.character(path))
   libtiledb_config_save_to_file(config@ptr, path)
 }
 
@@ -178,7 +165,7 @@ tiledb_config_save <- function(config, path) {
 #'
 #' @export
 tiledb_config_load <- function(path) {
-  stopifnot(typeof(path) == "character")
+  stopifnot(`The 'path' argument must be of type character` = is.character(path))
   ptr <- libtiledb_config_load_from_file(path)
   tiledb_config.from_ptr(ptr)
 }
@@ -195,6 +182,7 @@ tiledb_config_load <- function(path) {
 #'
 #' @export
 as.vector.tiledb_config <- function(x, mode="any") {
+  stopifnot(`The 'x' argument must be a tiledb_config object` = is(x, "tiledb_config"))
   libtiledb_config_vector(x@ptr)
 }
 
@@ -208,10 +196,11 @@ as.vector.tiledb_config <- function(x, mode="any") {
 #'
 #' @export
 as.data.frame.tiledb_config <- function(x, ...) {
+  stopifnot(`The 'x' argument must be a tiledb_config object` = is(x, "tiledb_config"))
   v <- libtiledb_config_vector(x@ptr)
   params <- names(v)
   values <- as.vector(v)
-  return(data.frame("parameter" = params, "value" = values, stringsAsFactors = FALSE))
+  data.frame("parameter" = params, "value" = values, stringsAsFactors = FALSE)
 }
 
 #' Limit TileDB core use to a given number of cores
@@ -242,6 +231,7 @@ limitTileDBCores <- function(ncores, verbose=FALSE) {
     ## and then keep the smaller
     ncores <- min(na.omit(c(ncores, ompcores)))
   }
+  stopifnot(`The 'ncores' argument must be numeric or character` = is.numeric(ncores) || is.character(ncores))
   cfg <- tiledb_config()
   if (tiledb_version(TRUE) >= "2.1.0") {
     cfg["sm.compute_concurrency_level"] <- ncores
@@ -251,11 +241,6 @@ limitTileDBCores <- function(ncores, verbose=FALSE) {
     cfg["sm.num_writer_threads"] <- ncores
     cfg["vfs.file.max_parallel_ops"] <- ncores
     cfg["vfs.num_threads"] <- ncores
-  }
-  if (tiledb_version(TRUE) >= "2.4.0" &&
-      isTRUE(Sys.getenv("TILEDB_USE_REFACTORED_READERS") == "true")) {
-      cfg["sm.use_refactored_readers"] <- "true"
-      if (verbose) message("Enabling refactored readers.")
   }
   if (verbose) message("Limiting TileDB to ",ncores," cores. See ?limitTileDBCores.")
   invisible(cfg)
@@ -268,7 +253,7 @@ limitTileDBCores <- function(ncores, verbose=FALSE) {
 #' @return The modified TileDB Config object
 #' @export
 tiledb_config_unset <- function(config, param) {
-  stopifnot(config_object=is(config, "tiledb_config"),
-            param_argument=is.character(param))
+  stopifnot(`The 'config' argument must be a tiledb_config object` = is(config, "tiledb_config"),
+            `The 'param' argument must be of type character` = is.character(param))
   libtiledb_config_unset(config@ptr, param)
 }

--- a/R/Ctx.R
+++ b/R/Ctx.R
@@ -57,6 +57,7 @@ getContext <- function() tiledb_get_context()
 #' storing the VFS object.
 #' @export
 tiledb_set_context <- function(ctx) {
+  stopifnot(`The 'ctx' argument must be a tiledb_ctx object` = is(ctx, "tiledb_ctx"))
   ## set the ctx entry from the package environment (a lightweight hash)
   .pkgenv[["ctx"]] <- ctx
   invisible(NULL)
@@ -152,7 +153,9 @@ setMethod("config", signature(object = "tiledb_ctx"),
 #'
 #' @export
 tiledb_is_supported_fs <- function(scheme, object = tiledb_get_context()) {
-            libtiledb_ctx_is_supported_fs(object@ptr, scheme)
+  stopifnot(`The 'object' argument must be a tiledb_ctx object` = is(object, "tiledb_ctx"),
+            `The 'scheme' argument must be of type character` = is.character(scheme))
+  libtiledb_ctx_is_supported_fs(object@ptr, scheme)
 }
 
 #' Sets a string:string "tag" on the Ctx
@@ -167,7 +170,9 @@ tiledb_is_supported_fs <- function(scheme, object = tiledb_get_context()) {
 #'
 #' @export
 tiledb_ctx_set_tag <- function(object, key, value) {
-  stopifnot(is(object, "tiledb_ctx"))
+  stopifnot(`The 'object' argument must be a tiledb_ctx object` = is(object, "tiledb_ctx"),
+            `The 'key' argument must be of type character` = is.character(key),
+            `The 'value' argument must be of type character` = is.character(key))
   return(libtiledb_ctx_set_tag(object@ptr, key, value))
 }
 
@@ -176,8 +181,7 @@ tiledb_ctx_set_tag <- function(object, key, value) {
 #' @param object `tiledb_ctx` object
 #' @importFrom utils packageVersion
 tiledb_ctx_set_default_tags <- function(object) {
-  stopifnot(is(object, "tiledb_ctx"))
-
+  stopifnot(`The 'object' argument must be a tiledb_ctx object` = is(object, "tiledb_ctx"))
   tiledb_ctx_set_tag(object, "x-tiledb-api-language", "r")
   tiledb_ctx_set_tag(object, "x-tiledb-api-language-version", as.character(packageVersion("tiledb")))
   info <- Sys.info()

--- a/R/DataFrame.R
+++ b/R/DataFrame.R
@@ -75,8 +75,8 @@ fromDataFrame <- function(obj, uri, col_index=NULL, sparse=TRUE, allows_dups=spa
                           cell_order = "COL_MAJOR", tile_order = "COL_MAJOR", filter="ZSTD",
                           capacity = 10000L, tile_domain = NULL, tile_extent = NULL, debug = FALSE) {
 
-    if (!inherits(obj, "data.frame")) stop("Argument 'obj' should be a 'data.frame' (or a related object).", call. = FALSE)
-    if (!is.character(uri)) stop("Argument 'uri' should be a character variable.", call. = FALSE)
+    stopifnot(`Argument 'obj' should be a 'data.frame' (or a related object)` = inherits(obj, "data.frame"),
+              `Argument 'uri' should be a character variable` = is.character(uri))
     if (!is.null(col_index) && is.character(col_index)) col_index <- match(col_index, colnames(obj))
     dims <- dim(obj)
 
@@ -224,7 +224,6 @@ fromDataFrame <- function(obj, uri, col_index=NULL, sparse=TRUE, allows_dups=spa
 }
 
 .testWithDate <- function(df, uri) {
-  #df <- read.csv("~/git/tiledb-data/csv-pandas/banklist.csv", stringsAsFactors = FALSE)
   bkdf <- within(df, {
     Closing.Date <- as.Date(Closing.Date, "%d-%b-%y")
     Updated.Date <- as.Date(Updated.Date, "%d-%b-%y")

--- a/R/DenseArray.R
+++ b/R/DenseArray.R
@@ -199,7 +199,8 @@ subarray_dim <- function(sub) {
 }
 
 attribute_buffers <- function(array, sch, dom, sub, selected) {
-  stopifnot(`The 'dom' argument must be a tiledb_domain object` = is(dom, "tiledb_domain"),
+  stopifnot(`The 'array' argument must be a tiledb_array` = .isArray(array),
+            `The 'dom' argument must be a tiledb_domain object` = is(dom, "tiledb_domain"),
             `The 'sch' argument must be a tiledb_array_schema` = is(sch, "tiledb_array_schema"))
   sub_dim <- subarray_dim(sub)
   ncells <- prod(sub_dim)

--- a/R/DenseArray.R
+++ b/R/DenseArray.R
@@ -1,6 +1,6 @@
 #  MIT License
 #
-#  Copyright (c) 2017-2020 TileDB Inc.
+#  Copyright (c) 2017-2021 TileDB Inc.
 #
 #  Permission is hereby granted, free of charge, to any person obtaining a copy
 #  of this software and associated documentation files (the "Software"), to deal
@@ -63,12 +63,9 @@ tiledb_dense <- function(uri,
                          attrs = character(),
                          extended = FALSE,
                          ctx = tiledb_get_context()) {
-  query_type = match.arg(query_type)
-  if (!is(ctx, "tiledb_ctx")) {
-    stop("argument ctx must be a tiledb_ctx")
-  } else if (missing(uri) || !is.scalar(uri, "character")) {
-    stop("argument uri must be a string scalar")
-  }
+  query_type <- match.arg(query_type)
+  stopifnot(`Argument 'ctx' must be a tiledb_ctx object` = is(ctx, "tiledb_ctx"),
+            `Argument 'uri' must be a string scalar` = !missing(uri) && is.scalar(uri, "character"))
   .Deprecated("tiledb_array")
   array_xptr <- libtiledb_array_open(ctx@ptr, uri, query_type)
   schema_xptr <- libtiledb_array_get_schema(array_xptr)
@@ -152,7 +149,7 @@ setMethod("schema", "tiledb_dense", function(object, ...) {
 })
 
 domain_subarray <- function(dom, index = NULL) {
-  stopifnot(is(dom, "tiledb_domain"))
+  stopifnot(`The 'dom' argument must be a tiledb_domain object` = is(dom, "tiledb_domain"))
   nd <- tiledb_ndim(dom)
   dims <- tiledb::dimensions(dom)
   # return the whole domain
@@ -202,8 +199,8 @@ subarray_dim <- function(sub) {
 }
 
 attribute_buffers <- function(array, sch, dom, sub, selected) {
-  stopifnot(is(sch, "tiledb_array_schema"))
-  stopifnot(is(dom, "tiledb_domain"))
+  stopifnot(`The 'dom' argument must be a tiledb_domain object` = is(dom, "tiledb_domain"),
+            `The 'sch' argument must be a tiledb_array_schema` = is(sch, "tiledb_array_schema"))
   sub_dim <- subarray_dim(sub)
   ncells <- prod(sub_dim)
   is_scalar <- all(sub_dim == 1L)
@@ -520,7 +517,7 @@ setMethod("[<-", "tiledb_dense",
 
 #' @export
 as.array.tiledb_dense <- function(x, ...) {
- return(x[])
+  return(x[])
 }
 
 #' @export

--- a/R/Dim.R
+++ b/R/Dim.R
@@ -1,6 +1,6 @@
 #  MIT License
 #
-#  Copyright (c) 2017-2020 TileDB Inc.
+#  Copyright (c) 2017-2021 TileDB Inc.
 #
 #  Permission is hereby granted, free of charge, to any person obtaining a copy
 #  of this software and associated documentation files (the "Software"), to deal
@@ -29,9 +29,7 @@ setClass("tiledb_dim",
 
 #' @importFrom methods new
 tiledb_dim.from_ptr <- function(ptr) {
-  if (missing(ptr) || typeof(ptr) != "externalptr" || is.null(ptr)) {
-    stop("ptr argument must be a non NULL externalptr to a tiledb::Dim instance")
-  }
+  stopifnot(`ptr must be a non-NULL externalptr to a tiledb_dim` = !missing(ptr) && typeof(ptr) == "externalptr" && !is.null(ptr))
   return(new("tiledb_dim", ptr = ptr))
 }
 
@@ -54,12 +52,9 @@ tiledb_dim.from_ptr <- function(ptr) {
 #' @importFrom methods new
 #' @export tiledb_dim
 tiledb_dim <- function(name, domain, tile, type, ctx = tiledb_get_context()) {
-  if (missing(name)) {
-    stop("'name' argument must be supplied when creating a dimension object.")
-  }
-  if (!is.scalar(name, "character")) {
-    stop("'name' argument must be a scalar string when creating a dimension object.")
-  }
+  stopifnot(`Argument 'name' must be supplied when creating a dimension object` = !missing(name),
+            `Argument 'name' must be a scalar string when creating a dimension object` = is.scalar(name, "character"),
+            `Argument 'ctx' must be a tiledb_ctx object` = is(ctx, "tiledb_ctx"))
   if (missing(type)) {
     type <- ifelse(is.integer(domain), "INT32", "FLOAT64")
   } else if (!type %in% c("INT8", "INT16", "INT32", "INT64",
@@ -85,9 +80,6 @@ tiledb_dim <- function(name, domain, tile, type, ctx = tiledb_get_context()) {
       options("warn" = -1)              # suppress warnings
       domain <- as.numeric(domain)      # for this lossy conversion
       options("warn" = w)               # restore warning levels
-  }
-  if (!is(ctx, "tiledb_ctx")) {
-    stop("ctx argument must be a tiledb_ctx")
   }
   # by default, tile extent should span the whole domain
   if (missing(tile)) {
@@ -199,6 +191,7 @@ setMethod("tiledb_ndim", "tiledb_dim",
 #'
 #' @export
 is.anonymous.tiledb_dim <- function(object) {
+  stopifnot(`Argument 'object' must a tiledb_dim object` = is(object, "tiledb_dim"))
   name <- libtiledb_dim_get_name(object@ptr)
   return(nchar(name) == 0)
 }

--- a/R/Dim.R
+++ b/R/Dim.R
@@ -29,7 +29,7 @@ setClass("tiledb_dim",
 
 #' @importFrom methods new
 tiledb_dim.from_ptr <- function(ptr) {
-  stopifnot(`ptr must be a non-NULL externalptr to a tiledb_dim` = !missing(ptr) && typeof(ptr) == "externalptr" && !is.null(ptr))
+  stopifnot(`ptr must be a non-NULL externalptr to a tiledb_dim` = !missing(ptr) && is(ptr, "externalptr") && !is.null(ptr))
   return(new("tiledb_dim", ptr = ptr))
 }
 

--- a/R/Domain.R
+++ b/R/Domain.R
@@ -1,6 +1,6 @@
 #  MIT License
 #
-#  Copyright (c) 2017-2020 TileDB Inc.
+#  Copyright (c) 2017-2021 TileDB Inc.
 #
 #  Permission is hereby granted, free of charge, to any person obtaining a copy
 #  of this software and associated documentation files (the "Software"), to deal
@@ -28,9 +28,7 @@ setClass("tiledb_domain",
          slots = list(ptr = "externalptr"))
 
 tiledb_domain.from_ptr <- function(ptr) {
-  if (missing(ptr) || typeof(ptr) != "externalptr" || is.null(ptr)) {
-    stop("ptr argument must be a non NULL externalptr to a tiledb_domain instance")
-  }
+  stopifnot(`ptr must be a non-NULL externalptr to a tiledb_domain` = !missing(ptr) && typeof(ptr) == "externalptr" && !is.null(ptr))
   return(new("tiledb_domain", ptr = ptr))
 }
 
@@ -49,9 +47,7 @@ tiledb_domain.from_ptr <- function(ptr) {
 #' @importFrom methods new
 #' @export tiledb_domain
 tiledb_domain <- function(dims, ctx = tiledb_get_context()) {
-  if (!is(ctx, "tiledb_ctx")) {
-    stop("argument ctx must be a tiledb_ctx")
-  }
+  stopifnot(`Argument 'ctx' must be a tiledb_ctx object` = is(ctx, "tiledb_ctx"))
   is_dim <- function(obj) is(obj, "tiledb_dim")
   if (is_dim(dims)) {                   # if a dim object given:
     dims <- list(dims)                  # make it a vector so that lapply works below
@@ -183,8 +179,8 @@ dim.tiledb_domain <- function(x) {
 #' @return TileDB Dimension object
 #' @export
 tiledb_domain_get_dimension_from_index <- function(domain, idx) {
-  stopifnot(domain_argument=is(domain, "tiledb_domain"),
-            idx_argument=is.numeric(idx))
+  stopifnot(`The 'domain' argument must be a tiledb_domain` = is(domain, "tiledb_domain"),
+            `The 'idx' argument must be numeric` = is.numeric(idx))
   return(new("tiledb_dim", ptr=libtiledb_domain_get_dimension_from_index(domain@ptr, idx)))
 }
 
@@ -195,8 +191,8 @@ tiledb_domain_get_dimension_from_index <- function(domain, idx) {
 #' @return TileDB Dimension object
 #' @export
 tiledb_domain_get_dimension_from_name <- function(domain, name) {
-  stopifnot(domain_argument=is(domain, "tiledb_domain"),
-            name_argument=is.character(name))
+  stopifnot(`The 'domain' argument must be a tiledb_domain` = is(domain, "tiledb_domain"),
+            `The 'name' argument must be character` = is.character(name))
   return(new("tiledb_dim", ptr=libtiledb_domain_get_dimension_from_name(domain@ptr, name)))
 }
 
@@ -207,7 +203,7 @@ tiledb_domain_get_dimension_from_name <- function(domain, name) {
 #' @return A boolean value indicating if the dimension exists in the domain
 #' @export
 tiledb_domain_has_dimension <- function(domain, name) {
-  stopifnot(domain_argument=is(domain, "tiledb_domain"),
-            name_argument=is.character(name))
+  stopifnot(`The 'domain' argument must be a tiledb_domain` = is(domain, "tiledb_domain"),
+            `The 'name' argument must be character` = is.character(name))
   libtiledb_domain_has_dimension(domain@ptr, name)
 }

--- a/R/Domain.R
+++ b/R/Domain.R
@@ -28,7 +28,7 @@ setClass("tiledb_domain",
          slots = list(ptr = "externalptr"))
 
 tiledb_domain.from_ptr <- function(ptr) {
-  stopifnot(`ptr must be a non-NULL externalptr to a tiledb_domain` = !missing(ptr) && typeof(ptr) == "externalptr" && !is.null(ptr))
+  stopifnot(`ptr must be a non-NULL externalptr to a tiledb_domain` = !missing(ptr) && is(ptr, "externalptr") && !is.null(ptr))
   return(new("tiledb_domain", ptr = ptr))
 }
 

--- a/R/Filter.R
+++ b/R/Filter.R
@@ -28,7 +28,7 @@ setClass("tiledb_filter",
          slots = list(ptr = "externalptr"))
 
 tiledb_filter.from_ptr <- function(ptr) {
-  stopifnot(is(ptr, "externalptr"))
+  stopifnot(`ptr must be a non-NULL externalptr to a tiledb_filter` = !missing(ptr) && is(ptr, "externalptr") && !is.null(ptr))
   return(new("tiledb_filter", ptr = ptr))
 }
 
@@ -59,11 +59,8 @@ tiledb_filter.from_ptr <- function(ptr) {
 #'
 #' @export tiledb_filter
 tiledb_filter <- function(name = "NONE", ctx = tiledb_get_context()) {
-  if (!is(ctx, "tiledb_ctx")) {
-    stop("argument ctx must be a tiledb_ctx")
-  } else if (!is.scalar(name, "character")) {
-    stop("filter argument must be scalar string")
-  }
+  stopifnot(`Argument 'ctx' must be a tiledb_ctx object` = is(ctx, "tiledb_ctx"),
+            `Argument 'filter' must be scalar string"` = is.scalar(name, "character"))
   ptr <- libtiledb_filter(ctx@ptr, name)
   return(new("tiledb_filter", ptr = ptr))
 }
@@ -79,7 +76,7 @@ tiledb_filter <- function(name = "NONE", ctx = tiledb_get_context()) {
 #'
 #' @export
 tiledb_filter_type <- function(object) {
-  stopifnot(is(object, "tiledb_filter"))
+  stopifnot(`The 'object' argument must be a tiledb_filter` = is(object, "tiledb_filter"))
   return(libtiledb_filter_get_type(object@ptr))
 }
 
@@ -95,7 +92,9 @@ tiledb_filter_type <- function(object) {
 #' tiledb_filter_get_option(c, "COMPRESSION_LEVEL")
 #' @export
 tiledb_filter_set_option <- function(object, option, value) {
-  stopifnot(is(object, "tiledb_filter"))
+  stopifnot(`The 'object' argument must be a tiledb_filter` = is(object, "tiledb_filter"),
+            `The 'option' argument must be character` = is.character(option),
+            `The 'value' argument must be numeric or character or logical` = is.numeric(value) || is.character(value) || is.logical(value))
   return(libtiledb_filter_set_option(object@ptr, option, value))
 }
 
@@ -112,6 +111,7 @@ tiledb_filter_set_option <- function(object, option, value) {
 #'
 #' @export
 tiledb_filter_get_option <- function(object, option) {
-  stopifnot(is(object, "tiledb_filter"))
+  stopifnot(`The 'object' argument must be a tiledb_filter` = is(object, "tiledb_filter"),
+            `The 'option' argument must be character` = is.character(option))
   return(libtiledb_filter_get_option(object@ptr, option))
 }

--- a/R/FilterList.R
+++ b/R/FilterList.R
@@ -1,6 +1,6 @@
 #  MIT License
 #
-#  Copyright (c) 2017-2020 TileDB Inc.
+#  Copyright (c) 2017-2021 TileDB Inc.
 #
 #  Permission is hereby granted, free of charge, to any person obtaining a copy
 #  of this software and associated documentation files (the "Software"), to deal
@@ -28,7 +28,7 @@ setClass("tiledb_filter_list",
          slots = list(ptr = "externalptr"))
 
 tiledb_filter_list.from_ptr <- function(ptr) {
-  stopifnot(is(ptr, "externalptr"))
+  stopifnot(`ptr must be a non-NULL externalptr to a tiledb_filter_list` = !missing(ptr) && is(ptr, "externalptr") && !is.null(ptr))
   return(new("tiledb_filter_list", ptr = ptr))
 }
 
@@ -47,9 +47,7 @@ tiledb_filter_list.from_ptr <- function(ptr) {
 #'
 #' @export tiledb_filter_list
 tiledb_filter_list <- function(filters = c(), ctx = tiledb_get_context()) {
-  if (!is(ctx, "tiledb_ctx")) {
-    stop("argument ctx must be a tiledb_ctx")
-  }
+  stopifnot(`Argument 'ctx' must be a tiledb_ctx object` = is(ctx, "tiledb_ctx"))
   is_filter <- function(obj) is(obj, "tiledb_filter")
   if (is_filter(filters)) {             # if a filters object given:
     filters <- list(filters)            # make it a list so that lapply works below
@@ -80,7 +78,7 @@ setMethod("set_max_chunk_size",
 #' Set the filter_list's max_chunk_size
 #'
 #' @param object tiledb_filter_list
-#' @param value string
+#' @param value A numeric value
 #' @examples
 #' \dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
 #' flt <- tiledb_filter("ZSTD")
@@ -89,6 +87,8 @@ setMethod("set_max_chunk_size",
 #' set_max_chunk_size(filter_list, 10)
 #' @export
 tiledb_filter_list_set_max_chunk_size <- function(object, value) {
+  stopifnot(`The 'object' argument must be a tiledb_filter_list` = is(object, "tiledb_filter_list"),
+            `The 'value' argument must be numeric` = is.numeric(value))
   libtiledb_filter_list_set_max_chunk_size(object@ptr, value)
 }
 
@@ -115,6 +115,7 @@ setMethod("max_chunk_size", signature(object = "tiledb_filter_list"), function(o
 #'
 #' @export
 tiledb_filter_list_get_max_chunk_size <- function(object) {
+  stopifnot(`The 'object' argument must be a tiledb_filter_list` = is(object, "tiledb_filter_list"))
   libtiledb_filter_list_get_max_chunk_size(object@ptr)
 }
 

--- a/R/FragmentInfo.R
+++ b/R/FragmentInfo.R
@@ -28,7 +28,7 @@ setClass("tiledb_fragment_info",
          slots = list(ptr = "externalptr"))
 
 tiledb_fragment_info.from_ptr <- function(ptr) {
-    stopifnot(is(ptr, "externalptr"))
+    stopifnot(`ptr must be a non-NULL externalptr to a tiledb_fragment_info` = !missing(ptr) && is(ptr, "externalptr") && !is.null(ptr))
     return(new("tiledb_fragment_info", ptr = ptr))
 }
 
@@ -40,9 +40,8 @@ tiledb_fragment_info.from_ptr <- function(ptr) {
 #' @return tiledb_fragment_info object
 #' @export tiledb_fragment_info
 tiledb_fragment_info <- function(uri, ctx = tiledb_get_context()) {
-    stopifnot(`argument ctx must be a tiledb_ctx object` = is(ctx, "tiledb_ctx"),
-              `argument uri must be a string scalar` = is.scalar(uri, "character"))
-
+    stopifnot(`Argument 'ctx' must be a tiledb_ctx object` = is(ctx, "tiledb_ctx"),
+              `Argument 'uri' must be a string scalar` = is.scalar(uri, "character"))
     ptr <- libtiledb_fragment_info(ctx@ptr, uri)
     return(new("tiledb_fragment_info", ptr = ptr))
 }
@@ -54,6 +53,8 @@ tiledb_fragment_info <- function(uri, ctx = tiledb_get_context()) {
 #' @return A character variable with URI
 #' @export
 tiledb_fragment_info_uri <- function(object, fid) {
+    stopifnot(`Argument object mustbe a tiledb_fragment_info` = is(object, "tiledb_fragment_info"),
+              `Argument fid must be a numeric` = is.numeric(fid))
     libtiledb_fragment_info_uri(object@ptr, fid)
 }
 
@@ -65,10 +66,13 @@ tiledb_fragment_info_uri <- function(object, fid) {
 #' @param fid A fragment object index
 #' @param did A domain index
 #' @param typestr An optional character variable describing the data type which will
-#' be accessed from the schema if missinh
+#' be accessed from the schema if missing
 #' @return A TileDB Domain object
 #' @export
 tiledb_fragment_info_get_non_empty_domain_index <- function(object, fid, did, typestr) {
+    stopifnot(`Argument object mustbe a tiledb_fragment_info` = is(object, "tiledb_fragment_info"),
+              `Argument fid must be a numeric` = is.numeric(fid),
+              `Argument did must be a numeric` = is.numeric(did))
     if (missing(typestr)) {
         uri <- dirname(libtiledb_fragment_info_uri(object@ptr, fid))
         typestr <- datatype( dimensions(domain(schema(uri)))[[did+1]] )
@@ -88,6 +92,9 @@ tiledb_fragment_info_get_non_empty_domain_index <- function(object, fid, did, ty
 #' @return A TileDB Domain object
 #' @export
 tiledb_fragment_info_get_non_empty_domain_name <- function(object, fid, dim_name, typestr) {
+    stopifnot(`Argument object mustbe a tiledb_fragment_info` = is(object, "tiledb_fragment_info"),
+              `Argument fid must be a numeric` = is.numeric(fid),
+              `Argument dim_name must be a scalar character` = is.scalar(dim_name, "character"))
     if (missing(typestr)) {
         uri <- dirname(libtiledb_fragment_info_uri(object@ptr, fid))
         names <- sapply(dimensions(domain(schema(uri))), name)
@@ -105,6 +112,9 @@ tiledb_fragment_info_get_non_empty_domain_name <- function(object, fid, dim_name
 #' @return A character vector with two elements
 #' @export
 tiledb_fragment_info_get_non_empty_domain_var_index <- function(object, fid, did) {
+    stopifnot(`Argument object mustbe a tiledb_fragment_info` = is(object, "tiledb_fragment_info"),
+              `Argument fid must be a numeric` = is.numeric(fid),
+              `Argument did must be a numeric` = is.numeric(did))
     libtiledb_fragment_info_get_non_empty_domain_var_index(object@ptr, fid, did)
 }
 
@@ -116,6 +126,9 @@ tiledb_fragment_info_get_non_empty_domain_var_index <- function(object, fid, did
 #' @return A character vector with two elements
 #' @export
 tiledb_fragment_info_get_non_empty_domain_var_name <- function(object, fid, dim_name) {
+    stopifnot(`Argument object mustbe a tiledb_fragment_info` = is(object, "tiledb_fragment_info"),
+              `Argument fid must be a numeric` = is.numeric(fid),
+              `Argument dim_name must be a scalar character` = is.scalar(dim_name, "character"))
     libtiledb_fragment_info_get_non_empty_domain_var_name(object@ptr, fid, dim_name)
 }
 
@@ -125,6 +138,7 @@ tiledb_fragment_info_get_non_empty_domain_var_name <- function(object, fid, dim_
 #' @return A numeric variable with the number of fragments
 #' @export
 tiledb_fragment_info_get_num <- function(object) {
+    stopifnot(`Argument object mustbe a tiledb_fragment_info` = is(object, "tiledb_fragment_info"))
     libtiledb_fragment_info_num(object@ptr)
 }
 
@@ -135,6 +149,8 @@ tiledb_fragment_info_get_num <- function(object) {
 #' @return A numeric variable with the number of fragments
 #' @export
 tiledb_fragment_info_get_size <- function(object, fid) {
+    stopifnot(`Argument object mustbe a tiledb_fragment_info` = is(object, "tiledb_fragment_info"),
+              `Argument fid must be a numeric` = is.numeric(fid))
     libtiledb_fragment_info_size(object@ptr, fid)
 }
 
@@ -145,6 +161,8 @@ tiledb_fragment_info_get_size <- function(object, fid) {
 #' @return A logical value indicating if the fragment is dense
 #' @export
 tiledb_fragment_info_dense <- function(object, fid) {
+    stopifnot(`Argument object mustbe a tiledb_fragment_info` = is(object, "tiledb_fragment_info"),
+              `Argument fid must be a numeric` = is.numeric(fid))
     libtiledb_fragment_info_dense(object@ptr, fid)
 }
 
@@ -155,6 +173,8 @@ tiledb_fragment_info_dense <- function(object, fid) {
 #' @return A logical value indicating if the fragment is sparse
 #' @export
 tiledb_fragment_info_sparse <- function(object, fid) {
+    stopifnot(`Argument object mustbe a tiledb_fragment_info` = is(object, "tiledb_fragment_info"),
+              `Argument fid must be a numeric` = is.numeric(fid))
     libtiledb_fragment_info_sparse(object@ptr, fid)
 }
 
@@ -175,6 +195,8 @@ tiledb_fragment_info_get_timestamp_range <- function(object, fid) {
 #' @return A numeric value with the number of cells
 #' @export
 tiledb_fragment_info_get_cell_num <- function(object, fid) {
+    stopifnot(`Argument object mustbe a tiledb_fragment_info` = is(object, "tiledb_fragment_info"),
+              `Argument fid must be a numeric` = is.numeric(fid))
     libtiledb_fragment_info_cell_num(object@ptr, fid)
 }
 
@@ -195,6 +217,8 @@ tiledb_fragment_info_get_version <- function(object, fid) {
 #' @return A logical value indicating consolidated metadata
 #' @export
 tiledb_fragment_info_has_consolidated_metadata <- function(object, fid) {
+    stopifnot(`Argument object mustbe a tiledb_fragment_info` = is(object, "tiledb_fragment_info"),
+              `Argument fid must be a numeric` = is.numeric(fid))
     libtiledb_fragment_info_has_consolidated_metadata(object@ptr, fid)
 }
 
@@ -204,6 +228,7 @@ tiledb_fragment_info_has_consolidated_metadata <- function(object, fid) {
 #' @return A numeric value with the number of unconsolidated metadata
 #' @export
 tiledb_fragment_info_get_unconsolidated_metadata_num <- function(object) {
+    stopifnot(`Argument object mustbe a tiledb_fragment_info` = is(object, "tiledb_fragment_info"))
     libtiledb_fragment_info_unconsolidated_metadata_num(object@ptr)
 }
 
@@ -213,6 +238,7 @@ tiledb_fragment_info_get_unconsolidated_metadata_num <- function(object) {
 #' @return A numeric value with the number of to be vacuumed fragments
 #' @export
 tiledb_fragment_info_get_to_vacuum_num <- function(object) {
+    stopifnot(`Argument object mustbe a tiledb_fragment_info` = is(object, "tiledb_fragment_info"))
     libtiledb_fragment_info_to_vacuum_num(object@ptr)
 }
 
@@ -223,6 +249,8 @@ tiledb_fragment_info_get_to_vacuum_num <- function(object) {
 #' @return A character variable with the URI of the be vacuumed index
 #' @export
 tiledb_fragment_info_get_to_vacuum_uri <- function(object, fid) {
+    stopifnot(`Argument object mustbe a tiledb_fragment_info` = is(object, "tiledb_fragment_info"),
+              `Argument fid must be a numeric` = is.numeric(fid))
     libtiledb_fragment_info_to_vacuum_uri(object@ptr, fid)
 }
 
@@ -232,5 +260,6 @@ tiledb_fragment_info_get_to_vacuum_uri <- function(object, fid) {
 #' @return Nothing is returned, as a side effect the fragment info is displayed
 #' @export
 tiledb_fragment_info_dump <- function(object) {
+    stopifnot(`Argument object mustbe a tiledb_fragment_info` = is(object, "tiledb_fragment_info"))
     libtiledb_fragment_info_dump(object@ptr)
 }

--- a/R/Matrix.R
+++ b/R/Matrix.R
@@ -39,8 +39,8 @@ fromMatrix <- function(obj,
                        filter="ZSTD",
                        capacity = 10000L) {
 
-    stopifnot(`obj must be matrix object` = inherits(obj, "matrix"),
-              `uri must character` = is.character(uri))
+    stopifnot(`Argument 'obj' must be matrix object` = inherits(obj, "matrix"),
+              `Argument 'uri' must be character` = is.character(uri))
 
     dims <- dim(obj)
     dimnm <- dimnames(obj)
@@ -83,5 +83,6 @@ fromMatrix <- function(obj,
 ##' @rdname fromMatrix
 ##' @export
 toMatrix <- function(uri) {
+    stopifnot(`Argument 'uri' must be character` = is.character(uri))
     tiledb_array(uri, return_as="matrix")[]
 }

--- a/R/Metadata.R
+++ b/R/Metadata.R
@@ -1,6 +1,6 @@
 #  MIT License
 #
-#  Copyright (c) 2017-2020 TileDB Inc.
+#  Copyright (c) 2017-2021 TileDB Inc.
 #
 #  Permission is hereby granted, free of charge, to any person obtaining a copy
 #  of this software and associated documentation files (the "Software"), to deal
@@ -19,14 +19,6 @@
 #  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 #  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 #  SOFTWARE.
-
-.isArray <- function(arr) {
-  is(arr, "tiledb_sparse") || is(arr, "tiledb_dense") || is(arr, "tiledb_array")
-}
-
-.assertArray <- function(arr) {
-  stopifnot(is(arr, "tiledb_sparse") || is(arr, "tiledb_dense") || is(arr, "tiledb_array"))
-}
 
 ##' Test if TileDB Array has Metadata
 ##'

--- a/R/Metadata.R
+++ b/R/Metadata.R
@@ -28,18 +28,11 @@
 ##'   metdata of the given array
 ##' @export
 tiledb_has_metadata <- function(arr, key) {
-  if (!.isArray(arr)) {
-    stop("Argument must be a (dense or sparse) TileDB array.", call.=FALSE)
-  }
-
-  ## Now deal with (default) case of an array object
-  ## Check for 'is it open' ?
-  if (!libtiledb_array_is_open_for_reading(arr@ptr)) {
-    stop("Array is not open for reading, cannot access metadata.", call.=FALSE)
-  }
-
+  stopifnot(`Argument 'arr' must be a (dense or sparse) TileDB array` = .isArray(arr),
+            `Argument 'key' must be a scalar character` = is.scalar(key, "character"),
+            `Array must be open for reading to access metadata` = libtiledb_array_is_open_for_reading(arr@ptr))
   res <- libtiledb_array_get_metadata_list(arr@ptr)
-  return(key %in% names(res))
+  key %in% names(res)
 }
 
 ##' Return count of TileDB Array Metadata objects
@@ -48,18 +41,9 @@ tiledb_has_metadata <- function(arr, key) {
 ##' @return A integer variable with the number of Metadata objects
 ##' @export
 tiledb_num_metadata <- function(arr) {
-  if (!.isArray(arr)) {
-    stop("Argument must be a (dense or sparse) TileDB array.", call.=FALSE)
-  }
-
-  ## Now deal with (default) case of an array object
-  ## Check for 'is it open' ?
-  if (!libtiledb_array_is_open_for_reading(arr@ptr)) {
-    stop("Array is not open for reading, cannot access metadata.", call.=FALSE)
-  }
-
-  ## Run query
-  return(libtiledb_array_get_metadata_num(arr@ptr))
+  stopifnot(`Argument 'arr' must be a (dense or sparse) TileDB array` = .isArray(arr),
+            `Array must be open for reading to access metadata` = libtiledb_array_is_open_for_reading(arr@ptr))
+  libtiledb_array_get_metadata_num(arr@ptr)
 }
 
 ##' Return a TileDB Array Metadata object given by key
@@ -70,21 +54,13 @@ tiledb_num_metadata <- function(arr) {
 ##' or \sQuote{NULL} if none found.
 ##' @export
 tiledb_get_metadata <- function(arr, key) {
-  if (!.isArray(arr)) {
-    stop("Argument must be a (dense or sparse) TileDB array.", call.=FALSE)
-  }
-
-  ## Now deal with (default) case of an array object
-  ## Check for 'is it open' ?
-  if (!libtiledb_array_is_open_for_reading(arr@ptr)) {
-    stop("Array is not open for reading, cannot access metadata.", call.=FALSE)
-  }
-
+  stopifnot(`Argument 'arr' must be a (dense or sparse) TileDB array` = .isArray(arr),
+            `Array must be open for reading to access metadata` = libtiledb_array_is_open_for_reading(arr@ptr))
   res <- libtiledb_array_get_metadata_list(arr@ptr)
   if (key %in% names(res))
-    return(res[[key]])
+    res[[key]]
   else
-    return(NULL)
+    NULL
 }
 
 ##' Store an object in TileDB Array Metadata under given key
@@ -107,20 +83,11 @@ tiledb_put_metadata <- function(arr, key, val) {
 ##' @return A object stored in the Metadata under the given key
 ##' @export
 tiledb_get_all_metadata <- function(arr) {
-  if (!.isArray(arr)) {
-    stop("Argument must be a (dense or sparse) TileDB array.", call.=FALSE)
-  }
-
-  ## Now deal with (default) case of an array object
-  ## Check for 'is it open' ?
-  if (!libtiledb_array_is_open_for_reading(arr@ptr)) {
-    stop("Array is not open for reading, cannot access metadata.", call.=FALSE)
-  }
-
-  ## Run query
+  stopifnot(`Argument 'arr' must be a (dense or sparse) TileDB array` = .isArray(arr),
+            `Array must be open for reading to access metadata` = libtiledb_array_is_open_for_reading(arr@ptr))
   res <- libtiledb_array_get_metadata_list(arr@ptr)
   class(res) <- "tiledb_metadata"
-  return(res)
+  res
 }
 
 ##' Print a TileDB Array Metadata object
@@ -146,17 +113,8 @@ print.tiledb_metadata <- function(x, width=NULL, ...) {
 ##' @return A boolean indicating success
 ##' @export
 tiledb_delete_metadata <- function(arr, key) {
-  if (!.isArray(arr)) {
-    stop("Argument must be a (dense or sparse) TileDB array.", call.=FALSE)
-  }
-
-  ## Now deal with (default) case of an array object
-  ## Check for 'is it open' ?
-  if (!libtiledb_array_is_open_for_writing(arr@ptr)) {
-    stop("Array is not open for writing, cannot access metadata.", call.=FALSE)
-  }
-
-  ## Run metadata removal
-  libtiledb_array_delete_metadata(arr@ptr, key);
-  invisible(TRUE)
+  stopifnot(`Argument must be a (dense or sparse) TileDB array.` = .isArray(arr),
+            `Array is not open for writing.` = libtiledb_array_is_open_for_writing(arr@ptr))
+  libtiledb_array_delete_metadata(arr@ptr, key)
+  TRUE                                  # we get NULL from C++
 }

--- a/R/Object.R
+++ b/R/Object.R
@@ -1,6 +1,6 @@
 #  MIT License
 #
-#  Copyright (c) 2017-2020 TileDB Inc.
+#  Copyright (c) 2017-2021 TileDB Inc.
 #
 #  Permission is hereby granted, free of charge, to any person obtaining a copy
 #  of this software and associated documentation files (the "Software"), to deal
@@ -20,16 +20,6 @@
 #  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 #  SOFTWARE.
 
-check_object_arguments <- function(uri, ctx = tiledb_get_context()) {
-  if (!is(ctx, "tiledb_ctx")) {
-    stop("argument ctx must a a tiledb_ctx")
-  }
-  if (missing(uri) || !is.scalar(uri, "character")) {
-    stop("argument uri must be a string scalar ")
-  }
-  return(TRUE)
-}
-
 #' Creates a TileDB group object at given uri path
 #'
 #' @param uri path which to create group
@@ -44,8 +34,9 @@ check_object_arguments <- function(uri, ctx = tiledb_get_context()) {
 #' }
 #'@export
 tiledb_group_create <- function(uri, ctx = tiledb_get_context()) {
-  check_object_arguments(uri, ctx)
-  return(libtiledb_group_create(ctx@ptr, uri))
+    stopifnot(`The 'ctx' argument must a tiledb_ctx` = is(ctx, "tiledb_ctx"),
+              `The 'uri' argument must be a string scalar` = !missing(uri) && is.scalar(uri,"character"))
+    libtiledb_group_create(ctx@ptr, uri)
 }
 
 #' Return the TileDB object type string of a TileDB resource
@@ -61,8 +52,9 @@ tiledb_group_create <- function(uri, ctx = tiledb_get_context()) {
 #'
 #' @export
 tiledb_object_type <- function(uri, ctx = tiledb_get_context()) {
-  check_object_arguments(uri, ctx)
-  return(libtiledb_object_type(ctx@ptr, uri))
+    stopifnot(`The 'ctx' argument must a tiledb_ctx` = is(ctx, "tiledb_ctx"),
+              `The 'uri' argument must be a string scalar` = !missing(uri) && is.scalar(uri,"character"))
+    libtiledb_object_type(ctx@ptr, uri)
 }
 
 #' Removes a TileDB resource
@@ -74,8 +66,9 @@ tiledb_object_type <- function(uri, ctx = tiledb_get_context()) {
 #' @return uri of removed TileDB resource
 #' @export
 tiledb_object_rm <- function(uri, ctx = tiledb_get_context()) {
-  check_object_arguments(uri, ctx)
-  return(libtiledb_object_remove(ctx@ptr, uri))
+    stopifnot(`The 'ctx' argument must a tiledb_ctx` = is(ctx, "tiledb_ctx"),
+              `The 'uri' argument must be a string scalar` = !missing(uri) && is.scalar(uri,"character"))
+    libtiledb_object_remove(ctx@ptr, uri)
 }
 
 #' Move a TileDB resource to new uri path
@@ -88,16 +81,10 @@ tiledb_object_rm <- function(uri, ctx = tiledb_get_context()) {
 #' @return new uri of moved tiledb resource
 #' @export
 tiledb_object_mv <- function(old_uri, new_uri, ctx = tiledb_get_context()) {
-  if (!is(ctx, "tiledb_ctx")) {
-    stop("argument ctx must a a tiledb_ctx")
-  }
-  if (missing(old_uri) || !is.scalar(old_uri, "character")) {
-    stop("argument old_uri must be a string scalar ")
-  }
-  if (missing(new_uri) || !is.scalar(new_uri, "character")) {
-    stop("argument old_uri must be a string scalar ")
-  }
-  return(libtiledb_object_move(ctx@ptr, old_uri, new_uri))
+    stopifnot(`The 'ctx' argument must a tiledb_ctx` = is(ctx, "tiledb_ctx"),
+              `The 'old_uri' argument must be a string scalar` = !missing(old_uri) && is.scalar(old_uri,"character"),
+              `The 'new_uri' argument must be a string scalar` = !missing(new_uri) && is.scalar(new_uri,"character"))
+    libtiledb_object_move(ctx@ptr, old_uri, new_uri)
 }
 
 #' List TileDB resources at a given root URI path
@@ -108,8 +95,9 @@ tiledb_object_mv <- function(old_uri, new_uri, ctx = tiledb_get_context()) {
 #' @return a dataframe with object type, object uri string columns
 #' @export
 tiledb_object_ls <- function(uri, filter = NULL, ctx = tiledb_get_context()) {
-  check_object_arguments(uri, ctx)
-  return(libtiledb_object_walk(ctx@ptr, uri, order = "PREORDER"))
+    stopifnot(`The 'ctx' argument must a tiledb_ctx` = is(ctx, "tiledb_ctx"),
+              `The 'uri' argument must be a string scalar` = !missing(uri) && is.scalar(uri,"character"))
+    libtiledb_object_walk(ctx@ptr, uri, order = "PREORDER")
 }
 
 #' Recursively discover TileDB resources at a given root URI path
@@ -120,6 +108,7 @@ tiledb_object_ls <- function(uri, filter = NULL, ctx = tiledb_get_context()) {
 #' @return a dataframe with object type, object uri string columns
 #' @export
 tiledb_object_walk <- function(uri, order = "PREORDER", ctx = tiledb_get_context()) {
-  check_object_arguments(uri, ctx)
-  return(libtiledb_object_walk(ctx@ptr, uri, order = order, recursive = TRUE))
+    stopifnot(`The 'ctx' argument must a tiledb_ctx` = is(ctx, "tiledb_ctx"),
+              `The 'uri' argument must be a string scalar` = !missing(uri) && is.scalar(uri,"character"))
+    libtiledb_object_walk(ctx@ptr, uri, order = order, recursive = TRUE)
 }

--- a/R/Query.R
+++ b/R/Query.R
@@ -35,9 +35,8 @@ setClass("tiledb_query",
 #' @return 'tiledb_query' object
 #' @export tiledb_query
 tiledb_query <- function(array, type = c("READ", "WRITE"), ctx = tiledb_get_context()) {
+  stopifnot(`Argument 'arr' must be a tiledb_array object` = .isArray(array))
   type <- match.arg(type)
-  stopifnot(valid_array=is(array, "tiledb_array") ||
-              is(array, "tiledb_dense") || is(array, "tiledb_sparse"))
   array <- tiledb_array_open(array, type)
   ptr <- libtiledb_query(ctx@ptr, array@ptr, type)
   query <- new("tiledb_query", ptr = ptr)
@@ -50,7 +49,7 @@ tiledb_query <- function(array, type = c("READ", "WRITE"), ctx = tiledb_get_cont
 #' @return A character value, either 'READ' or 'WRITE'
 #' @export
 tiledb_query_type <- function(query) {
-  stopifnot(query_object=is(query, "tiledb_query"))
+  stopifnot(`Argument 'query' must be a tiledb_query object` = is(query, "tiledb_query"))
   libtiledb_query_type(query@ptr)
 }
 
@@ -63,8 +62,8 @@ tiledb_query_type <- function(query) {
 #' @export
 tiledb_query_set_layout <- function(query, layout=c("COL_MAJOR", "ROW_MAJOR",
                                                     "GLOBAL_ORDER", "UNORDERED")) {
+  stopifnot(`Argument 'query' must be a tiledb_query object` = is(query, "tiledb_query"))
   layout <- match.arg(layout)
-  stopifnot(query_object=is(query, "tiledb_query"))
   libtiledb_query_set_layout(query@ptr, layout)
   invisible(query)
 }
@@ -75,7 +74,7 @@ tiledb_query_set_layout <- function(query, layout=c("COL_MAJOR", "ROW_MAJOR",
 #' @return The TileDB Query layout as a string
 #' @export
 tiledb_query_get_layout <- function(query) {
-  stopifnot(query_object=is(query, "tiledb_query"))
+  stopifnot(`Argument 'query' must be a tiledb_query object` = is(query, "tiledb_query"))
   libtiledb_query_layout(query@ptr)
 }
 
@@ -88,7 +87,7 @@ tiledb_query_get_layout <- function(query) {
 #' @return The modified query object, invisibly
 #' @export
 tiledb_query_set_subarray <- function(query, subarray, type) {
-  stopifnot(query_object=is(query, "tiledb_query"))
+  stopifnot(`Argument 'query' must be a tiledb_query object` = is(query, "tiledb_query"))
   if (missing(type)) {
     libtiledb_query_set_subarray(query@ptr, subarray)
   } else {
@@ -109,8 +108,9 @@ tiledb_query_set_subarray <- function(query, subarray, type) {
 #' @return The modified query object, invisisibly
 #' @export
 tiledb_query_set_buffer <- function(query, attr, buffer) {
-  stopifnot(query_object=is(query, "tiledb_query"),
-            attr_variable=is.character(attr))
+  stopifnot(`Argument 'query' must be a tiledb_query object` = is(query, "tiledb_query"),
+            `Argument 'attr' must be character_variable` = is.character(attr),
+            `Argument 'buffer' must be integer, numeric or logical` = is.numeric(buffer) || is.logical(buffer))
   libtiledb_query_set_buffer(query@ptr, attr, buffer)
   invisible(query)
 }
@@ -122,8 +122,8 @@ tiledb_query_set_buffer <- function(query, attr, buffer) {
 #' @return An external pointer to the allocated buffer object
 #' @export
 tiledb_query_create_buffer_ptr_char <- function(query, varvec) {
-  stopifnot(query_object=is(query, "tiledb_query"),
-            is_vector=is.vector(varvec))
+  stopifnot(`Argument 'query' must be a tiledb_query object` = is(query, "tiledb_query"),
+            `Argument 'varvec' must be a character vector` = is.vector(varvec) && is.character(varvec))
   n <- length(varvec)
   offsets <- integer(n)
   data <- convertStringVectorIntoOffsetsAndString(varvec, offsets)
@@ -133,11 +133,13 @@ tiledb_query_create_buffer_ptr_char <- function(query, varvec) {
 
 #' Allocate a Query buffer for reading a character attribute
 #'
-#' @param sizeoffsets An optional value of the size of the offsets vector
-#' @param sizedata An optional value of the size of the data string
+#' @param sizeoffsets A numeric value with the size of the offsets vector
+#' @param sizedata A numeric value of the size of the data string
 #' @return An external pointer to the allocated buffer object
 #' @export
 tiledb_query_alloc_buffer_ptr_char <- function(sizeoffsets, sizedata) {
+  stopifnot(`Argument 'sizeoffset' must be numeric` = is.numeric(sizeoffsets),
+            `Argument 'sizedata' must be numeric` = is.numeric(sizedata))
   bufptr <- libtiledb_query_buffer_var_char_alloc_direct(sizeoffsets, sizedata)
   bufptr
 }
@@ -169,9 +171,9 @@ tiledb_query_alloc_buffer_ptr_char <- function(sizeoffsets, sizedata) {
 #' @return The modified query object, invisibly
 #' @export
 tiledb_query_set_buffer_ptr_char <- function(query, attr, bufptr) {
-  stopifnot(query_object=is(query, "tiledb_query"),
-            attribute_string=is.character(attr),
-            bufptr=is(bufptr, "externalptr"))
+  stopifnot(`Argument 'query' must be a tiledb_query object` = is(query, "tiledb_query"),
+            `Argument 'attr' must be a character object` = is.character(attr),
+            `Argument 'bufptr' must be an external pointer` = is(bufptr, "externalptr"))
   libtiledb_query_set_buffer_var_char(query@ptr, attr, bufptr)
   invisible(query)
 
@@ -186,9 +188,11 @@ tiledb_query_set_buffer_ptr_char <- function(query, attr, bufptr) {
 #' @return An external pointer to the allocated buffer object
 #' @export
 tiledb_query_buffer_alloc_ptr <- function(query, datatype, ncells) {
-  stopifnot(query_object=is(query, "tiledb_query"),
-            datatype_string=is.character(datatype))
+  stopifnot(`Argument 'query' must be a tiledb_query object` = is(query, "tiledb_query"),
+            `Argument 'datatype' must be a character object` = is.character(datatype),
+            `Argument 'ncells' must be numeric` = is.numeric(ncells))
   bufptr <- libtiledb_query_buffer_alloc_ptr(query@ptr, datatype, ncells)
+  bufptr
 }
 
 #' Allocate and populate a Query buffer for a given object of a given data type.
@@ -201,9 +205,9 @@ tiledb_query_buffer_alloc_ptr <- function(query, datatype, ncells) {
 #' @return An external pointer to the allocated buffer object
 #' @export
 tiledb_query_create_buffer_ptr <- function(query, datatype, object) {
-  stopifnot(query_object=is(query, "tiledb_query"),
-            #is_vector=is.vector(object),
-            datatype_string=is.character(datatype))
+  stopifnot(`Argument 'query' must be a tiledb_query object` = is(query, "tiledb_query"),
+            `Argument 'object' must be a vector` = is.vector(object),
+            `Argument 'datatype' must be a character object` = is.character(datatype))
   ncells <- length(object)
   bufptr <- libtiledb_query_buffer_alloc_ptr(query@ptr, datatype, ncells)
   bufptr <- libtiledb_query_buffer_assign_ptr(bufptr, datatype, object)
@@ -219,9 +223,9 @@ tiledb_query_create_buffer_ptr <- function(query, datatype, object) {
 #' @return The modified query object, invisibly
 #' @export
 tiledb_query_set_buffer_ptr <- function(query, attr, bufptr) {
-  stopifnot(query_object=is(query, "tiledb_query"),
-            attribute_string=is.character(attr),
-            bufptr=is(bufptr, "externalptr"))
+  stopifnot(`Argument 'query' must be a tiledb_query object` = is(query, "tiledb_query"),
+            `Argument 'attr' must be a character object` = is.character(attr),
+            `Argument 'bufptr' must be an external pointer` = is(bufptr, "externalptr"))
   libtiledb_query_set_buffer_ptr(query@ptr, attr, bufptr)
   invisible(query)
 }
@@ -233,7 +237,7 @@ tiledb_query_set_buffer_ptr <- function(query, attr, bufptr) {
 #' @return An R object as resulting from the query
 #' @export
 tiledb_query_get_buffer_ptr <- function(bufptr) {
-  stopifnot(bufptr=is(bufptr, "externalptr"))
+  stopifnot(`Argument 'bufptr' must be an external pointer` = is(bufptr, "externalptr"))
   libtiledb_query_get_buffer_ptr(bufptr)
 }
 
@@ -247,7 +251,7 @@ tiledb_query_get_buffer_ptr <- function(bufptr) {
 #' @return An R object as resulting from the query
 #' @export
 tiledb_query_get_buffer_char <- function(bufptr, sizeoffsets=0, sizestring=0) {
-  stopifnot(bufptr=is(bufptr, "externalptr"))
+  stopifnot(`Argument 'bufptr' must be an external pointer` = is(bufptr, "externalptr"))
   libtiledb_query_get_buffer_var_char(bufptr, sizeoffsets, sizestring)
 }
 
@@ -260,7 +264,7 @@ tiledb_query_get_buffer_char <- function(bufptr, sizeoffsets=0, sizestring=0) {
 #' @return The modified query object, invisibly
 #' @export
 tiledb_query_submit <- function(query) {
-  stopifnot(query_object=is(query, "tiledb_query"))
+  stopifnot(`Argument 'query' must be a tiledb_query object` = is(query, "tiledb_query"))
   libtiledb_query_submit(query@ptr)
   invisible(query)
 }
@@ -273,7 +277,7 @@ tiledb_query_submit <- function(query) {
 #' @return The modified query object, invisibly
 #' @export
 tiledb_query_submit_async <- function(query) {
-  stopifnot(query_object=is(query, "tiledb_query"))
+  stopifnot(`Argument 'query' must be a tiledb_query object` = is(query, "tiledb_query"))
   libtiledb_query_submit_async(query@ptr)
   invisible(query)
 }
@@ -284,7 +288,7 @@ tiledb_query_submit_async <- function(query) {
 #' @return A character value, either 'READ' or 'WRITE'
 #' @export
 tiledb_query_finalize <- function(query) {
-  stopifnot(query_object=is(query, "tiledb_query"))
+  stopifnot(`Argument 'query' must be a tiledb_query object` = is(query, "tiledb_query"))
   libtiledb_query_finalize(query@ptr)
   .pkgenv[["query_status"]] <- libtiledb_query_status(query@ptr)
   invisible(query)
@@ -296,7 +300,7 @@ tiledb_query_finalize <- function(query) {
 #' @return A character value describing the query status
 #' @export
 tiledb_query_status <- function(query) {
-  stopifnot(query_object=is(query, "tiledb_query"))
+  stopifnot(`Argument 'query' must be a tiledb_query object` = is(query, "tiledb_query"))
   libtiledb_query_status(query@ptr)
 }
 
@@ -319,8 +323,8 @@ tiledb_query_status <- function(query) {
 #' @seealso tiledb_query_result_buffer_elements_vec
 #' @export
 tiledb_query_result_buffer_elements <- function(query, attr) {
-  stopifnot(query_object=is(query, "tiledb_query"),
-            attr_variable=is.character(attr))
+  stopifnot(`Argument 'query' must be a tiledb_query object` = is(query, "tiledb_query"),
+            `Argument 'attr' must be a character object` = is.character(attr))
   libtiledb_query_result_buffer_elements(query@ptr, attr, 1) # request 2nd el in pair
 }
 
@@ -346,9 +350,9 @@ tiledb_query_result_buffer_elements <- function(query, attr) {
 #' @seealso tiledb_query_result_buffer_elements
 #' @export
 tiledb_query_result_buffer_elements_vec <- function(query, attr, nullable = FALSE) {
-  stopifnot(`query must be a query_object` = is(query, "tiledb_query"),
-            `attr must be a string` = is.character(attr),
-            `nullable must be a logical` = is.logical(nullable))
+  stopifnot(`Argument 'query' must be a tiledb_query object` = is(query, "tiledb_query"),
+            `Argument 'attr' must be a character object` = is.character(attr),
+            `Argument 'nullable' must be a logical` = is.logical(nullable))
   libtiledb_query_result_buffer_elements_vec(query@ptr, attr, nullable)
 }
 
@@ -363,9 +367,12 @@ tiledb_query_result_buffer_elements_vec <- function(query, attr, nullable = FALS
 #' @return The query object, invisibly
 #' @export
 tiledb_query_add_range <- function(query, schema, attr, lowval, highval, stride=NULL) {
-  stopifnot(schema_object=is(schema, "tiledb_array_schema"),
-            query_object=is(query, "tiledb_query"),
-            datatype_variable=is.character(attr))
+  stopifnot(`Argument 'query' must be a tiledb_query object` = is(query, "tiledb_query"),
+            `Argument 'schema' must be a tiledb_array_schema object` = is(schema, "tiledb_array_schema"),
+            `Argument 'attr' must be a character object` = is.character(attr),
+            `Argument 'lowval' must be numeric` = is.numeric(lowval),
+            `Argument 'highval' must be numeric` = is.numeric(highval),
+            `Argument 'stride' must be numeric (or NULL)` = is.null(stride) || is.numeric(lowval))
   names <- tiledb_schema_get_names(schema)
   types <- tiledb_schema_get_types(schema)
   idx <- which(names == attr)
@@ -384,8 +391,12 @@ tiledb_query_add_range <- function(query, schema, attr, lowval, highval, stride=
 #' @return The query object, invisibly
 #' @export
 tiledb_query_add_range_with_type <- function(query, idx, datatype, lowval, highval, stride=NULL) {
-  stopifnot(query_object=is(query, "tiledb_query"),
-            datatype_variable=is.character(datatype))
+  stopifnot(`Argument 'query' must be a tiledb_query object` = is(query, "tiledb_query"),
+            `Argument 'idx' must be integer` = is.integer(idx),
+            `Argument 'datatype' must be character` = is.character(datatype),
+            `Argument 'lowval' must be numeric` = is.numeric(lowval),
+            `Argument 'highval' must be numeric` = is.numeric(highval),
+            `Argument 'stride' must be numeric (or NULL)` = is.null(stride) || is.numeric(lowval))
   query@ptr <- libtiledb_query_add_range_with_type(query@ptr, idx, datatype, lowval, highval, stride)
   invisible(query)
 }
@@ -398,7 +409,7 @@ tiledb_query_add_range_with_type <- function(query, idx, datatype, lowval, highv
 #' @return An integer with the number of fragments for the given query
 #' @export
 tiledb_query_get_fragment_num <- function(query) {
-  stopifnot(query_object=is(query, "tiledb_query"))
+  stopifnot(`Argument 'query' must be a tiledb_query object` = is(query, "tiledb_query"))
   libtiledb_query_get_fragment_num(query@ptr)
 }
 
@@ -410,8 +421,8 @@ tiledb_query_get_fragment_num <- function(query) {
 #' @return An character value with the fragment URI
 #' @export
 tiledb_query_get_fragment_uri <- function(query, idx) {
-  stopifnot(query_object=is(query, "tiledb_query"),
-            idx_numeric=is.numeric(idx))
+  stopifnot(`Argument 'query' must be a tiledb_query object` = is(query, "tiledb_query"),
+            `Argument 'idx' must be numeric` = is.numeric(idx))
   libtiledb_query_get_fragment_uri(query@ptr, idx)
 }
 
@@ -424,9 +435,9 @@ tiledb_query_get_fragment_uri <- function(query, idx) {
 #' @return A two-element datetime vector with the start and end time of the fragment write.
 #' @export
 tiledb_query_get_fragment_timestamp_range <- function(query, idx) {
-  stopifnot(query_object=is(query, "tiledb_query"),
-            idx_numeric=is.numeric(idx))
-  libtiledb_query_get_fragment_uri(query@ptr, idx)
+  stopifnot(`Argument 'query' must be a tiledb_query object` = is(query, "tiledb_query"),
+            `Argument 'idx' must be numeric` = is.numeric(idx))
+  libtiledb_query_get_fragment_timestamp_range(query@ptr, idx)
 }
 
 
@@ -442,8 +453,8 @@ tiledb_query_get_fragment_timestamp_range <- function(query, idx) {
 #' @return An estimate of the query result size
 #' @export
 tiledb_query_get_est_result_size <- function(query, name) {
-  stopifnot(query_object=is(query, "tiledb_query"),
-            name_argument=is.character(name))
+  stopifnot(`Argument 'query' must be a tiledb_query object` = is(query, "tiledb_query"),
+            `Argument 'name' must be character` = is.character(name))
   libtiledb_query_get_est_result_size(query@ptr, name)
 }
 
@@ -459,36 +470,36 @@ tiledb_query_get_est_result_size <- function(query, name) {
 #' @return An estimate of the query result size
 #' @export
 tiledb_query_get_est_result_size_var <- function(query, name) {
-  stopifnot(query_object=is(query, "tiledb_query"),
-            name_argument=is.character(name))
+  stopifnot(`Argument 'query' must be a tiledb_query object` = is(query, "tiledb_query"),
+            `Argument 'name' must be character` = is.character(name))
   libtiledb_query_get_est_result_size_var(query@ptr, name)
 }
 
 #' Retrieve the number of ranges for a query dimension
 #'
 #' @param query A TileDB Query object
-#' @param idx An integer index selecting the dimension
+#' @param idx An integer or numeric index selecting the dimension
 #' @return An integer with the number of query range for the
 #' given dimensions
 #' @export
 tiledb_query_get_range_num <- function(query, idx) {
-  stopifnot(query_object=is(query, "tiledb_query"),
-            idx_argument=is.numeric(idx))
+  stopifnot(`Argument 'query' must be a tiledb_query object` = is(query, "tiledb_query"),
+            `Argument 'idx' must be numeric` = is.numeric(idx))
   libtiledb_query_get_range_num(query@ptr, idx-1)
 }
 
 #' Retrieve the query range for a query dimension and range index
 #'
 #' @param query A TileDB Query object
-#' @param dimidx An integer index selecting the dimension
-#' @param rngidx An integer index selection the given range for the dimension
+#' @param dimidx An integer or numeric index selecting the dimension
+#' @param rngidx An integer or numeric index selection the given range for the dimension
 #' @return An integer vector with elements start, end and stride for the query
 #' range for the given dimension and range index
 #' @export
 tiledb_query_get_range <- function(query, dimidx, rngidx) {
-  stopifnot(query_object=is(query, "tiledb_query"),
-            dimidx_argument=is.numeric(dimidx),
-            rngidx_argument=is.numeric(rngidx))
+  stopifnot(`Argument 'query' must be a tiledb_query object` = is(query, "tiledb_query"),
+            `Argument 'dimidx' must be numeric` = is.numeric(dimidx),
+            `Argument 'rngidx' must be numeric` = is.numeric(rngidx))
   libtiledb_query_get_range(query@ptr, dimidx-1, rngidx-1)
 }
 
@@ -501,9 +512,9 @@ tiledb_query_get_range <- function(query, dimidx, rngidx) {
 #' range for the given dimension and range index
 #' @export
 tiledb_query_get_range <- function(query, dimidx, rngidx) {
-  stopifnot(query_object=is(query, "tiledb_query"),
-            dimidx_argument=is.numeric(dimidx),
-            rngidx_argument=is.numeric(rngidx))
+  stopifnot(`Argument 'query' must be a tiledb_query object` = is(query, "tiledb_query"),
+            `Argument 'dimidx' must be numeric` = is.numeric(dimidx),
+            `Argument 'rngidx' must be numeric` = is.numeric(rngidx))
   libtiledb_query_get_range_var(query@ptr, dimidx-1, rngidx-1)
 }
 
@@ -514,8 +525,8 @@ tiledb_query_get_range <- function(query, dimidx, rngidx) {
 #' @return The modified query object, invisibly
 #' @export
 tiledb_query_set_condition <- function(query, qc) {
-    stopifnot(`needs query object`=is(query, "tiledb_query"),
-              `needs query condition object`=is(qc, "tiledb_query_condition"))
+    stopifnot(`Argument 'query' must be a tiledb_query object` = is(query, "tiledb_query"),
+              `Argument 'qc' must be a query_condition object` = is(qc, "tiledb_query_condition"))
     query@ptr <- libtiledb_query_set_condition(query@ptr, qc@ptr)
     invisible(query)
 }

--- a/R/Query.R
+++ b/R/Query.R
@@ -206,7 +206,7 @@ tiledb_query_buffer_alloc_ptr <- function(query, datatype, ncells) {
 #' @export
 tiledb_query_create_buffer_ptr <- function(query, datatype, object) {
   stopifnot(`Argument 'query' must be a tiledb_query object` = is(query, "tiledb_query"),
-            `Argument 'object' must be a vector` = is.vector(object),
+            #`Argument 'object' must be a vector` = is.vector(object),
             `Argument 'datatype' must be a character object` = is.character(datatype))
   ncells <- length(object)
   bufptr <- libtiledb_query_buffer_alloc_ptr(query@ptr, datatype, ncells)

--- a/R/QueryCondition.R
+++ b/R/QueryCondition.R
@@ -37,8 +37,8 @@ setClass("tiledb_query_condition",
 #' @return A 'tiledb_query_condition' object
 #' @export
 tiledb_query_condition <- function(ctx = tiledb_get_context()) {
-    stopifnot(`needs ctx object` = is(ctx, "tiledb_ctx"),
-              `needs TileDB 2.3.0 or newer` = tiledb_version(TRUE) >= "2.3.0")
+    stopifnot(`The argument must be a ctx object` = is(ctx, "tiledb_ctx"),
+              `This function needs TileDB 2.3.0 or newer` = tiledb_version(TRUE) >= "2.3.0")
     ptr <- libtiledb_query_condition(ctx@ptr)
     query_condition <- new("tiledb_query_condition", ptr = ptr, init = FALSE)
     invisible(query_condition)
@@ -61,11 +61,11 @@ tiledb_query_condition <- function(ctx = tiledb_get_context()) {
 #' @return The initialized 'tiledb_query_condition' object
 #' @export
 tiledb_query_condition_init <- function(attr, value, dtype, op, qc = tiledb_query_condition()) {
-    stopifnot(`needs query condition object`=is(qc, "tiledb_query_condition"),
-              `attr must be character`=is.character(attr),
-              `value must be of length one`=is.vector(value) && all.equal(length(value),1),
-              `dtype must be character`=is.character(dtype),
-              `op must be character`=is.character(op))
+    stopifnot(`Argument 'qc' with query condition object required` = is(qc, "tiledb_query_condition"),
+              `Argument 'attr' must be character` = is.character(attr),
+              `Argument 'value' must be of length one` = is.vector(value) && all.equal(length(value),1),
+              `Argument 'dtype' must be character` = is.character(dtype),
+              `Argument 'op' must be character` = is.character(op))
     op <- match.arg(op, c("LT", "LE", "GT", "GE", "EQ", "NE"))
     ## maybe check dtype too
     libtiledb_query_condition_init(qc@ptr, attr, value, dtype, op)
@@ -83,9 +83,9 @@ tiledb_query_condition_init <- function(attr, value, dtype, op, qc = tiledb_quer
 #' @return The combined 'tiledb_query_condition' object
 #' @export
 tiledb_query_condition_combine <- function(lhs, rhs, op) {
-    stopifnot(`needs query condition object on lhs`=is(lhs, "tiledb_query_condition"),
-              `needs query condition object on rhs`=is(rhs, "tiledb_query_condition"),
-              `op must be character`=is.character(op))
+    stopifnot(`Argument 'lhs' must be a query condition object` = is(lhs, "tiledb_query_condition"),
+              `Argument 'rhs' must be a query condition object` = is(rhs, "tiledb_query_condition"),
+              `Argument 'op' must be a character` = is.character(op))
     op <- match.arg(op, c("AND", "OR", "NOT"))
     qc <- tiledb_query_condition()
     qc@ptr <- libtiledb_query_condition_combine(lhs@ptr, rhs@ptr, op)

--- a/R/SparseArray.R
+++ b/R/SparseArray.R
@@ -66,11 +66,8 @@ tiledb_sparse <- function(uri,
                           extended = TRUE,
                           ctx = tiledb_get_context()) {
   query_type = match.arg(query_type)
-  if (!is(ctx, "tiledb_ctx")) {
-    stop("argument ctx must be a tiledb_ctx")
-  } else if (missing(uri) || !is.scalar(uri, "character")) {
-    stop("argument uri must be a string scalar")
-  }
+  stopifnot(`Argument 'ctx' must be a tiledb_ctx object` = is(ctx, "tiledb_ctx"),
+            `Argument 'uri' must be a string scalar` = !missing(uri) && is.scalar(uri, "character"))
   .Deprecated("tiledb_array")
   array_xptr <- libtiledb_array_open(ctx@ptr, uri, query_type)
   schema_xptr <- libtiledb_array_get_schema(array_xptr)
@@ -97,9 +94,9 @@ setMethod("schema", "tiledb_sparse", function(object, ...) {
 })
 
 sparse_attribute_buffers <- function(array, sch, dom, sub, selected, ncells=1000) {
-  stopifnot(is(sch, "tiledb_array_schema"))
-  stopifnot(is(dom, "tiledb_domain"))
-  #domaintype <- libtiledb_domain_get_type(dom@ptr)
+  stopifnot(`The 'array' argument must be a tiledb_array` = .isArray(array),
+            `The 'dom' argument must be a tiledb_domain object` = is(dom, "tiledb_domain"),
+            `The 'sch' argument must be a tiledb_array_schema` = is(sch, "tiledb_array_schema"))
   domaintype <- sapply(libtiledb_domain_get_dimensions(dom@ptr),
                        libtiledb_dim_get_datatype)
   attributes <- list()
@@ -145,9 +142,7 @@ sparse_attribute_buffers <- function(array, sch, dom, sub, selected, ncells=1000
 #' @return data.frame object constructed from `data`
 #' @export
 as_data_frame <- function(dom, data, extended=FALSE) {
-  if (!is(dom, "tiledb_domain")) {
-    stop("as_data_frame must be called with a tiledb_domain object")
-  }
+  stopifnot(`Argument 'dom' must be a tiledb_domain object` = is(dom, "tiledb_domain"))
   # If coordinates are present convert to columns in the data.frame
   if (!is.null(data[["coords"]])) {
     if (extended) {
@@ -463,9 +458,7 @@ setMethod("is.sparse", "tiledb_sparse", function(object) TRUE)
 #' @return list of attributes being returned with query results
 #' @export
 tiledb_subarray <- function(A, subarray_vector, attrs=c()) {
-  if (!is(A, "tiledb_sparse") && !is(A, "tiledb_dense")) {
-    stop("tiledb_subarray must be called with a tiledb_dense or tiledb_sparse object")
-  }
+  stopifnot(`First argument must be a tiledb_dense or tiledb_sparse object` = is(A, "tiledb_sparse") || is(A, "tiledb_dense"))
   ctx <- A@ctx
   uri <- A@uri
   schema <- tiledb::schema(A)

--- a/R/SparseMatrix.R
+++ b/R/SparseMatrix.R
@@ -61,9 +61,9 @@ fromSparseMatrix <- function(obj,
                              filter="ZSTD",
                              capacity = 10000L) {
 
-    stopifnot(`obj must be Matrix object` = inherits(obj, "Matrix"),
-              `obj must be sparse` = is(obj, "sparseMatrix"),
-              `uri must character` = is.character(uri))
+    stopifnot(`Argument 'obj' must be Matrix object` = inherits(obj, "Matrix"),
+              `Argument 'obj' must be sparse` = is(obj, "sparseMatrix"),
+              `Argument 'uri' must be character` = is.character(uri))
 
     dimnm <- dimnames(obj)
     classIn <- "dgTMatrix"
@@ -110,6 +110,7 @@ fromSparseMatrix <- function(obj,
 ##' @rdname fromSparseMatrix
 ##' @export
 toSparseMatrix <- function(uri) {
+    stopifnot(`Argument 'uri' must be character` = is.character(uri))
 
     arr <- tiledb_array(uri, as.data.frame=TRUE, query_layout="UNORDERED")
     obj <- arr[]

--- a/R/Stats.R
+++ b/R/Stats.R
@@ -1,6 +1,6 @@
 #  MIT License
 #
-#  Copyright (c) 2017-2020 TileDB Inc.
+#  Copyright (c) 2017-2021 TileDB Inc.
 #
 #  Permission is hereby granted, free of charge, to any person obtaining a copy
 #  of this software and associated documentation files (the "Software"), to deal
@@ -56,6 +56,7 @@ tiledb_stats_reset <- function() {
 #'
 #' @export
 tiledb_stats_dump <- function(path) {
+  stopifnot(`Argument 'path' must be character` = is.character(path))
   libtiledb_stats_dump(path)
 }
 
@@ -81,7 +82,8 @@ tiledb_stats_print <- function() {
 #' }
 #' @export
 tiledb_stats_raw_dump <- function(path) {
-  if (tiledb_version(TRUE) < "2.0.3") stop("Raw statistics are available with TileDB Embedded verion 2.0.3 or later")
+  stopifnot(`Argument 'path' must be character` = is.character(path),
+            `Raw statistics are available with TileDB Embedded verion 2.0.3 or later` = tiledb_version(TRUE) >= "2.0.3")
   libtiledb_stats_raw_dump(path)
 }
 
@@ -91,7 +93,7 @@ tiledb_stats_raw_dump <- function(path) {
 #' It required TileDB Embedded 2.0.3 or later.
 #' @export
 tiledb_stats_raw_print <- function() {
-  if (tiledb_version(TRUE) < "2.0.3") stop("Raw statistics are available with TileDB Embedded verion 2.0.3 or later")
+  stopifnot(`Raw statistics are available with TileDB Embedded verion 2.0.3 or later` = tiledb_version(TRUE) >= "2.0.3")
   libtiledb_stats_raw_dump("")
 }
 
@@ -102,6 +104,6 @@ tiledb_stats_raw_print <- function() {
 #' It required TileDB Embedded 2.0.3 or later.
 #' @export
 tiledb_stats_raw_get <- function() {
-  if (tiledb_version(TRUE) < "2.0.3") stop("Raw statistics are available with TileDB Embedded verion 2.0.3 or later")
+  stopifnot(`Raw statistics are available with TileDB Embedded verion 2.0.3 or later` = tiledb_version(TRUE) >= "2.0.3")
   libtiledb_stats_raw_get()
 }

--- a/R/Utils.R
+++ b/R/Utils.R
@@ -1,6 +1,6 @@
 #  MIT License
 #
-#  Copyright (c) 2017-2020 TileDB Inc.
+#  Copyright (c) 2017-2021 TileDB Inc.
 #
 #  Permission is hereby granted, free of charge, to any person obtaining a copy
 #  of this software and associated documentation files (the "Software"), to deal
@@ -108,11 +108,11 @@ nd_index_from_syscall <- function(call, env_frame) {
 }
 
 isNestedList <- function(l) {
-  stopifnot(is.list(l))
-  for (i in l) {
-    if (is.list(i)) return(TRUE)
-  }
-  return(FALSE)
+    stopifnot(`Argument 'l' must be a list` = is.list(l))
+    for (i in l) {
+        if (is.list(i)) return(TRUE)
+    }
+    return(FALSE)
 }
 
 ##' Look up TileDB type corresponding to the type of an R object
@@ -122,22 +122,22 @@ isNestedList <- function(l) {
 ##' @return single character, e.g. INT32
 ##' @export
 r_to_tiledb_type <- function(x) {
-    storage_mode = storage.mode(x)
+    storage_mode <- storage.mode(x)
     if (storage_mode == "list")
-        storage_mode = storage.mode(x[[1]])
+        storage_mode <- storage.mode(x[[1]])
     if (storage_mode == "integer" || storage_mode == "logical") {
-        type = "INT32"
+        type <- "INT32"
     } else if (storage_mode == "double"){
-        type = "FLOAT64"
+        type <- "FLOAT64"
     } else if (storage_mode == "character"){
-        type = "UTF8"
+        type <- "UTF8"
     } else {
         message("Data type ", storage_mode, " not supported for now.")
     }
     type
 }
 
-## was in file MetaData.R
+## next two were in file MetaData.R
 
 .isArray <- function(arr) {
     is(arr, "tiledb_sparse") || is(arr, "tiledb_dense") || is(arr, "tiledb_array")

--- a/R/Utils.R
+++ b/R/Utils.R
@@ -136,3 +136,13 @@ r_to_tiledb_type <- function(x) {
     }
     type
 }
+
+## was in file MetaData.R
+
+.isArray <- function(arr) {
+    is(arr, "tiledb_sparse") || is(arr, "tiledb_dense") || is(arr, "tiledb_array")
+}
+
+.assertArray <- function(arr) {
+    stopifnot(is(arr, "tiledb_sparse") || is(arr, "tiledb_dense") || is(arr, "tiledb_array"))
+}

--- a/R/VFS.R
+++ b/R/VFS.R
@@ -1,6 +1,6 @@
 #  MIT License
 #
-#  Copyright (c) 2017-2020 TileDB Inc.
+#  Copyright (c) 2017-2021 TileDB Inc.
 #
 #  Permission is hereby granted, free of charge, to any person obtaining a copy
 #  of this software and associated documentation files (the "Software"), to deal
@@ -76,8 +76,8 @@ tiledb_vfs_create_bucket <- function(uri, vfs = tiledb_get_vfs()) {
      vfs <- uri
      uri <- tmp
   }
-  stopifnot(vfs_argument=is(vfs, "tiledb_vfs"),
-            uri_argument=is.character(uri))
+  stopifnot(`Argument 'vfs' must a tiledb_vfs object` = is(vfs, "tiledb_vfs"),
+            `Argument 'uri' must be character` = is.character(uri))
   libtiledb_vfs_create_bucket(vfs@ptr, uri)
 }
 
@@ -94,8 +94,8 @@ tiledb_vfs_remove_bucket <- function(uri, vfs = tiledb_get_vfs()) {
      vfs <- uri
      uri <- tmp
   }
-  stopifnot(vfs_argument=is(vfs, "tiledb_vfs"),
-            uri_argument=is.character(uri))
+  stopifnot(`Argument 'vfs' must a tiledb_vfs object` = is(vfs, "tiledb_vfs"),
+            `Argument 'uri' must be character` = is.character(uri))
   libtiledb_vfs_remove_bucket(vfs@ptr, uri)
 }
 
@@ -121,8 +121,8 @@ tiledb_vfs_is_bucket <- function(uri, vfs = tiledb_get_vfs()) {
      vfs <- uri
      uri <- tmp
   }
-  stopifnot(vfs_argument=is(vfs, "tiledb_vfs"),
-            uri_argument=is.character(uri))
+  stopifnot(`Argument 'vfs' must a tiledb_vfs object` = is(vfs, "tiledb_vfs"),
+            `Argument 'uri' must be character` = is.character(uri))
   libtiledb_vfs_is_bucket(vfs@ptr, uri)
 }
 
@@ -148,8 +148,8 @@ tiledb_vfs_is_empty_bucket <- function(uri, vfs = tiledb_get_vfs()) {
      vfs <- uri
      uri <- tmp
   }
-  stopifnot(vfs_argument=is(vfs, "tiledb_vfs"),
-            uri_argument=is.character(uri))
+  stopifnot(`Argument 'vfs' must a tiledb_vfs object` = is(vfs, "tiledb_vfs"),
+            `Argument 'uri' must be character` = is.character(uri))
   libtiledb_vfs_is_empty_bucket(vfs@ptr, uri)
 }
 
@@ -166,8 +166,8 @@ tiledb_vfs_empty_bucket <- function(uri, vfs = tiledb_get_vfs()) {
      vfs <- uri
      uri <- tmp
   }
-  stopifnot(vfs_argument=is(vfs, "tiledb_vfs"),
-            uri_argument=is.character(uri))
+  stopifnot(`Argument 'vfs' must a tiledb_vfs object` = is(vfs, "tiledb_vfs"),
+            `Argument 'uri' must be character` = is.character(uri))
   libtiledb_vfs_empty_bucket(vfs@ptr, uri)
 }
 
@@ -184,8 +184,8 @@ tiledb_vfs_create_dir <- function(uri, vfs = tiledb_get_vfs()) {
      vfs <- uri
      uri <- tmp
   }
-  stopifnot(vfs_argument=is(vfs, "tiledb_vfs"),
-            uri_argument=is.character(uri))
+  stopifnot(`Argument 'vfs' must a tiledb_vfs object` = is(vfs, "tiledb_vfs"),
+            `Argument 'uri' must be character` = is.character(uri))
   libtiledb_vfs_create_dir(vfs@ptr, uri)
 }
 
@@ -202,8 +202,8 @@ tiledb_vfs_is_dir <- function(uri, vfs = tiledb_get_vfs()) {
      vfs <- uri
      uri <- tmp
   }
-  stopifnot(vfs_argument=is(vfs, "tiledb_vfs"),
-            uri_argument=is.character(uri))
+  stopifnot(`Argument 'vfs' must a tiledb_vfs object` = is(vfs, "tiledb_vfs"),
+            `Argument 'uri' must be character` = is.character(uri))
   libtiledb_vfs_is_dir(vfs@ptr, uri)
 }
 
@@ -220,8 +220,8 @@ tiledb_vfs_remove_dir <- function(uri, vfs = tiledb_get_vfs()) {
      vfs <- uri
      uri <- tmp
   }
-  stopifnot(vfs_argument=is(vfs, "tiledb_vfs"),
-            uri_argument=is.character(uri))
+  stopifnot(`Argument 'vfs' must a tiledb_vfs object` = is(vfs, "tiledb_vfs"),
+            `Argument 'uri' must be character` = is.character(uri))
   invisible(libtiledb_vfs_remove_dir(vfs@ptr, uri))
 }
 
@@ -238,8 +238,8 @@ tiledb_vfs_is_file <- function(uri, vfs = tiledb_get_vfs()) {
      vfs <- uri
      uri <- tmp
   }
-  stopifnot(vfs_argument=is(vfs, "tiledb_vfs"),
-            uri_argument=is.character(uri))
+  stopifnot(`Argument 'vfs' must a tiledb_vfs object` = is(vfs, "tiledb_vfs"),
+            `Argument 'uri' must be character` = is.character(uri))
   libtiledb_vfs_is_file(vfs@ptr, uri)
 }
 
@@ -256,8 +256,8 @@ tiledb_vfs_remove_file <- function(uri, vfs = tiledb_get_vfs()) {
      vfs <- uri
      uri <- tmp
   }
-  stopifnot(vfs_argument=is(vfs, "tiledb_vfs"),
-            uri_argument=is.character(uri))
+  stopifnot(`Argument 'vfs' must a tiledb_vfs object` = is(vfs, "tiledb_vfs"),
+            `Argument 'uri' must be character` = is.character(uri))
   libtiledb_vfs_remove_file(vfs@ptr, uri)
 }
 
@@ -274,8 +274,8 @@ tiledb_vfs_file_size <- function(uri, vfs = tiledb_get_vfs()) {
      vfs <- uri
      uri <- tmp
   }
-  stopifnot(vfs_argument=is(vfs, "tiledb_vfs"),
-            uri_argument=is.character(uri))
+  stopifnot(`Argument 'vfs' must a tiledb_vfs object` = is(vfs, "tiledb_vfs"),
+            `Argument 'uri' must be character` = is.character(uri))
   libtiledb_vfs_file_size(vfs@ptr, uri)
 }
 
@@ -296,9 +296,9 @@ tiledb_vfs_move_file <- function(olduri, newuri, vfs = tiledb_get_vfs()) {
      olduri <- newuri
      newuri <- tmp
   }
-  stopifnot(vfs_argument=is(vfs, "tiledb_vfs"),
-            olduri_argument=is.character(olduri),
-            newuri_argument=is.character(newuri))
+  stopifnot(`Argument 'vfs' must a tiledb_vfs object` = is(vfs, "tiledb_vfs"),
+            `Argument 'olduri' must be character` = is.character(olduri),
+            `Argument 'newuri' must be character` = is.character(newuri))
   libtiledb_vfs_move_file(vfs@ptr, olduri, newuri)
 }
 
@@ -317,9 +317,9 @@ tiledb_vfs_move_dir <- function(olduri, newuri, vfs = tiledb_get_vfs()) {
      olduri <- newuri
      newuri <- tmp
   }
-  stopifnot(vfs_argument=is(vfs, "tiledb_vfs"),
-            olduri_argument=is.character(olduri),
-            newuri_argument=is.character(newuri))
+  stopifnot(`Argument 'vfs' must a tiledb_vfs object` = is(vfs, "tiledb_vfs"),
+            `Argument 'olduri' must be character` = is.character(olduri),
+            `Argument 'newuri' must be character` = is.character(newuri))
   libtiledb_vfs_move_dir(vfs@ptr, olduri, newuri)
 }
 
@@ -336,8 +336,8 @@ tiledb_vfs_touch <- function(uri, vfs = tiledb_get_vfs()) {
      vfs <- uri
      uri <- tmp
   }
-  stopifnot(vfs_argument=is(vfs, "tiledb_vfs"),
-            uri_argument=is.character(uri))
+  stopifnot(`Argument 'vfs' must a tiledb_vfs object` = is(vfs, "tiledb_vfs"),
+            `Argument 'uri' must be character` = is.character(uri))
   libtiledb_vfs_touch(vfs@ptr, uri)
 }
 
@@ -364,6 +364,7 @@ tiledb_get_vfs <- function() {
 #' storing the VFS object.
 #' @export
 tiledb_set_vfs <- function(vfs) {
+  stopifnot(`Argument 'vfs' must a tiledb_vfs object` = is(vfs, "tiledb_vfs"))
   ## set the ctx entry from the package environment (a lightweight hash)
   .pkgenv[["vfs"]] <- vfs
   invisible(NULL)
@@ -381,9 +382,9 @@ tiledb_set_vfs <- function(vfs) {
 tiledb_vfs_open <- function(binfile, mode = c("READ", "WRITE", "APPEND"),
                             vfs = tiledb_get_vfs(), ctx = tiledb_get_context()) {
   mode <- match.arg(mode)
-  stopifnot(binfile_argument=is.character(binfile),
-            vfs_argument=is(vfs, "tiledb_vfs"),
-            ctx_argument=is(ctx, "tiledb_ctx"))
+  stopifnot(`Argument 'vfs' must a tiledb_vfs object` = is(vfs, "tiledb_vfs"),
+            `Argument 'ctx' must a tiledb_ctx object` = is(ctx, "tiledb_ctx"),
+            `Argument 'binfile' must be character` = is.character(binfile))
   libtiledb_vfs_open(ctx@ptr, vfs@ptr, binfile, mode)
 }
 
@@ -394,8 +395,8 @@ tiledb_vfs_open <- function(binfile, mode = c("READ", "WRITE", "APPEND"),
 #' @return The result of the close operation is returned.
 #' @export
 tiledb_vfs_close <- function(fh, ctx = tiledb_get_context()) {
-  stopifnot(fh_argument=is(fh, "externalptr"),
-            ctx_argument=is(ctx, "tiledb_ctx"))
+  stopifnot(`Argument 'fh' must be an external pointer` = is(fh, "externalptr"),
+            `Argument 'ctx' must a tiledb_ctx object` = is(ctx, "tiledb_ctx"))
   libtiledb_vfs_close(ctx@ptr, fh)
 }
 
@@ -406,15 +407,15 @@ tiledb_vfs_close <- function(fh, ctx = tiledb_get_context()) {
 #' @return The result of the sync operation is returned.
 #' @export
 tiledb_vfs_sync <- function(fh, ctx = tiledb_get_context()) {
-  stopifnot(fh_argument=is(fh, "externalptr"),
-            ctx_argument=is(ctx, "tiledb_ctx"))
+  stopifnot(`Argument 'fh' must be an external pointer` = is(fh, "externalptr"),
+            `Argument 'ctx' must a tiledb_ctx object` = is(ctx, "tiledb_ctx"))
   libtiledb_vfs_sync(ctx@ptr, fh)
 }
 
 #' Write to a TileDB VFS Filehandle
 #'
 #' This interface currently defaults to using an integer vector. This is suitable for R objects
- #' as the raw vector result from serialization can be mapped easily to an integer vector. It is
+#' as the raw vector result from serialization can be mapped easily to an integer vector. It is
 #' also possible to \code{memcpy} to the contiguous memory of an integer vector should other
 #' (non-R) data be transferred.
 #' @param fh A TileDB VFS Filehandle external pointer as returned from \code{tiledb_vfs_open}
@@ -423,9 +424,9 @@ tiledb_vfs_sync <- function(fh, ctx = tiledb_get_context()) {
 #' @return The result of the write operation is returned.
 #' @export
 tiledb_vfs_write <- function(fh, vec, ctx = tiledb_get_context()) {
-  stopifnot(fh_argument=is(fh, "externalptr"),
-            vec_argument=is.integer(vec),
-            ctx_argument=is(ctx, "tiledb_ctx"))
+  stopifnot(`Argument 'fh' must be an external pointer` = is(fh, "externalptr"),
+            `Argument 'vec' must be integer` = is.integer(vec),
+            `Argument 'ctx' must a tiledb_ctx object` = is(ctx, "tiledb_ctx"))
   libtiledb_vfs_write(ctx@ptr, fh, vec)
 }
 
@@ -444,11 +445,11 @@ tiledb_vfs_write <- function(fh, vec, ctx = tiledb_get_context()) {
 #' @export
 tiledb_vfs_read <- function(fh, offset, nbytes, ctx = tiledb_get_context()) {
   if (missing(offset)) offset <- bit64::as.integer64(0)
-  if (missing(nbytes)) stop("nbytes currently a required parameter")
-  stopifnot(fh_argument=is(fh, "externalptr"),
-            offset_argument=is(offset, "integer64"),
-            nbytes_argument=is(nbytes, "integer64"),
-            ctx_argument=is(ctx, "tiledb_ctx"))
+  stopifnot(`Argument 'fh' must be an external pointer` = is(fh, "externalptr"),
+            `Argument 'offset' must be integer64` = is(offset, "integer64"),
+            `Argument 'nbytes' currently a required parameter` = !missing(nbytes),
+            `Argument 'nbytes' must be integer64` = is(nbytes, "integer64"),
+            `Argument 'ctx' must a tiledb_ctx object` = is(ctx, "tiledb_ctx"))
   libtiledb_vfs_read(ctx@ptr, fh, offset, nbytes)
 }
 
@@ -459,8 +460,8 @@ tiledb_vfs_read <- function(fh, offset, nbytes, ctx = tiledb_get_context()) {
 #' @return The size of the directory
 #' @export
 tiledb_vfs_dir_size <- function(uri, vfs = tiledb_get_vfs()) {
-  stopifnot(vfs_argument=is(vfs, "tiledb_vfs"),
-            uri_argument=is.character(uri))
+  stopifnot(`Argument 'vfs' must a tiledb_vfs object` = is(vfs, "tiledb_vfs"),
+            `Argument 'uri' must be character` = is.character(uri))
   libtiledb_vfs_dir_size(vfs@ptr, uri)
 }
 
@@ -471,7 +472,7 @@ tiledb_vfs_dir_size <- function(uri, vfs = tiledb_get_vfs()) {
 #' @return The content of the directory, non-recursive
 #' @export
 tiledb_vfs_ls <- function(uri, vfs = tiledb_get_vfs()) {
-  stopifnot(vfs_argument=is(vfs, "tiledb_vfs"),
-            uri_argument=is.character(uri))
+  stopifnot(`Argument 'vfs' must a tiledb_vfs object` = is(vfs, "tiledb_vfs"),
+            `Argument 'uri' must be character` = is.character(uri))
   libtiledb_vfs_ls(vfs@ptr, uri)
 }

--- a/R/Version.R
+++ b/R/Version.R
@@ -1,6 +1,6 @@
 #  MIT License
 #
-#  Copyright (c) 2017-2020 TileDB Inc.
+#  Copyright (c) 2017-2021 TileDB Inc.
 #
 #  Permission is hereby granted, free of charge, to any person obtaining a copy
 #  of this software and associated documentation files (the "Software"), to deal
@@ -32,8 +32,9 @@
 #' tiledb_version(compact = TRUE)
 #' @export
 tiledb_version <- function(compact = FALSE) {
-  if (compact)
-    as.package_version(paste(unname(tiledb_version()), collapse="."))
-  else
-    libtiledb_version()
+    stopifnot(`Argument 'compact' must be logical` = is.logical(compact))
+    if (compact)
+        as.package_version(paste(unname(tiledb_version()), collapse="."))
+    else
+        libtiledb_version()
 }

--- a/inst/tinytest/test_fragmentinfo.R
+++ b/inst/tinytest/test_fragmentinfo.R
@@ -48,7 +48,7 @@ rng <- tiledb_fragment_info_get_timestamp_range(fraginf, 0)
 expect_true(inherits(rng, "POSIXt"))
 expect_equal(length(rng), 2)
 expect_equal(as.Date(rng[1]), as.Date(as.POSIXlt(Sys.time(), tz="UTC")))  # very coarse :)
-expect_true(as.numeric(difftime(Sys.time(), rng[1], "secs")) < 0.5 + 1.0*isMacOS) # at most 0.5 sec after array creation (plus extra for maxOS which failed here randomly)
+expect_true(as.numeric(difftime(Sys.time(), rng[1], "secs")) < 10) # ten is very conservative but when this runs under valgrind it can be slooooooooow
 expect_equal(tiledb_fragment_info_get_cell_num(fraginf, 0), 10)
 
 expect_true(tiledb_fragment_info_get_version(fraginf, 0) > 5) # we may test with older core libs

--- a/inst/tinytest/test_misc.R
+++ b/inst/tinytest/test_misc.R
@@ -7,10 +7,8 @@ if (isOldWindows) exit_file("skip this file on old Windows releases")
 
 ctx <- tiledb_ctx(limitTileDBCores())
 
-if (tiledb_version(TRUE) < "2.6.0") exit_file("These tests require TileDB 2.6.0 or newer")
+if (tiledb_version(TRUE) < "2.5.1") exit_file("These tests require TileDB 2.5.1 or newer")
 
-#if (is.null(get0("tiledb_error_message"))) exit_file("No 'tiledb_error_message'")
-#res <- tryCatch(tiledb_error_message, error = function(e) NULL)
-#if (is.null(res)) exit_file("TileDB library prior to PR #2634")
+if (is.null(get0("tiledb_error_message"))) exit_file("No 'tiledb_error_message'")
 expect_true(inherits(tiledb_error_message(), "character"))
-#expect_error(tiledb_error_message())
+expect_true(is.character(tiledb_error_message()))

--- a/src/libtiledb.cpp
+++ b/src/libtiledb.cpp
@@ -1245,8 +1245,8 @@ XPtr<tiledb::FilterList> libtiledb_filter_list(XPtr<tiledb::Context> ctx, List f
 }
 
 //[[Rcpp::export]]
-void libtiledb_filter_list_set_max_chunk_size(XPtr<tiledb::FilterList> filterList, uint32_t max_chunk_sie) {
-  filterList->set_max_chunk_size(max_chunk_sie);
+void libtiledb_filter_list_set_max_chunk_size(XPtr<tiledb::FilterList> filterList, uint32_t max_chunk_size) {
+  filterList->set_max_chunk_size(max_chunk_size);
 }
 
 //[[Rcpp::export]]


### PR DESCRIPTION
This PR updates the package to check all user-facing arguments consistently via the 'named vector' form of `stopifnot()` that has been available since R 4.0.0.  No actual package functionality was added or removed.