### PR TITLE
Roll valgrind CI to 2.9.3 and 2.10 branch [ci skip]

### DIFF
--- a/.github/workflows/valgrind.yaml
+++ b/.github/workflows/valgrind.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tag: [ 2.8.3, 2.9.3, release-2.9, dev ]
+        tag: [ 2.9.3, release-2.10, dev ]
 
     steps:
     - name: Checkout


### PR DESCRIPTION
This PR is 'code less' and only updates the default CI run for valgrind to branch 2.10 (and retires the 2.8.3 release).

No code or code changes so no CI.