### PR TITLE
Use TileDB 2.6.0

### DIFF
--- a/tools/tiledbVersion.txt
+++ b/tools/tiledbVersion.txt
@@ -1,2 +1,2 @@
-version: 2.6.0-rc2
+version: 2.6.0
 sha: 66f4b41

--- a/tools/tiledbVersion.txt
+++ b/tools/tiledbVersion.txt
@@ -1,2 +1,2 @@
-version: 2.6.0-rc0
-sha: cb4b761
+version: 2.6.0-rc1
+sha: 69c34b7

--- a/tools/tiledbVersion.txt
+++ b/tools/tiledbVersion.txt
@@ -1,2 +1,2 @@
-version: 2.6.0-rc1
-sha: 69c34b7
+version: 2.6.0-rc2
+sha: 66f4b41

--- a/tools/tiledbVersion.txt
+++ b/tools/tiledbVersion.txt
@@ -1,2 +1,2 @@
-version: 2.5.3
-sha: dd6a41b
+version: 2.6.0-rc0
+sha: cb4b761


### PR DESCRIPTION
~(Draft) PR to start the tests for 2.6.0.  This can remain open and updated til 2.6.0 is final.~

Use TileDB 2.6.0 in the R package.  No changes apart from the updated tag.