### PR TITLE
Analyse valgrind losses (via awk) and send summary if losses seen

### DIFF
--- a/.github/workflows/valgrind.yaml
+++ b/.github/workflows/valgrind.yaml
@@ -32,4 +32,4 @@ jobs:
       run: tools/ci/valgrind/showTestLogs.sh
 
     - name: Show Valgrind Summary
-      run: tools/ci/valgrind/valgrindSummary.sh
+      run: tools/ci/valgrind/valgrindSummary.sh ${{ matrix.tag }}

--- a/tools/ci/valgrind/sumLosses.awk
+++ b/tools/ci/valgrind/sumLosses.awk
@@ -1,0 +1,14 @@
+#!/bin/awk
+
+BEGIN {
+    sum = 0
+    deflst = 0
+    indlst = 0
+    posslst = 0
+}
+
+/definitely lost:/ { sum += $4; deflst = $4 }
+/indirectly lost:/ { sum += $4; indlst = $4 }
+/possibly lost:/ { sum += $4; posslst = $4 }
+
+END { if (sum > 0) print "Definitely lost:", deflst, "\\nIndirectly lost:", indlst, "\\nPossibly lost:", posslst }

--- a/tools/ci/valgrind/valgrindSummary.sh
+++ b/tools/ci/valgrind/valgrindSummary.sh
@@ -3,6 +3,11 @@
 ver="<unknown>"
 hook="${SLACK_WEBHOOK_SECRET}"
 
+if [ $# -ge 1 ]; then
+     ver=$1
+     #echo "Version is ${ver}."
+fi
+
 ## check for successful, or unsuccessful, output and use either
 for suffix in Rout Rout.fail; do
     file="tiledb.Rcheck/tests/tinytest.${suffix}"

--- a/tools/ci/valgrind/valgrindSummary.sh
+++ b/tools/ci/valgrind/valgrindSummary.sh
@@ -1,12 +1,32 @@
 #!/bin/bash
 
-## check for successful, or unsuccessful, output and show either
+ver="<unknown>"
+hook="${SLACK_WEBHOOK_SECRET}"
+
+## check for successful, or unsuccessful, output and use either
 for suffix in Rout Rout.fail; do
-    if test -f tiledb.Rcheck/tests/tinytest.${suffix}; then
+    file="tiledb.Rcheck/tests/tinytest.${suffix}"
+    if test -f ${file}; then
         echo ""
         echo "** Using ${suffix}"
         echo ""
-        grep "^==" tiledb.Rcheck/tests/tinytest.${suffix}
+        grep "^==" ${file}
+
+        ## pipe log through tr(1) to translate "345,678" (for humans) into "345678"
+        ## then use an awk script to pick the three figures of interest and, if
+        ## their sum is non-negative, emit a summary string
+        lostsummary=$(cat ${file} | tr -d [,] | awk -f tools/ci/valgrind/sumLosses.awk )
+
+        if [ ${lostsummary} != "" ] && [ ${hook} != "" ]; then
+            curl -X POST -H 'Content-type: application/json' --data "{\"text\":\"Running *$ver*:\n $lostsummary\"}" https://hooks.slack.com/services/"${hook}"
+            echo ""
+            echo "Message '${ver}' : '${lostsummary}' sent"
+            echo ""
+        else
+            echo ""
+            echo "No losses. Good. Nothing to send."
+            echo ""
+        fi
     fi
 done
 


### PR DESCRIPTION
This PR extends the scheduled nightly `valgrind` setup to look for reported losses, and if any are seen reports those via `curl` and a custom (hidden) webhook.

No actual code or package content changes.