### PR TITLE
Update GitHub Actions setup-r to v2 to skip qpdf installation step

### DIFF
--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -18,10 +18,9 @@ jobs:
     steps:
       - run: git config --global core.autocrlf false
       - uses: actions/checkout@v2
-      - uses: r-lib/actions/setup-r@v1
+      - uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.r }}
-      - uses: r-lib/actions/setup-pandoc@v1
       - name: Install dependencies
         run: |
           install.packages(c("remotes", "rcmdcheck"))


### PR DESCRIPTION
This PR updates the r-lib/actions/setup-r step to v2 which [corrects](https://github.com/r-lib/actions/issues/474) an now unnecessary explicit `qpdf` installation (as `qpdf` is now inside Rtools, apparently).  While at it we removed the `pandoc` installation step as we test here without manuals or vignettes.

The `qpdf` download step (from chocolatey) had broken about half of our recent Windows Actions so it was a nuisance.  As we do not need the binary, this PR should avoid the breakage by not downloading `pqdf`.

No changes to the actual R package, or deployment other than via GHA for Windows.