### PR TITLE
Relax minimum version for test to 2.6.0

### DIFF
--- a/inst/tinytest/test_misc.R
+++ b/inst/tinytest/test_misc.R
@@ -7,7 +7,7 @@ if (isOldWindows) exit_file("skip this file on old Windows releases")
 
 ctx <- tiledb_ctx(limitTileDBCores())
 
-if (tiledb_version(TRUE) < "2.5.1") exit_file("These tests require TileDB 2.5.1 or newer")
+if (tiledb_version(TRUE) < "2.6.0") exit_file("These tests require TileDB 2.6.0 or newer")
 
 if (is.null(get0("tiledb_error_message"))) exit_file("No 'tiledb_error_message'")
 expect_true(inherits(tiledb_error_message(), "character"))


### PR DESCRIPTION
This PR corrects one test in its checks for minimum requirements which were too lax and have been seen failing with pre-build 2.5.2 and download setups.