### PR TITLE
Update nightly valgrind check

### DIFF
--- a/.github/workflows/valgrind.yaml
+++ b/.github/workflows/valgrind.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   valgrind:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     name: ${{ matrix.tag }}
 
     strategy:

--- a/tools/ci/valgrind/buildAndCheckPackage.sh
+++ b/tools/ci/valgrind/buildAndCheckPackage.sh
@@ -7,6 +7,8 @@ echo "::endgroup::"
 
 
 echo "::group::Check TileDB R package"
+## set flag to tolerate missing suggested packages (as eg vignette building tools)
+export _R_CHECK_FORCE_SUGGESTS_=FALSE
 ## check package
 R CMD check --use-valgrind --as-cran --no-manual --ignore-vignettes tiledb_*.tar.gz
 echo "::endgroup::"

--- a/tools/ci/valgrind/showTestLogs.sh
+++ b/tools/ci/valgrind/showTestLogs.sh
@@ -6,7 +6,7 @@ for suffix in Rout Rout.fail; do
         echo ""
         echo "** Using ${suffix}"
         echo ""
-        cat tiledb.Rcheck/tests/tinytest.Rout
+        cat tiledb.Rcheck/tests/tinytest.${suffix}
     fi
 done
 


### PR DESCRIPTION
This PR switches the nightly Action for `valgrind` checks to run under Ubuntu 22.04 (and generally newer compilers etc).  The installation script was refactored a little to deploy more binaries, and one small bug in result file use was fixed.

No new code. 