### PR TITLE
Only call fill value getter if TileDB 2.1.0 or later

### DIFF
--- a/R/Attribute.R
+++ b/R/Attribute.R
@@ -85,7 +85,7 @@ setMethod("show", signature(object = "tiledb_attr"),
     show(fl)
     ## NB: prints NA whereas core shows -2147483648 as core does not know about R's NA
     cat("- Fill value: ",
-        if (tiledb_attribute_get_nullable(object)) ""
+        if (tiledb_attribute_get_nullable(object) || tiledb_version(TRUE) < "2.1.0") ""
         else format(tiledb_attribute_get_fill_value(object)), "\n")
     cat("\n")
 })


### PR DESCRIPTION
This micro-PR addresses a micro issue in #342 and #345 in that fill value display for attributes requires TileDB 2.1.0 or later.  By adding the one line here we maintain buildability on six release families which is nice.