### PR TITLE
Use TileDB 2.9.2

### DIFF
--- a/.github/workflows/valgrind.yaml
+++ b/.github/workflows/valgrind.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tag: [ 2.8.3, 2.9.1, release-2.9, dev ]
+        tag: [ 2.8.3, 2.9.2, release-2.9, dev ]
 
     steps:
     - name: Checkout

--- a/tools/tiledbVersion.txt
+++ b/tools/tiledbVersion.txt
@@ -1,2 +1,2 @@
-version: 2.9.2-rc0
+version: 2.9.2
 sha: 5c41d9a

--- a/tools/tiledbVersion.txt
+++ b/tools/tiledbVersion.txt
@@ -1,2 +1,2 @@
-version: 2.9.1
-sha: 1855f7c
+version: 2.9.2-rc0
+sha: 5c41d9a


### PR DESCRIPTION
This PR updates the package preference (and the nightly check) to TileDB 2.9.2.