### PR TITLE
Add support for list-column data.frames 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tiledb
 Type: Package
-Version: 0.14.0
+Version: 0.14.0.1
 Title: Universal Storage Engine for Sparse and Dense Multidimensional Arrays
 Authors@R: c(person("TileDB, Inc.", role = c("aut", "cph")),
  person("Dirk", "Eddelbuettel", email = "dirk@tiledb.com", role = "cre"))

--- a/R/DataFrame.R
+++ b/R/DataFrame.R
@@ -177,7 +177,14 @@ fromDataFrame <- function(obj, uri, col_index=NULL, sparse=TRUE, allows_dups=spa
 
     makeAttr <- function(ind) {
         col <- obj[,ind]
-        cl <- class(col)[1]
+        if (inherits(col, "AsIs")) {
+            ## we just look at the first list column, others have to have same type and length
+            cl <- class(obj[,ind][[1]])
+            nc <- length(obj[,ind][[1]])
+        } else {
+            cl <- class(col)[1]
+            nc <- 1
+        }
         if (cl == "integer")
             tp <- "INT32"
         else if (cl == "numeric")
@@ -201,7 +208,7 @@ fromDataFrame <- function(obj, uri, col_index=NULL, sparse=TRUE, allows_dups=spa
         }
         tiledb_attr(colnames(obj)[ind],
                     type = tp,
-                    ncells = ifelse(tp %in% c("CHAR","ASCII"), NA_integer_, 1),
+                    ncells = if (tp %in% c("CHAR","ASCII")) NA_integer_ else nc,
                     filter_list = filterlist,
                     nullable = any(is.na(col)))
     }

--- a/R/TileDBArray.R
+++ b/R/TileDBArray.R
@@ -796,51 +796,43 @@ setMethod("[", "tiledb_array",
               break
           }
           ## get results
-          getResult <- function(buf, name, varnum, resrv, qryptr) {
+          getResult <- function(buf, name, varnum, estsz, qryptr) {
               has_dumpbuffers <- length(x@dumpbuffers) > 0
+              #message("For ", name, " seeing ", estsz)
               if (is.na(varnum)) {
                   vec <- libtiledb_query_result_buffer_elements_vec(qryptr, name)
                   if (has_dumpbuffers) {
                       vlcbuf_to_shmem(x@dumpbuffers, name, buf, vec)
                   }
-                  libtiledb_query_get_buffer_var_char(buf, vec[1], vec[2])[,1]
+                  libtiledb_query_get_buffer_var_char(buf, vec[1], vec[2])[,1][seq_len(estsz)]
               } else {
                   if (has_dumpbuffers) {
-                      vecbuf_to_shmem(x@dumpbuffers, name, buf, resrv)
+                      vecbuf_to_shmem(x@dumpbuffers, name, buf, estsz)
                   }
-                  libtiledb_query_get_buffer_ptr(buf, asint64)
+                  libtiledb_query_get_buffer_ptr(buf, asint64)[seq_len(estsz)]
               }
           }
-          reslist <- mapply(getResult, buflist, allnames, allvarnum,
-                            MoreArgs=list(resrv=resrv, qryptr=qryptr), SIMPLIFY=FALSE)
-
+          reslist <- mapply(getResult, buflist, allnames, allvarnum, estsz,
+                            MoreArgs=list(qryptr=qryptr), SIMPLIFY=FALSE)
           ## convert list into data.frame (possibly dealing with list columns) and subset
           vnum <- 1   # default value of variable number of elements per cell
           if (is.list(allvarnum)) allvarnum <- unlist(allvarnum)
           vnum <- max(allvarnum, na.rm=TRUE)
           if (is.finite(vnum) && (vnum > 1)) {
-              ## we know the length of returned data for all columns (resrv) and the max
-              ## of ncells so we can infer to length of columns with ncells==1
-              lengthguess <- resrv/vnum
               ## turn to list col if a varnum != 1 (and not NA) seen
               ind <- which(allvarnum != 1 & !is.na(allvarnum))
               for (k in ind) {
                   ncells <- allvarnum[k]
-                  currcollength <- ncells * lengthguess
-                  v <- reslist[[k]][seq_len(currcollength)]
+                  v <- reslist[[k]]
+                  ## we split a vector v into 'list-columns' which element containing
+                  ## ncells value (and we get ncells from the Array schema)
                   ## see https://stackoverflow.com/a/9547594/143305 for I()
                   ## and https://stackoverflow.com/a/3321659/143305 for split()
                   reslist[[k]] <- I(unname(split(v, ceiling(seq_along(v)/ncells))))
               }
-              for (k in seq_along(reslist)) {
-                  if (length(reslist[[k]]) >= resrv) {
-                      reslist[[k]] <- reslist[[k]][seq_len(resrv/vnum)]
-                  }
-              }
-              res <- data.frame(reslist)[,,drop=FALSE]
-          } else {
-              res <- data.frame(reslist)[seq_len(resrv),,drop=FALSE]
           }
+          ## the list columns are now all of equal lenthth as R needs and we can form a data.frame
+          res <- data.frame(reslist)[,,drop=FALSE]
           colnames(res) <- allnames
           #if (verbose) cat("Retrieved ", paste(dim(res), collapse="x"), "...\n")
           overallresults[[counter]] <- res

--- a/R/TileDBArray.R
+++ b/R/TileDBArray.R
@@ -1139,10 +1139,14 @@ setMethod("[<-", "tiledb_array",
         buflist[[k]] <- libtiledb_query_buffer_var_char_create(txtvec, allnullable[k])
         qryptr <- libtiledb_query_set_buffer_var_char(qryptr, colnam, buflist[[k]])
       } else {
-        nr <- NROW(value[[k]])
-        #cat("Alloc buf", i, " ", colnam, ":", alltypes[i], "nr:", nr, "null:", allnullable[i], "asint64:", asint64, "\n")
+        col <- value[[k]]
+        if (is.list(col)) {
+            col <- unname(do.call(c, col))
+        }
+        nr <- NROW(col)
+        # cat("Alloc buf", i, " ", colnam, ":", alltypes[i], "nr:", nr, "null:", allnullable[i], "asint64:", asint64, "\n")
         buflist[[k]] <- libtiledb_query_buffer_alloc_ptr(alltypes[k], nr, allnullable[k])
-        buflist[[k]] <- libtiledb_query_buffer_assign_ptr(buflist[[k]], alltypes[k], value[[k]], asint64)
+        buflist[[k]] <- libtiledb_query_buffer_assign_ptr(buflist[[k]], alltypes[k], col, asint64)
         qryptr <- libtiledb_query_set_buffer_ptr(qryptr, colnam, buflist[[k]])
       }
     }

--- a/R/TileDBArray.R
+++ b/R/TileDBArray.R
@@ -819,13 +819,18 @@ setMethod("[", "tiledb_array",
           if (is.list(allvarnum)) allvarnum <- unlist(allvarnum)
           vnum <- max(allvarnum, na.rm=TRUE)
           if (is.finite(vnum) && (vnum > 1)) {
+              ## we know the length of returned data for all columns (resrv) and the max
+              ## of ncells so we can infer to length of columns with ncells==1
+              lengthguess <- resrv/vnum
               ## turn to list col if a varnum != 1 (and not NA) seen
               ind <- which(allvarnum != 1 & !is.na(allvarnum))
               for (k in ind) {
-                  v <- reslist[[k]][seq_len(resrv)]
+                  ncells <- allvarnum[k]
+                  currcollength <- ncells * lengthguess
+                  v <- reslist[[k]][seq_len(currcollength)]
                   ## see https://stackoverflow.com/a/9547594/143305 for I()
                   ## and https://stackoverflow.com/a/3321659/143305 for split()
-                  reslist[[k]] <- I(unname(split(v, ceiling(seq_along(v)/vnum))))
+                  reslist[[k]] <- I(unname(split(v, ceiling(seq_along(v)/ncells))))
               }
               for (k in seq_along(reslist)) {
                   if (length(reslist[[k]]) >= resrv) {

--- a/inst/tinytest/test_dataframe.R
+++ b/inst/tinytest/test_dataframe.R
@@ -168,7 +168,6 @@ for (i in seq_len(dim(df)[2])) {
 uri <- tempfile()
 set.seed(42)
 nobs <- 50L
-set.seed(42)
 df <- data.frame(time = round(Sys.time(), "secs") + trunc(cumsum(runif(nobs)*3600)),
                  double_range = seq(-1000, 1000, length=nobs),
                  int_vals = sort(as.integer(runif(nobs)*1e9)),

--- a/inst/tinytest/test_dataframe.R
+++ b/inst/tinytest/test_dataframe.R
@@ -328,3 +328,14 @@ arr2 <- tiledb_array(uri, return_as="data.frame")
 res2 <- arr2[]
 attr(res2, "query_status") <- NULL
 expect_equal(D, res2)
+
+
+## list columns
+D <- data.frame(a=1:5,
+                b=I(split(1:10, ceiling((1:10)/2))),
+                c=I(split(101:115, ceiling((1:15)/3))))
+uri <- tempfile()
+fromDataFrame(D, uri, col_index=1)
+arr <- tiledb_array(uri, return_as="data.frame")
+res <- arr[]
+expect_equivalent(res, D)

--- a/src/libtiledb.cpp
+++ b/src/libtiledb.cpp
@@ -1327,6 +1327,7 @@ XPtr<tiledb::Attribute> libtiledb_attribute(XPtr<tiledb::Context> ctx,
         attr_dtype == TILEDB_DATETIME_FS  ||
         attr_dtype == TILEDB_DATETIME_AS) {
         attr = make_xptr<tiledb::Attribute>(new tiledb::Attribute(*ctx.get(), name, attr_dtype));
+        attr->set_cell_val_num(static_cast<uint64_t>(ncells));
     } else if (attr_dtype == TILEDB_CHAR ||
                attr_dtype == TILEDB_STRING_ASCII) {
         attr = make_xptr<tiledb::Attribute>(new tiledb::Attribute(*ctx.get(), name, attr_dtype));


### PR DESCRIPTION
This PR adds the ability to read and write `data.frame` objects with list columns by mapping them arrays with proper (fixed) `ncells` settings.  While such `data.frame` objects are somewhat rare within known R applications and use case, it may provide a useful extension for some use cases.   A simple test was added as well.