### PR TITLE
Refactor large string vector buffer allocation and creation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tiledb
 Type: Package
-Version: 0.12.0.1
+Version: 0.12.0.2
 Title: Universal Storage Engine for Sparse and Dense Multidimensional Arrays
 Authors@R: c(person("TileDB, Inc.", role = c("aut", "cph")),
  person("Dirk", "Eddelbuettel", email = "dirk@tiledb.com", role = "cre"))

--- a/R/Query.R
+++ b/R/Query.R
@@ -125,12 +125,9 @@ tiledb_query_set_buffer <- function(query, attr, buffer) {
 #' @return An external pointer to the allocated buffer object
 #' @export
 tiledb_query_create_buffer_ptr_char <- function(query, varvec) {
-  stopifnot(`Argument 'query' must be a tiledb_query object` = is(query, "tiledb_query"),
-            `Argument 'varvec' must be a character vector` = is.vector(varvec) && is.character(varvec))
-  n <- length(varvec)
-  offsets <- integer(n)
-  data <- convertStringVectorIntoOffsetsAndString(varvec, offsets)
-  bufptr <- libtiledb_query_buffer_var_char_create(offsets, data)
+  stopifnot("Argument 'query' must be a tiledb_query object" = is(query, "tiledb_query"),
+            "Argument 'varvec' must be a character vector" = is.vector(varvec) && is.character(varvec))
+  bufptr <- libtiledb_query_buffer_var_char_create(varvec, TRUE)
   bufptr
 }
 

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -560,10 +560,6 @@ libtiledb_query_buffer_var_char_alloc_direct <- function(szoffsets, szdata, null
     .Call(`_tiledb_libtiledb_query_buffer_var_char_alloc_direct`, szoffsets, szdata, nullable, cols)
 }
 
-convertStringVectorIntoOffsetsAndString <- function(vec, offsets) {
-    .Call(`_tiledb_convertStringVectorIntoOffsetsAndString`, vec, offsets)
-}
-
 libtiledb_query_buffer_var_char_create <- function(vec, nullable) {
     .Call(`_tiledb_libtiledb_query_buffer_var_char_create`, vec, nullable)
 }

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -564,16 +564,8 @@ convertStringVectorIntoOffsetsAndString <- function(vec, offsets) {
     .Call(`_tiledb_convertStringVectorIntoOffsetsAndString`, vec, offsets)
 }
 
-libtiledb_query_buffer_var_char_create <- function(intoffsets, data) {
-    .Call(`_tiledb_libtiledb_query_buffer_var_char_create`, intoffsets, data)
-}
-
-libtiledb_query_buffer_var_char_create_large <- function(vec) {
-    .Call(`_tiledb_libtiledb_query_buffer_var_char_create_large`, vec)
-}
-
-libtiledb_query_buffer_var_char_create_nullable <- function(intoffsets, data, nullable, navec) {
-    .Call(`_tiledb_libtiledb_query_buffer_var_char_create_nullable`, intoffsets, data, nullable, navec)
+libtiledb_query_buffer_var_char_create <- function(vec, nullable) {
+    .Call(`_tiledb_libtiledb_query_buffer_var_char_create`, vec, nullable)
 }
 
 libtiledb_query_set_buffer_var_char <- function(query, attr, bufptr) {

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -568,6 +568,10 @@ libtiledb_query_buffer_var_char_create <- function(intoffsets, data) {
     .Call(`_tiledb_libtiledb_query_buffer_var_char_create`, intoffsets, data)
 }
 
+libtiledb_query_buffer_var_char_create_large <- function(vec) {
+    .Call(`_tiledb_libtiledb_query_buffer_var_char_create_large`, vec)
+}
+
 libtiledb_query_buffer_var_char_create_nullable <- function(intoffsets, data, nullable, navec) {
     .Call(`_tiledb_libtiledb_query_buffer_var_char_create_nullable`, intoffsets, data, nullable, navec)
 }

--- a/R/TileDBArray.R
+++ b/R/TileDBArray.R
@@ -1113,10 +1113,14 @@ setMethod("[<-", "tiledb_array",
       if (alltypes[k] %in% c("CHAR", "ASCII")) { # variable length
           if (!allnullable[k]) {
               txtvec <- as.character(value[[k]])
-              offsets <- c(0L, cumsum(nchar(txtvec[-length(txtvec)])))
-              data <- paste(txtvec, collapse="")
-              ##cat("Alloc char buffer", k, "for", colnam, ":", alltypes[k], "\n")
-              buflist[[k]] <- libtiledb_query_buffer_var_char_create(offsets, data)
+              #offsets <- c(0L, cumsum(nchar(txtvec[-length(txtvec)])))
+              #offsets <- integer(length(txtvec))
+              #message("Have offsets A")
+              #data <- paste(txtvec, collapse="")
+              #data <- convertStringVectorIntoOffsetsAndString(txtvec, offsets)
+              #cat("Alloc char buffer", k, "for", colnam, ":", alltypes[k], "\n")
+              #buflist[[k]] <- libtiledb_query_buffer_var_char_create(offsets, data)
+              buflist[[k]] <- libtiledb_query_buffer_var_char_create_large(txtvec)
               qryptr <- libtiledb_query_set_buffer_var_char(qryptr, colnam, buflist[[k]])
           } else { # variable length and nullable
               txtvec <- as.character(value[[k]])

--- a/R/TileDBArray.R
+++ b/R/TileDBArray.R
@@ -1111,27 +1111,10 @@ setMethod("[<-", "tiledb_array",
       ## when an index column is use this may be unordered to remap to position in 'nm' names
       k <- match(colnam, nm)
       if (alltypes[k] %in% c("CHAR", "ASCII")) { # variable length
-          if (!allnullable[k]) {
-              txtvec <- as.character(value[[k]])
-              #offsets <- c(0L, cumsum(nchar(txtvec[-length(txtvec)])))
-              #offsets <- integer(length(txtvec))
-              #message("Have offsets A")
-              #data <- paste(txtvec, collapse="")
-              #data <- convertStringVectorIntoOffsetsAndString(txtvec, offsets)
-              #cat("Alloc char buffer", k, "for", colnam, ":", alltypes[k], "\n")
-              #buflist[[k]] <- libtiledb_query_buffer_var_char_create(offsets, data)
-              buflist[[k]] <- libtiledb_query_buffer_var_char_create_large(txtvec)
-              qryptr <- libtiledb_query_set_buffer_var_char(qryptr, colnam, buflist[[k]])
-          } else { # variable length and nullable
-              txtvec <- as.character(value[[k]])
-              navec <- is.na(txtvec)
-              newvec <- txtvec
-              newvec[navec] <- ".."     # somehow we need two chars for NA as if we passed the char
-              offsets <- c(0L, cumsum(nchar(newvec[-length(newvec)])))
-              data <- paste(txtvec, collapse="")
-              buflist[[k]] <- libtiledb_query_buffer_var_char_create_nullable(offsets, data, allnullable[k], navec)
-              qryptr <- libtiledb_query_set_buffer_var_char(qryptr, colnam, buflist[[k]])
-          }
+        txtvec <- as.character(value[[k]])
+        #cat("Alloc char buffer", k, "for", colnam, ":", alltypes[k], "\n")
+        buflist[[k]] <- libtiledb_query_buffer_var_char_create(txtvec, allnullable[k])
+        qryptr <- libtiledb_query_set_buffer_var_char(qryptr, colnam, buflist[[k]])
       } else {
         nr <- NROW(value[[k]])
         #cat("Alloc buf", i, " ", colnam, ":", alltypes[i], "nr:", nr, "null:", allnullable[i], "asint64:", asint64, "\n")

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -1632,6 +1632,17 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// libtiledb_query_buffer_var_char_create_large
+XPtr<vlc_buf_t> libtiledb_query_buffer_var_char_create_large(CharacterVector vec);
+RcppExport SEXP _tiledb_libtiledb_query_buffer_var_char_create_large(SEXP vecSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< CharacterVector >::type vec(vecSEXP);
+    rcpp_result_gen = Rcpp::wrap(libtiledb_query_buffer_var_char_create_large(vec));
+    return rcpp_result_gen;
+END_RCPP
+}
 // libtiledb_query_buffer_var_char_create_nullable
 XPtr<vlc_buf_t> libtiledb_query_buffer_var_char_create_nullable(IntegerVector intoffsets, std::string data, bool nullable, std::vector<bool> navec);
 RcppExport SEXP _tiledb_libtiledb_query_buffer_var_char_create_nullable(SEXP intoffsetsSEXP, SEXP dataSEXP, SEXP nullableSEXP, SEXP navecSEXP) {
@@ -3170,6 +3181,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_tiledb_libtiledb_query_buffer_var_char_alloc_direct", (DL_FUNC) &_tiledb_libtiledb_query_buffer_var_char_alloc_direct, 4},
     {"_tiledb_convertStringVectorIntoOffsetsAndString", (DL_FUNC) &_tiledb_convertStringVectorIntoOffsetsAndString, 2},
     {"_tiledb_libtiledb_query_buffer_var_char_create", (DL_FUNC) &_tiledb_libtiledb_query_buffer_var_char_create, 2},
+    {"_tiledb_libtiledb_query_buffer_var_char_create_large", (DL_FUNC) &_tiledb_libtiledb_query_buffer_var_char_create_large, 1},
     {"_tiledb_libtiledb_query_buffer_var_char_create_nullable", (DL_FUNC) &_tiledb_libtiledb_query_buffer_var_char_create_nullable, 4},
     {"_tiledb_libtiledb_query_set_buffer_var_char", (DL_FUNC) &_tiledb_libtiledb_query_set_buffer_var_char, 3},
     {"_tiledb_libtiledb_query_get_buffer_var_char", (DL_FUNC) &_tiledb_libtiledb_query_get_buffer_var_char, 3},

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -1621,39 +1621,14 @@ BEGIN_RCPP
 END_RCPP
 }
 // libtiledb_query_buffer_var_char_create
-XPtr<vlc_buf_t> libtiledb_query_buffer_var_char_create(IntegerVector intoffsets, std::string data);
-RcppExport SEXP _tiledb_libtiledb_query_buffer_var_char_create(SEXP intoffsetsSEXP, SEXP dataSEXP) {
-BEGIN_RCPP
-    Rcpp::RObject rcpp_result_gen;
-    Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< IntegerVector >::type intoffsets(intoffsetsSEXP);
-    Rcpp::traits::input_parameter< std::string >::type data(dataSEXP);
-    rcpp_result_gen = Rcpp::wrap(libtiledb_query_buffer_var_char_create(intoffsets, data));
-    return rcpp_result_gen;
-END_RCPP
-}
-// libtiledb_query_buffer_var_char_create_large
-XPtr<vlc_buf_t> libtiledb_query_buffer_var_char_create_large(CharacterVector vec);
-RcppExport SEXP _tiledb_libtiledb_query_buffer_var_char_create_large(SEXP vecSEXP) {
+XPtr<vlc_buf_t> libtiledb_query_buffer_var_char_create(CharacterVector vec, bool nullable);
+RcppExport SEXP _tiledb_libtiledb_query_buffer_var_char_create(SEXP vecSEXP, SEXP nullableSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< CharacterVector >::type vec(vecSEXP);
-    rcpp_result_gen = Rcpp::wrap(libtiledb_query_buffer_var_char_create_large(vec));
-    return rcpp_result_gen;
-END_RCPP
-}
-// libtiledb_query_buffer_var_char_create_nullable
-XPtr<vlc_buf_t> libtiledb_query_buffer_var_char_create_nullable(IntegerVector intoffsets, std::string data, bool nullable, std::vector<bool> navec);
-RcppExport SEXP _tiledb_libtiledb_query_buffer_var_char_create_nullable(SEXP intoffsetsSEXP, SEXP dataSEXP, SEXP nullableSEXP, SEXP navecSEXP) {
-BEGIN_RCPP
-    Rcpp::RObject rcpp_result_gen;
-    Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< IntegerVector >::type intoffsets(intoffsetsSEXP);
-    Rcpp::traits::input_parameter< std::string >::type data(dataSEXP);
     Rcpp::traits::input_parameter< bool >::type nullable(nullableSEXP);
-    Rcpp::traits::input_parameter< std::vector<bool> >::type navec(navecSEXP);
-    rcpp_result_gen = Rcpp::wrap(libtiledb_query_buffer_var_char_create_nullable(intoffsets, data, nullable, navec));
+    rcpp_result_gen = Rcpp::wrap(libtiledb_query_buffer_var_char_create(vec, nullable));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -3181,8 +3156,6 @@ static const R_CallMethodDef CallEntries[] = {
     {"_tiledb_libtiledb_query_buffer_var_char_alloc_direct", (DL_FUNC) &_tiledb_libtiledb_query_buffer_var_char_alloc_direct, 4},
     {"_tiledb_convertStringVectorIntoOffsetsAndString", (DL_FUNC) &_tiledb_convertStringVectorIntoOffsetsAndString, 2},
     {"_tiledb_libtiledb_query_buffer_var_char_create", (DL_FUNC) &_tiledb_libtiledb_query_buffer_var_char_create, 2},
-    {"_tiledb_libtiledb_query_buffer_var_char_create_large", (DL_FUNC) &_tiledb_libtiledb_query_buffer_var_char_create_large, 1},
-    {"_tiledb_libtiledb_query_buffer_var_char_create_nullable", (DL_FUNC) &_tiledb_libtiledb_query_buffer_var_char_create_nullable, 4},
     {"_tiledb_libtiledb_query_set_buffer_var_char", (DL_FUNC) &_tiledb_libtiledb_query_set_buffer_var_char, 3},
     {"_tiledb_libtiledb_query_get_buffer_var_char", (DL_FUNC) &_tiledb_libtiledb_query_get_buffer_var_char, 3},
     {"_tiledb_libtiledb_query_get_buffer_var_char_simple", (DL_FUNC) &_tiledb_libtiledb_query_get_buffer_var_char_simple, 1},

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -1608,18 +1608,6 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
-// convertStringVectorIntoOffsetsAndString
-std::string convertStringVectorIntoOffsetsAndString(Rcpp::CharacterVector vec, Rcpp::IntegerVector offsets);
-RcppExport SEXP _tiledb_convertStringVectorIntoOffsetsAndString(SEXP vecSEXP, SEXP offsetsSEXP) {
-BEGIN_RCPP
-    Rcpp::RObject rcpp_result_gen;
-    Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< Rcpp::CharacterVector >::type vec(vecSEXP);
-    Rcpp::traits::input_parameter< Rcpp::IntegerVector >::type offsets(offsetsSEXP);
-    rcpp_result_gen = Rcpp::wrap(convertStringVectorIntoOffsetsAndString(vec, offsets));
-    return rcpp_result_gen;
-END_RCPP
-}
 // libtiledb_query_buffer_var_char_create
 XPtr<vlc_buf_t> libtiledb_query_buffer_var_char_create(CharacterVector vec, bool nullable);
 RcppExport SEXP _tiledb_libtiledb_query_buffer_var_char_create(SEXP vecSEXP, SEXP nullableSEXP) {
@@ -3154,7 +3142,6 @@ static const R_CallMethodDef CallEntries[] = {
     {"_tiledb_libtiledb_query_set_subarray", (DL_FUNC) &_tiledb_libtiledb_query_set_subarray, 2},
     {"_tiledb_libtiledb_query_set_buffer", (DL_FUNC) &_tiledb_libtiledb_query_set_buffer, 3},
     {"_tiledb_libtiledb_query_buffer_var_char_alloc_direct", (DL_FUNC) &_tiledb_libtiledb_query_buffer_var_char_alloc_direct, 4},
-    {"_tiledb_convertStringVectorIntoOffsetsAndString", (DL_FUNC) &_tiledb_convertStringVectorIntoOffsetsAndString, 2},
     {"_tiledb_libtiledb_query_buffer_var_char_create", (DL_FUNC) &_tiledb_libtiledb_query_buffer_var_char_create, 2},
     {"_tiledb_libtiledb_query_set_buffer_var_char", (DL_FUNC) &_tiledb_libtiledb_query_set_buffer_var_char, 3},
     {"_tiledb_libtiledb_query_get_buffer_var_char", (DL_FUNC) &_tiledb_libtiledb_query_get_buffer_var_char, 3},

--- a/src/libtiledb.cpp
+++ b/src/libtiledb.cpp
@@ -2578,7 +2578,8 @@ XPtr<vlc_buf_t> libtiledb_query_buffer_var_char_alloc_direct(int szoffsets, int 
   return buf;
 }
 
-// helper function to turn a vector of strings
+// helper function to turn a vector of strings into long string and offsets vector
+// note that offsets is returned here too
 // [[Rcpp::export]]
 std::string convertStringVectorIntoOffsetsAndString(Rcpp::CharacterVector vec,
                                                     Rcpp::IntegerVector offsets) {
@@ -2612,6 +2613,26 @@ XPtr<vlc_buf_t> libtiledb_query_buffer_var_char_create(IntegerVector intoffsets,
   bufptr->nullable = false;
   return(bufptr);
 }
+// [[Rcpp::export]]
+XPtr<vlc_buf_t> libtiledb_query_buffer_var_char_create_large(CharacterVector vec) {
+    size_t n = vec.size();
+    XPtr<vlc_buf_t> bufptr = make_xptr<vlc_buf_t>(new vlc_buf_t);
+    bufptr->offsets.resize(n);
+    bufptr->str = "";
+    uint64_t cumlen = 0;
+    for (size_t i=0; i<n; i++) {
+        std::string s(vec[i]);
+        bufptr->offsets[i] = cumlen;
+        bufptr->str += s;
+        cumlen += s.length();
+    }
+    bufptr->rows = bufptr->cols = 0; // signal unassigned for the write case
+    bufptr->validity_map.resize(n);  // validity_map resized but not used
+    bufptr->nullable = false;
+    return(bufptr);
+}
+
+
 
 // assigning (for a write) allocates with nullable vector
 // [[Rcpp::export]]

--- a/src/libtiledb.cpp
+++ b/src/libtiledb.cpp
@@ -2578,24 +2578,6 @@ XPtr<vlc_buf_t> libtiledb_query_buffer_var_char_alloc_direct(int szoffsets, int 
   return buf;
 }
 
-// helper function to turn a vector of strings into long string and offsets vector
-// note that offsets is returned here too
-// [[Rcpp::export]]
-std::string convertStringVectorIntoOffsetsAndString(Rcpp::CharacterVector vec,
-                                                    Rcpp::IntegerVector offsets) {
-  size_t n = vec.size();
-  if (offsets.size() != (R_xlen_t)n) Rcpp::stop("offsets needs to be of same size as vec");
-  std::string data = "";
-  int cumlen = 0;
-  for (size_t i=0; i<n; i++) {
-    std::string s(vec[i]);
-    offsets[i] = cumlen;
-    data += s;
-    cumlen += s.length();
-  }
-  return data;
-}
-
 // assigning (for a write) allocates
 // [[Rcpp::export]]
 XPtr<vlc_buf_t> libtiledb_query_buffer_var_char_create(CharacterVector vec, bool nullable) {

--- a/src/libtiledb.cpp
+++ b/src/libtiledb.cpp
@@ -2596,28 +2596,14 @@ std::string convertStringVectorIntoOffsetsAndString(Rcpp::CharacterVector vec,
   return data;
 }
 
-
 // assigning (for a write) allocates
 // [[Rcpp::export]]
-XPtr<vlc_buf_t> libtiledb_query_buffer_var_char_create(IntegerVector intoffsets,
-                                                       std::string data) {
-  XPtr<vlc_buf_t> bufptr = make_xptr<vlc_buf_t>(new vlc_buf_t);
-  int n = intoffsets.size();
-  bufptr->offsets.resize(n);
-  for (int i=0; i<n; i++) {
-    bufptr->offsets[i] = static_cast<uint64_t>(intoffsets[i]);
-  }
-  bufptr->str = data;
-  bufptr->rows = bufptr->cols = 0; // signal unassigned for the write case
-  bufptr->validity_map.resize(n);  // validity_map resized but not used
-  bufptr->nullable = false;
-  return(bufptr);
-}
-// [[Rcpp::export]]
-XPtr<vlc_buf_t> libtiledb_query_buffer_var_char_create_large(CharacterVector vec) {
+XPtr<vlc_buf_t> libtiledb_query_buffer_var_char_create(CharacterVector vec, bool nullable) {
     size_t n = vec.size();
     XPtr<vlc_buf_t> bufptr = make_xptr<vlc_buf_t>(new vlc_buf_t);
     bufptr->offsets.resize(n);
+    bufptr->validity_map.resize(n);
+    bufptr->nullable = nullable;
     bufptr->str = "";
     uint64_t cumlen = 0;
     for (size_t i=0; i<n; i++) {
@@ -2625,39 +2611,13 @@ XPtr<vlc_buf_t> libtiledb_query_buffer_var_char_create_large(CharacterVector vec
         bufptr->offsets[i] = cumlen;
         bufptr->str += s;
         cumlen += s.length();
+        if (nullable) {
+          bufptr->validity_map[i] = vec[i] == NA_STRING;
+        }
     }
     bufptr->rows = bufptr->cols = 0; // signal unassigned for the write case
-    bufptr->validity_map.resize(n);  // validity_map resized but not used
-    bufptr->nullable = false;
     return(bufptr);
 }
-
-
-
-// assigning (for a write) allocates with nullable vector
-// [[Rcpp::export]]
-XPtr<vlc_buf_t> libtiledb_query_buffer_var_char_create_nullable(IntegerVector intoffsets,
-                                                                std::string data,
-                                                                bool nullable,
-                                                                std::vector<bool> navec) {
-  XPtr<vlc_buf_t> bufptr = make_xptr<vlc_buf_t>(new vlc_buf_t);
-  int n = intoffsets.size();
-  bufptr->offsets.resize(n);
-  for (int i=0; i<n; i++) {
-    bufptr->offsets[i] = static_cast<uint64_t>(intoffsets[i]);
-  }
-  bufptr->str = data;
-  bufptr->rows = bufptr->cols = 0; // signal unassigned for the write case
-  if (nullable) {
-      bufptr->validity_map.resize(n);
-      for (int i=0; i<n; i++) {
-          bufptr->validity_map[i] = (navec[i] ? 0 : 1);
-      }
-  }
-  bufptr->nullable = nullable;
-  return(bufptr);
-}
-
 
 // [[Rcpp::export]]
 XPtr<tiledb::Query> libtiledb_query_set_buffer_var_char(XPtr<tiledb::Query> query,


### PR DESCRIPTION
This PR updates and refactors how character vectors are handles in write queries, and replaces a return of a temporary back to R (where R's size limits apply) by keeping everything at the C++ level.  In the process we can also remove one helper function.

This helps with the issue documented in [`tiledbsc` #43](https://github.com/TileDB-Inc/tiledbsc/issues/43). 