### PR TITLE
Analyse valgrind losses (via awk) and send summary if losses seen (2nd PR)

### DIFF
--- a/.github/workflows/valgrind.yaml
+++ b/.github/workflows/valgrind.yaml
@@ -32,4 +32,6 @@ jobs:
       run: tools/ci/valgrind/showTestLogs.sh
 
     - name: Show Valgrind Summary
-      run: tools/ci/valgrind/valgrindSummary.sh ${{ matrix.tag }}
+      env:
+        slack_web_hook: ${{ secrets.SLACK_WEBHOOK_SECRET }}
+      run: tools/ci/valgrind/valgrindSummary.sh ${{ matrix.tag }} "${slack_web_hook}"

--- a/tools/ci/valgrind/valgrindSummary.sh
+++ b/tools/ci/valgrind/valgrindSummary.sh
@@ -1,11 +1,12 @@
 #!/bin/bash
 
-ver="<unknown>"
-hook="${SLACK_WEBHOOK_SECRET}"
+ver=""
+hook=""
 
 if [ $# -ge 1 ]; then
-     ver=$1
-     #echo "Version is ${ver}."
+    ver=$1
+    hook=$2
+    #echo "Version is ${ver}."
 fi
 
 ## check for successful, or unsuccessful, output and use either
@@ -22,7 +23,7 @@ for suffix in Rout Rout.fail; do
         ## their sum is non-negative, emit a summary string
         lostsummary=$(cat ${file} | tr -d [,] | awk -f tools/ci/valgrind/sumLosses.awk )
 
-        if [ ${lostsummary} != "" ] && [ ${hook} != "" ]; then
+        if [ "${lostsummary}" != "" ] && [ "${hook}" != "" ]; then
             curl -X POST -H 'Content-type: application/json' --data "{\"text\":\"Running *$ver*:\n $lostsummary\"}" https://hooks.slack.com/services/"${hook}"
             echo ""
             echo "Message '${ver}' : '${lostsummary}' sent"


### PR DESCRIPTION
This PR follows #382 and corrects both a shell variable expansion, and makes the passing of URL argument more explicit.  It worked as expected in another repo posting to another instance and channel.