### PR TITLE
Reduce windows build matrix to just ucrt

### DIFF
--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -11,8 +11,8 @@ jobs:
       fail-fast: false
       matrix:
         include: [
-          { windows: windows-2019, r: release    },
-          { windows: windows-2022, r: devel      },
+          #{ windows: windows-2019, r: release    },
+          #{ windows: windows-2022, r: devel      },
           { windows: windows-2022, r: devel-ucrt }
         ]
     steps:


### PR DESCRIPTION
This PR reduces the build matrix for Windows by skipping the 32 and 64 bit builds from the previous, non-UCRT setup.  A proper UCRT setup is to follow but requires more work on the core side first.

No code changes.