### PR TITLE
Allow nightly valgrind check on release branches

### DIFF
--- a/.github/workflows/valgrind.yaml
+++ b/.github/workflows/valgrind.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tag: [ 2.6.4, 2.7.1, dev ]
+        tag: [ 2.6.4, release-2.7, release-2.8, dev ]
 
     steps:
     - name: Checkout

--- a/tools/ci/valgrind/buildTileDB.sh
+++ b/tools/ci/valgrind/buildTileDB.sh
@@ -11,10 +11,15 @@ fi
 ## cmdline arg gives us desired release version, most recent could be read off GitHub Releases tag too
 version="$1"
 
+## check if version is of the form release-*; use grep here to not use bash [[ ]] notation
+echo "${version}" | grep -q "^release-" -
+isrelease=$?
 
+## fetch appropriate sources
 echo "::group::Setup sources"
-## standard build off source, enabling s3 and serialization
-if [ ${version} = "dev" ]; then
+if [ ${isrelease} -eq 0 ]; then
+    git clone --single-branch --branch ${version} https://github.com/TileDB-Inc/TileDB.git TileDB-${version}
+elif [ ${version} = "dev" ]; then
     wget https://github.com/TileDB-Inc/TileDB/archive/refs/heads/${version}.zip
     unzip ${version}.zip
     rm ${version}.zip
@@ -28,6 +33,7 @@ cd tiledb
 echo "::endgroup::"
 
 
+## standard build off source, enabling s3 and serialization
 echo "::group::Build from source"
 mkdir build
 cd build


### PR DESCRIPTION
This PR generalizes the nightly script to also operate from branches matching `release-*`, and adds release branches for 2.7 and 2.8 to the mix (removing 2.7.1). 

It also restores `docs/.nojekyll` as removing that files seems to have made the (unavoidable) pages-deployment action run longer.

No code changes.