### PR TITLE
Update tiledb_group_member() to return the optional group member name

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tiledb
 Type: Package
-Version: 0.12.0
+Version: 0.12.0.1
 Title: Universal Storage Engine for Sparse and Dense Multidimensional Arrays
 Authors@R: c(person("TileDB, Inc.", role = c("aut", "cph")),
  person("Dirk", "Eddelbuettel", email = "dirk@tiledb.com", role = "cre"))

--- a/R/Group.R
+++ b/R/Group.R
@@ -302,12 +302,13 @@ tiledb_group_member_count <- function(grp) {
 
 ##' Get a Member (Description) by Index from TileDB Group
 ##'
-##' This function returns a two-element character vector with the member object translated to
-##' character, and the uri.
+##' This function returns a three-element character vector with the member object translated to
+##' character, uri, and optional name.
 ##'
 ##' @param grp A TileDB Group object as for example returned by \code{tiledb_group()}
 ##' @param idx A numeric value with the index of the metadata object to be retrieved
-##' @return A character vector with two elements: the member type, and its uri.
+##' @return A character vector with three elements: the member type, its uri, and name
+##' (or \code{""} if the member is unnamed).
 ##' @export
 tiledb_group_member <- function(grp, idx) {
     stopifnot("The 'grp' argument must be a tiledb_group object" = is(grp, "tiledb_group"),

--- a/inst/tinytest/test_group.R
+++ b/inst/tinytest/test_group.R
@@ -129,9 +129,16 @@ grp <- tiledb_group_open(grp, "READ")
 expect_equal(tiledb_group_member_count(grp), 2)
 
 obj <- tiledb_group_member(grp, 0)
+expect_equal(length(obj), 3)
 expect_true(is.character(obj[1]))
 expect_equal(obj[1], "ARRAY")
 expect_true(is.character(obj[2]))
+expect_equal(obj[2], file.path(tiledb_group_uri(grp), "chloe"))
+expect_true(is.character(obj[3]))
+expect_equal(obj[3], "name_is_chloe")
+
+obj <- tiledb_group_member(grp, 1) 									# group member with no name
+expect_equal(obj[3], "")
 
 txt <- tiledb_group_member_dump(grp, TRUE)
 dat <- read.csv(text=txt, sep=' ', header=FALSE)

--- a/man/tiledb_group_member.Rd
+++ b/man/tiledb_group_member.Rd
@@ -12,9 +12,10 @@ tiledb_group_member(grp, idx)
 \item{idx}{A numeric value with the index of the metadata object to be retrieved}
 }
 \value{
-A character vector with two elements: the member type, and its uri.
+A character vector with three elements: the member type, its uri, and name
+(or \code{""} if the member is unnamed).
 }
 \description{
-This function returns a two-element character vector with the member object translated to
-character, and the uri.
+This function returns a three-element character vector with the member object translated to
+character, uri, and optional name.
 }

--- a/src/libtiledb.cpp
+++ b/src/libtiledb.cpp
@@ -4634,9 +4634,9 @@ CharacterVector libtiledb_group_member(XPtr<tiledb::Group> grp, int idx) {
     check_xptr_tag<tiledb::Group>(grp);
 #if TILEDB_VERSION >= TileDB_Version(2,8,0)
     tiledb::Object obj = grp->member(idx);
-    CharacterVector v = CharacterVector::create(_object_type_to_string(obj.type()), obj.uri());
+    CharacterVector v = CharacterVector::create(_object_type_to_string(obj.type()), obj.uri(), obj.name().value_or(""));
 #else
-    CharacterVector v = CharacterVector::create("", "");
+    CharacterVector v = CharacterVector::create("", "", "");
 #endif
     return v;
 }


### PR DESCRIPTION
This updates `tiledb_group_member()` to include a group member's name if one was set or `""` if not. 

The implementation required only a small change to the underlying the c++ function that retrieves the optional group name from the [`GroupMember`](https://github.com/TileDB-Inc/TileDB/blob/f8efd39240b2e310e3ddd91d0b482218e7086163/tiledb/sm/group/group_member.h#L55) class.

Tests were added to verify that `tiledb_group_member()` returns a 3-element character vector whether or not a member is named.
