### PR TITLE
Use TileDB 2 9 3

### DIFF
--- a/.github/workflows/valgrind.yaml
+++ b/.github/workflows/valgrind.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tag: [ 2.8.3, 2.9.2, release-2.9, dev ]
+        tag: [ 2.8.3, 2.9.3, release-2.9, dev ]
 
     steps:
     - name: Checkout

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -11,8 +11,8 @@ jobs:
       fail-fast: false
       matrix:
         include: [
-          #{ windows: windows-2019, r: release    },
-          #{ windows: windows-2022, r: devel      },
+          { windows: windows-2019, r: release    },
+          { windows: windows-2022, r: devel      },
           { windows: windows-2022, r: devel-ucrt }
         ]
     steps:

--- a/inst/tinytest/test_tiledbarray.R
+++ b/inst/tinytest/test_tiledbarray.R
@@ -990,7 +990,7 @@ arr <- tiledb_array(uri = tmp)
 arr[I, J] <- data
 expect_false(tiledb_array_is_open(arr))
 arr <- tiledb_array_open(arr)
-expect_True(tiledb_array_is_open(arr))
+expect_true(tiledb_array_is_open(arr))
 expect_equal(tiledb_array_get_non_empty_domain_from_index(arr, 1), c(1, 3))
 expect_equal(tiledb_array_get_non_empty_domain_from_name(arr, "d1"), c(1, 3))
 expect_equal(tiledb_array_get_non_empty_domain_from_index(arr, 2), c("a", "c"))

--- a/tools/tiledbVersion.txt
+++ b/tools/tiledbVersion.txt
@@ -1,2 +1,2 @@
-version: 2.9.2
-sha: 5c41d9a
+version: 2.9.3-rc0
+sha: 9f4129b

--- a/tools/tiledbVersion.txt
+++ b/tools/tiledbVersion.txt
@@ -1,2 +1,2 @@
-version: 2.9.3-rc0
+version: 2.9.3
 sha: 9f4129b


### PR DESCRIPTION
This PR updates the package preference (and the nightly check) to TileDB 2.9.3.

It also contains a one-char test fix for #421.