### PR TITLE
Use TileDB 2.9.0

### DIFF
--- a/.github/workflows/valgrind.yaml
+++ b/.github/workflows/valgrind.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tag: [ 2.8.3, release-2.9, dev ]
+        tag: [ 2.8.3, 2.9.0, release-2.9, dev ]
 
     steps:
     - name: Checkout

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tiledb
 Type: Package
-Version: 0.12.0.3
+Version: 0.12.0.4
 Title: Universal Storage Engine for Sparse and Dense Multidimensional Arrays
 Authors@R: c(person("TileDB, Inc.", role = c("aut", "cph")),
  person("Dirk", "Eddelbuettel", email = "dirk@tiledb.com", role = "cre"))

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -6,7 +6,7 @@ PKG_LIBS = \
 	-L$(RWINLIB)/lib$(subst gcc,,$(COMPILED_BY))$(R_ARCH) \
 	-L$(RWINLIB)/lib$(R_ARCH)$(CRT) \
 	-ltiledbstatic -lbz2 -lzstd -llz4 -lz -lspdlog \
-        -llibmagic -lpcre2-8 -lpcre2-posix \
+        -llibmagic -lpcre2-posix -lpcre2-8 \
 	-laws-cpp-sdk-identity-management -laws-cpp-sdk-cognito-identity -laws-cpp-sdk-sts -laws-cpp-sdk-s3 -laws-cpp-sdk-core -laws-c-event-stream -laws-checksums -laws-c-common \
 	-lShlwapi -lBcrypt -lRpcrt4 -lWininet -lWinhttp -lws2_32 -lVersion -lUserenv
 

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -6,6 +6,7 @@ PKG_LIBS = \
 	-L$(RWINLIB)/lib$(subst gcc,,$(COMPILED_BY))$(R_ARCH) \
 	-L$(RWINLIB)/lib$(R_ARCH)$(CRT) \
 	-ltiledbstatic -lbz2 -lzstd -llz4 -lz -lspdlog \
+        -llibmagic -lpcre2-8 -lpcre2-posix \
 	-laws-cpp-sdk-identity-management -laws-cpp-sdk-cognito-identity -laws-cpp-sdk-sts -laws-cpp-sdk-s3 -laws-cpp-sdk-core -laws-c-event-stream -laws-checksums -laws-c-common \
 	-lShlwapi -lBcrypt -lRpcrt4 -lWininet -lWinhttp -lws2_32 -lVersion -lUserenv
 

--- a/tools/tiledbVersion.txt
+++ b/tools/tiledbVersion.txt
@@ -1,2 +1,2 @@
-version: 2.8.3
-sha: 04a9da7
+version: 2.9.0-rc0
+sha: f768ec9

--- a/tools/tiledbVersion.txt
+++ b/tools/tiledbVersion.txt
@@ -1,2 +1,2 @@
-version: 2.9.0-rc1
+version: 2.9.0
 sha: e4aa2b5

--- a/tools/tiledbVersion.txt
+++ b/tools/tiledbVersion.txt
@@ -1,2 +1,2 @@
-version: 2.9.0-rc0
-sha: f768ec9
+version: 2.9.0-rc1
+sha: e4aa2b5


### PR DESCRIPTION
This release updates the package preference (and the nightly check) to TileDB 2.9.0.  

No code changes.