### PR TITLE
Further unit test cleanup

### DIFF
--- a/inst/tinytest/test_arrowio.R
+++ b/inst/tinytest/test_arrowio.R
@@ -178,4 +178,6 @@ for (i in c(1:7,9:10)) {
 }
 expect_equivalent(df[,8], as.integer64(1:10))
 
-#detach(package:arrow, unload=TRUE)
+## detaching arrow should not be necessary as we generally do not need to unload
+## packages but had been seen as beneficial in some instanced so there is now an option
+if (Sys.getenv("R_TESTING_CLEANUP", "") == "yes") detach(package:arrow, unload=TRUE)

--- a/inst/tinytest/test_arrowio.R
+++ b/inst/tinytest/test_arrowio.R
@@ -177,3 +177,5 @@ for (i in c(1:7,9:10)) {
     expect_equivalent(df[,i], 1:10)
 }
 expect_equivalent(df[,8], as.integer64(1:10))
+
+detach(package:arrow, unload=TRUE)

--- a/inst/tinytest/test_arrowio.R
+++ b/inst/tinytest/test_arrowio.R
@@ -178,4 +178,4 @@ for (i in c(1:7,9:10)) {
 }
 expect_equivalent(df[,8], as.integer64(1:10))
 
-detach(package:arrow, unload=TRUE)
+#detach(package:arrow, unload=TRUE)

--- a/inst/tinytest/test_tiledbarray.R
+++ b/inst/tinytest/test_tiledbarray.R
@@ -991,17 +991,15 @@ expect_equal(tiledb_array_get_non_empty_domain_from_name(arr, "d1"), c(1, 3))
 expect_equal(tiledb_array_get_non_empty_domain_from_index(arr, 2), c("a", "c"))
 expect_equal(tiledb_array_get_non_empty_domain_from_name(arr, "d2"), c("a", "c"))
 
-if (FALSE) {                            # this tests fine in isolation but croaks in bulk
-    ## access schema from uri
-    schema2 <- schema(tmp)
-    expect_true(is(schema2, "tiledb_array_schema"))
-    expect_equal(schema, schema2)
+## access schema from uri
+schema2 <- schema(tmp)
+expect_true(is(schema2, "tiledb_array_schema"))
+expect_equal(schema, schema2)
 
-    ## access schema from array
-    schema3 <- schema(arr)
-    expect_true(is(schema3, "tiledb_array_schema"))
-    expect_equal(schema, schema3)
-}
+## access schema from array
+schema3 <- schema(arr)
+expect_true(is(schema3, "tiledb_array_schema"))
+expect_equal(schema, schema3)
 
 ## time travel
 tmp <- tempfile()


### PR DESCRIPTION
This small PR adds a cleanup action to one test script, and re-activates a temporarily de-activated short section in another.