### PR TITLE
Refactor plugin setup

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tiledb
 Type: Package
-Version: 0.11.1
+Version: 0.11.1.1
 Title: Universal Storage Engine for Sparse and Dense Multidimensional Arrays
 Authors@R: c(person("TileDB, Inc.", role = c("aut", "cph")),
  person("Dirk", "Eddelbuettel", email = "dirk@tiledb.com", role = "cre"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# Under development
+
+## Bug Fixes
+
+* The detection of TileDB headers and library is now more robust for cases where `pkg-config` is present but does not know about TileDB (#385)
+
+
 # tiledb 0.11.1
 
 * This release of the R package builds against [TileDB 2.6.4](https://github.com/TileDB-Inc/TileDB/releases/tag/2.6.4), but has also been tested against earlier releases, and the development version.

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -68,7 +68,8 @@
 ## this uses an interface offered by the Rcpp package which, when seeing 'Rcpp::depends(pkgname)'
 ## will look for a pkgname::inlineCxxPlugin callback to learn about compile + link options
 inlineCxxPlugin <- function(...) {
-    plugin <- Rcpp::Rcpp.plugin.maker(libs = .pkgenv$tiledb_ldflag,
+    stopifnot("No TileDB installation found." = .pkgenv[["tiledb_ldflag"]] != "")
+    plugin <- Rcpp::Rcpp.plugin.maker(libs = .pkgenv[["tiledb_ldflag"]],
                                       package = "tiledb",
                                       Makevars = NULL,
                                       Makevars.win = NULL)
@@ -82,12 +83,16 @@ inlineCxxPlugin <- function(...) {
 .set_compile_link_options <- function(cppflag, ldflag) {
     if (missing(cppflag) && missing(ldflag)) {
         pkgcfg <- unname(Sys.which("pkg-config"))
+        have_tiledb_pkgcfg <- isTRUE(pkgcfg != "") && isTRUE(system2("pkg-config", c("tiledb", "--exists"))==0)
         if ((tiledb <- Sys.getenv("TILEDB_INSTALL_DIR", "")) != "") {
             .pkgenv[["tiledb_cppflag"]] <- sprintf("-I%s/include", tiledb)
             .pkgenv[["tiledb_ldflag"]] <- sprintf("-L%s -ltiledb", tiledb)
-        } else if (pkgcfg != "") {
+        } else if (have_tiledb_pkgcfg != "") {
             .pkgenv[["tiledb_cppflag"]] <- system2(pkgcfg, c("tiledb", "--cflags"), stdout = TRUE)
             .pkgenv[["tiledb_ldflag"]] <- system2(pkgcfg, c("tiledb", "--libs"), stdout = TRUE)
+        } else {
+            .pkgenv[["tiledb_cppflag"]] <- ""
+            .pkgenv[["tiledb_ldflag"]] <- ""
         }
     } else {
         .pkgenv[["tiledb_cppflag"]] <- cppflag

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -83,11 +83,11 @@ inlineCxxPlugin <- function(...) {
 .set_compile_link_options <- function(cppflag, ldflag) {
     if (missing(cppflag) && missing(ldflag)) {
         pkgcfg <- unname(Sys.which("pkg-config"))
-        have_tiledb_pkgcfg <- isTRUE(pkgcfg != "") && isTRUE(system2("pkg-config", c("tiledb", "--exists"))==0)
+        have_tiledb_pkgcfg <- isTRUE(pkgcfg != "" && system2(pkgcfg, c("tiledb", "--exists")) == 0)
         if ((tiledb <- Sys.getenv("TILEDB_INSTALL_DIR", "")) != "") {
             .pkgenv[["tiledb_cppflag"]] <- sprintf("-I%s/include", tiledb)
             .pkgenv[["tiledb_ldflag"]] <- sprintf("-L%s -ltiledb", tiledb)
-        } else if (have_tiledb_pkgcfg != "") {
+        } else if (have_tiledb_pkgcfg) {
             .pkgenv[["tiledb_cppflag"]] <- system2(pkgcfg, c("tiledb", "--cflags"), stdout = TRUE)
             .pkgenv[["tiledb_ldflag"]] <- system2(pkgcfg, c("tiledb", "--libs"), stdout = TRUE)
         } else {

--- a/inst/tinytest/test_dim.R
+++ b/inst/tinytest/test_dim.R
@@ -120,9 +120,7 @@ dimtypes <- c("ASCII",  		# Variable length string
               "DATETIME_AS"     # attosecond
               )
 for (dtype in dimtypes) {
-    if (tiledb_vfs_is_dir(uri)) {
-        tiledb_vfs_remove_dir(uri)
-    }
+    if (dir.exists(uri)) unlink(uri, recursive=TRUE)
     dom <- switch(dtype,
                   "ASCII"          = NULL,
                   "INT8"           =,

--- a/inst/tinytest/test_query.R
+++ b/inst/tinytest/test_query.R
@@ -133,7 +133,7 @@ if (requireNamespace("nanotime", quietly=TRUE)) {
   d1ptr <- tiledb_query_buffer_alloc_ptr(qry, "DATETIME_US", 6)
   qry <- tiledb_query_set_buffer_ptr(qry, "d1", d1ptr)
 
-  qry <- tiledb_query_add_range(qry, schema(arr), "rows", as.integer64(4), as.integer64(7))
+  qry <- tiledb_query_add_range(qry, tiledb::schema(arr), "rows", as.integer64(4), as.integer64(7))
 
   tiledb_query_submit(qry)
   tiledb_query_finalize(qry)

--- a/inst/tinytest/test_tiledbarray.R
+++ b/inst/tinytest/test_tiledbarray.R
@@ -995,12 +995,12 @@ expect_equal(tiledb_array_get_non_empty_domain_from_index(arr, 2), c("a", "c"))
 expect_equal(tiledb_array_get_non_empty_domain_from_name(arr, "d2"), c("a", "c"))
 
 ## access schema from uri
-schema2 <- schema(tmp)
+schema2 <- tiledb::schema(tmp)
 expect_true(is(schema2, "tiledb_array_schema"))
 expect_equal(schema, schema2)
 
 ## access schema from array
-schema3 <- schema(arr)
+schema3 <- tiledb::schema(arr)
 expect_true(is(schema3, "tiledb_array_schema"))
 expect_equal(schema, schema3)
 


### PR DESCRIPTION
This PR cleans up two issues that came up only after 0.11.1 was released namely covering the case of `pkg-config` use where TileDB is not installed, and protecting a call to `schema` in tests by an explicit `tiledb::schema` call to not be perturbed by other packages also offering a `schema()` function.

