### PR TITLE
Adjust call to libtiledb_group_create

### DIFF
--- a/R/Group.R
+++ b/R/Group.R
@@ -119,7 +119,7 @@ tiledb_group_create <- function(uri, ctx = tiledb_get_context()) {
     stopifnot("The 'ctx' argument must be a Context object" = is(ctx, "tiledb_ctx"),
               "The 'uri' argument must be character" = is.character(uri),
               "This function needs TileDB 2.8.*" = .tiledb28())
-    libtiledb_group_create_(ctx@ptr, uri)
+    libtiledb_group_create(ctx@ptr, uri)
     invisible(uri)
 }
 


### PR DESCRIPTION
This PR follows PR #391 and makes a required one-character adjustment.  As (preliminary) support for groups was present in the existing code for objects, we for a brief moment differentiated two group create functions by a trailing underscore.  When #391 correctly simplified this consolidating the support for groups in file `R/Groups.R` the underscore should have been removed but wasn't.

No other changes to functionality or documentation.