### PR TITLE
Use TileDB 2.8.3

### DIFF
--- a/.github/workflows/valgrind.yaml
+++ b/.github/workflows/valgrind.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tag: [ 2.8.2, release-2.9, dev ]
+        tag: [ 2.8.3, release-2.9, dev ]
 
     steps:
     - name: Checkout

--- a/tools/tiledbVersion.txt
+++ b/tools/tiledbVersion.txt
@@ -1,2 +1,2 @@
-version: 2.8.3-rc0
+version: 2.8.3
 sha: 04a9da7

--- a/tools/tiledbVersion.txt
+++ b/tools/tiledbVersion.txt
@@ -1,2 +1,2 @@
-version: 2.8.2
-sha: 6f382df
+version: 2.8.3-rc0
+sha: 04a9da7


### PR DESCRIPTION
This PR updates the package preference (and the nightly check) to TileDB 2.8.3.

No code changes.