### PR TITLE
Add vignette on data ingestion

### DIFF
--- a/.ci/azure/install-dependencies.yaml
+++ b/.ci/azure/install-dependencies.yaml
@@ -1,3 +1,3 @@
 steps:
-  - script: Rscript -e 'install.packages(c("Rcpp", "nanotime", "tinytest", "curl", "bit64", "knitr", "rmarkdown", "minidown", "Matrix", "palmerpenguins", "nycflights13", "tibble", "data.table"))'
+  - script: Rscript -e 'install.packages(c("Rcpp", "nanotime", "tinytest", "curl", "bit64", "knitr", "rmarkdown", "minidown", "Matrix", "palmerpenguins", "nycflights13", "tibble", "data.table", "simplermarkdown"))'
     displayName: 'Install dependencies'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tiledb
 Type: Package
-Version: 0.11.0
+Version: 0.11.0.1
 Title: Universal Storage Engine for Sparse and Dense Multidimensional Arrays
 Authors@R: c(person("TileDB, Inc.", role = c("aut", "cph")),
  person("Dirk", "Eddelbuettel", email = "dirk@tiledb.com", role = "cre"))
@@ -26,8 +26,8 @@ SystemRequirements: A C++17 compiler is required, and on macOS
  build or download was specified by the user.
 Imports: methods, Rcpp, nanotime
 LinkingTo: Rcpp
-Suggests: tinytest, rmarkdown, knitr, minidown, curl, bit64, Matrix, palmerpenguins, nycflights13, data.table, tibble
-VignetteBuilder: knitr
+Suggests: tinytest, rmarkdown, knitr, minidown, simplermarkdown, curl, bit64, Matrix, palmerpenguins, nycflights13, data.table, tibble
+VignetteBuilder: knitr, simplermarkdown
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.1.2
 Encoding: UTF-8

--- a/vignettes/data-ingestion-from-sql.md
+++ b/vignettes/data-ingestion-from-sql.md
@@ -4,7 +4,7 @@
 %\VignetteEncoding{UTF-8}
 -->
 ---
-title: "TileDB Ingestion Example from SQL"
+title: "TileDB Ingestion from SQL: A Commented Example"
 date: "2022-01-25"
 css: "water.css"
 ---
@@ -26,8 +26,9 @@ connection packages that adhere to, and utilise, the DBI framework.  Some exampl
 [RPostgres](https://cran.r-project.org/web/packages/RPostgres/index.html),
 [RPostgreSQL](https://cran.r-project.org/web/packages/RPostgreSQL/index.html),
 [RPresto](https://cran.r-project.org/web/packages/RPresto/index.html),
-[RRedshiftSQL](https://cran.r-project.org/web/packages/RRedshiftSQL/index.html), and
-[RSQLite](https://cran.r-project.org/web/packages/RSQLite/index.html).
+[RRedshiftSQL](https://cran.r-project.org/web/packages/RRedshiftSQL/index.html),
+[RSQLite](https://cran.r-project.org/web/packages/RSQLite/index.html), and many more as seen via the
+[CRAN page](https://cran.r-project.org/package=DBI).
 
 We provide a simple example using
 [RPostgreSQL](https://cran.r-project.org/web/packages/RPostgreSQL/index.html) and an existing

--- a/vignettes/data-ingestion-from-sql.md
+++ b/vignettes/data-ingestion-from-sql.md
@@ -1,0 +1,145 @@
+<!--
+%\VignetteIndexEntry{Data Ingestion from SQL}
+%\VignetteEngine{simplermarkdown::mdweave_to_html}
+%\VignetteEncoding{UTF-8}
+-->
+---
+title: "TileDB Ingestion Example from SQL"
+date: "2022-01-25"
+css: "water.css"
+---
+
+## Introduction
+
+[TileDB](https://www.tiledb.com/) provides the _Universal Data Engine_ that can be accessed in a
+variety of ways. Users sometimes wonder how to transfer data from existing databases.  This short
+vignettes shows an example relying on the [DBI](https://cran.r-project.org/package=DBI) package for
+R. It offers a powerful and convenient abstraction layer on top a number of database backends with
+connection packages that adhere to, and utilise, the DBI framework.  Some examples are the packages
+(listed in alphabetical order) [duckdb](https://cran.r-project.org/web/packages/duckdb/index.html),
+[RClickhouse](https://cran.r-project.org/web/packages/RClickhouse/index.html),
+[RGreenplum](https://cran.r-project.org/web/packages/RGreenplum/index.html),
+[RJDBC](https://cran.r-project.org/web/packages/RJDBC/index.html),
+[RMariaDB](https://cran.r-project.org/web/packages/RMariaDB/index.html),
+[RMySQL](https://cran.r-project.org/web/packages/RMySQL/index.html),
+[ROracle](https://cran.r-project.org/web/packages/ROracle/index.html),
+[RPostgres](https://cran.r-project.org/web/packages/RPostgres/index.html),
+[RPostgreSQL](https://cran.r-project.org/web/packages/RPostgreSQL/index.html),
+[RPresto](https://cran.r-project.org/web/packages/RPresto/index.html),
+[RRedshiftSQL](https://cran.r-project.org/web/packages/RRedshiftSQL/index.html), and
+[RSQLite](https://cran.r-project.org/web/packages/RSQLite/index.html).
+
+We provide a simple example using
+[RPostgreSQL](https://cran.r-project.org/web/packages/RPostgreSQL/index.html) and an existing
+database of historical stockmarket price data.
+
+## Load Required Packages
+
+The basic setup is straightforward. We load the required package
+[RPostgreSQL](https://cran.r-project.org/web/packages/RPostgreSQL/index.html) which in turn imports
+[DBI]([RPostgreSQL](https://cran.r-project.org/web/packages/DBI/index.html)) as well as
+[tiledb](https://cran.r-project.org/web/packages/tiledb/index.html). We use
+[data.table](https://cran.r-project.org/package=data.table) for its print method, the
+[tibble](https://cran.r-project.org/package=tibble) package offers an alternative):
+
+```r
+library(RPostgreSQL)
+library(data.table)
+library(tiledb)
+```
+
+## Connect to Database
+
+This step uses the DBI abstraction. A compliant backend driver can be loaded via `dbDriver`, and a
+connection can be established via `dbConnect` using appropriate arguments `dbname`, `user`,
+`password`, `host`, and `port`, as needed, with proper dispatching the implementation provided by
+the driver.  The details depend on the chosen backend, this can be as simple as `con <-
+dbConnect(RSQLite::SQLite(), ":memory:")` in the case of
+[RSQLite](https://cran.r-project.org/web/packages/RSQLite/index.html) and an in-memory (and likely
+transient) database.
+
+```r
+## a local SQL db we have here -- about 617k rows
+dbSetup <- function() {
+    drv <- dbDriver("PostgreSQL")
+    con <- dbConnect(drv,
+                     user="...omitted...",
+                     password="...omitted...", # Could use e.g. Sys.getenv("DB_PASSWD")
+                     dbname="...omitted...")
+    con
+}
+```
+
+## Fetch Data
+
+In the next step we fetch the data---and for simplicity issue just one `select` statement returning
+a single `data.frame` (or here a `data.table` variant). In larger-than-memory settings the SQL query
+could easily bucket by symbols, or date range, or ...
+
+
+```r
+getDataFromSQL <- function() {
+    con <- dbSetup()
+    sql <- "select * from stockprices order by symbol, date;"
+    res <- dbGetQuery(con, sql)
+    dbDisconnect(con)
+    setDT(res)                          # create data.table
+    res
+}
+```
+
+## Writing Data to TileDB
+
+Having read the data into memory we can use the TileDB R function `fromDataFrame`. It has numerous
+option to configure, as well as sensible defaults (to for example enable ZSTD compression). Here we
+select the first two columns for symbol and data as dimensions. Symbols, being text, do not set a
+domain set.  For the date we set two 'safe' outer values for the range.
+
+```r
+storeDataTDB <- function(dat, uri) {
+    fromDataFrame(dat, uri,
+                  col_index=1:2,
+                  tile_domain=list(date=c(as.numeric(as.Date("1985-01-01")),
+                                          as.numeric(as.Date("2030-12-31")))))
+}
+```
+
+### Reading Data Back In
+
+Reading data from TileDB is a very standard operation of opening the URI, possibly specifying the
+return type and possibly subsetting by dimension values, or attributes.  Here, for simplicity,
+we just read everything.
+
+```r
+getDataTDB <- function(uri) {
+    set_allocation_size_preference(1e7) # larger than local default value
+    arr <- tiledb_array(uri, return_as="data.frame")
+    res <- arr[]
+    res
+}
+
+uri <- "/tmp/tiledb/beancounter"
+
+res <- getDataFromSQL(con)
+storeData(dat, uri)
+chk <- getDataTDB(uri)
+print(dim(chk))
+cat("Done!\n")
+```
+
+
+## See Also
+
+The vignette [TileDB MariaDB Examples](tiledb-mariadb-examples.html) shows to
+use MariaDB via the MyTile integration of TileDB as a direct backend.
+
+The [TileDB R Tutorial at useR!
+2021](https://github.com/TileDB-Inc/tiledb-r-tutorials/blob/master/2021-06-user-slides/) contained a
+worked example of writing _much_ larger data set in chunks.  The process is very similar to the
+simple example we showed here -- and in addition requires a suffient domain range for the dimension
+along with a (sequential or parallel) loop of reading chunks and writing them to TileDB.
+
+## Summary
+
+This vignette provides a commented walk-through of a worked example of a SQL-to-TileDB data
+ingestion.

--- a/vignettes/water.css
+++ b/vignettes/water.css
@@ -1,0 +1,84 @@
+/* our addition */
+body {
+  max-width: 50rem;
+  margin-left: auto;
+  margin-right: auto;
+  font-family: system-ui;
+}
+
+/* Inline codes */
+code {
+  padding: 2px;
+  border-radius: unset;
+}
+
+/* Code blocks */
+
+pre {
+  background-color: unset;
+  border: solid #aaa 1px;
+  padding: 8px;
+}
+
+pre.numberSource {
+  margin: 0;
+  padding-left: 0;
+}
+
+div.sourceCode {
+  overflow: visible;
+}
+pre, pre.sourceCode {
+  overflow-x: auto;
+}
+pre>code {
+  white-space: pre;
+  overflow: visible;
+  background-color: unset;
+  padding: 0;
+}
+
+pre.sourceCode.numberSource {
+  overflow-x: visible;
+}
+pre.sourceCode.numberSource>code {
+  white-space: pre-wrap
+}
+pre.sourceCode.numberSource>code>span {
+  left: 8px;
+  text-indent: -4.6em;
+}
+
+/* code folding */
+.chunk-summary {
+  text-align: right;
+}
+.chunk-summary+pre,
+.chunk-summary+div.sourceCode {
+  margin-top: 2px;
+}
+
+/* TOC */
+nav > ul {
+  border: .0625rem solid #444;
+  border-radius: 4px;
+  margin: 5px;
+  padding: 5px;
+}
+nav ul {
+  list-style-type: none;
+  padding-inline-start: 1rem;
+}
+nav ul li {
+  padding: 0;
+}
+nav ul ul {
+  margin-top: 0;
+  margin-bottom: 0;
+  padding-top: 0;
+  padding-bottom: 0;
+}
+nav code {
+  background-color: unset;
+  color: unset;
+}


### PR DESCRIPTION
This PR adds a simple vignette for a worked data ingestion example relying on R's DBI to unify the approach no matter where data may come from. 