### PR TITLE
Update valgrind test for Ubuntu 22.04

### DIFF
--- a/inst/tinytest/test_querycondition.R
+++ b/inst/tinytest/test_querycondition.R
@@ -4,6 +4,8 @@ library(tiledb)
 isOldWindows <- Sys.info()[["sysname"]] == "Windows" && grepl('Windows Server 2008', osVersion)
 if (isOldWindows) exit_file("skip this file on old Windows releases")
 
+if (Sys.getenv("_RUNNING_UNDER_VALGRIND_", "FALSE") == "TRUE") exit_file("Skipping under valgrind")
+
 ctx <- tiledb_ctx(limitTileDBCores())
 
 if (tiledb_version(TRUE) < "2.3.0") exit_file("TileDB Query Condition requires TileDB 2.3.* or greater")

--- a/inst/tinytest/test_querycondition.R
+++ b/inst/tinytest/test_querycondition.R
@@ -4,7 +4,7 @@ library(tiledb)
 isOldWindows <- Sys.info()[["sysname"]] == "Windows" && grepl('Windows Server 2008', osVersion)
 if (isOldWindows) exit_file("skip this file on old Windows releases")
 
-if (Sys.getenv("_RUNNING_UNDER_VALGRIND_", "FALSE") == "TRUE") exit_file("Skipping under valgrind")
+if (Sys.getenv("_RUNNING_UNDER_VALGRIND_", "FALSE") == "TRUE" && Sys.Date() < as.Date("2022-08-06")) exit_file("Skipping under valgrind until Aug 6")
 
 ctx <- tiledb_ctx(limitTileDBCores())
 

--- a/tools/ci/valgrind/buildAndCheckPackage.sh
+++ b/tools/ci/valgrind/buildAndCheckPackage.sh
@@ -9,6 +9,8 @@ echo "::endgroup::"
 echo "::group::Check TileDB R package"
 ## set flag to tolerate missing suggested packages (as eg vignette building tools)
 export _R_CHECK_FORCE_SUGGESTS_=FALSE
+## set an 'under valgrind' variable (see SC-19185)
+export _RUNNING_UNDER_VALGRIND_=TRUE
 ## check package
 R CMD check --use-valgrind --as-cran --no-manual --ignore-vignettes tiledb_*.tar.gz
 echo "::endgroup::"

--- a/tools/ci/valgrind/installDependencies.sh
+++ b/tools/ci/valgrind/installDependencies.sh
@@ -9,16 +9,17 @@ apt update -qq
 # Install packages for add-apt-repository
 export DEBIAN_FRONTEND=noninteractive
 # Install with recommends to get ca-certificates as well
-apt install --yes wget
+apt install --yes wget lsb-release
+
 # marutter key
 wget -qO- https://cloud.r-project.org/bin/linux/ubuntu/marutter_pubkey.asc | tee -a /etc/apt/trusted.gpg.d/cran.asc
-echo "deb [arch=amd64] https://cloud.r-project.org/bin/linux/ubuntu jammy-cran40/" > /etc/apt/sources.list.d/cranubuntu.list
+echo "deb [arch=amd64] https://cloud.r-project.org/bin/linux/ubuntu $(lsb_release -sc)-cran40/" > /etc/apt/sources.list.d/cranubuntu.list
 # edd key and cranapt / r2u for CRAN binaries
 wget -q -O- https://eddelbuettel.github.io/r2u/assets/dirk_eddelbuettel_key.asc | tee -a /etc/apt/trusted.gpg.d/cranapt_key.asc
-echo "deb [arch=amd64] https://dirk.eddelbuettel.com/cranapt jammy main" > /etc/apt/sources.list.d/cranapt.list
+echo "deb [arch=amd64] https://dirk.eddelbuettel.com/cranapt $(lsb_release -sc) main" > /etc/apt/sources.list.d/cranapt.list
 # edd launchpad key and launchpad PPA for AWS packages
 wget -q -O- https://eddelbuettel.github.io/r2u/assets/dirk_eddelbuettel_launchpad_ppa_key.asc | tee -a /etc/apt/trusted.gpg.d/eddppa_key.asc
-echo "deb [arch=amd64] http://ppa.launchpad.net/edd/misc/ubuntu jammy main" > /etc/apt/sources.list.d/eddppa.list
+echo "deb [arch=amd64] http://ppa.launchpad.net/edd/misc/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/eddppa.list
 
 # Refresh repo content metadata again
 apt update -qq


### PR DESCRIPTION
This PR updates the nightlty valgrind action to skip one test file (for query conditions).  This should restore completion of the action (as it has in tests in another repo), and give us results while we look into the root cause of the failure to complete query condition tests.

No code changes.