### PR TITLE
Use TileDB 2.10.1

### DIFF
--- a/tools/tiledbVersion.txt
+++ b/tools/tiledbVersion.txt
@@ -1,2 +1,2 @@
-version: 2.10.0
-sha: 0b54e51
+version: 2.10.1
+sha: 6535d4c


### PR DESCRIPTION
This PR updates the package preference to TileDB 2.10.1.