### PR TITLE
Roll nightly CI schedule to 2.8.0, release-2.8.0, dev

### DIFF
--- a/.github/workflows/valgrind.yaml
+++ b/.github/workflows/valgrind.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tag: [ 2.6.4, release-2.7, release-2.8, dev ]
+        tag: [ 2.8.0, release-2.8, dev ]
 
     steps:
     - name: Checkout


### PR DESCRIPTION
This PR updates the scheduled job.  No actual package or documentation changes.