### PR TITLE
Check array status before array close() call

### DIFF
--- a/R/TileDBArray.R
+++ b/R/TileDBArray.R
@@ -1417,9 +1417,8 @@ array_vacuum <- function(uri, cfg = NULL,
 #' @export
 tiledb_array_get_non_empty_domain_from_index <- function(arr, idx) {
   stopifnot(`Argument 'arr' must be a tiledb_array` = is(arr, "tiledb_array"),
-            `Argument 'idx' must be numeric and positive` = is.numeric(idx) && idx > 0)
-  if (libtiledb_array_is_open(arr@ptr)) arr <- tiledb_array_close(arr)
-  arr <- tiledb_array_open(arr, "READ")
+            `Argument 'idx' must be numeric and positive` = is.numeric(idx) && idx > 0,
+            `Argument 'arr' must be open` = libtiledb_array_is_open(arr@ptr))
   sch <- schema(arr)
   dom <- domain(sch)
   dims <- dimensions(dom)
@@ -1445,7 +1444,8 @@ tiledb_array_get_non_empty_domain_from_index <- function(arr, idx) {
 #' @export
 tiledb_array_get_non_empty_domain_from_name <- function(arr, name) {
     stopifnot(`Argument 'arr' must be a tiledb_array` = is(arr, "tiledb_array"),
-              `Argument 'name' must be character` = is.character(name))
+              `Argument 'name' must be character` = is.character(name),
+              `Argument 'arr' must be open` = libtiledb_array_is_open(arr@ptr))
 
     sch <- schema(arr)
     dom <- domain(sch)

--- a/R/TileDBArray.R
+++ b/R/TileDBArray.R
@@ -1418,7 +1418,7 @@ array_vacuum <- function(uri, cfg = NULL,
 tiledb_array_get_non_empty_domain_from_index <- function(arr, idx) {
   stopifnot(`Argument 'arr' must be a tiledb_array` = is(arr, "tiledb_array"),
             `Argument 'idx' must be numeric and positive` = is.numeric(idx) && idx > 0)
-  arr <- tiledb_array_close(arr)
+  if (libtiledb_array_is_open(arr@ptr)) arr <- tiledb_array_close(arr)
   arr <- tiledb_array_open(arr, "READ")
   sch <- schema(arr)
   dom <- domain(sch)

--- a/inst/tinytest/test_metadata.R
+++ b/inst/tinytest/test_metadata.R
@@ -21,7 +21,9 @@ unlink_and_create_simple <- function(tmp) {
 
   arr <- tiledb_sparse(tmp, as.data.frame=FALSE)
 
-  tiledb_array_close(arr)
+  if (tiledb:::libtiledb_array_is_open(arr@ptr)) {
+      tiledb_array_close(arr)
+  }
   tiledb_array_open(arr, "WRITE")
 
   ## write one record directly to (text) URI
@@ -97,7 +99,7 @@ unlink(tmp, recursive = TRUE, force = TRUE)
 #test_that("Can put metadata", {
 arr <- unlink_and_create_ptr(tmp)
 
-tiledb_array_close(arr)
+if (tiledb:::libtiledb_array_is_open(arr@ptr)) tiledb_array_close(arr)
 arr <- tiledb_array_open(arr, "WRITE")
 
 expect_true(tiledb_put_metadata(arr, "foo", "the quick brown fox"))

--- a/inst/tinytest/test_tiledbarray.R
+++ b/inst/tinytest/test_tiledbarray.R
@@ -937,6 +937,7 @@ if (requireNamespace("bit64", quietly=TRUE)) {
   unlink(tmp, recursive = TRUE)
 }
 
+## FYI: 101 tests here
 ## test encrypted arrays via high-level accessor
 ## (lower-level tests in test_densearray and test_arrayschema)
 tmp <- tempfile()
@@ -967,7 +968,7 @@ expect_equal(chk[,"a"], c(3L,2L))
 unlink(tmp, recursive = TRUE)
 
 
-
+## FYI: 105 tests here
 ## non-empty domain, var and plain
 tmp <- tempfile()
 dir.create(tmp)
@@ -984,7 +985,7 @@ J <- letters[1:3]
 data <- c(1L, 2L, 3L)
 arr <- tiledb_array(uri = tmp)
 arr[I, J] <- data
-
+arr <- tiledb_array_open(arr)
 expect_equal(tiledb_array_get_non_empty_domain_from_index(arr, 1), c(1, 3))
 expect_equal(tiledb_array_get_non_empty_domain_from_name(arr, "d1"), c(1, 3))
 expect_equal(tiledb_array_get_non_empty_domain_from_index(arr, 2), c("a", "c"))

--- a/inst/tinytest/test_tiledbarray.R
+++ b/inst/tinytest/test_tiledbarray.R
@@ -937,7 +937,6 @@ if (requireNamespace("bit64", quietly=TRUE)) {
   unlink(tmp, recursive = TRUE)
 }
 
-
 ## test encrypted arrays via high-level accessor
 ## (lower-level tests in test_densearray and test_arrayschema)
 tmp <- tempfile()
@@ -977,7 +976,7 @@ dir.create(tmp)
 dom <- tiledb_domain(dims = c(tiledb_dim("d1", c(1L, 4L), 4L, "INT32"),
                               tiledb_dim("d2", NULL, NULL, "ASCII")))
 schema <- tiledb_array_schema(dom, attrs=c(tiledb_attr("a", type = "INT32")), sparse = TRUE)
-invisible( tiledb_array_create(tmp, schema) )
+tiledb_array_create(tmp, schema)
 
 ## write
 I <- c(1L, 2L, 3L)


### PR DESCRIPTION
TileDB Embedded is now less tolerant of `close()` attempts on non-open arrays.  This PRs adjust one R function and one test file which otherwise get into trouble.

No other functional changes.