### PR TITLE
Do not run filter compression tests on Linux without AVX2

### DIFF
--- a/inst/tinytest/test_filter.R
+++ b/inst/tinytest/test_filter.R
@@ -93,6 +93,10 @@ name_list <- c("NONE",
 if (!requireNamespace("palmerpenguins", quietly=TRUE)) exit_file("remainder needs 'palmerpenguins'")
 dat <- palmerpenguins::penguins
 
+## we have seen some test setups fail and suspect lack of AVX2
+if (Sys.info()[["sysname"]]=="Linux" && isFALSE(any(grepl("avx2", readLines("/proc/cpuinfo")))))
+    exit_file("Skipping remainder on Linux systems without AVX2")
+
 vfs <- tiledb_vfs()                     # use an explicit VFS instance for the ops in loop over filters
 for (name in name_list) {
     dat2 <- dat


### PR DESCRIPTION
This PR exists out of filter tests before compression tests are run if two conditions are met: running on Linux, and not seeing AVX2 capabiltiies stated (in lowercase) in `/proc/cpuinfo`.  This avoids some tests failure observed on older hardware.

No new code.  