### PR TITLE
Update to TileDB 2.5.3

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -196,8 +196,8 @@ libtiledb_filter_list <- function(ctx, filters) {
     .Call(`_tiledb_libtiledb_filter_list`, ctx, filters)
 }
 
-libtiledb_filter_list_set_max_chunk_size <- function(filterList, max_chunk_sie) {
-    invisible(.Call(`_tiledb_libtiledb_filter_list_set_max_chunk_size`, filterList, max_chunk_sie))
+libtiledb_filter_list_set_max_chunk_size <- function(filterList, max_chunk_size) {
+    invisible(.Call(`_tiledb_libtiledb_filter_list_set_max_chunk_size`, filterList, max_chunk_size))
 }
 
 libtiledb_filter_list_get_max_chunk_size <- function(filterList) {

--- a/man/tiledb_error_message.Rd
+++ b/man/tiledb_error_message.Rd
@@ -13,5 +13,5 @@ tiledb_error_message(ctx = tiledb_get_context())
 A character variable with the error message
 }
 \description{
-Return the error message for a given context
+Note that this function requires an actual error to have occurred.
 }

--- a/man/tiledb_filter_list_set_max_chunk_size.Rd
+++ b/man/tiledb_filter_list_set_max_chunk_size.Rd
@@ -15,7 +15,7 @@ tiledb_filter_list_set_max_chunk_size(object, value)
 \arguments{
 \item{object}{tiledb_filter_list}
 
-\item{value}{string}
+\item{value}{A numeric value}
 }
 \description{
 Set the filter_list's max_chunk_size

--- a/man/tiledb_fragment_info_get_non_empty_domain_index.Rd
+++ b/man/tiledb_fragment_info_get_non_empty_domain_index.Rd
@@ -14,7 +14,7 @@ tiledb_fragment_info_get_non_empty_domain_index(object, fid, did, typestr)
 \item{did}{A domain index}
 
 \item{typestr}{An optional character variable describing the data type which will
-be accessed from the schema if missinh}
+be accessed from the schema if missing}
 }
 \value{
 A TileDB Domain object

--- a/man/tiledb_query_alloc_buffer_ptr_char.Rd
+++ b/man/tiledb_query_alloc_buffer_ptr_char.Rd
@@ -7,9 +7,9 @@
 tiledb_query_alloc_buffer_ptr_char(sizeoffsets, sizedata)
 }
 \arguments{
-\item{sizeoffsets}{An optional value of the size of the offsets vector}
+\item{sizeoffsets}{A numeric value with the size of the offsets vector}
 
-\item{sizedata}{An optional value of the size of the data string}
+\item{sizedata}{A numeric value of the size of the data string}
 }
 \value{
 An external pointer to the allocated buffer object

--- a/man/tiledb_query_get_range_num.Rd
+++ b/man/tiledb_query_get_range_num.Rd
@@ -9,7 +9,7 @@ tiledb_query_get_range_num(query, idx)
 \arguments{
 \item{query}{A TileDB Query object}
 
-\item{idx}{An integer index selecting the dimension}
+\item{idx}{An integer or numeric index selecting the dimension}
 }
 \value{
 An integer with the number of query range for the

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -539,13 +539,13 @@ BEGIN_RCPP
 END_RCPP
 }
 // libtiledb_filter_list_set_max_chunk_size
-void libtiledb_filter_list_set_max_chunk_size(XPtr<tiledb::FilterList> filterList, uint32_t max_chunk_sie);
-RcppExport SEXP _tiledb_libtiledb_filter_list_set_max_chunk_size(SEXP filterListSEXP, SEXP max_chunk_sieSEXP) {
+void libtiledb_filter_list_set_max_chunk_size(XPtr<tiledb::FilterList> filterList, uint32_t max_chunk_size);
+RcppExport SEXP _tiledb_libtiledb_filter_list_set_max_chunk_size(SEXP filterListSEXP, SEXP max_chunk_sizeSEXP) {
 BEGIN_RCPP
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< XPtr<tiledb::FilterList> >::type filterList(filterListSEXP);
-    Rcpp::traits::input_parameter< uint32_t >::type max_chunk_sie(max_chunk_sieSEXP);
-    libtiledb_filter_list_set_max_chunk_size(filterList, max_chunk_sie);
+    Rcpp::traits::input_parameter< uint32_t >::type max_chunk_size(max_chunk_sizeSEXP);
+    libtiledb_filter_list_set_max_chunk_size(filterList, max_chunk_size);
     return R_NilValue;
 END_RCPP
 }

--- a/tools/tiledbVersion.txt
+++ b/tools/tiledbVersion.txt
@@ -1,2 +1,2 @@
-version: 2.5.2
-sha: f9c058f
+version: 2.5.3
+sha: dd6a41b


### PR DESCRIPTION
This PR does the usual update to version and sha1 for the most recent release artifacts.

It also adds a minor cleanup in 
- an update from one function (made in early) correcting a typo in a function argument from 'sie' to 'size' which is carried over to the (autogenerated) file RcppExports.cpp, 
- plus two minor edits for wording in manual files, generated from the R files via `roxygen2`
- but no functional change.