### PR TITLE
Update nightly valgrind run to 2.8.1 and release-2.9

### DIFF
--- a/.github/workflows/valgrind.yaml
+++ b/.github/workflows/valgrind.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tag: [ 2.8.0, release-2.8, dev ]
+        tag: [ 2.8.1, release-2.9, dev ]
 
     steps:
     - name: Checkout


### PR DESCRIPTION
This PR updates the workflow to use both 2.8.1 (instead of 2.8.0) and release-2.9 (instead of release-2.8).

No code or documentation changes in the package.