### PR TITLE
Add and remove group members by name

### DIFF
--- a/R/Group.R
+++ b/R/Group.R
@@ -260,21 +260,24 @@ tiledb_group_get_all_metadata <- function(grp) {
 ##' @param grp A TileDB Group object as for example returned by \code{tiledb_group()}
 ##' @param uri A character value with a new URI
 ##' @param relative A logical value indicating whether URI is relative to the group
+##' @param name An optional character providing a name for the object, defaults to \code{NULL}
 ##' @return The TileDB Group object, invisibly
 ##' @export
-tiledb_group_add_member <- function(grp, uri, relative) {
+tiledb_group_add_member <- function(grp, uri, relative, name=NULL) {
     stopifnot("The 'grp' argument must be a tiledb_group object" = is(grp, "tiledb_group"),
               "The 'uri' argument must be character" = is.character(uri),
               "The 'relative' argument must be logical" = is.logical(relative),
+              "The 'name' argument must be NULL or character" = is.null(name) || is.character(name),
               "This function needs TileDB 2.8.*" = .tiledb28())
-    grp@ptr <- libtiledb_group_add_member(grp@ptr, uri, relative)
+    grp@ptr <- libtiledb_group_add_member(grp@ptr, uri, relative, name)
     invisible(grp)
 }
 
 ##' Remove Member from TileDB Group
 ##'
 ##' @param grp A TileDB Group object as for example returned by \code{tiledb_group()}
-##' @param uri A character value with a new URI
+##' @param uri A character value with a the URI of the member to be removed, or (if added
+##' with a name) the name of the member
 ##' @param relative A boolean variables describing absolute or relative (to group) uri use
 ##' @return The TileDB Group object, invisibly
 ##' @export

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -996,8 +996,8 @@ libtiledb_group_get_metadata_from_index <- function(grp, idx) {
     .Call(`_tiledb_libtiledb_group_get_metadata_from_index`, grp, idx)
 }
 
-libtiledb_group_add_member <- function(grp, uri, relative) {
-    .Call(`_tiledb_libtiledb_group_add_member`, grp, uri, relative)
+libtiledb_group_add_member <- function(grp, uri, relative, optional_name = NULL) {
+    .Call(`_tiledb_libtiledb_group_add_member`, grp, uri, relative, optional_name)
 }
 
 libtiledb_group_remove_member <- function(grp, uri) {

--- a/inst/tinytest/test_group.R
+++ b/inst/tinytest/test_group.R
@@ -88,34 +88,40 @@ grp <- tiledb_group_close(grp)
 uri1 <- file.path(uri, "anny")
 uri2 <- file.path(uri, "bob")
 uri3 <- file.path(uri, "chloe")
+uri4 <- file.path(uri, "dave")
 df1 <- data.frame(val=seq(100, 200, by=10))
 df2 <- data.frame(letters=letters)
 df3 <- data.frame(nine=rep(9L, 9))
+df4 <- data.frame(dat=c(1.1, 2.2, 3.3))
 tiledb::fromDataFrame(df1, uri1)
 tiledb::fromDataFrame(df2, uri2)
 tiledb::fromDataFrame(df3, uri3)
+tiledb::fromDataFrame(df4, uri4)
 
 ## add member
 grp <- tiledb_group_open(grp, "WRITE")
-grp <- tiledb_group_add_member(grp, uri1, FALSE) 	# use absolute URL
+grp <- tiledb_group_add_member(grp, uri1, FALSE) 					# use absolute URL
 grp <- tiledb_group_close(grp)
 grp <- tiledb_group_open(grp, "READ")
 expect_equal(tiledb_group_member_count(grp), 1)
 
 grp <- tiledb_group_close(grp)
 grp <- tiledb_group_open(grp, "WRITE")
-grp <- tiledb_group_add_member(grp, "bob", TRUE) 	# use relative URL
-grp <- tiledb_group_add_member(grp, "chloe", TRUE)
+grp <- tiledb_group_add_member(grp, "bob", TRUE) 					# use relative URL
+grp <- tiledb_group_add_member(grp, "chloe", TRUE, "name_is_chloe") # and an optional name
+grp <- tiledb_group_add_member(grp, "dave", TRUE, "name_is_dave") 	# and an optional name
 grp <- tiledb_group_close(grp)
 grp <- tiledb_group_open(grp, "READ")
-expect_equal(tiledb_group_member_count(grp), 3)
+expect_equal(tiledb_group_member_count(grp), 4)
 
 ## adding a member that is not a group or an array errors
 expect_error(tiledb_group_add_member(grp, "doesNotExist", TRUE))
 
 grp <- tiledb_group_close(grp)
 grp <- tiledb_group_open(grp, "WRITE")
-grp <- tiledb_group_remove_member(grp, "bob")
+grp <- tiledb_group_remove_member(grp, "bob") 						# remove by (rel.) uri
+grp <- tiledb_group_remove_member(grp, "name_is_dave") 				# remove by name
+expect_error(tiledb_remove_member(grp, "does_not_exists"))
 grp <- tiledb_group_close(grp)
 grp <- tiledb_group_open(grp, "READ")
 expect_equal(tiledb_group_member_count(grp), 2)

--- a/man/tiledb_group_add_member.Rd
+++ b/man/tiledb_group_add_member.Rd
@@ -4,7 +4,7 @@
 \alias{tiledb_group_add_member}
 \title{Add Member to TileDB Group}
 \usage{
-tiledb_group_add_member(grp, uri, relative)
+tiledb_group_add_member(grp, uri, relative, name = NULL)
 }
 \arguments{
 \item{grp}{A TileDB Group object as for example returned by \code{tiledb_group()}}
@@ -12,6 +12,8 @@ tiledb_group_add_member(grp, uri, relative)
 \item{uri}{A character value with a new URI}
 
 \item{relative}{A logical value indicating whether URI is relative to the group}
+
+\item{name}{An optional character providing a name for the object, defaults to \code{NULL}}
 }
 \value{
 The TileDB Group object, invisibly

--- a/man/tiledb_group_remove_member.Rd
+++ b/man/tiledb_group_remove_member.Rd
@@ -9,7 +9,8 @@ tiledb_group_remove_member(grp, uri, relative)
 \arguments{
 \item{grp}{A TileDB Group object as for example returned by \code{tiledb_group()}}
 
-\item{uri}{A character value with a new URI}
+\item{uri}{A character value with a the URI of the member to be removed, or (if added
+with a name) the name of the member}
 
 \item{relative}{A boolean variables describing absolute or relative (to group) uri use}
 }

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -2919,15 +2919,16 @@ BEGIN_RCPP
 END_RCPP
 }
 // libtiledb_group_add_member
-XPtr<tiledb::Group> libtiledb_group_add_member(XPtr<tiledb::Group> grp, std::string uri, bool relative);
-RcppExport SEXP _tiledb_libtiledb_group_add_member(SEXP grpSEXP, SEXP uriSEXP, SEXP relativeSEXP) {
+XPtr<tiledb::Group> libtiledb_group_add_member(XPtr<tiledb::Group> grp, std::string uri, bool relative, Nullable<Rcpp::String> optional_name);
+RcppExport SEXP _tiledb_libtiledb_group_add_member(SEXP grpSEXP, SEXP uriSEXP, SEXP relativeSEXP, SEXP optional_nameSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< XPtr<tiledb::Group> >::type grp(grpSEXP);
     Rcpp::traits::input_parameter< std::string >::type uri(uriSEXP);
     Rcpp::traits::input_parameter< bool >::type relative(relativeSEXP);
-    rcpp_result_gen = Rcpp::wrap(libtiledb_group_add_member(grp, uri, relative));
+    Rcpp::traits::input_parameter< Nullable<Rcpp::String> >::type optional_name(optional_nameSEXP);
+    rcpp_result_gen = Rcpp::wrap(libtiledb_group_add_member(grp, uri, relative, optional_name));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -3276,7 +3277,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_tiledb_libtiledb_group_has_metadata", (DL_FUNC) &_tiledb_libtiledb_group_has_metadata, 2},
     {"_tiledb_libtiledb_group_metadata_num", (DL_FUNC) &_tiledb_libtiledb_group_metadata_num, 1},
     {"_tiledb_libtiledb_group_get_metadata_from_index", (DL_FUNC) &_tiledb_libtiledb_group_get_metadata_from_index, 2},
-    {"_tiledb_libtiledb_group_add_member", (DL_FUNC) &_tiledb_libtiledb_group_add_member, 3},
+    {"_tiledb_libtiledb_group_add_member", (DL_FUNC) &_tiledb_libtiledb_group_add_member, 4},
     {"_tiledb_libtiledb_group_remove_member", (DL_FUNC) &_tiledb_libtiledb_group_remove_member, 2},
     {"_tiledb_libtiledb_group_member_count", (DL_FUNC) &_tiledb_libtiledb_group_member_count, 1},
     {"_tiledb_libtiledb_group_member", (DL_FUNC) &_tiledb_libtiledb_group_member, 2},

--- a/src/libtiledb.cpp
+++ b/src/libtiledb.cpp
@@ -4595,10 +4595,17 @@ SEXP libtiledb_group_get_metadata_from_index(XPtr<tiledb::Group> grp, int idx) {
 
 // [[Rcpp::export]]
 XPtr<tiledb::Group> libtiledb_group_add_member(XPtr<tiledb::Group> grp,
-                                               std::string uri, bool relative) {
+                                               std::string uri, bool relative,
+                                               Nullable<Rcpp::String> optional_name = R_NilValue) {
     check_xptr_tag<tiledb::Group>(grp);
 #if TILEDB_VERSION == TileDB_Version(2,8,0)
-    grp->add_member(uri, relative);
+    if (optional_name.isNotNull()) {
+        Rcpp::String string_name(optional_name);
+        std::string name(string_name);
+        grp->add_member(uri, relative, name);
+    } else {
+        grp->add_member(uri, relative);
+    }
 #endif
     return grp;
 }


### PR DESCRIPTION
This PR adds the ability to set an (optional) name for a group member, and to remove by either name or uri.  Tests have been added as well.