### PR TITLE
Add tests for overlapping ranges

### DIFF
--- a/inst/tinytest/test_querycondition.R
+++ b/inst/tinytest/test_querycondition.R
@@ -284,3 +284,19 @@ qc <- parse_query_condition(year < 2008 || year > 2010)
 arr <- tiledb_array(uri, as.data.frame=TRUE, query_condition=qc)
 expect_equal(NROW(arr[]),
              sum(with(penguins, year < 2008 | year > 2010)))
+
+## Overlapping ranges
+qc <- parse_query_condition(year < 2009 && year < 2010)
+arr <- tiledb_array(uri, as.data.frame=TRUE, query_condition=qc)
+expect_equal(NROW(arr[]),
+             sum(with(penguins, year < 2009)))
+
+qc <- parse_query_condition(year <= 2009 && year >= 2009)
+arr <- tiledb_array(uri, as.data.frame=TRUE, query_condition=qc)
+expect_equal(NROW(arr[]),
+             sum(with(penguins, year == 2009)))
+
+qc <- parse_query_condition(year < 2009 || year < 2010)
+arr <- tiledb_array(uri, as.data.frame=TRUE, query_condition=qc)
+expect_equal(NROW(arr[]),
+             sum(with(penguins, year < 2010)))


### PR DESCRIPTION
This PR adds tests for overlapping ranges in query conditions.

No new code.