### PR TITLE
Use TileDB 2.6.1

### DIFF
--- a/tools/tiledbVersion.txt
+++ b/tools/tiledbVersion.txt
@@ -1,2 +1,2 @@
-version: 2.6.0
-sha: 66f4b41
+version: 2.6.1
+sha: 2f6b7f6


### PR DESCRIPTION
This PR upgrades the package preference to TileDB 2.6.1.

No code changes.