### PR TITLE
Map (u)int64 indices and restore third dim when indexing

### DIFF
--- a/R/TileDBArray.R
+++ b/R/TileDBArray.R
@@ -470,6 +470,16 @@ setMethod("[", "tiledb_array",
   ## add defaults
   if (missing(i)) i <- NULL
   if (missing(j)) j <- NULL
+  k <- NULL
+
+  ## deal with possible n-dim indexing
+  ndlist <- nd_index_from_syscall(sys.call(), parent.frame())
+  if (length(ndlist) >= 0) {
+    if (length(ndlist) >= 1 && !is.null(ndlist[[1]])) i <- ndlist[[1]]
+    if (length(ndlist) >= 2 && !is.null(ndlist[[2]])) j <- ndlist[[2]]
+    if (length(ndlist) >= 3 && !is.null(ndlist[[3]])) k <- ndlist[[3]]
+    if (length(ndlist) >= 4) message("Indices beyond the third dimension not supported in [i,j,k] form. Use selected_ranges().")
+  }
 
   ctx <- x@ctx
   uri <- x@uri
@@ -608,6 +618,15 @@ setMethod("[", "tiledb_array",
       }
       x@selected_ranges[[2]] <- j
   }
+
+  if (!is.null(k)) {
+      if (!is.null(x@selected_ranges[[3]])) {
+          stop("Cannot set both 'k' and second element of 'selected_ranges'.", call. = FALSE)
+      }
+      x@selected_ranges[[3]] <- k
+  }
+  ## (i,j,k) are now done and transferred to x@select_ranges
+
 
   ## if ranges selected, use those
   for (k in seq_len(length(x@selected_ranges))) {

--- a/R/TileDBArray.R
+++ b/R/TileDBArray.R
@@ -420,9 +420,9 @@ setValidity("tiledb_array", function(object) {
 ## as.numeric(as.Date("2021-01-01")) yields 18628.
 ##
 ## We also convert the value to integer64 because that is the internal storage format
-.mapDatetime2integer64 <- function(val, dtype) {
-    ## in case it is not a datetime type, or already an int64, return unchanged
-    if (!grepl("^DATETIME_", dtype) || inherits(val, "integer64"))
+.map2integer64 <- function(val, dtype) {
+    ## in case it is not a (datetime or (u)int64) type), or already an int64, return unchanged
+    if ((!grepl("^DATETIME_", dtype) && !grepl("INT64$", dtype)) || inherits(val, "integer64"))
         return(val)
 
     val <- switch(dtype,
@@ -438,10 +438,11 @@ setValidity("tiledb_array", function(object) {
                   "DATETIME_NS" = as.numeric(val),
                   "DATETIME_PS" = as.numeric(val) * 1e3,
                   "DATETIME_FS" = as.numeric(val) * 1e6,
-                  "DATETIME_AS" = as.numeric(val) * 1e9)
+                  "DATETIME_AS" = as.numeric(val) * 1e9,
+                  "UINT64"      = val,
+                  "INT64"       = val)
     bit64::as.integer64(val)
 }
-
 
 #' Returns a TileDB array, allowing for specific subset ranges.
 #'
@@ -611,22 +612,23 @@ setMethod("[", "tiledb_array",
   ## if ranges selected, use those
   for (k in seq_len(length(x@selected_ranges))) {
     if (is.null(x@selected_ranges[[k]])) {
-      #cat("Adding null dim", k, "on", dimtypes[[k]], "\n")
-      vec <- .mapDatetime2integer64(nonemptydom[[k]], dimtypes[k])
+      #cat("Adding null dim", k, "on", dimtypes[k], "\n")
+      vec <- .map2integer64(nonemptydom[[k]], dimtypes[k])
       if (vec[1] != 0 && vec[2] != 0) { # corner case of A[] on empty array
           qryptr <- libtiledb_query_add_range_with_type(qryptr, k-1, dimtypes[k], vec[1], vec[2])
           rangeunset <- FALSE
       }
     } else if (is.null(nrow(x@selected_ranges[[k]]))) {
-      #cat("Adding nrow null dim", k, "on", dimtypes[[k]], "\n")
+      #cat("Adding nrow null dim", k, "on", dimtypes[k], "\n")
       vec <- x@selected_ranges[[k]]
+      vec <- .map2integer64(vec, dimtypes[k])
       qryptr <- libtiledb_query_add_range_with_type(qryptr, k-1, dimtypes[k], min(vec), max(vec))
       rangeunset <- FALSE
     } else {
-      #cat("Adding non-zero dim", k, "on", dimtypes[[k]], "\n")
+      #cat("Adding non-zero dim", k, "on", dimtypes[k], "\n")
       m <- x@selected_ranges[[k]]
       for (i in seq_len(nrow(m))) {
-        vec <- .mapDatetime2integer64(c(m[i,1], m[i,2]), dimtypes[k])
+        vec <- .map2integer64(c(m[i,1], m[i,2]), dimtypes[k])
         qryptr <- libtiledb_query_add_range_with_type(qryptr, k-1, dimtypes[k], vec[1], vec[2])
       }
       rangeunset <- FALSE

--- a/inst/tinytest/test_tiledbarray.R
+++ b/inst/tinytest/test_tiledbarray.R
@@ -1355,10 +1355,22 @@ res <- A[2,2,2]
 expect_equal(res[, "a", drop=TRUE], 22)
 res <- A[2,2:3,2]
 expect_equal(res[, "a", drop=TRUE], c(22,26))
+res <- A[2,]
+expect_true(all(res[, "rows", drop=TRUE] == 2))
+expect_equal(res[, "a", drop=TRUE], c(2L, 18L, 34L, 50L, 6L, 22L, 38L, 54L, 10L, 26L, 42L, 58L, 14L,
+30L, 46L, 62L))
+res <- A[,2]
+expect_true(all(res[, "cols", drop=TRUE] == 2))
+expect_equal(res[, "a", drop=TRUE], c(5L, 21L, 37L, 53L, 6L, 22L, 38L, 54L, 7L, 23L, 39L, 55L, 8L, 24L, 40L, 56L))
+res <- A[,,2]
+expect_true(all(res[, "depth", drop=TRUE] == 2))
+expect_equal(res[, "a", drop=TRUE], c(17L, 21L, 25L, 29L, 18L, 22L, 26L, 30L, 19L, 23L, 27L, 31L, 20L, 24L, 28L, 32L))
 selected_ranges(A) <- list(cbind(2,2), cbind(2,2), cbind(2,2))
 res <- A[]
 expect_equal(res[, "a", drop=TRUE], 22)
-
+selected_ranges(A) <- list(cbind(2,2), cbind(2,3), cbind(2,2))
+res <- A[]
+expect_equal(res[, "a", drop=TRUE], c(22,26))
 
 if (requireNamespace("bit64", quietly=TRUE)) {
   suppressMessages(library(bit64))
@@ -1380,4 +1392,7 @@ if (requireNamespace("bit64", quietly=TRUE)) {
   selected_ranges(A) <- list(cbind(2,2), cbind(2,2), cbind(2,2))
   res <- A[]
   expect_equal(res[, "a", drop=TRUE], as.integer64(22))
+  selected_ranges(A) <- list(cbind(2,2), cbind(2,3), cbind(2,2))
+  res <- A[]
+  expect_equal(res[, "a", drop=TRUE], as.integer64(c(22,26)))
 }


### PR DESCRIPTION
This PR takes uses of the base layer we added via `selected_ranges()` and adds mapping "automagic" mapping for (u)int64 dimensions, and restores the third dimension.   Full generality is still available via `selected_ranges()`. 