### PR TITLE
Use TileDB 2.9.5

### DIFF
--- a/.github/workflows/valgrind.yaml
+++ b/.github/workflows/valgrind.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tag: [ 2.9.4, release-2.10, dev ]
+        tag: [ 2.9.5, release-2.10, dev ]
 
     steps:
     - name: Checkout

--- a/tools/tiledbVersion.txt
+++ b/tools/tiledbVersion.txt
@@ -1,2 +1,2 @@
-version: 2.9.4
-sha: 4e14c01
+version: 2.9.5
+sha: 81e3fd1


### PR DESCRIPTION
This PR updates the package preference (and the nightly check) to TileDB 2.9.5.