### PR TITLE
Additinal polish on show methods

### DIFF
--- a/R/ArraySchema.R
+++ b/R/ArraySchema.R
@@ -157,11 +157,12 @@ setMethod("show", signature(object = "tiledb_array_schema"),
     cat("- Offsets filters:", nfilters(fl$offsets), "\n")
     show(fl$offsets)
     ## Validity filters are not currently exposed in either the Python or R API
+    cat("\n")
 
     show(domain(object))
 
     ## attrs() returns a list, could make it proper tiledb_* object with its show() method
-    sapply(seq_along(attrs(object)), function(i) { cat("\n"); show(attrs(object, i)) } )
+    sapply(attrs(object), show)
 })
 
 #' @rdname generics

--- a/R/ArraySchema.R
+++ b/R/ArraySchema.R
@@ -144,37 +144,25 @@ tiledb_array_schema.from_array <- function(x, ctx = tiledb_get_context()) {
 #' @param object An array_schema object
 #' @export
 setMethod("show", signature(object = "tiledb_array_schema"),
-          function(object) {
-            cat("- Array type:", if (is.sparse(object)) "sparse" else "dense", "\n")
-            cat("- Cell order:", cell_order(object), "\n")
-            cat("- Tile order:", tile_order(object), "\n")
-            cat("- Capacity:", capacity(object), "\n")
-            if (is.sparse(object)) {
-              cat("- Allows duplicates:", allows_dups(object), "\n")
-            } else {
-              cat("- Allows duplicates:", FALSE, "\n")
-            }
+          definition = function(object) {
+    cat("- Array type:", if (is.sparse(object)) "sparse" else "dense", "\n")
+    cat("- Cell order:", cell_order(object), "\n")
+    cat("- Tile order:", tile_order(object), "\n")
+    cat("- Capacity:", capacity(object), "\n")
+    cat("- Allows duplicates:", if (is.sparse(object)) allows_dups(object) else FALSE, "\n")
 
-            fl <- filter_list(object)
+    fl <- filter_list(object)
+    cat("- Coordinates filters:", nfilters(fl$coords), "\n")
+    show(fl$coords)
+    cat("- Offsets filters:", nfilters(fl$offsets), "\n")
+    show(fl$offsets)
+    ## Validity filters are not currently exposed in either the Python or R API
 
-            flc <- fl$coords
-            cat("- Coordinates filters:", nfilters(flc), "\n")
-            show(flc)
+    show(domain(object))
 
-            flo <- fl$offsets
-            cat("- Offsets filters:", nfilters(flo), "\n")
-            show(flo)
-
-            # Validity filters are not currently exposed in either the Python or R API
-
-            show(domain(object))
-
-            nattr <- length(attrs(object))
-            for (i in 1:nattr) {
-              cat("\n")
-              show(attrs(object, i))
-            }
-          })
+    ## attrs() returns a list, could make it proper tiledb_* object with its show() method
+    sapply(seq_along(attrs(object)), function(i) { cat("\n"); show(attrs(object, i)) } )
+})
 
 #' @rdname generics
 #' @export

--- a/R/Attribute.R
+++ b/R/Attribute.R
@@ -73,20 +73,21 @@ tiledb_attr <- function(name,
 #'
 #' @param object An attribute object
 #' @export
-setMethod("show", "tiledb_attr",
-          function(object) {
-            cat("### Attribute ###\n")
-            cat("- Name:", name(object), "\n")
-            cat("- Type:", datatype(object), "\n")
-            cat("- Nullable:", tiledb_attribute_get_nullable(object), "\n")
-            cat("- Cell val num:", cell_val_num(object), "\n")
-            fl <- filter_list(object)
-            cat("- Filters: ", nfilters(fl), "\n", sep="")
-            show(fl)
-            # TODO: prints as NA but core says -2147483648
-            cat("- Fill value: ")
-            try(cat(tiledb_attribute_get_fill_value(object), "\n"))
-          })
+setMethod("show", signature(object = "tiledb_attr"),
+          definition = function(object) {
+    cat("### Attribute ###\n")
+    cat("- Name:", name(object), "\n")
+    cat("- Type:", datatype(object), "\n")
+    cat("- Nullable:", tiledb_attribute_get_nullable(object), "\n")
+    cat("- Cell val num:", cell_val_num(object), "\n")
+    fl <- filter_list(object)
+    cat("- Filters: ", nfilters(fl), "\n", sep="")
+    show(fl)
+    ## NB: prints NA whereas core shows -2147483648 as core does not know about R's NA
+    cat("- Fill value: ",
+        if (tiledb_attribute_get_nullable(object)) ""
+        else format(tiledb_attribute_get_fill_value(object)), "\n")
+})
 
 
 #' @rdname generics

--- a/R/Attribute.R
+++ b/R/Attribute.R
@@ -87,6 +87,7 @@ setMethod("show", signature(object = "tiledb_attr"),
     cat("- Fill value: ",
         if (tiledb_attribute_get_nullable(object)) ""
         else format(tiledb_attribute_get_fill_value(object)), "\n")
+    cat("\n")
 })
 
 

--- a/R/Dim.R
+++ b/R/Dim.R
@@ -110,6 +110,7 @@ setMethod("show", signature(object = "tiledb_dim"),
     fl <- filter_list(object)
     cat("- Filters: ", nfilters(fl), "\n", sep="")
     show(fl)
+    cat("\n")
 })
 
 #' Return the `tiledb_dim` name

--- a/R/Dim.R
+++ b/R/Dim.R
@@ -98,35 +98,19 @@ tiledb_dim <- function(name, domain, tile, type, ctx = tiledb_get_context()) {
 #' @param object An array_schema object
 #' @export
 setMethod("show", signature(object = "tiledb_dim"),
-          function(object) {
-            cat("### Dimension ###\n")
-            cat("- Name:", name(object), "\n")
-            cat("- Type:", datatype(object), "\n")
-
-            cell_val_num <- tiledb_dim_get_cell_val_num(object)
-            cat("- Cell val num: ", cell_val_num, "\n")
-
-            # Example output: "1 4". If we do
-            #   cat(ifelse(is.na(cell_val_num), "(null)", domain(object)), "\n")
-            # then only the "1" prints.
-            cat("- Domain: ")
-            if (is.na(cell_val_num)) {
-              cat("(null)\n")
-            } else {
-              cat(domain(object), "\n", sep="")
-            }
-
-            cat("- Tile extent: ")
-            if (is.na(cell_val_num)) {
-              cat("(null)\n")
-            } else {
-              cat(tile(object), "\n", sep="")
-            }
-
-            fl <- filter_list(object)
-            cat("- Filters: ", nfilters(fl), "\n", sep="")
-            show(fl)
-          })
+          definition = function(object) {
+    cat("### Dimension ###\n")
+    cat("- Name:", name(object), "\n")
+    cat("- Type:", datatype(object), "\n")
+    cells <- cell_val_num(object)
+    cat("- Cell val num:", cells, "\n")
+    cat("- Domain:", if (is.na(cells)) "(null,null)"
+                     else paste0("[", paste0(domain(object), collapse=","), "]"), "\n")
+    cat("- Tile extent:", if (is.na(cells)) "(null)" else dim(object), "\n")
+    fl <- filter_list(object)
+    cat("- Filters: ", nfilters(fl), "\n", sep="")
+    show(fl)
+})
 
 #' Return the `tiledb_dim` name
 #'

--- a/R/Domain.R
+++ b/R/Domain.R
@@ -65,14 +65,9 @@ tiledb_domain <- function(dims, ctx = tiledb_get_context()) {
 #' @param object A domain object
 #' @export
 setMethod("show", "tiledb_domain",
-          function(object) {
-            ndim <- tiledb_ndim(object)
-            dims <- dimensions(object)
-            for (i in 1:ndim) {
-              cat("\n")
-              show(dims[[i]])
-            }
-          })
+          definition = function(object) {
+    sapply(dimensions(object), show)
+})
 
 #' Returns a list of the tiledb_domain dimension objects
 #'

--- a/R/Filter.R
+++ b/R/Filter.R
@@ -70,17 +70,21 @@ tiledb_filter <- function(name = "NONE", ctx = tiledb_get_context()) {
 #' @param object A filter object
 #' @export
 setMethod("show", signature(object = "tiledb_filter"),
-          function(object) {
-            cat("  > ")
-            cat(tiledb_filter_type(object), ": ", sep="")
-            for (option in c("COMPRESSION_LEVEL", "BIT_WIDTH_MAX_WINDOW", "POSITIVE_DELTA_MAX_WINDOW")) {
-              tryCatch(
-                cat(option, "=", tiledb_filter_get_option(object, option), sep=""),
-                error=function(x){}
-              )
-            }
-            cat("\n")
-          })
+          definition = function(object) {
+    flt <- tiledb_filter_type(object)
+    .getAndShow <- function(obj, arg) cat(paste0(arg, "=", tiledb_filter_get_option(obj, arg)))
+    cat("  > ", flt, ": ", sep="")
+    if (flt %in% c("GZIP", "ZSTD", "LZ4", "BZIP2")) {
+        .getAndShow(object, "COMPRESSION_LEVEL")
+    } else if (flt %in% "BIT_WIDTH_REDUCTION") {
+        .getAndShow(object, "BIT_WIDTH_MAX_WINDOW")
+    } else if (flt %in% "POSITIVE_DELTA") {
+        .getAndShow(object, "POSITIVE_DELTA_MAX_WINDOW")
+    } else {
+        cat("NA")
+    }
+    cat("\n")
+})
 
 #' Returns the type of the filter used
 #'

--- a/R/FilterList.R
+++ b/R/FilterList.R
@@ -68,17 +68,10 @@ tiledb_filter_list <- function(filters = c(), ctx = tiledb_get_context()) {
 #' @param object A filter_list object
 #' @export
 setMethod("show", signature(object = "tiledb_filter_list"),
-          function(object) {
-            nfi <- nfilters(object)
-            # This is necessary to avoid out-of-bounds error on nfi == 0 case.
-            # That's because these are 0-up indexed (unusually for R), and 1:0 is
-            # the two-element sequence (1,0).
-            if (nfi > 0) {
-              for (i in 1:nfi) {
-                show(object[i-1])
-              }
-            }
-          })
+          definition = function(object) {
+    ## This is necessary as these are 0-up indexed (unusually for R, a leftover from older code here)
+    sapply(seq_len(nfilters(object)), function(i) show(object[i-1]))
+})
 
 #' @rdname tiledb_filter_list_set_max_chunk_size
 #' @export

--- a/inst/tinytest/test_attr.R
+++ b/inst/tinytest/test_attr.R
@@ -93,10 +93,10 @@ sch <- tiledb_array_schema(dom, attr)
 uri <- tempfile()
 if (dir.exists(uri)) unlink(uri, recursive=TRUE)
 tiledb_array_create(uri, sch)
-arr <- tiledb_dense(uri)
-val <- arr[]
+arr <- tiledb_array(uri, return_as="asis", extended=FALSE)
+val <- arr[1:4][[1]]
 ## when fill value has been set, expect value
-expect_equal(val, array(rep(42, 4)))
+expect_equal(val, rep(42, 4))
 expect_equal(tiledb_attribute_get_fill_value(attr), 42)
 
 attr <- tiledb_attr("b", type = "CHAR", ncells = NA)


### PR DESCRIPTION
PR #342 is really good and gets us almost to the finish line of not relying on core code (to `stdout`) for object display and adding a numer of missing `show()` methods.   

It tickled an error an real `penguins` data set (with `NA` values, as opposed to the cleansed one in cloud use) which I fixed that. While at it, I also made the code a little tighter and more idiomatic (and removed use of `try`).   I apologise for the whitespace changes but I am quite used to how ESS typesets in base R defaults and this brings methods in further to the left. 

Please have a look with your test arrays, it it is looking ok on the ones I tried. 

(The last commit was needed or else one test on `UINT32` would balk here.  I am not sure how that didn't come up when we looked at the PR that brought it in.  I should also have caught the use of `tiledb_dense` there which we try to phase out / will remove next month.)