### PR TITLE
Support array reads that returning no attributes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tiledb
 Type: Package
-Version: 0.11.0.15
+Version: 0.11.0.16
 Title: Universal Storage Engine for Sparse and Dense Multidimensional Arrays
 Authors@R: c(person("TileDB, Inc.", role = c("aut", "cph")),
  person("Dirk", "Eddelbuettel", email = "dirk@tiledb.com", role = "cre"))

--- a/inst/tinytest/test_tiledbarray.R
+++ b/inst/tinytest/test_tiledbarray.R
@@ -1408,3 +1408,13 @@ if (requireNamespace("bit64", quietly=TRUE)) {
   res <- A[]
   expect_equal(res[, "a", drop=TRUE], as.integer64(c(22,26)))
 }
+
+
+## test for no attributes
+library(palmerpenguins)
+uri <- tempfile()
+fromDataFrame(penguins, uri, sparse = TRUE, col_index = c("species", "year"))
+arr <- tiledb_array(uri, as.data.frame = TRUE, attrs = NA_character_)
+res <- arr[]
+expect_equal(NCOL(res), 2)
+expect_equal(colnames(res), c("species", "year"))

--- a/man/attrs-set-tiledb_array-method.Rd
+++ b/man/attrs-set-tiledb_array-method.Rd
@@ -9,7 +9,9 @@
 \arguments{
 \item{x}{A \code{tiledb_array} object}
 
-\item{value}{A character vector with attributes}
+\item{value}{A character vector with attributes; the value \code{NA_character_}
+signals no attributes should be returned; default is an empty character vector
+implying all columns are returned.}
 }
 \value{
 The modified \code{tiledb_array} object

--- a/man/attrs-tiledb_array-ANY-method.Rd
+++ b/man/attrs-tiledb_array-ANY-method.Rd
@@ -11,7 +11,7 @@
 }
 \value{
 An empty character vector if no attributes have been selected or else
-a vector with attributes.
+a vector with attributes; \code{NA} means no attributes will be returned.
 }
 \description{
 By default, all attributes will be selected. But if a subset of attribute

--- a/man/tiledb_array-class.Rd
+++ b/man/tiledb_array-class.Rd
@@ -20,7 +20,9 @@ based on a refactored implementation utilising newer TileDB features.
 
 \item{\code{as.data.frame}}{A logical value}
 
-\item{\code{attrs}}{A character vector to select particular column \sQuote{attributes}}
+\item{\code{attrs}}{A character vector to select particular column \sQuote{attributes};
+default is an empty character vector implying \sQuote{all} columns, the special
+value \code{NA_character_} has the opposite effect and selects \sQuote{none}.}
 
 \item{\code{extended}}{A logical value, defaults to \code{TRUE}, indicating whether index
 columns are returned as well.}

--- a/man/tiledb_array.Rd
+++ b/man/tiledb_array.Rd
@@ -46,7 +46,8 @@ tiledb_sparse(...)
 \item{as.data.frame}{optional logical switch, defaults to "FALSE"}
 
 \item{attrs}{optional character vector to select attributes, default is
-empty implying all are selected}
+empty implying all are selected, the special value \code{NA_character_}
+has the opposite effect and implies no attributes are returned.}
 
 \item{extended}{optional logical switch selecting wide \sQuote{data.frame}
 format, defaults to \code{TRUE}}

--- a/src/libtiledb.cpp
+++ b/src/libtiledb.cpp
@@ -1487,9 +1487,6 @@ libtiledb_array_schema(XPtr<tiledb::Context> ctx,
                        bool sparse = false) {
     // check that external pointers are supported
     R_xlen_t nattr = attributes.length();
-    //if (nattr == 0) {
-    //  Rcpp::stop("libtiledb_array_schema requires one or more attributes");
-    //}
     if (nattr > 0) {
         for (R_xlen_t i=0; i < nattr; i++)  {
             SEXP attr = attributes[i];


### PR DESCRIPTION
This PR follows #378 and covers the read side.  Selection of columns upon reading has always been supported via the `attrs` argument, and getter/setter methods.  An empty character vector signifies 'all', this PR adds support for `NA_character_` selecting none. 

