### PR TITLE
Use TileDB 2.8.2

### DIFF
--- a/.github/workflows/valgrind.yaml
+++ b/.github/workflows/valgrind.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tag: [ 2.8.1, release-2.9, dev ]
+        tag: [ 2.8.2, release-2.9, dev ]
 
     steps:
     - name: Checkout

--- a/tools/tiledbVersion.txt
+++ b/tools/tiledbVersion.txt
@@ -1,2 +1,2 @@
-version: 2.8.1
-sha: e9a945c
+version: 2.8.2
+sha: 6f382df


### PR DESCRIPTION
This PR updates the package preference (and the nightly check) to TileDB 2.8.1.

No code changes.