### PR TITLE
In unit tests change directory for consolidation and vacuuming counts to __fragments

### DIFF
--- a/inst/tinytest/test_timetravel.R
+++ b/inst/tinytest/test_timetravel.R
@@ -46,13 +46,13 @@ while (deltat < 30) {
     epst <- deltat/2
 
     res1 <- tiledb_array(uri, as.data.frame=TRUE)[]							 		# no limits
-    res2 <- tiledb_array(uri, as.data.frame=TRUE, timestamp_end=times[1]+epst)[]    # end after 1st timestamp
+    res2 <- tiledb_array(uri, as.data.frame=TRUE, timestamp_start=times[1]-epst, timestamp_end=times[2]+epst)[]    # end after 2nd timestamp
     res3 <- tiledb_array(uri, as.data.frame=TRUE, timestamp_start=times[4]+epst)[] 	# start after fourth
     res4 <- tiledb_array(uri, as.data.frame=TRUE, timestamp_end=times[3]-epst)[]    # end before 3rd
     res5 <- tiledb_array(uri, as.data.frame=TRUE, timestamp_start=times[2]-epst, timestamp_end=times[3]+epst)[]
 
     if (isTRUE(all.equal(NROW(res1), 40)) &&                    # all four groups
-        isTRUE(all.equal(NROW(res2), 10)) &&		            # expect group one (10 elements)
+        isTRUE(all.equal(NROW(res2), 20)) &&		            # expect group one + two (20 elements)
         isTRUE(all.equal(NROW(res3), 0))  &&		            # expect zero data
         isTRUE(all.equal(NROW(res4), 20)) &&  					# expect 2 groups, 20 obs
         isTRUE(all.equal(max(res4$grp), 2))  &&		            # with groups being 1 and 2
@@ -116,15 +116,17 @@ expect_equal(max(res5$grp), 3)
 
 ## time-travel vaccum test
 vfs <- tiledb_vfs()
-ndirfull <- tiledb_vfs_ls(uri, vfs=vfs)
+uridir <- if (tiledb_version(TRUE) >= "2.7.0") file.path(uri, "__fragments") else uri
+ndirfull <- tiledb_vfs_ls(uridir, vfs=vfs)
 array_consolidate(uri, start_time=times[2]-epst, end_time=times[3]+epst)
 array_vacuum(uri, start_time=times[2]-epst, end_time=times[3]+epst)
-ndircons <- tiledb_vfs_ls(uri, vfs=vfs)
+ndircons <- tiledb_vfs_ls(uridir, vfs=vfs)
 expect_true(length(ndircons) < length(ndirfull))
 array_consolidate(uri, start_time=times[1]-0.5, end_time=times[3])
 array_vacuum(uri, start_time=times[1]-0.5, end_time=times[3])
-ndircons2 <- tiledb_vfs_ls(uri, vfs=vfs)
+ndircons2 <- tiledb_vfs_ls(uridir, vfs=vfs)
 expect_true(length(ndircons2) < length(ndircons))
+
 
 ## earlier time travel test recast via timestamp_{start,end}
 ## time travel


### PR DESCRIPTION
This PR updates a check for consolidation and vaccuming to the now added `_fragments` directory.

