### PR TITLE
Add a nightly valgrind action

### DIFF
--- a/.github/workflows/valgrind.yaml
+++ b/.github/workflows/valgrind.yaml
@@ -1,0 +1,35 @@
+name: valgrind
+
+on:
+  push:
+  schedule:
+    - cron: "17 01 * * *"
+
+jobs:
+  valgrind:
+    runs-on: ubuntu-latest
+    name: ${{ matrix.tag }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        tag: [ 2.6.3, 2.7.1, dev ]
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Install Dependencies
+      run: sudo tools/ci/valgrind/installDependencies.sh
+
+    - name: Build TileDB
+      run: sudo tools/ci/valgrind/buildTileDB.sh ${{ matrix.tag }}
+
+    - name: Build and Check Package
+      run: tools/ci/valgrind/buildAndCheckPackage.sh
+
+    - name: Show Test Log
+      run: tools/ci/valgrind/showTestLogs.sh
+
+    - name: Show Valgrind Summary
+      run: tools/ci/valgrind/valgrindSummary.sh

--- a/.github/workflows/valgrind.yaml
+++ b/.github/workflows/valgrind.yaml
@@ -1,9 +1,9 @@
 name: valgrind
 
 on:
-  push:
   schedule:
     - cron: "17 01 * * *"
+  # push:
 
 jobs:
   valgrind:

--- a/.github/workflows/valgrind.yaml
+++ b/.github/workflows/valgrind.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tag: [ 2.6.3, 2.7.1, dev ]
+        tag: [ 2.6.4, 2.7.1, dev ]
 
     steps:
     - name: Checkout

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tiledb
 Type: Package
-Version: 0.11.0.14
+Version: 0.11.0.13
 Title: Universal Storage Engine for Sparse and Dense Multidimensional Arrays
 Authors@R: c(person("TileDB, Inc.", role = c("aut", "cph")),
  person("Dirk", "Eddelbuettel", email = "dirk@tiledb.com", role = "cre"))

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tiledb
 Type: Package
-Version: 0.11.0.12
+Version: 0.11.0.14
 Title: Universal Storage Engine for Sparse and Dense Multidimensional Arrays
 Authors@R: c(person("TileDB, Inc.", role = c("aut", "cph")),
  person("Dirk", "Eddelbuettel", email = "dirk@tiledb.com", role = "cre"))

--- a/inst/tinytest/test_timetravel.R
+++ b/inst/tinytest/test_timetravel.R
@@ -93,12 +93,12 @@ n <- tiledb_fragment_info_get_num(fi)
 expect_equal(n, 4)
 times <- do.call(c, lapply(seq_len(n), function(i) tiledb_fragment_info_get_timestamp_range(fi, i-1)[1]))
 
-epst <- 0.005
-res1 <- tiledb_array(uri, as.data.frame=TRUE)[]							 		# no limits
-res2 <- tiledb_array(uri, as.data.frame=TRUE, timestamp_end=times[1]+epst)[]    # end before 1st timestamp
-res3 <- tiledb_array(uri, as.data.frame=TRUE, timestamp_start=times[4]+epst)[] 	# start after fourth
-res4 <- tiledb_array(uri, as.data.frame=TRUE, timestamp_end=times[3]-epst)[]    # end before 3rd
-res5 <- tiledb_array(uri, as.data.frame=TRUE, timestamp_start=times[2]-epst, timestamp_end=times[3]+epst)[]
+epstsml <- 0.005
+res1 <- tiledb_array(uri, as.data.frame=TRUE)[]						# no limits
+res2 <- tiledb_array(uri, as.data.frame=TRUE, timestamp_end=times[1]+epstsml)[]    	# end after 1st timestamp
+res3 <- tiledb_array(uri, as.data.frame=TRUE, timestamp_start=times[4]+epstsml)[]  	# start after fourth
+res4 <- tiledb_array(uri, as.data.frame=TRUE, timestamp_end=times[3]-epstsml)[]    	# end before 3rd
+res5 <- tiledb_array(uri, as.data.frame=TRUE, timestamp_start=times[2]-epstsml, timestamp_end=times[3]+epstsml)[]
 expect_equal(NROW(res1), 40)
 expect_equal(NROW(res2), 10)		            # expect group one (10 elements)
 expect_equal(NROW(res3), 0)			            # expect zero data
@@ -153,7 +153,6 @@ now2 <- Sys.time()
 A <- tiledb_array(uri = tmp, timestamp_start=now2)
 A[I, J] <- data
 
-epst <- 0.1
 A <- tiledb_array(uri = tmp, as.data.frame=TRUE, timestamp_end=now1 - epst)
 expect_equal(nrow(A[]), 0)
 A <- tiledb_array(uri = tmp, as.data.frame=TRUE, timestamp_start=now1 + epst)

--- a/tools/ci/valgrind/buildAndCheckPackage.sh
+++ b/tools/ci/valgrind/buildAndCheckPackage.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+echo "::group::Build TileDB R package"
+## build package
+R CMD build --no-build-vignettes --no-manual .
+echo "::endgroup::"
+
+
+echo "::group::Check TileDB R package"
+## check package
+R CMD check --use-valgrind --as-cran --no-manual --ignore-vignettes tiledb_*.tar.gz
+echo "::endgroup::"

--- a/tools/ci/valgrind/buildTileDB.sh
+++ b/tools/ci/valgrind/buildTileDB.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+set -u
+
+## check for argument
+if [ $# -ne 1 ]; then
+    echo "Need version argument. Exiting."
+    exit 1
+fi
+
+## cmdline arg gives us desired release version, most recent could be read off GitHub Releases tag too
+version="$1"
+
+
+echo "::group::Setup sources"
+## standard build off source, enabling s3 and serialization
+if [ ${version} = "dev" ]; then
+    wget https://github.com/TileDB-Inc/TileDB/archive/refs/heads/${version}.zip
+    unzip ${version}.zip
+    rm ${version}.zip
+else
+    wget https://github.com/TileDB-Inc/TileDB/archive/${version}.tar.gz
+    tar xaf ${version}.tar.gz
+    rm ${version}.tar.gz
+fi
+mv TileDB-${version} tiledb
+cd tiledb
+echo "::endgroup::"
+
+
+echo "::group::Build from source"
+mkdir build
+cd build
+export AWSSDK_ROOT_DIR=/usr
+../bootstrap --prefix=/usr/local --enable-s3 --enable-serialization
+make -j 8
+make -C tiledb install
+ldconfig
+cd ../..
+rm -rf tiledb
+echo "::endgroup::"

--- a/tools/ci/valgrind/installDependencies.sh
+++ b/tools/ci/valgrind/installDependencies.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+
+set -u
+
+echo "::group::Set up apt"
+# Refresh repo content 
+apt update -qq
+
+# Install packages for add-apt-repository
+export DEBIAN_FRONTEND=noninteractive
+apt install --yes --no-install-recommends software-properties-common dirmngr wget
+
+# Get repo signing keys for R at CRAN and cran2deb4ubuntu, and for edd/misc
+for key in C9A7585B49D51698710F3A115E25F516B04C661B E298A3A825C0D65DFD57CBB651716619E084DAB9 39A90F2E6D5DCC5DFB39462B67C2D66C4B1D4339; do
+    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys ${key}
+    gpg -a --export ${key} | apt-key add -
+done
+# Add R builds mirrored at CRAN 
+#add-apt-repository --yes "deb https://cloud.r-project.org/bin/linux/ubuntu $(lsb_release -cs)-cran40/"
+add-apt-repository --yes ppa:marutter/rrutter4.0
+# Add 'cran2deb4ubuntu' repo with 5k CRAN binaries
+add-apt-repository --yes ppa:c2d4u.team/c2d4u4.0+
+# Add PPA with some AWS SDK packaging to skip AWS SDK build
+add-apt-repository --yes ppa:edd/misc
+
+# Refresh repo content metadata again
+apt update -qq
+echo "::endgroup::"
+
+
+
+echo "::group::Install Binary Packages"
+# Install and skip recommended packages
+apt install --yes --no-install-recommends \
+    git \
+    cmake \
+    libaws-c-common-dev \
+    libaws-c-event-stream-dev \
+    libaws-checksums-dev \
+    libaws-sdk-cpp-only-s3-dev \
+    libcapnp-dev \
+    libcurl4-openssl-dev \
+    liblz4-dev \
+    libspdlog-dev \
+    libssl-dev \
+    libzstd-dev \
+    r-base-dev \
+    r-cran-bit64 \
+    r-cran-curl \
+    r-cran-data.table \
+    r-cran-littler \
+    r-cran-matrix \
+    r-cran-palmerpenguins \
+    r-cran-rcpp \
+    r-cran-tibble \
+    r-cran-tinytest \
+    r-cran-zoo \
+    valgrind 
+
+apt clean
+
+# littler helpers (currently only use install.r)
+for script in install.r installGithub.r build.r rcc.r; do
+    ln -s /usr/lib/R/site-library/littler/examples/${script} /usr/local/bin/
+done
+echo "::endgroup::"
+
+
+
+echo "::group::Install R Packages"
+# Some R packages not (yet) available as binaries
+install.r nanotime nycflights13 simplermarkdown
+
+## Not:
+#    r-cran-bookdown \
+#    r-cran-knitr \
+#    r-cran-rmarkdown \
+#    r-cran-testthat \
+#    libv8-dev \
+echo "::endgroup::"
+
+
+echo "::group::Install cmake"
+# deal with cmake
+wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null
+echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ focal main' | tee /etc/apt/sources.list.d/kitware.list >/dev/null
+apt-get update -qq
+apt install --yes --no-install-recommends cmake
+echo "::endgroup::"

--- a/tools/ci/valgrind/showTestLogs.sh
+++ b/tools/ci/valgrind/showTestLogs.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+## check for successful, or unsuccessful, output and show either
+for suffix in Rout Rout.fail; do
+    if test -f tiledb.Rcheck/tests/tinytest.${suffix}; then
+        echo ""
+        echo "** Using ${suffix}"
+        echo ""
+        cat tiledb.Rcheck/tests/tinytest.Rout
+    fi
+done
+
+echo "Done."

--- a/tools/ci/valgrind/valgrindSummary.sh
+++ b/tools/ci/valgrind/valgrindSummary.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+## check for successful, or unsuccessful, output and show either
+for suffix in Rout Rout.fail; do
+    if test -f tiledb.Rcheck/tests/tinytest.${suffix}; then
+        echo ""
+        echo "** Using ${suffix}"
+        echo ""
+        grep "^==" tiledb.Rcheck/tests/tinytest.${suffix}
+    fi
+done
+
+echo "Done."


### PR DESCRIPTION
This PR adds a new GitHub Action which is set up to be running nightly. It checks out two recent releases (currently 2.6.3 and 2.7.1) as well as dev and builds TileDB Embedded in each. Next, it builds the R package (defaulting to this repo status, i.e. the current master branch which is by design always buildable) and build and then tests the corresponding R package.  In the test, option `--use-valgrind` is used.   This affects specifcally our ~ 900 unit tests, and the tail of the unit test log (with the added `valgrind` summary) is displayed.

There is a shortcoming in `R CMD check --use-valgrind` in that leaks detected by `valgrind` do _not_ lead to test failure. This may simply be an unimplemented R feature (see [thread raised on r-package-devel](https://stat.ethz.ch/pipermail/r-package-devel/2022q1/007799.html)) but we may have to added another small step to grep this and trigger and error or issue -- to be seen.  

The code from this PR has been tested in several runs in another one-off test repo. Runs take about 20 minutes. As also seen in the initial run before the 'on push' feature was commented-out, this (copying from another recent run) finds 2.7.1 to be having an issue:

```
==15079== Memcheck, a memory error detector
==15079== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==15079== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==15079== Command: /usr/lib/R/bin/exec/R -f tinytest.R --restore --save --no-readline --vanilla
==15079== 
==15079== 
==15079== HEAP SUMMARY:
==15079==     in use at exit: 295,256,649 bytes in [8](https://github.com/eddelbuettel/tldbrvlgrnd/runs/5458496684?check_suite_focus=true#step:7:8)3,080 blocks
==1507[9](https://github.com/eddelbuettel/tldbrvlgrnd/runs/5458496684?check_suite_focus=true#step:7:9)==   total heap usage: 6,590,526 allocs, 6,507,446 frees, 30,559,404,147 bytes allocated
==15079== 
==15079== LEAK SUMMARY:
==15079==    definitely lost: 242,728 bytes in 850 blocks
==15079==    indirectly lost: 2,846,997 bytes in 29,837 blocks
==15079==      possibly lost: [11](https://github.com/eddelbuettel/tldbrvlgrnd/runs/5458496684?check_suite_focus=true#step:7:11)9,026 bytes in 1,027 blocks
==[15](https://github.com/eddelbuettel/tldbrvlgrnd/runs/5458496684?check_suite_focus=true#step:7:15)079==    still reachable: 292,047,898 bytes in 51,366 blocks
==15079==         suppressed: 0 bytes in 0 blocks
==15079== Rerun with --leak-check=full to see details of leaked memory
==15079== 
==15079== For lists of detected and suppressed errors, rerun with: -s
==15079== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

but 2.6.3 and dev are fine (log from dev follows):

```
==15147== Memcheck, a memory error detector
==15147== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==15147== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==15147== Command: /usr/lib/R/bin/exec/R -f tinytest.R --restore --save --no-readline --vanilla
==15147== 
==15147== 
==15147== HEAP SUMMARY:
==15147==     in use at exit: 292,036,951 bytes in 51,332 blocks
==15147==   total heap usage: 6,271,[8](https://github.com/eddelbuettel/tldbrvlgrnd/runs/5458496738?check_suite_focus=true#step:7:8)1[9](https://github.com/eddelbuettel/tldbrvlgrnd/runs/5458496738?check_suite_focus=true#step:7:9) allocs, 6,220,487 frees, 30,362,934,240 bytes allocated
==15[14](https://github.com/eddelbuettel/tldbrvlgrnd/runs/5458496738?check_suite_focus=true#step:7:14)7== 
==[15](https://github.com/eddelbuettel/tldbrvlgrnd/runs/5458496738?check_suite_focus=true#step:7:15)147== LEAK SUMMARY:
==15147==    definitely lost: 0 bytes in 0 blocks
==15147==    indirectly lost: 0 bytes in 0 blocks
==15147==      possibly lost: 0 bytes in 0 blocks
==15147==    still reachable: 292,036,951 bytes in 51,332 blocks
==15147==         suppressed: 0 bytes in 0 blocks
==15147== Rerun with --leak-check=full to see details of leaked memory
==15147== 
==15147== For lists of detected and suppressed errors, rerun with: -s
==15147== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

No new code added, but one test file modified to re-use a calibrated time-step in time-travel test by renaming another time-step variable when testing fragment info timestamps.

