### PR TITLE
Switch vignettes to simplermarkdown

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,8 +26,8 @@ SystemRequirements: A C++17 compiler is required, and on macOS
  build or download was specified by the user.
 Imports: methods, Rcpp, nanotime
 LinkingTo: Rcpp
-Suggests: tinytest, rmarkdown, knitr, minidown, simplermarkdown, curl, bit64, Matrix, palmerpenguins, nycflights13, data.table, tibble
-VignetteBuilder: knitr, simplermarkdown
+Suggests: tinytest, simplermarkdown, curl, bit64, Matrix, palmerpenguins, nycflights13, data.table, tibble
+VignetteBuilder: simplermarkdown
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.1.2
 Encoding: UTF-8

--- a/inst/tinytest/test_dataframe.R
+++ b/inst/tinytest/test_dataframe.R
@@ -282,6 +282,7 @@ expect_equivalent(df, res)
 
 
 ## test ingest vs schema_only vs append
+if (tiledb_version(TRUE) < "2.4.0") exit_file("Neeeds TileDB 2.4.* or later")
 if (!requireNamespace("palmerpenguins", quietly=TRUE)) exit_file("remainder needs 'palmerpenguins'")
 library(palmerpenguins)
 data <- penguins

--- a/vignettes/documentation.md
+++ b/vignettes/documentation.md
@@ -1,28 +1,12 @@
+<!--
+%\VignetteIndexEntry{TileDB API Documentation}
+%\VignetteEngine{simplermarkdown::mdweave_to_html}
+%\VignetteEncoding{UTF-8}
+-->
 ---
 title: "TileDB API Documentation"
-output:
-  minidown::mini_document:
-    framework: water
-    toc: yes
-    toc_float: true
-vignette: |
-  %\VignetteIndexEntry{TileDB API Documentation}
-  %\VignettePackage{tiledb}
-  %\VignetteEngine{knitr::rmarkdown}
-  %\VignetteEncoding{UTF-8}
+css: "water.css"
 ---
-
-
-```{r setup, include=FALSE}
-library(tiledb)
-tdir <- tempdir()
-urisparse <- file.path(tdir, "sparse")
-uridense <- file.path(tdir, "dense")
-uridensefix <- file.path(tdir, "densefix")
-uridensevar <- file.path(tdir, "densevar")
-uridensewkey <- file.path(tdir, "denseenc")
-notWindows <- .Platform$OS.type != "windows"
-```
 
 This document follows the [TileDB API usage examples](https://docs.tiledb.com/main/how-to).
 A shorter [introductory vignette](introduction.html) is also available.
@@ -32,7 +16,7 @@ A shorter [introductory vignette](introduction.html) is also available.
 We will show two initial and basic examples for a dense and sparse array simply to create
 array data on disk to refer to later in examples that follow.
 
-```{r runexamples, eval=notWindows}
+```r
 library(tiledb)
 
 tdir <- tempdir()
@@ -111,15 +95,13 @@ close_and_reopen <- function(arr, txt) {
 }
 ```
 
-
-
 # API Usage
 
 ## Creating Arrays
 
 ### Creating Dimensions
 
-```{r createdim}
+```r
 library(tiledb)
 
 # Create dimension
@@ -130,9 +112,10 @@ strdim <- tiledb_dim("dim2", NULL, NULL, "ASCII")
 ```
 
 
+
 ### Creating the Array Domain
 
-```{r creatarrdom}
+```r
 library(tiledb)
 
 #  .. create dimensions `dim1`, `dim2`
@@ -146,7 +129,7 @@ dom <- tiledb_domain(dims = c(dim1, dim2))
 
 ### Creating Attributes
 
-```{r createattr}
+```r
 # Create attribute
 attr <- tiledb_attr("attr", type = "INT32")
 
@@ -168,7 +151,7 @@ tiledb_attribute_set_cell_val_num(attr, NA)
 
 #### Setting Fill Values
 
-```{r setfillvalues}
+```r
 # ... create int attribute attr
 attr <- tiledb_attr("a1", type = "INT32")
 # set fill value to 42L
@@ -182,9 +165,8 @@ tiledb_attribute_set_fill_value(attr, "...")
 ```
 
 #### Setting a Compressor
-<!-- #### ?? -->
 
-```{r setcompr}
+```r
 comp <- tiledb_filter("GZIP")
 tiledb_filter_set_option(comp,"COMPRESSION_LEVEL", 10)
 
@@ -197,9 +179,8 @@ attr <- tiledb_attr("attr", "INT32", filter_list = filter_list)
 
 
 #### Setting Other Filters
-<!-- #### ?? -->
 
-```{r setfilr}
+```r
 # Create filters
 f1 <- tiledb_filter("BIT_WIDTH_REDUCTION")
 f2 <- tiledb_filter("ZSTD")
@@ -211,11 +192,9 @@ filter_list <- tiledb_filter_list(c(f1,f2))
 attr <- tiledb_attr("attr", "INT32", filter_list = filter_list)
 ```
 
-
-
 ### Creating the Array Schema
 
-```{r createarrschema}
+```r
 # ... create domain dom
 attr1 <- tiledb_attr("attr1", "INT32", filter_list = filter_list)
 attr2 <- tiledb_attr("attr2", "FLOAT64", filter_list = filter_list)
@@ -228,7 +207,7 @@ schema <- tiledb_array_schema(dom, c(attr1, attr2), sparse = FALSE)
 
 #### Setting the Tile and Cell Order
 
-```{r settilecellorder}
+```r
 # ... create domain dom
 # ... create attributes attr1, attr2
 
@@ -240,7 +219,7 @@ schema <- tiledb_array_schema(dom, c(attr1, attr2),
 
 #### Setting the Data Tile Capacity
 
-```{r settilecapacity}
+```r
 # set capacity
 capacity(schema) <- 100000
 tiledb_array_schema_set_capacity(schema, 10000)
@@ -253,7 +232,7 @@ tiledb_array_schema_get_capacity(schema)
 
 #### Allowing Duplicates
 
-```{r allowdupes, eval=notWindows}
+```r
 sch <- schema(urisparse)
 
 # get 'duplicates allowed?' status
@@ -267,7 +246,7 @@ tiledb_array_schema_set_allows_dups(sch, TRUE)
 
 #### Checking Correctness
 
-```{r checkcorrect, eval=notWindows}
+```r
 check(sch)
 tiledb_array_schema_check(sch)
 ```
@@ -276,7 +255,7 @@ tiledb_array_schema_check(sch)
 
 #### Creating a Filter List
 
-```{r createfilterlist, eval=notWindows}
+```r
 # create a "GZIP" compression filter
 flt <- tiledb_filter("GZIP")
 # set the option 'COMPRESSION_LEVEL' to 10
@@ -286,17 +265,16 @@ tiledb_filter_set_option(flt, "COMPRESSION_LEVEL", 10)
 fltlst <- tiledb_filter_list(flt)
 ```
 
-
 #### Other Filters
 
-```{r otherfilterlist, eval=FALSE}
+```r
 # create a filter list object with both
 fltlst <- tiledb_filter_list(c(flt1, flt2))
 ```
 
 #### Setting the Tile Chunk Size
 
-```{r settilechunksize, eval=notWindows}
+```r
 # ... create filter list
 set_max_chunk_size(filter_list, 10000)
 tiledb_filter_list_set_max_chunk_size(filter_list, 10000)
@@ -307,7 +285,7 @@ tiledb_filter_list_get_max_chunk_size(filter_list)
 
 #### Setting a Filter List for an Attribute
 
-```{r settingfilterlistforattribute, eval=notWindows}
+```r
 # create (or access) an attribute
 attr <- tiledb_attr("a", "INT32")
 
@@ -322,7 +300,7 @@ filter_list(attr) <- fltlst
 
 #### Setting a Filter List for a Dimension
 
-```{r settingfilterlistfordim, eval=notWindows}
+```r
 d <- tiledb_dim("d", c(1L, 10L), 1L, "INT32")
 
 # create a filter list
@@ -336,7 +314,7 @@ filter_list(d) <- fltlst
 
 #### Setting a Filter List for All Dimensions
 
-```{r settingfilterlistalldims, eval=FALSE}
+```r
 # ... create (or retrieve) array schema sch
 # ... create filter list fl
 
@@ -349,7 +327,7 @@ sch <- tiledb_array_schema(dom, c(attr1, attr2), coords_filter_list = fl)
 
 #### Setting a Filter List for Variable-Sized Value Offsets
 
-```{r settingfilterlistforvarsized, eval=FALSE}
+```r
 # ... create (or retrieve) array schema sch
 # ... create filter list fl
 
@@ -360,11 +338,9 @@ tiledb_array_schema_set_offsets_filter_list(sch, fl)
 sch <- tiledb_array_schema(dom, c(attr1, attr2), offsets_filter_list = fl)
 ```
 
-
 #### Setting Coordinate and Offset Filters
-<!-- #### ?? -->
 
-```{r setcoordoffsetfilt, eval=notWindows}
+```r
 # ... create domain dom
 # ... create attributes attr1, attr2
 # ... create filter lists fl1, fl2, similar to attributes
@@ -380,12 +356,9 @@ schema <- tiledb_array_schema(dom, c(attr1, attr2),
 ```
 
 
-
-
-
 ### Creating the Array
 
-```{r createarray, eval=FALSE}
+```r
 # ... create array schema
 
 # Create the array
@@ -394,7 +367,7 @@ tiledb_array_create(uridense, schema)
 
 ### Creating Encrypted Arrays
 
-```{r createwithkey, eval=notWindows}
+```r
 # assume previously created schema 'sch'
 # use encryption key
 encryption_key <- "0123456789abcdeF0123456789abcdeF"
@@ -403,12 +376,11 @@ encryption_key <- "0123456789abcdeF0123456789abcdeF"
 tiledb_array_create(uridensewkey, sch, encryption_key)
 ```
 
-
 ## Writing Arrays
 
 ### Writing in Dense Subarrays
 
-```{r writedensesubarr, eval=FALSE}
+```r
 ## prepare a larger 5 x 5 to embed into
 tmp <- tempfile()
 d1  <- tiledb_dim("d1", domain = c(1L, 5L))
@@ -438,10 +410,9 @@ A[I, J] <- data
 unlink(tmp, recursive=TRUE)
 ```
 
-
 #### Basic Writing using Low-Level Code
 
-```{r basiscwritinglowlevel, eval=notWindows}
+```r
 ctx <- tiledb_ctx()
 arrptr <- tiledb:::libtiledb_array_open(ctx@ptr, uridense, "WRITE")
 
@@ -460,7 +431,7 @@ res <- tiledb:::libtiledb_array_close(arrptr)
 
 ### Writing Sparse Cells
 
-```{r writesparsecells, eval=notWindows}
+```r
 tmp <- urisparse
 unlink(tmp, recursive=TRUE)
 
@@ -483,21 +454,18 @@ A <- tiledb_array(uri = tmp)
 A[I, J] <- data
 ```
 
-
 ### Writing Encrypted Arrays
 
-```{r writingencryptedlowlevel, eval=FALSE}
+```r
 # open for writing with corresponding encryption key
 A <- tiledb_array(uridensewkey, encryption_key = encryption_key)
 # access array as usual
 ```
 
 
-
-
 ### Fixed-length Attributes
 
-```{r fixedlengthattributes, eval=notWindows}
+```r
 if (dir.exists(uridensefix)) unlink(uridensefix, recursive=TRUE)
 d1  <- tiledb_dim("d1", domain = c(1L, 4L))
 d2  <- tiledb_dim("d2", domain = c(1L, 4L))
@@ -527,7 +495,7 @@ res <- tiledb:::libtiledb_array_close(arrptr)
 
 ### Var-length Attributes
 
-```{r, eval=notWindows}
+```r
 if (dir.exists(uridensevar)) unlink(uridensevar, recursive=TRUE)
 ## Define array
 ## The array will be 4x4 with dimensions "rows" and "cols", with domain [1,4].
@@ -568,10 +536,9 @@ tiledb:::libtiledb_array_close(arrptr)
 #TODO Higher-level R support
 ```
 
-
 ### Writing at a Timestamp
 
-```{r writeattimestamp, eval=FALSE}
+```r
 # 'at' uses Sys.time() from R in seconds, and shifts back 10 minutes
 at <- Sys.time() - 10*60
 
@@ -584,7 +551,7 @@ arr <- tiledb_array_open_at(arr, "WRITE", Sys.time() - 600)
 
 ### Getting the Fragment Info
 
-```{r fragmentinfo, eval=FALSE}
+```r
 # continuing from previous example on dense variable length array
 # (but this works of course with any array after a write is needed
 
@@ -604,7 +571,7 @@ tsrange <- tiledb_query_get_fragment_timestamp_range(qry, idx)
 
 #### Inspecting the array schema
 
-```{r schemaload, eval=FALSE}
+```r
 # get a schema directly from storage, uri holds a valid array URI
 uri <- "<array_uri>"
 sch <- schema(uri)
@@ -627,7 +594,7 @@ sch <- schema(A)
 
 
 
-```{r schemainspect, eval=notWindows}
+```r
 # Get array schema, this shows the sparse accessor
 # and it is similar for tiledb_dense()
 A <- tiledb_array(uri = urisparse, is.sparse = TRUE)
@@ -667,7 +634,7 @@ show(schema)
 
 #### Inspecting Domain
 
-```{r inspectdomain, eval=FALSE}
+```r
 # ... get array schema
 # ... get domain from schema
 
@@ -695,7 +662,7 @@ show(dom)
 
 #### Inspecting Dimensions
 
-```{r inspectdimensions, eval=FALSE}
+```r
 # ... get array schema
 # ... get domain
 # ... get dimension by index or name
@@ -720,7 +687,7 @@ show(dim)
 
 #### Inspecting Attributes
 
-```{r inspectattr, eval=FALSE}
+```r
 # ... get array schema
 # ... get attribute by index or name
 
@@ -753,7 +720,7 @@ show(attr)
 
 #### Inspecting Filters
 
-```{r inspectfilters, eval=FALSE}
+```r
 # dim hold a previously created or load Dimension object
 fltrlst <- filter_list(dim)
 # or fltrlst <- filter_list(attr) for some attribute `attr`
@@ -780,7 +747,7 @@ tiledb_filter_type(fltr)
 
 ### Basic Reading
 
-```{r basiscreading, eval=notWindows}
+```r
 # Open a dense array
 A <- tiledb_array(uri = uridense)
 
@@ -794,7 +761,7 @@ show(data)
 
 #### Basic Reading using Low-Level Code
 
-```{r basiscreadinglowlevel, eval=notWindows}
+```r
 ctx <- tiledb_ctx()
 arrptr <- tiledb:::libtiledb_array_open(ctx@ptr, uridense, "READ")
 ## subarray of rows 1,2 and cols 2,3,4
@@ -812,7 +779,7 @@ res <- tiledb:::libtiledb_array_close(arrptr)
 
 #### Variable-length Attributes
 
-```{r readvarlength, eval=FALSE}
+```r
 ctx <- tiledb_ctx()
 arrptr <- tiledb:::libtiledb_array_open(ctx@ptr, uridensevar, "READ")
 
@@ -833,7 +800,7 @@ print(mat, quote=FALSE)
 
 #### Getting the Non-empty Domain
 
-```{r nonempty, eval=FALSE}
+```r
 # example with one fixed- and one variable-sized domain
 dom <- tiledb_domain(dims = c(tiledb_dim("d1", c(1L, 4L), 4L, "INT32"),
                               tiledb_dim("d2", NULL, NULL, "ASCII")))
@@ -851,7 +818,7 @@ tiledb_array_get_non_empty_domain_from_name(arr, "d2")
 
 #### Reopening Arrays
 
-```{r reopeningarrays, eval=FALSE}
+```r
 # Arrays are reopened automatically for you based on
 # read or write being performed. For direct pointer-based
 # access you can also explicitly reopen
@@ -861,7 +828,7 @@ arr@ptr <- tiledb:::libtiledb_array_reopen(arr@ptr)
 
 ### Reading Encrypted Arrays
 
-```{r readencrypted, eval=FALSE}
+```r
 # Open the array and read as a data.frame from it.
 A <- tiledb_array(uri = array_name, as.data.frame=TRUE,
                   encryption_key = encryption_key)
@@ -879,7 +846,7 @@ A <- tiledb_array_open_at(A, "READ", tstamp)
 
 ### Multi-range Subarrays
 
-```{r multirange, eval=FALSE}
+```r
 # create query, allocate result buffer, ...
 
 # add two query range on the first dimension
@@ -902,7 +869,7 @@ strrng <- tiledb_query_get_range_var(qry, idx, i)
 
 ### Incomplete Queries
 
-```{r incompletereads, eval=notWindows}
+```r
 ctx <- tiledb_ctx()
 arrptr <- tiledb:::libtiledb_array_open(ctx@ptr, uridense, "READ")
 qryptr <- tiledb:::libtiledb_query(ctx@ptr, arrptr, "READ")
@@ -921,7 +888,7 @@ res <- tiledb:::libtiledb_array_close(arrptr)
 
 ### Result Estimation
 
-```{r resultestimation, eval=FALSE}
+```r
 # ...create query object
 
 # estimated size of a fixed-length attribute in sparse array
@@ -933,7 +900,7 @@ sz <- tiledb_query_get_est_result_size_var(qry, "b")
 
 ### Time Traveling
 
-```{r timetravel, eval=FALSE}
+```r
 # time traveling is currently only accessible via the lower-level API
 # we use the R Datetime type; internally TileDB uses milliseconds since epoch
 tstamp <- Sys.time() - 60*60 # one hour ago
@@ -960,7 +927,7 @@ arrptr <- tiledb:::libtiledb_array_open_at_with_key(ctx@ptr, uridensewkey, "READ
 
 ## Asynchronous Queries
 
-```{r asyncquery, eval=FALSE}
+```r
 #  ... create read or write query
 
 # Instead of using tiledb_query_submit(), use tiledb_query_submit_async()
@@ -973,7 +940,7 @@ tiledb_query_submit_async(qry)
 
 #### Basic Usage
 
-```{r configbasic, eval=notWindows}
+```r
 # Create a configuration object
 config <- tiledb_config()
 
@@ -989,7 +956,7 @@ tiledb_config_unset(config, "sm.tile_cache_size")
 
 #### Save and Load to File
 
-```{r configsaveload, eval=notWindows}
+```r
 # Save to file
 config <- tiledb_config()
 config["sm.tile_cache_size"] <- 0;
@@ -1004,7 +971,7 @@ tile_cache_size = config_loaded["sm.tile_cache_size"]
 
 #### Configuration Iterator
 
-```{r configiterator, eval=notWindows}
+```r
 # R has no native iterator but one loop over the config elements
 # by retrieving the configuration as a vector
 
@@ -1021,7 +988,7 @@ for (n in names(cfg))
 
 #### Writing Array Metadata
 
-```{r writemetadata, eval=FALSE}
+```r
 # 'array' can be a URI, or an array opened for writing
 tiledb_put_metadata(array, "aaa", 100L)
 tiledb_put_metadata(array, "bb", c(1.1, 2.2))
@@ -1031,14 +998,14 @@ tiledb_put_metadata(array, "bb", c(1.1, 2.2))
 
 One can read by key:
 
-```{r readmetadata, eval=FALSE}
+```r
 # 'array' can be a URI, or an array opened for reading
 tiledb_get_metadata(array, "aaa")
 ```
 
 Or one can retrieve all metadata at once:
 
-```{r readmetadataall, eval=FALSE}
+```r
 # 'array' can be a URI, or an array opened for reading
 md <- tiledb_get_all_metadata(array)
 
@@ -1048,7 +1015,7 @@ print(md)
 
 #### Deleting Array Metadata
 
-```{r deletemetadata, eval=FALSE}
+```r
 # 'array' can be a URI, or an array opened for writing
 tiledb_delete_metadata(array, "aaa")
 ```
@@ -1057,7 +1024,7 @@ tiledb_delete_metadata(array, "aaa")
 
 #### Fragments
 
-```{r fragments, eval=FALSE}
+```r
 # An array URI
 uri <- "<array_uri>"
 
@@ -1073,7 +1040,7 @@ array_consolidate(uri, cfg)
 
 #### Vacuuming
 
-```{r vacuuming, eval=FALSE}
+```r
 # An array URI
 uri <- "<array_uri>"
 
@@ -1090,20 +1057,20 @@ array_vacuum(uri, cfg)
 
 #### Creating TileDB Groups
 
-```{r groupcreate, eval=FALSE}
+```r
 tiledb_group_create("/tmp/my_group")
 ```
 
 
 #### Getting the Object Type
 
-```{r getobjecttype, eval=FALSE}
+```r
 type <- tiledb_object_type("<path>")
 ```
 
 #### List the Object Hierarchy
 
-```{r listobjecthierarchy, eval=FALSE}
+```r
 # List arrays (defaults to default "PREORDER" traversal)
 tiledb_object_ls(uri)
 
@@ -1116,7 +1083,7 @@ print(res)
 
 #### Move / Remove Object
 
-```{r moveremove, eval=FALSE}
+```r
 tiledb_object_mv("/tmp/my_group", "/tmp/my_group_2")
 
 tiledb_object_remove(ctx, "/tmp/my_group_2/dense_array")
@@ -1127,7 +1094,7 @@ tiledb_object_remove(ctx, "/tmp/my_group_2/dense_array")
 
 #### Writing
 
-```{r vfswrite, eval=notWindows}
+```r
 # binary file to be written
 uri <- tempfile(pattern = "tiledb_vfs", fileext = ".bin")
 # open file
@@ -1154,7 +1121,7 @@ tiledb_vfs_close(fhbuf)
 
 #### Reading
 
-```{r vfsread, eval=FALSE}
+```r
 # open a binary file for reading
 fhbuf <- tiledb_vfs_open(uri, "READ")
 vec <- tiledb_vfs_read(fhbuf, as.integer64(0), as.integer64(488))
@@ -1163,7 +1130,7 @@ tiledb_vfs_close(fhbuf)
 
 #### Managing
 
-```{r vfsmanaging, eval=FALSE}
+```r
 # Creating a directory
 if (!tiledb_vfs_is_dir("dir_A")) {
     tiledb_vfs_create_dir("dir_A")
@@ -1195,7 +1162,7 @@ tiledb_vfs_remove_dir("dir_A")
 
 #### S3
 
-```{r vfss3, eval=FALSE}
+```r
 tiledb_vfs_create_bucket("s3://my_bucket")
 
 tiledb_vfs_remove_bucket("s3://my_bucket")
@@ -1204,7 +1171,7 @@ tiledb_vfs_remove_bucket("s3://my_bucket")
 
 #### Configuring VFS
 
-```{r vfsconfigure, eval=notWindows}
+```r
 ctx <- tiledb_get_context()
 
 config <- tiledb_config()
@@ -1218,7 +1185,7 @@ vfs <- tiledb_vfs(config, ctx)
 
 ## Using Performance Statistics
 
-```{r perfstats, eval=FALSE}
+```r
 # Start collecting statistics
 tiledb_stats_enable()
 
@@ -1241,7 +1208,7 @@ tiledb_stats_reset()
 
 ## Catching Errors
 
-```{r catchingerror, eval=FALSE}
+```r
 result <- tryCatch({
     # Create a group. The code below creates a group `my_group` and prints a
     # message because (normally) it will succeed.

--- a/vignettes/introduction.md
+++ b/vignettes/introduction.md
@@ -1,15 +1,11 @@
+<!--
+%\VignetteIndexEntry{Introduction to TileDB}
+%\VignetteEngine{simplermarkdown::mdweave_to_html}
+%\VignetteEncoding{UTF-8}
+-->
 ---
 title: "First Steps with TileDB"
-output:
-  minidown::mini_document:
-    framework: water
-    toc: yes
-    toc_float: true
-vignette: |
-  %\VignetteIndexEntry{Introduction to TileDB}
-  %\VignettePackage{tiledb}
-  %\VignetteEngine{knitr::rmarkdown}
-  %\VignetteEncoding{UTF-8}
+css: "water.css"
 ---
 
 This document introduces TileDB via several simple examples. A corresponding
@@ -56,11 +52,13 @@ The first example extracts rows 1 to 2 and column 2 from an array. It also limit
 just one attribute (via `attrs`), asks for the return to be a `data.frame` (instead of a simpler list)
 and for the (row and column, if present as here) indices to not be printed (via `extended=FALSE`).
 
-    > A <- tiledb_array(uri = uri, attrs = "b",
-    +                   as.data.frame=TRUE, extended=FALSE))
-    > A[1:2,2]
-    [1] 101.5 104.0
-    >
+```r
+> A <- tiledb_array(uri = uri, attrs = "b",
++                   as.data.frame=TRUE, extended=FALSE))
+> A[1:2,2]
+[1] 101.5 104.0
+>
+```
 
 Note that the examples create three two-dimensional attributes. The attributes can be selected via
 the `attrs` argument, or the `attrs()` method on the array object.  The square-bracket indexing then
@@ -70,52 +68,57 @@ If multiple objects are returned (as `list` or `data.frame`), subsetting on the
 returned object works via `[[var]]` or `$var`.  A numeric index also works (but needs to account for
 `rows` and `cols`).
 
-    > A <- tiledb_array(uri = uri, attrs = c("a","b"),
-    +                   as.data.frame = TRUE)
-    > A[1:2,2][["a"]]
-    [1] 2 7
-    > A[1:2,2]$a
-    [1] 2 7
-    >
-
+```r
+> A <- tiledb_array(uri = uri, attrs = c("a","b"),
++                   as.data.frame = TRUE)
+> A[1:2,2][["a"]]
+[1] 2 7
+> A[1:2,2]$a
+[1] 2 7
+>
+```
 
 *Read 2-D*
 
 This works analogously.  Note that the results are generally returned as vectors, or as a columns of
 a `data.frame` object in case that option was set.
 
-    > A[6:9,3:4]
-    $a
-    [1] 28 29 33 34 38 39 43 44
+```r
+> A[6:9,3:4]
+$a
+[1] 28 29 33 34 38 39 43 44
 
-    $b
-    [1] 114.5 115.0 117.0 117.5 119.5 120.0 122.0 122.5
+$b
+[1] 114.5 115.0 117.0 117.5 119.5 120.0 122.0 122.5
 
-    $c
-    [1] "fox" "A"   "E"   "F"   "J"   "K"   "O"   "P"
-    >
+$c
+[1] "fox" "A"   "E"   "F"   "J"   "K"   "O"   "P"
+>
+```
 
 ## Read 2-D with attribute selection
 
 We can restrict the selection to a subset of attributes when opening the array.
 
-    > A <- tiledb_dense(uri = uri, attrs = c("b","c"),
-    +                   as.data.frame = TRUE, extended=FALSE)
-    > A[6:9,2:4]
-           b     c
-    1  114.0 brown
-    2  114.5   fox
-    3  115.0     A
-    4  116.5     D
-    5  117.0     E
-    6  117.5     F
-    7  119.0     I
-    8  119.5     J
-    9  120.0     K
-    10 121.5     N
-    11 122.0     O
-    12 122.5     P
-    >
+```r
+> A <- tiledb_dense(uri = uri, attrs = c("b","c"),
++                   as.data.frame = TRUE, extended=FALSE)
+> A[6:9,2:4]
+       b     c
+1  114.0 brown
+2  114.5   fox
+3  115.0     A
+4  116.5     D
+5  117.0     E
+6  117.5     F
+7  119.0     I
+8  119.5     J
+9  120.0     K
+10 121.5     N
+11 122.0     O
+12 122.5     P
+>
+```
 
 This also illustrated the effect of setting `as.data.frame=TRUE` when opening the array.
 
@@ -126,20 +129,23 @@ The column types correspond to the attribute typed in the array schema, subject 
 mentioned above on R types.  (The char comes in as a factor variable as is still the R 3.6.* default
 which is about to change. We can also override, users can too.)
 
-    > A <- tiledb_array("/tmp/tiledb/ex_1/", attrs=c("b","c"),
-    +                   as.data.frame = TRUE, extended=TRUE)
-    > sapply(A[6:9, 3:4], "class")
-           rows        cols           b           c
-      "integer"   "integer"   "numeric" "character"
-    >
+```r
+> A <- tiledb_array("/tmp/tiledb/ex_1/", attrs=c("b","c"),
++                   as.data.frame = TRUE, extended=TRUE)
+> sapply(A[6:9, 3:4], "class")
+       rows        cols           b           c
+  "integer"   "integer"   "numeric" "character"
+>
+```
 
 Consistent with the `data.frame` semantics, *now* requesting a named column *reduces to a vector* as
 this happens at the R side:
 
-    > A[6:9, 3:4]$b
-    [1] 114.5 115.0 117.0 117.5 119.5 120.0 122.0 122.5
-    >
-
+```
+> A[6:9, 3:4]$b
+[1] 114.5 115.0 117.0 117.5 119.5 120.0 122.0 122.5
+>
+```
 
 
 # Sparse Arrays
@@ -151,52 +157,59 @@ this happens at the R side:
 Basic reading returns the coordinates and any attributes.  The following examples use the array
 created by the [quickstart_sparse][qs_sparse] example.
 
-    > A <- tiledb_array(uri = uri, is.sparse = TRUE)
-    > A[]
-    $rows
-    [1] 1 2 2
+```r
+> A <- tiledb_array(uri = uri, is.sparse = TRUE)
+> A[]
+$rows
+[1] 1 2 2
 
-    $cols
-    [1] 1 3 4
+$cols
+[1] 1 3 4
 
-    $a
-    [1] 1 3 2
+$a
+[1] 1 3 2
 
-    >
-
+>
+```
 We can also request a `data.frame` object, either when opening or by changing this object characteristic on the fly:
 
-    > return.data.frame(A) <- TRUE
-    > A[]
-      a rows cols
-    1 1    1    1
-    2 3    2    3
-    3 2    2    4
+```r
+> return.data.frame(A) <- TRUE
+> A[]
+  a rows cols
+1 1    1    1
+2 3    2    3
+3 2    2    4
+```
 
 For sparse arrays, the return type is by default ‘extended’ showing rows and column but this can be overridden.
 
 Assignment works similarly:
 
-    > A[4,2] <- 42L
-    > A[]
-    > A[]
-      rows cols  a
-    1    1    1  1
-    2    2    3  3
-    3    2    4  2
-    4    4    2 42
-    >
+```r
+> A[4,2] <- 42L
+> A[]
+> A[]
+  rows cols  a
+1    1    1  1
+2    2    3  3
+3    2    4  2
+4    4    2 42
+>
+```
 
 Reads can select rows and or columns:
 
-    > A[2,]
-      rows cols a
-    1    2    3 3
-    2    2    4 2
-    > A[,2]
-      rows cols  a
-    1    4    2 42
-    >
+```r
+> A[2,]
+  rows cols a
+1    2    3 3
+2    2    4 2
+> A[,2]
+  rows cols  a
+1    4    2 42
+>
+```
 
 Attributes can be selected similarly.
 
@@ -206,28 +219,32 @@ Similar to the dense array case described earlier, the file [ex_2.R][ex_2]
 illustrates some basic operations on sparse arrays. It also shows date and datetime types instead of
 just integer and double precision floats.
 
-    > A <- tiledb_array(uri = uri, as.data.frame = TRUE)
-    > A[1577858403:1577858408]
-            rows cols a   b          d                       e
-    1 1577858403    1 3 103 2020-01-11 2020-01-02 18:24:33.844
-    2 1577858404    1 4 104 2020-01-15 2020-01-05 02:28:36.214
-    3 1577858405    1 5 105 2020-01-19 2020-01-05 00:44:04.805
-    4 1577858406    1 6 106 2020-01-21 2020-01-06 12:58:51.770
-    5 1577858407    1 7 107 2020-01-25 2020-01-09 04:29:56.309
-    6 1577858408    1 8 108 2020-01-26 2020-01-07 13:55:10.240
-    >
+```r
+> A <- tiledb_array(uri = uri, as.data.frame = TRUE)
+> A[1577858403:1577858408]
+        rows cols a   b          d                       e
+1 1577858403    1 3 103 2020-01-11 2020-01-02 18:24:33.844
+2 1577858404    1 4 104 2020-01-15 2020-01-05 02:28:36.214
+3 1577858405    1 5 105 2020-01-19 2020-01-05 00:44:04.805
+4 1577858406    1 6 106 2020-01-21 2020-01-06 12:58:51.770
+5 1577858407    1 7 107 2020-01-25 2020-01-09 04:29:56.309
+6 1577858408    1 8 108 2020-01-26 2020-01-07 13:55:10.240
+>
+```
 
 The row coordinate is currently a floating point representation of the underlying time type.  We can
 both select attributes (here we excluded the “a” column) and select rows by time (as the time stamps
 get converted to the required floating point value).
 
-    > attrs(A) <- c("b", "d", "e")
-    > A[as.POSIXct("2020-01-01"):as.POSIXct("2020-01-01 00:00:03")]
-            rows cols   b          d                       e
-    1 1577858401    1 101 2020-01-05 2020-01-01 03:03:07.548
-    2 1577858402    1 102 2020-01-10 2020-01-02 21:02:19.747
-    3 1577858403    1 103 2020-01-11 2020-01-02 18:24:33.844
-    >
+```r
+> attrs(A) <- c("b", "d", "e")
+> A[as.POSIXct("2020-01-01"):as.POSIXct("2020-01-01 00:00:03")]
+        rows cols   b          d                       e
+1 1577858401    1 101 2020-01-05 2020-01-01 03:03:07.548
+2 1577858402    1 102 2020-01-10 2020-01-02 21:02:19.747
+3 1577858403    1 103 2020-01-11 2020-01-02 18:24:33.844
+>
+```
 
 More extended examples are available showing indexing by date(time) as well as character dimension.
 

--- a/vignettes/tiledb-mariadb-examples.md
+++ b/vignettes/tiledb-mariadb-examples.md
@@ -1,21 +1,11 @@
+<!--
+%\VignetteIndexEntry{TileDB RMariaDB Examples}
+%\VignetteEngine{simplermarkdown::mdweave_to_html}
+%\VignetteEncoding{UTF-8}
+-->
 ---
 title: "TileDB and (R)MariaDB Examples"
-output:
-  minidown::mini_document:
-    framework: water
-    toc: true
-    toc_float: true
-    code_folding:
-      source: show
-      output: show
-      message: hide
-      warning: hide
-      error: hide
-vignette: >
-  %\VignetteIndexEntry{TileDB RMariaDB Examples}
-  %\VignettePackage{tiledb}
-  %\VignetteEngine{knitr::rmarkdown}
-  %\VignetteEncoding{UTF-8}
+css: "water.css"
 ---
 
 ## Introduction
@@ -51,7 +41,8 @@ MariaDB to accept an empty password (using an older MySQL variable setting), and
 name the running image 'tiledb-mariadb-r':
 
 ```sh
-docker run --name tiledb-mariadb-r -it -d --rm -e MYSQL_ALLOW_EMPTY_PASSWORD=1 tiledb/tiledb-mariadb-r
+docker run --name tiledb-mariadb-r -it -d --rm \
+       -e MYSQL_ALLOW_EMPTY_PASSWORD=1 tiledb/tiledb-mariadb-r
 ```
 
 #### Access Container Once to Write via TileDB


### PR DESCRIPTION
The vignettes introduces in #357 and #358 introduced use the [simplermarkdown](https://cloud.r-project.org/package=simplermarkdown) vignette engine, this PR extends its use to the three vignettes previously using [knitr](https://cloud.r-project.org/package=knitr), [rmarkdown](https://cloud.r-project.org/package=rmarkdown) (for processing) and [minidown](https://cloud.r-project.org/package=minidown) for styling.  The main gain is a smaller build-time footprint.

It also updates one test in a recently added test expression which needs to check for TileDB 2.4.0 or later.