### PR TITLE
Adjust one test to ensure 'length 1' after coercion to logical

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tiledb
 Type: Package
-Version: 0.11.0.16
+Version: 0.11.0.17
 Title: Universal Storage Engine for Sparse and Dense Multidimensional Arrays
 Authors@R: c(person("TileDB, Inc.", role = c("aut", "cph")),
  person("Dirk", "Eddelbuettel", email = "dirk@tiledb.com", role = "cre"))

--- a/inst/tinytest/test_dimsubset.R
+++ b/inst/tinytest/test_dimsubset.R
@@ -100,7 +100,8 @@ expect_equal(unique(dat$dest), "BOS")
 daterange <- c(as.POSIXct("2013-01-10 00:00:00"), as.POSIXct("2013-01-19 23:59:99"))
 selected_ranges(newarr) <- list(time_hour = cbind(daterange[1], daterange[2]))
 dat <- newarr[]
-expect_true(dat$time_hour >= daterange[1] && dat$time_hour <= daterange[2])
+expect_true(all(dat$time_hour >= daterange[1]))
+expect_true(all(dat$time_hour <= daterange[2]))
 
 
 ## test named lists of two


### PR DESCRIPTION
This PR adjusts one test expression flagged by CRAN as having a vector of lengther greater than one coerced to a logical. 

No other changes, no new code.