### PR TITLE
Use TileDB 2.6.2

### DIFF
--- a/tools/tiledbVersion.txt
+++ b/tools/tiledbVersion.txt
@@ -1,2 +1,2 @@
-version: 2.6.1
-sha: 2f6b7f6
+version: 2.6.2
+sha: bf10e49


### PR DESCRIPTION
This PR updates the package preference to TileDB 2.6.1.

No code changes.  The two prior PRs from today have been rebased as well.