### PR TITLE
Propagate incomplete query status via warning

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tiledb
 Type: Package
-Version: 0.13.0.1
+Version: 0.13.0.3
 Title: Universal Storage Engine for Sparse and Dense Multidimensional Arrays
 Authors@R: c(person("TileDB, Inc.", role = c("aut", "cph")),
  person("Dirk", "Eddelbuettel", email = "dirk@tiledb.com", role = "cre"))

--- a/R/TileDBArray.R
+++ b/R/TileDBArray.R
@@ -791,6 +791,8 @@ setMethod("[", "tiledb_array",
           if (resrv == 0 && counter > 1L) {
               finished <- TRUE
               #if (verbose) message("Breaking loop at zero length expected")
+              if (status != "COMPLETE") warning("Query returned '", status, "'.", call. = FALSE)
+              .pkgenv[["query_status"]] <- status
               break
           }
           ## get results

--- a/inst/tinytest/test_query.R
+++ b/inst/tinytest/test_query.R
@@ -232,6 +232,7 @@ expect_equal(nv[3], n)                  # third is length of validity buffer (if
 #})
 
 ## check for warning in insufficient memory
+oldcfg <- tiledb_config()
 cfg <- tiledb_config()
 cfg["sm.memory_budget"] <- "16"
 cfg["sm.memory_budget_var"] <- "32"
@@ -249,3 +250,5 @@ expect_true(nchar(res) > 1000)  		# safe lower boundary
 res <- tiledb_ctx_stats()               # test here rather than in test_ctx to have real query
 expect_true(is.character(res))
 expect_true(nchar(res) > 1000)  		# safe lower boundary
+
+ctx <- tiledb_ctx(oldcfg)               # reset config

--- a/inst/tinytest/test_tiledbarray.R
+++ b/inst/tinytest/test_tiledbarray.R
@@ -1418,3 +1418,10 @@ arr <- tiledb_array(uri, as.data.frame = TRUE, attrs = NA_character_)
 res <- arr[]
 expect_equal(NCOL(res), 2)
 expect_equal(colnames(res), c("species", "year"))
+
+
+## check for incomplete status on unsuccessful query
+set_allocation_size_preference(256)     # too low for penguins to return something
+array <- tiledb_array(uri, as.data.frame=TRUE)
+expect_warning(res <- array[])          # warning emitted
+expect_equal(attr(res, "query_status"), "INCOMPLETE") # and query status reported


### PR DESCRIPTION
This PR ensures an incomplete query status is reported to the user in case of a query resulting in status 'INCOMPLETE'.  A new test has been added to check for this.

The micro release number is updated to 0.13.0.3.