### PR TITLE
For domain info cast int64 to double if overflowing

### DIFF
--- a/R/Dim.R
+++ b/R/Dim.R
@@ -101,7 +101,7 @@ tiledb_dim <- function(name, domain, tile, type, ctx = tiledb_get_context()) {
     nf <- nfilters(fl)
     tp <- datatype(object)
     dm <- if (is.na(cells)) "" else paste0(domain(object), if (grepl("INT", tp)) "L" else "", collape="")
-    ex <- if (is.na(cells)) "" else paste0(dim(object), if (grepl("INT", tp)) "L" else "", collape="")
+    ex <- if (is.na(cells)) "" else paste0(tile(object), if (grepl("INT", tp)) "L" else "", collape="")
     txt <- paste0("tiledb_dim(name=\"", name(object), "\", ",
                   "domain=c(", if (is.na(cells)) "NULL,NULL"
                                else paste0(dm, collapse=","), "), ",

--- a/src/libtiledb.cpp
+++ b/src/libtiledb.cpp
@@ -856,11 +856,8 @@ SEXP libtiledb_dim_get_domain(XPtr<tiledb::Dimension> dim) {
       using DataType = tiledb::impl::tiledb_to_type<TILEDB_INT64>::type;
       auto d1 = dim->domain<DataType>().first;
       auto d2 = dim->domain<DataType>().second;
-      if (d1 <= R_NaInt || d1 > std::numeric_limits<int64_t>::max() ||
-          d2 <= R_NaInt || d2 > std::numeric_limits<int64_t>::max()) {
-          //Rcpp::stop("tiledb_dim domain INT64 value not representable as an R integer64 type");
+      if (d1 > std::numeric_limits<int64_t>::max() || d2 > std::numeric_limits<int64_t>::max()) {
           return NumericVector({static_cast<double>(d1), static_cast<double>(d2)});
-
       }
       std::vector<int64_t> v = { d1, d2 };
       return makeInteger64(v);
@@ -869,9 +866,7 @@ SEXP libtiledb_dim_get_domain(XPtr<tiledb::Dimension> dim) {
       using DataType = tiledb::impl::tiledb_to_type<TILEDB_UINT64>::type;
       auto d1 = dim->domain<DataType>().first;
       auto d2 = dim->domain<DataType>().second;
-      if (d1 > std::numeric_limits<int64_t>::max() ||
-          d2 > std::numeric_limits<int64_t>::max()) {
-          //Rcpp::stop("tiledb_dim domain UINT64 value not representable as an R integer64 type");
+      if (d1 > std::numeric_limits<int64_t>::max() || d2 > std::numeric_limits<int64_t>::max()) {
           return NumericVector({static_cast<double>(d1), static_cast<double>(d2)});
       }
       std::vector<int64_t> v = { static_cast<int64_t>(d1), static_cast<int64_t>(d2) };

--- a/src/libtiledb.cpp
+++ b/src/libtiledb.cpp
@@ -858,7 +858,9 @@ SEXP libtiledb_dim_get_domain(XPtr<tiledb::Dimension> dim) {
       auto d2 = dim->domain<DataType>().second;
       if (d1 <= R_NaInt || d1 > std::numeric_limits<int64_t>::max() ||
           d2 <= R_NaInt || d2 > std::numeric_limits<int64_t>::max()) {
-        Rcpp::stop("tiledb_dim domain INT64 value not representable as an R integer64 type");
+          //Rcpp::stop("tiledb_dim domain INT64 value not representable as an R integer64 type");
+          return NumericVector({static_cast<double>(d1), static_cast<double>(d2)});
+
       }
       std::vector<int64_t> v = { d1, d2 };
       return makeInteger64(v);
@@ -869,7 +871,8 @@ SEXP libtiledb_dim_get_domain(XPtr<tiledb::Dimension> dim) {
       auto d2 = dim->domain<DataType>().second;
       if (d1 > std::numeric_limits<int64_t>::max() ||
           d2 > std::numeric_limits<int64_t>::max()) {
-          Rcpp::stop("tiledb_dim domain UINT64 value not representable as an R integer64 type");
+          //Rcpp::stop("tiledb_dim domain UINT64 value not representable as an R integer64 type");
+          return NumericVector({static_cast<double>(d1), static_cast<double>(d2)});
       }
       std::vector<int64_t> v = { static_cast<int64_t>(d1), static_cast<int64_t>(d2) };
       return makeInteger64(v);


### PR DESCRIPTION
Using `uint64_t` one can create domain bounds larger than what R can represent.  So far we have savely errored but that blocks e.g. the schema display of the MTA demo.  An alternative is to (only in the overflow case) cast to `double` instead which, while lossy in values beyond the max for the (signed or unsigned) integer types offers greater range.  

The change has not shown any side effects in testing so far but may merit another discussion.

~Marking this as draft for now.~  Upon further reflection, this is a net-improvement and ready for review, and I'd argue, merging.