### PR TITLE
Minor fix for tiledb_array's attr setter

### DIFF
--- a/R/TileDBArray.R
+++ b/R/TileDBArray.R
@@ -1203,7 +1203,8 @@ setReplaceMethod("attrs",
                  signature = "tiledb_array",
                  function(x, value) {
   nm <- names(attrs(schema(x)))
-  if (length(nm) == 0) {                # none set so far
+  value_is_na <- length(value) == 1 && is.na(value)  # no attribute query
+  if (length(nm) == 0 || value_is_na) {              # none set so far
     x@attrs <- value
   } else {
     pm <- pmatch(value, nm)

--- a/inst/tinytest/test_attr.R
+++ b/inst/tinytest/test_attr.R
@@ -255,6 +255,5 @@ expect_equal(tiledb_query_status(qry), "COMPLETE")
 
 arr2 <- tiledb_array(uri, return_as="data.frame")
 res2 <- arr2[0:3]
-print(res2)
 attr(res2, "query_status") <- NULL
 expect_equal(v, res2[,"val"])

--- a/inst/tinytest/test_tiledbarray.R
+++ b/inst/tinytest/test_tiledbarray.R
@@ -1421,6 +1421,13 @@ res <- arr[]
 expect_equal(NCOL(res), 2)
 expect_equal(colnames(res), c("species", "year"))
 
+## check that we can specify no attributes with the setter
+arr <- tiledb_array(uri)
+expect_identical(attrs(arr), character(length = 0L))
+
+attrs(arr) <- NA_character_
+expect_true(is.na(attrs(arr)))
+
 
 ## check for incomplete status on unsuccessful query
 set_allocation_size_preference(256)     # too low for penguins to return something


### PR DESCRIPTION
Small fix for using the attr setter to specify no attributes with `NA_character_`, ie:

```
attrs(arr) <- NA_character
```

which previously would trigger `any(is.na(pm))` and proceed to the stop condition. I added a check to handle the special case where `value` is both scalar and `NA` so it can proceed as expected when attempting to setup a 0-attribute query.

