### PR TITLE
Add mode=... for data.frame ingestion

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tiledb
 Type: Package
-Version: 0.11.0.1
+Version: 0.11.0
 Title: Universal Storage Engine for Sparse and Dense Multidimensional Arrays
 Authors@R: c(person("TileDB, Inc.", role = c("aut", "cph")),
  person("Dirk", "Eddelbuettel", email = "dirk@tiledb.com", role = "cre"))

--- a/inst/tinytest/test_dataframe.R
+++ b/inst/tinytest/test_dataframe.R
@@ -279,3 +279,30 @@ if (getRversion() < '4.0.0') {
     res$dd <- as.character(res$dd)
 }
 expect_equivalent(df, res)
+
+
+## test ingest vs schema_only vs append
+if (!requireNamespace("palmerpenguins", quietly=TRUE)) exit_file("remainder needs 'palmerpenguins'")
+library(palmerpenguins)
+data <- penguins
+
+uri <- tempfile()
+
+fromDataFrame(data, uri, col_index=1:2, mode="schema_only")
+arr <- tiledb_array(uri, return_as="data.frame")
+chk <- arr[]
+expect_equal(nrow(chk), 0)              # no data
+expect_equal(ncol(chk), ncol(data))     # but all columns
+
+fromDataFrame(data, uri, col_index=1:2, mode="append")
+arr <- tiledb_array(uri, return_as="data.frame")
+chk <- arr[]
+expect_equal(nrow(chk), nrow(data))     # all data
+expect_equal(ncol(chk), ncol(data))     # all columns
+
+tiledb_vfs_remove_dir(uri)
+fromDataFrame(data, uri, col_index=1:2) # default mode
+arr <- tiledb_array(uri, return_as="data.frame")
+chk <- arr[]
+expect_equal(nrow(chk), nrow(data))     # all data
+expect_equal(ncol(chk), ncol(data))     # all columns

--- a/man/fromDataFrame.Rd
+++ b/man/fromDataFrame.Rd
@@ -16,6 +16,7 @@ fromDataFrame(
   capacity = 10000L,
   tile_domain = NULL,
   tile_extent = NULL,
+  mode = c("ingest", "schema_only", "append"),
   debug = FALSE
 )
 }
@@ -53,7 +54,12 @@ dimension of the \code{obj} is used.}
 if \code{NULL} the row dimension of the \code{obj} is used. Note that the \code{tile_extent}
 cannot exceed the tile domain.}
 
-\item{debug}{Logical flag to select additional output}
+\item{mode}{A character variable with possible values \sQuote{ingest} (for schema creation and
+data ingestion, the default behavior), \sQuote{schema_only} (to create the array schema without
+writing to the newly-created array) and \sQuote{append} (to only append to an already existing
+array).}
+
+\item{debug}{Logical flag to select additional output.}
 }
 \value{
 Null, invisibly.

--- a/vignettes/data-ingestion-from-sql.md
+++ b/vignettes/data-ingestion-from-sql.md
@@ -105,6 +105,10 @@ storeDataTDB <- function(dat, uri) {
 }
 ```
 
+The `mode="append"` argument of `fromDataFrame` can be used to append to an existing array to
+support chunked operation.
+
+
 ### Reading Data Back In
 
 Reading data from TileDB is a very standard operation of opening the URI, possibly specifying the
@@ -127,7 +131,6 @@ chk <- getDataTDB(uri)
 print(dim(chk))
 cat("Done!\n")
 ```
-
 
 ## See Also
 


### PR DESCRIPTION
This PR follows the lead ot the Python package and adds a `mode` argument for array creation from `data.frame` objects.  A unit tests ensures the behaviour of `ingest` (schema + write), `schema_only` and `append` are as expected.
