### PR TITLE
Extend validity map support to list column 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tiledb
 Type: Package
-Version: 0.14.0.1
+Version: 0.14.0.2
 Title: Universal Storage Engine for Sparse and Dense Multidimensional Arrays
 Authors@R: c(person("TileDB, Inc.", role = c("aut", "cph")),
  person("Dirk", "Eddelbuettel", email = "dirk@tiledb.com", role = "cre"))

--- a/R/Query.R
+++ b/R/Query.R
@@ -118,7 +118,7 @@ tiledb_query_set_buffer <- function(query, attr, buffer) {
       libtiledb_query_set_buffer(query@ptr, attr, buffer)
   } else {              # logical now maps to BOOL which is a uint8_t, we need a different approach
       nr <- NROW(buffer)
-      bufptr <- libtiledb_query_buffer_alloc_ptr("BOOL", nr, 1, FALSE)
+      bufptr <- libtiledb_query_buffer_alloc_ptr("BOOL", nr, FALSE, 1)
       bufptr <- libtiledb_query_buffer_assign_ptr(bufptr, "BOOL", buffer, FALSE)
       query@ptr <- libtiledb_query_set_buffer_ptr(query@ptr, attr, bufptr)
   }

--- a/R/Query.R
+++ b/R/Query.R
@@ -118,7 +118,7 @@ tiledb_query_set_buffer <- function(query, attr, buffer) {
       libtiledb_query_set_buffer(query@ptr, attr, buffer)
   } else {              # logical now maps to BOOL which is a uint8_t, we need a different approach
       nr <- NROW(buffer)
-      bufptr <- libtiledb_query_buffer_alloc_ptr("BOOL", nr, FALSE)
+      bufptr <- libtiledb_query_buffer_alloc_ptr("BOOL", nr, 1, FALSE)
       bufptr <- libtiledb_query_buffer_assign_ptr(bufptr, "BOOL", buffer, FALSE)
       query@ptr <- libtiledb_query_set_buffer_ptr(query@ptr, attr, bufptr)
   }

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -592,8 +592,8 @@ libtiledb_query_get_buffer_var_vec <- function(query, attr, buf) {
     .Call(`_tiledb_libtiledb_query_get_buffer_var_vec`, query, attr, buf)
 }
 
-libtiledb_query_buffer_alloc_ptr <- function(domaintype, ncells, numvar = 1L, nullable = FALSE) {
-    .Call(`_tiledb_libtiledb_query_buffer_alloc_ptr`, domaintype, ncells, numvar, nullable)
+libtiledb_query_buffer_alloc_ptr <- function(domaintype, ncells, nullable = FALSE, numvar = 1L) {
+    .Call(`_tiledb_libtiledb_query_buffer_alloc_ptr`, domaintype, ncells, nullable, numvar)
 }
 
 libtiledb_query_buffer_assign_ptr <- function(buf, dtype, vec, asint64 = FALSE) {

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -592,8 +592,8 @@ libtiledb_query_get_buffer_var_vec <- function(query, attr, buf) {
     .Call(`_tiledb_libtiledb_query_get_buffer_var_vec`, query, attr, buf)
 }
 
-libtiledb_query_buffer_alloc_ptr <- function(domaintype, ncells, nullable = FALSE) {
-    .Call(`_tiledb_libtiledb_query_buffer_alloc_ptr`, domaintype, ncells, nullable)
+libtiledb_query_buffer_alloc_ptr <- function(domaintype, ncells, numvar = 1L, nullable = FALSE) {
+    .Call(`_tiledb_libtiledb_query_buffer_alloc_ptr`, domaintype, ncells, numvar, nullable)
 }
 
 libtiledb_query_buffer_assign_ptr <- function(buf, dtype, vec, asint64 = FALSE) {
@@ -1044,8 +1044,8 @@ libtiledb_mime_type_from_str <- function(mime_type) {
     .Call(`_tiledb_libtiledb_mime_type_from_str`, mime_type)
 }
 
-vecbuf_to_shmem <- function(dir, name, buf, sz) {
-    invisible(.Call(`_tiledb_vecbuf_to_shmem`, dir, name, buf, sz))
+vecbuf_to_shmem <- function(dir, name, buf, sz, numvar) {
+    invisible(.Call(`_tiledb_vecbuf_to_shmem`, dir, name, buf, sz, numvar))
 }
 
 vlcbuf_to_shmem <- function(dir, name, buf, vec) {

--- a/R/TileDBArray.R
+++ b/R/TileDBArray.R
@@ -701,7 +701,16 @@ setMethod("[", "tiledb_array",
           }
       }
       reslist <- mapply(getResultShmem, buflist, allnames, allvarnum, SIMPLIFY=FALSE)
-      ## convert list into data.frame (cheaply)
+      ind <- which(allvarnum != 1 & !is.na(allvarnum))
+      for (k in ind) {
+          ncells <- allvarnum[k]
+          v <- reslist[[k]]
+          ## we split a vector v into 'list-columns' which element containing
+          ## ncells value (and we get ncells from the Array schema)
+          ## see https://stackoverflow.com/a/9547594/143305 for I()
+          ## and https://stackoverflow.com/a/3321659/143305 for split()
+          reslist[[k]] <- I(unname(split(v, ceiling(seq_along(v)/ncells))))
+      }
       res <- data.frame(reslist)
       colnames(res) <- allnames
 
@@ -739,8 +748,8 @@ setMethod("[", "tiledb_array",
                   message("Non-char var.num columns are not currently supported.")
               }
           } else {
-              #if (verbose) message("Allocating with ", resrv, " and ", memory_budget)
-              buf <- libtiledb_query_buffer_alloc_ptr(type, resrv, nullable)
+              ##if (verbose) message("Alloc ", resrv, " and ", memory_budget, " and ", ifelse(nullable,"(yes)", "(no)"))
+              buf <- libtiledb_query_buffer_alloc_ptr(type, resrv, varnum, nullable)
               qryptr <- libtiledb_query_set_buffer_ptr(qryptr, name, buf)
               buf
           }
@@ -798,7 +807,7 @@ setMethod("[", "tiledb_array",
           ## get results
           getResult <- function(buf, name, varnum, estsz, qryptr) {
               has_dumpbuffers <- length(x@dumpbuffers) > 0
-              #message("For ", name, " seeing ", estsz)
+              ## message("For ", name, " seeing ", estsz, " and ", varnum)
               if (is.na(varnum)) {
                   vec <- libtiledb_query_result_buffer_elements_vec(qryptr, name)
                   if (has_dumpbuffers) {
@@ -807,7 +816,7 @@ setMethod("[", "tiledb_array",
                   libtiledb_query_get_buffer_var_char(buf, vec[1], vec[2])[,1][seq_len(estsz)]
               } else {
                   if (has_dumpbuffers) {
-                      vecbuf_to_shmem(x@dumpbuffers, name, buf, estsz)
+                      vecbuf_to_shmem(x@dumpbuffers, name, buf, estsz, varnum)
                   }
                   libtiledb_query_get_buffer_ptr(buf, asint64)[seq_len(estsz)]
               }
@@ -817,7 +826,7 @@ setMethod("[", "tiledb_array",
           ## convert list into data.frame (possibly dealing with list columns) and subset
           vnum <- 1   # default value of variable number of elements per cell
           if (is.list(allvarnum)) allvarnum <- unlist(allvarnum)
-          vnum <- max(allvarnum, na.rm=TRUE)
+          if (length(allvarnum) > 0 && any(!is.na(allvarnum))) vnum <- max(allvarnum, na.rm=TRUE)
           if (is.finite(vnum) && (vnum > 1)) {
               ## turn to list col if a varnum != 1 (and not NA) seen
               ind <- which(allvarnum != 1 & !is.na(allvarnum))
@@ -863,7 +872,6 @@ setMethod("[", "tiledb_array",
           res <- res[, -k, drop=FALSE]
       }
   }
-
   if (x@return_as == "asis") {
       if (!x@as.data.frame && !x@as.matrix && !x@as.array) {
           res <- as.list(res)
@@ -1141,8 +1149,9 @@ setMethod("[<-", "tiledb_array",
             col <- unname(do.call(c, col))
         }
         nr <- NROW(col)
-        # cat("Alloc buf", i, " ", colnam, ":", alltypes[i], "nr:", nr, "null:", allnullable[i], "asint64:", asint64, "\n")
-        buflist[[k]] <- libtiledb_query_buffer_alloc_ptr(alltypes[k], nr, allnullable[k])
+        #cat("Alloc buf", i, " ", colnam, ":", alltypes[i], "nr:", nr,
+        #    "null:", ifelse(allnullable[k], "(yes)", "(no)"), "asint64:", asint64, "\n")
+        buflist[[k]] <- libtiledb_query_buffer_alloc_ptr(alltypes[k], nr, allvarnum[k], allnullable[k])
         buflist[[k]] <- libtiledb_query_buffer_assign_ptr(buflist[[k]], alltypes[k], col, asint64)
         qryptr <- libtiledb_query_set_buffer_ptr(qryptr, colnam, buflist[[k]])
       }

--- a/R/TileDBArray.R
+++ b/R/TileDBArray.R
@@ -749,7 +749,7 @@ setMethod("[", "tiledb_array",
               }
           } else {
               ##if (verbose) message("Alloc ", resrv, " and ", memory_budget, " and ", ifelse(nullable,"(yes)", "(no)"))
-              buf <- libtiledb_query_buffer_alloc_ptr(type, resrv, varnum, nullable)
+              buf <- libtiledb_query_buffer_alloc_ptr(type, resrv, nullable, varnum)
               qryptr <- libtiledb_query_set_buffer_ptr(qryptr, name, buf)
               buf
           }
@@ -1151,7 +1151,7 @@ setMethod("[<-", "tiledb_array",
         nr <- NROW(col)
         #cat("Alloc buf", i, " ", colnam, ":", alltypes[i], "nr:", nr,
         #    "null:", ifelse(allnullable[k], "(yes)", "(no)"), "asint64:", asint64, "\n")
-        buflist[[k]] <- libtiledb_query_buffer_alloc_ptr(alltypes[k], nr, allvarnum[k], allnullable[k])
+        buflist[[k]] <- libtiledb_query_buffer_alloc_ptr(alltypes[k], nr, allnullable[k], allvarnum[k])
         buflist[[k]] <- libtiledb_query_buffer_assign_ptr(buflist[[k]], alltypes[k], col, asint64)
         qryptr <- libtiledb_query_set_buffer_ptr(qryptr, colnam, buflist[[k]])
       }

--- a/R/batchedQuery.R
+++ b/R/batchedQuery.R
@@ -242,7 +242,7 @@ createBatched <- function(x) {
                 }
             } else {
                                         #if (verbose) message("Allocating with ", resrv, " and ", memory_budget)
-                buf <- libtiledb_query_buffer_alloc_ptr(type, resrv, varnum, nullable)
+                buf <- libtiledb_query_buffer_alloc_ptr(type, resrv, nullable, varnum)
                 qryptr <- libtiledb_query_set_buffer_ptr(qryptr, name, buf)
                 buf
             }

--- a/R/batchedQuery.R
+++ b/R/batchedQuery.R
@@ -242,7 +242,7 @@ createBatched <- function(x) {
                 }
             } else {
                                         #if (verbose) message("Allocating with ", resrv, " and ", memory_budget)
-                buf <- libtiledb_query_buffer_alloc_ptr(type, resrv, nullable)
+                buf <- libtiledb_query_buffer_alloc_ptr(type, resrv, varnum, nullable)
                 qryptr <- libtiledb_query_set_buffer_ptr(qryptr, name, buf)
                 buf
             }

--- a/R/batchedQuery.R
+++ b/R/batchedQuery.R
@@ -330,24 +330,40 @@ fetchBatched <- function(x, obj) {
                                         #break
     #}
     ## get results
-    getResult <- function(buf, name, varnum, resrv, qryptr) {
+    getResult <- function(buf, name, varnum, estsz, qryptr) {
         has_dumpbuffers <- length(x@dumpbuffers) > 0
         if (is.na(varnum)) {
             vec <- libtiledb_query_result_buffer_elements_vec(qryptr, name)
             if (has_dumpbuffers) {
                 vlcbuf_to_shmem(x@dumpbuffers, name, buf, vec)
             }
-            libtiledb_query_get_buffer_var_char(buf, vec[1], vec[2])[,1]
+            libtiledb_query_get_buffer_var_char(buf, vec[1], vec[2])[,1][seq_len(estsz)]
         } else {
             if (has_dumpbuffers) {
-                vecbuf_to_shmem(x@dumpbuffers, name, buf, resrv)
+                vecbuf_to_shmem(x@dumpbuffers, name, buf, estsz, varnum)
             }
-            libtiledb_query_get_buffer_ptr(buf, asint64)
+            libtiledb_query_get_buffer_ptr(buf, asint64)[seq_len(estsz)]
         }
     }
-    reslist <- mapply(getResult, buflist, allnames, allvarnum,
-                      MoreArgs=list(resrv=resrv, qryptr=qryptr), SIMPLIFY=FALSE)
-    ## convert list into data.frame (cheaply) and subset
+    reslist <- mapply(getResult, buflist, allnames, allvarnum, estsz,
+                      MoreArgs=list(qryptr=qryptr), SIMPLIFY=FALSE)
+    ## convert list into data.frame (possibly dealing with list columns) and subset
+    vnum <- 1   # default value of variable number of elements per cell
+    if (is.list(allvarnum)) allvarnum <- unlist(allvarnum)
+    if (length(allvarnum) > 0 && any(!is.na(allvarnum))) vnum <- max(allvarnum, na.rm=TRUE)
+    if (is.finite(vnum) && (vnum > 1)) {
+        ## turn to list col if a varnum != 1 (and not NA) seen
+        ind <- which(allvarnum != 1 & !is.na(allvarnum))
+        for (k in ind) {
+            ncells <- allvarnum[k]
+            v <- reslist[[k]]
+            ## we split a vector v into 'list-columns' which element containing
+            ## ncells value (and we get ncells from the Array schema)
+            ## see https://stackoverflow.com/a/9547594/143305 for I()
+            ## and https://stackoverflow.com/a/3321659/143305 for split()
+            reslist[[k]] <- I(unname(split(v, ceiling(seq_along(v)/ncells))))
+        }
+    }
     res <- data.frame(reslist)[seq_len(resrv),,drop=FALSE]
     colnames(res) <- allnames
     ##if (verbose) cat("Retrieved ", paste(dim(res), collapse="x"), "...\n")

--- a/inst/include/tiledb.h
+++ b/inst/include/tiledb.h
@@ -29,23 +29,6 @@ struct var_length_char_buffer {
 };
 typedef struct var_length_char_buffer vlc_buf_t;
 
-// template <typename T>
-// struct var_length_vec_buffer_initial {
-//   std::vector<uint64_t> offsets;  // vector for offset values
-//   std::vector<T> data;            // vector for data values
-// };
-// using vli_buf_t_old = struct var_length_vec_buffer_initial<int32_t>;
-// using vld_buf_t_old = struct var_length_vec_buffer_initial<double>;
-
-// THIS WORKS
-// template <typename T>
-// struct var_length_vec_buffer {
-// public:
-//   std::vector<uint64_t> offsets;  // vector for offset values
-//   std::vector<T> data;            // vector for data values
-// };
-// using vli_buf_t = struct var_length_vec_buffer<int32_t>;
-// using vld_buf_t = struct var_length_vec_buffer<double>;
 
 struct var_length_vec_buffer {
 public:
@@ -63,8 +46,9 @@ struct query_buffer {
     //void *ptr;                    	// pointer to data as an alternative
     std::vector<int8_t> vec;        	// vector of int8_t as a memory container
     tiledb_datatype_t dtype;        	// data type
-    R_xlen_t ncells;                	// extent
-    size_t size;                    	// element size
+    R_xlen_t ncells;                	// extent, i.e. number elements
+    size_t size;                    	// element size, i.e. sizeof() given data type
+    int32_t numvar;                     // number of elements per cells, generally fixed
     std::vector<uint8_t> validity_map;  // for nullable vectors
     bool nullable;                      // flag
 };

--- a/inst/tinytest/test_dataframe.R
+++ b/inst/tinytest/test_dataframe.R
@@ -331,8 +331,8 @@ expect_equal(D, res2)
 
 ## list columns
 D <- data.frame(a=1:5,
-                b=I(split(1:10, ceiling((1:10)/2))),
-                c=I(split(101:115, ceiling((1:15)/3))))
+                b=I(split(c(1:4,NA,NA,7:10), ceiling((1:10)/2))),
+                c=I(split(c(101:109, NA, NA, NA, 113:115), ceiling((1:15)/3))))
 uri <- tempfile()
 fromDataFrame(D, uri, col_index=1)
 arr <- tiledb_array(uri, return_as="data.frame")

--- a/inst/tinytest/test_query.R
+++ b/inst/tinytest/test_query.R
@@ -169,7 +169,7 @@ vals <- seq(101,110)
 qry <- tiledb_query_set_buffer(qry, "vals", vals)
 
 keys <- c(201:204, NA_integer_, 206L, NA_integer_, 208:210)
-buf <- tiledb:::libtiledb_query_buffer_alloc_ptr("INT32", 10, TRUE)
+buf <- tiledb:::libtiledb_query_buffer_alloc_ptr("INT32", 10, 1, TRUE)
 buf <- tiledb:::libtiledb_query_buffer_assign_ptr(buf, "INT32", keys, FALSE)
 qry@ptr <- tiledb:::libtiledb_query_set_buffer_ptr(qry@ptr, "keys", buf)
 
@@ -187,7 +187,7 @@ qry <- tiledb_query_set_buffer(qry, "rows", rowdat)
 valdat <- integer(10)
 qry <- tiledb_query_set_buffer(qry, "vals", valdat)
 
-buf <- tiledb:::libtiledb_query_buffer_alloc_ptr("INT32", 10, TRUE)
+buf <- tiledb:::libtiledb_query_buffer_alloc_ptr("INT32", 10, 1, TRUE)
 buf <- tiledb:::libtiledb_query_buffer_assign_ptr(buf, "INT32", keys, FALSE)
 qry@ptr <- tiledb:::libtiledb_query_set_buffer_ptr(qry@ptr, "keys", buf)
 

--- a/inst/tinytest/test_query.R
+++ b/inst/tinytest/test_query.R
@@ -169,7 +169,7 @@ vals <- seq(101,110)
 qry <- tiledb_query_set_buffer(qry, "vals", vals)
 
 keys <- c(201:204, NA_integer_, 206L, NA_integer_, 208:210)
-buf <- tiledb:::libtiledb_query_buffer_alloc_ptr("INT32", 10, 1, TRUE)
+buf <- tiledb:::libtiledb_query_buffer_alloc_ptr("INT32", 10, TRUE, 1)
 buf <- tiledb:::libtiledb_query_buffer_assign_ptr(buf, "INT32", keys, FALSE)
 qry@ptr <- tiledb:::libtiledb_query_set_buffer_ptr(qry@ptr, "keys", buf)
 
@@ -187,7 +187,7 @@ qry <- tiledb_query_set_buffer(qry, "rows", rowdat)
 valdat <- integer(10)
 qry <- tiledb_query_set_buffer(qry, "vals", valdat)
 
-buf <- tiledb:::libtiledb_query_buffer_alloc_ptr("INT32", 10, 1, TRUE)
+buf <- tiledb:::libtiledb_query_buffer_alloc_ptr("INT32", 10, TRUE, 1)
 buf <- tiledb:::libtiledb_query_buffer_assign_ptr(buf, "INT32", keys, FALSE)
 qry@ptr <- tiledb:::libtiledb_query_set_buffer_ptr(qry@ptr, "keys", buf)
 

--- a/inst/tinytest/test_shmem.R
+++ b/inst/tinytest/test_shmem.R
@@ -33,3 +33,18 @@ pathroot <- file.path("/", "dev", "shm", "penguins", "buffers", "data")
 arr@buffers <- sapply(colnames(v3), function(x) file.path(pathroot, x), simplify=FALSE)
 v4 <- arr[]
 expect_true(all.equal(v3, v4))
+
+## list columns
+D <- data.frame(a=1:5,
+                b=I(split(c(1:4,NA,NA,7:10), ceiling((1:10)/2))),
+                c=I(split(c(101:109, NA, NA, NA, 113:115), ceiling((1:15)/3))))
+uri <- tempfile()
+fromDataFrame(D, uri, col_index=1)
+arr <- tiledb_array(uri, return_as="data.frame")
+arr@dumpbuffers <- "listcols"
+v5 <- arr[]
+arr@dumpbuffers <- character()          			# turn buffer store off again
+pathroot <- file.path("/", "dev", "shm", "listcols", "buffers", "data")
+arr@buffers <- sapply(colnames(v5), function(x) file.path(pathroot, x), simplify=FALSE)
+v6 <- arr[]
+expect_true(all.equal(v5, v6))

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -1707,15 +1707,16 @@ BEGIN_RCPP
 END_RCPP
 }
 // libtiledb_query_buffer_alloc_ptr
-XPtr<query_buf_t> libtiledb_query_buffer_alloc_ptr(std::string domaintype, R_xlen_t ncells, bool nullable);
-RcppExport SEXP _tiledb_libtiledb_query_buffer_alloc_ptr(SEXP domaintypeSEXP, SEXP ncellsSEXP, SEXP nullableSEXP) {
+XPtr<query_buf_t> libtiledb_query_buffer_alloc_ptr(std::string domaintype, R_xlen_t ncells, int32_t numvar, bool nullable);
+RcppExport SEXP _tiledb_libtiledb_query_buffer_alloc_ptr(SEXP domaintypeSEXP, SEXP ncellsSEXP, SEXP numvarSEXP, SEXP nullableSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< std::string >::type domaintype(domaintypeSEXP);
     Rcpp::traits::input_parameter< R_xlen_t >::type ncells(ncellsSEXP);
+    Rcpp::traits::input_parameter< int32_t >::type numvar(numvarSEXP);
     Rcpp::traits::input_parameter< bool >::type nullable(nullableSEXP);
-    rcpp_result_gen = Rcpp::wrap(libtiledb_query_buffer_alloc_ptr(domaintype, ncells, nullable));
+    rcpp_result_gen = Rcpp::wrap(libtiledb_query_buffer_alloc_ptr(domaintype, ncells, numvar, nullable));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -3065,15 +3066,16 @@ BEGIN_RCPP
 END_RCPP
 }
 // vecbuf_to_shmem
-void vecbuf_to_shmem(std::string dir, std::string name, XPtr<query_buf_t> buf, int sz);
-RcppExport SEXP _tiledb_vecbuf_to_shmem(SEXP dirSEXP, SEXP nameSEXP, SEXP bufSEXP, SEXP szSEXP) {
+void vecbuf_to_shmem(std::string dir, std::string name, XPtr<query_buf_t> buf, int sz, int numvar);
+RcppExport SEXP _tiledb_vecbuf_to_shmem(SEXP dirSEXP, SEXP nameSEXP, SEXP bufSEXP, SEXP szSEXP, SEXP numvarSEXP) {
 BEGIN_RCPP
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< std::string >::type dir(dirSEXP);
     Rcpp::traits::input_parameter< std::string >::type name(nameSEXP);
     Rcpp::traits::input_parameter< XPtr<query_buf_t> >::type buf(bufSEXP);
     Rcpp::traits::input_parameter< int >::type sz(szSEXP);
-    vecbuf_to_shmem(dir, name, buf, sz);
+    Rcpp::traits::input_parameter< int >::type numvar(numvarSEXP);
+    vecbuf_to_shmem(dir, name, buf, sz, numvar);
     return R_NilValue;
 END_RCPP
 }
@@ -3261,7 +3263,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_tiledb_libtiledb_query_buffer_var_vec_create", (DL_FUNC) &_tiledb_libtiledb_query_buffer_var_vec_create, 2},
     {"_tiledb_libtiledb_query_set_buffer_var_vec", (DL_FUNC) &_tiledb_libtiledb_query_set_buffer_var_vec, 3},
     {"_tiledb_libtiledb_query_get_buffer_var_vec", (DL_FUNC) &_tiledb_libtiledb_query_get_buffer_var_vec, 3},
-    {"_tiledb_libtiledb_query_buffer_alloc_ptr", (DL_FUNC) &_tiledb_libtiledb_query_buffer_alloc_ptr, 3},
+    {"_tiledb_libtiledb_query_buffer_alloc_ptr", (DL_FUNC) &_tiledb_libtiledb_query_buffer_alloc_ptr, 4},
     {"_tiledb_libtiledb_query_buffer_assign_ptr", (DL_FUNC) &_tiledb_libtiledb_query_buffer_assign_ptr, 4},
     {"_tiledb_libtiledb_query_set_buffer_ptr", (DL_FUNC) &_tiledb_libtiledb_query_set_buffer_ptr, 3},
     {"_tiledb_length_from_vlcbuf", (DL_FUNC) &_tiledb_length_from_vlcbuf, 1},
@@ -3374,7 +3376,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_tiledb_libtiledb_filestore_size", (DL_FUNC) &_tiledb_libtiledb_filestore_size, 2},
     {"_tiledb_libtiledb_mime_type_to_str", (DL_FUNC) &_tiledb_libtiledb_mime_type_to_str, 1},
     {"_tiledb_libtiledb_mime_type_from_str", (DL_FUNC) &_tiledb_libtiledb_mime_type_from_str, 1},
-    {"_tiledb_vecbuf_to_shmem", (DL_FUNC) &_tiledb_vecbuf_to_shmem, 4},
+    {"_tiledb_vecbuf_to_shmem", (DL_FUNC) &_tiledb_vecbuf_to_shmem, 5},
     {"_tiledb_vlcbuf_to_shmem", (DL_FUNC) &_tiledb_vlcbuf_to_shmem, 4},
     {"_tiledb_querybuf_from_shmem", (DL_FUNC) &_tiledb_querybuf_from_shmem, 2},
     {"_tiledb_vlcbuf_from_shmem", (DL_FUNC) &_tiledb_vlcbuf_from_shmem, 2},

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -1707,16 +1707,16 @@ BEGIN_RCPP
 END_RCPP
 }
 // libtiledb_query_buffer_alloc_ptr
-XPtr<query_buf_t> libtiledb_query_buffer_alloc_ptr(std::string domaintype, R_xlen_t ncells, int32_t numvar, bool nullable);
-RcppExport SEXP _tiledb_libtiledb_query_buffer_alloc_ptr(SEXP domaintypeSEXP, SEXP ncellsSEXP, SEXP numvarSEXP, SEXP nullableSEXP) {
+XPtr<query_buf_t> libtiledb_query_buffer_alloc_ptr(std::string domaintype, R_xlen_t ncells, bool nullable, int32_t numvar);
+RcppExport SEXP _tiledb_libtiledb_query_buffer_alloc_ptr(SEXP domaintypeSEXP, SEXP ncellsSEXP, SEXP nullableSEXP, SEXP numvarSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< std::string >::type domaintype(domaintypeSEXP);
     Rcpp::traits::input_parameter< R_xlen_t >::type ncells(ncellsSEXP);
-    Rcpp::traits::input_parameter< int32_t >::type numvar(numvarSEXP);
     Rcpp::traits::input_parameter< bool >::type nullable(nullableSEXP);
-    rcpp_result_gen = Rcpp::wrap(libtiledb_query_buffer_alloc_ptr(domaintype, ncells, numvar, nullable));
+    Rcpp::traits::input_parameter< int32_t >::type numvar(numvarSEXP);
+    rcpp_result_gen = Rcpp::wrap(libtiledb_query_buffer_alloc_ptr(domaintype, ncells, nullable, numvar));
     return rcpp_result_gen;
 END_RCPP
 }

--- a/src/libtiledb.cpp
+++ b/src/libtiledb.cpp
@@ -2743,6 +2743,7 @@ List libtiledb_query_get_buffer_var_vec(XPtr<tiledb::Query> query, std::string a
 // [[Rcpp::export]]
 XPtr<query_buf_t> libtiledb_query_buffer_alloc_ptr(std::string domaintype,
                                                    R_xlen_t ncells,
+                                                   int32_t numvar = 1,
                                                    bool nullable = false) {
   XPtr<query_buf_t> buf = make_xptr<query_buf_t>(new query_buf_t);
   if (domaintype == "INT32"  || domaintype == "UINT32") {
@@ -2785,7 +2786,8 @@ XPtr<query_buf_t> libtiledb_query_buffer_alloc_ptr(std::string domaintype,
   buf->dtype = _string_to_tiledb_datatype(domaintype);
   buf->ncells = ncells;
   buf->vec.resize(ncells * buf->size);
-  if (nullable) buf->validity_map.resize(ncells);
+  if (nullable) buf->validity_map.resize(ncells/numvar);
+  buf->numvar = numvar;
   buf->nullable = nullable;
   return buf;
 }
@@ -2798,20 +2800,19 @@ XPtr<query_buf_t> libtiledb_query_buffer_assign_ptr(XPtr<query_buf_t> buf, std::
     IntegerVector v(vec);
     std::memcpy(buf->vec.data(), &(v[0]), buf->ncells*buf->size);
     if (buf->nullable)
-        getValidityMapFromInteger(v, buf->validity_map);
-    //if (buf->nullable) for (int i=0; i<buf->ncells; i++) Rprintf("%d : %d\n", i, buf->validity_map[i]);
+        getValidityMapFromInteger(v, buf->validity_map, buf->numvar);
   } else if (dtype == "FLOAT64") {
     NumericVector v(vec);
     std::memcpy(buf->vec.data(), &(v[0]), buf->ncells*buf->size);
     if (buf->nullable)
-        getValidityMapFromNumeric(v, buf->validity_map);
+        getValidityMapFromNumeric(v, buf->validity_map, buf->numvar);
   } else if (dtype == "INT64" ||
              (asint64 && is_datetime_column(buf->dtype))) {
     // integer64 from the bit64 package uses doubles, sees nanosecond
     NumericVector v(vec);
     std::memcpy(buf->vec.data(), &(v[0]), buf->ncells*buf->size);
     if (buf->nullable)
-        getValidityMapFromInt64(v, buf->validity_map);
+        getValidityMapFromInt64(v, buf->validity_map, buf->numvar);
   } else if (dtype == "DATETIME_YEAR" ||
              dtype == "DATETIME_MONTH" ||
              dtype == "DATETIME_WEEK" ||
@@ -2844,7 +2845,7 @@ XPtr<query_buf_t> libtiledb_query_buffer_assign_ptr(XPtr<query_buf_t> buf, std::
     NumericVector v(vec);
     std::vector<int64_t> iv = getInt64Vector(v);
     if (buf->nullable)
-        getValidityMapFromInt64(v, buf->validity_map);
+        getValidityMapFromInt64(v, buf->validity_map, buf->numvar);
     auto n = v.length();
     std::vector<uint64_t> uiv(n);
     for (auto i=0; i<n; i++) {
@@ -2860,7 +2861,7 @@ XPtr<query_buf_t> libtiledb_query_buffer_assign_ptr(XPtr<query_buf_t> buf, std::
     }
     std::memcpy(buf->vec.data(), &(x[0]), buf->ncells*buf->size);
     if (buf->nullable)
-        getValidityMapFromInteger(v, buf->validity_map);
+        getValidityMapFromInteger(v, buf->validity_map, buf->numvar);
   } else if (dtype == "INT16") {
     IntegerVector v(vec);
     auto n = v.length();
@@ -2870,7 +2871,7 @@ XPtr<query_buf_t> libtiledb_query_buffer_assign_ptr(XPtr<query_buf_t> buf, std::
     }
     std::memcpy(buf->vec.data(), &(x[0]), buf->ncells*buf->size);
     if (buf->nullable)
-        getValidityMapFromInteger(v, buf->validity_map);
+        getValidityMapFromInteger(v, buf->validity_map, buf->numvar);
   } else if (dtype == "UINT16") {
     IntegerVector v(vec);
     auto n = v.length();
@@ -2880,7 +2881,7 @@ XPtr<query_buf_t> libtiledb_query_buffer_assign_ptr(XPtr<query_buf_t> buf, std::
     }
     std::memcpy(buf->vec.data(), &(x[0]), buf->ncells*buf->size);
     if (buf->nullable)
-        getValidityMapFromInteger(v, buf->validity_map);
+        getValidityMapFromInteger(v, buf->validity_map, buf->numvar);
   } else if (dtype == "INT8") {
     IntegerVector v(vec);
     auto n = v.length();
@@ -2890,7 +2891,7 @@ XPtr<query_buf_t> libtiledb_query_buffer_assign_ptr(XPtr<query_buf_t> buf, std::
     }
     std::memcpy(buf->vec.data(), &(x[0]), buf->ncells*buf->size);
     if (buf->nullable)
-        getValidityMapFromInteger(v, buf->validity_map);
+        getValidityMapFromInteger(v, buf->validity_map, buf->numvar);
   } else if (dtype == "UINT8") {
     IntegerVector v(vec);
     auto n = v.length();
@@ -2900,11 +2901,11 @@ XPtr<query_buf_t> libtiledb_query_buffer_assign_ptr(XPtr<query_buf_t> buf, std::
     }
     std::memcpy(buf->vec.data(), &(x[0]), buf->ncells*buf->size);
     if (buf->nullable)
-        getValidityMapFromInteger(v, buf->validity_map);
+        getValidityMapFromInteger(v, buf->validity_map, buf->numvar);
   } else if (dtype == "FLOAT32") {
     NumericVector v(vec);
     if (buf->nullable)
-        getValidityMapFromNumeric(v, buf->validity_map);
+        getValidityMapFromNumeric(v, buf->validity_map, buf->numvar);
     auto n = v.length();
     std::vector<float> x(n);
     for (auto i=0; i<n; i++) {
@@ -2921,7 +2922,7 @@ XPtr<query_buf_t> libtiledb_query_buffer_assign_ptr(XPtr<query_buf_t> buf, std::
     }
     std::memcpy(buf->vec.data(), &(x[0]), buf->ncells*buf->size);
     if (buf->nullable)
-        getValidityMapFromLogical(v, buf->validity_map);
+        getValidityMapFromLogical(v, buf->validity_map, buf->numvar);
 #endif
   } else {
     Rcpp::stop("Assignment to '%s' currently unsupported.", dtype.c_str());
@@ -2969,26 +2970,26 @@ RObject libtiledb_query_get_buffer_ptr(XPtr<query_buf_t> buf, bool asint64 = fal
     IntegerVector v(buf->ncells);
     std::memcpy(&(v[0]), (void*) buf->vec.data(), buf->ncells * buf->size);
     if (buf->nullable)
-        setValidityMapForInteger(v, buf->validity_map);
+        setValidityMapForInteger(v, buf->validity_map, buf->numvar);
     return v;
   } else if (dtype == "UINT32") {
     IntegerVector v(buf->ncells);
     std::memcpy(&(v[0]), (void*) buf->vec.data(), buf->ncells * buf->size);
     if (buf->nullable)
-        setValidityMapForInteger(v, buf->validity_map);
+        setValidityMapForInteger(v, buf->validity_map, buf->numvar);
     return v;
   } else if (dtype == "FLOAT64") {
     NumericVector v(buf->ncells);
     std::memcpy(&(v[0]), (void*) buf->vec.data(), buf->ncells * buf->size);
     if (buf->nullable)
-        setValidityMapForNumeric(v, buf->validity_map);
+        setValidityMapForNumeric(v, buf->validity_map, buf->numvar);
     return v;
   } else if (dtype == "FLOAT32") {
     std::vector<float> v(buf->ncells);
     std::memcpy(&(v[0]), (void*) buf->vec.data(), buf->ncells * buf->size);
     NumericVector w(wrap(v));
     if (buf->nullable)
-        setValidityMapForNumeric(w, buf->validity_map);
+        setValidityMapForNumeric(w, buf->validity_map, buf->numvar);
     return w;
   } else if (dtype == "UINT64") {
     auto n = buf->ncells;
@@ -3000,14 +3001,14 @@ RObject libtiledb_query_get_buffer_ptr(XPtr<query_buf_t> buf, bool asint64 = fal
     }
     NumericVector res = wrap(iv);
     if (buf->nullable)
-        setValidityMapForNumeric(res, buf->validity_map);
+        setValidityMapForNumeric(res, buf->validity_map, buf->numvar);
     //return makeInteger64(iv); // we could return as int64,
     return res;                 // but current 'contract' is return as NumericVector
   } else if (dtype == "INT64") {
     std::vector<int64_t> v(buf->ncells);
     std::memcpy(&(v[0]), (void*) buf->vec.data(), buf->ncells * buf->size);
     if (buf->nullable)
-        setValidityMapForInt64(v, buf->validity_map);
+        setValidityMapForInt64(v, buf->validity_map, buf->numvar);
     return makeInteger64(v);
   } else if (asint64 && is_datetime_column(buf->dtype)) {
     std::vector<int64_t> v(buf->ncells);
@@ -3051,7 +3052,7 @@ RObject libtiledb_query_get_buffer_ptr(XPtr<query_buf_t> buf, bool asint64 = fal
       out[i] = static_cast<int32_t>(intvec[i]);
     }
     if (buf->nullable)
-        setValidityMapForInteger(out, buf->validity_map);
+        setValidityMapForInteger(out, buf->validity_map, buf->numvar);
     return out;
   } else if (dtype == "UINT16") {
     size_t n = buf->ncells;
@@ -3062,7 +3063,7 @@ RObject libtiledb_query_get_buffer_ptr(XPtr<query_buf_t> buf, bool asint64 = fal
       out[i] = static_cast<int32_t>(intvec[i]);
     }
     if (buf->nullable)
-        setValidityMapForInteger(out, buf->validity_map);
+        setValidityMapForInteger(out, buf->validity_map, buf->numvar);
     return out;
   } else if (dtype == "INT8") {
     size_t n = buf->ncells;
@@ -3073,7 +3074,7 @@ RObject libtiledb_query_get_buffer_ptr(XPtr<query_buf_t> buf, bool asint64 = fal
       out[i] = static_cast<int32_t>(intvec[i]);
     }
     if (buf->nullable)
-        setValidityMapForInteger(out, buf->validity_map);
+        setValidityMapForInteger(out, buf->validity_map, buf->numvar);
     return out;
   } else if (dtype == "UINT8") {
     size_t n = buf->ncells;
@@ -3084,7 +3085,7 @@ RObject libtiledb_query_get_buffer_ptr(XPtr<query_buf_t> buf, bool asint64 = fal
       out[i] = static_cast<int32_t>(uintvec[i]);
     }
     if (buf->nullable)
-        setValidityMapForInteger(out, buf->validity_map);
+        setValidityMapForInteger(out, buf->validity_map, buf->numvar);
     return out;
 #if TILEDB_VERSION >= TileDB_Version(2,7,0)
   } else if (dtype == "BLOB") {
@@ -3106,7 +3107,7 @@ RObject libtiledb_query_get_buffer_ptr(XPtr<query_buf_t> buf, bool asint64 = fal
       out[i] = static_cast<int32_t>(uintvec[i]); // logical is int32_t internally
     }
     if (buf->nullable)
-        setValidityMapForLogical(out, buf->validity_map);
+        setValidityMapForLogical(out, buf->validity_map, buf->numvar);
     return out;
 #endif
   } else {

--- a/src/libtiledb.cpp
+++ b/src/libtiledb.cpp
@@ -2743,8 +2743,8 @@ List libtiledb_query_get_buffer_var_vec(XPtr<tiledb::Query> query, std::string a
 // [[Rcpp::export]]
 XPtr<query_buf_t> libtiledb_query_buffer_alloc_ptr(std::string domaintype,
                                                    R_xlen_t ncells,
-                                                   int32_t numvar = 1,
-                                                   bool nullable = false) {
+                                                   bool nullable = false,
+                                                   int32_t numvar = 1) {
   XPtr<query_buf_t> buf = make_xptr<query_buf_t>(new query_buf_t);
   if (domaintype == "INT32"  || domaintype == "UINT32") {
      buf->size = sizeof(int32_t);

--- a/src/libtiledb.h
+++ b/src/libtiledb.h
@@ -59,14 +59,14 @@ std::vector<int64_t> subnano_to_int64(NumericVector nv, tiledb_datatype_t dtype)
 Rcpp::NumericVector int64_to_subnano(std::vector<int64_t> iv, tiledb_datatype_t dtype);
 
 // nullable helpers
-void getValidityMapFromInteger(Rcpp::IntegerVector & vec, std::vector<uint8_t> & map);
-void setValidityMapForInteger(Rcpp::IntegerVector & vec, const std::vector<uint8_t> & map);
-void getValidityMapFromNumeric(Rcpp::NumericVector & vec, std::vector<uint8_t> & map);
-void setValidityMapForNumeric(Rcpp::NumericVector & vec, const std::vector<uint8_t> & map);
-void getValidityMapFromInt64(Rcpp::NumericVector & vec, std::vector<uint8_t> & map);
-void setValidityMapForInt64(std::vector<int64_t> & vec, const std::vector<uint8_t> & map);
-void getValidityMapFromLogical(Rcpp::LogicalVector & vec, std::vector<uint8_t> & map);
-void setValidityMapForLogical(Rcpp::LogicalVector & vec, const std::vector<uint8_t> & map);
+void getValidityMapFromInteger(Rcpp::IntegerVector & vec, std::vector<uint8_t> & map, int32_t nc);
+void setValidityMapForInteger(Rcpp::IntegerVector & vec, const std::vector<uint8_t> & map, int32_t nc);
+void getValidityMapFromNumeric(Rcpp::NumericVector & vec, std::vector<uint8_t> & map, int32_t nc);
+void setValidityMapForNumeric(Rcpp::NumericVector & vec, const std::vector<uint8_t> & map, int32_t nc);
+void getValidityMapFromInt64(Rcpp::NumericVector & vec, std::vector<uint8_t> & map, int32_t nc);
+void setValidityMapForInt64(std::vector<int64_t> & vec, const std::vector<uint8_t> & map, int32_t nc);
+void getValidityMapFromLogical(Rcpp::LogicalVector & vec, std::vector<uint8_t> & map, int32_t nc);
+void setValidityMapForLogical(Rcpp::LogicalVector & vec, const std::vector<uint8_t> & map, int32_t nc);
 
 // type and size helper
 tiledb_datatype_t _string_to_tiledb_datatype(std::string typestr);


### PR DESCRIPTION
The PR in #438 added the ability read and write arrays with a 'cell value number' greater than one which are stored as list column in R (which `data.frame`, `data.table`, `tibble`, ... all support to some degree).   The treatment of missing values via `validity_map` in this context of list columns / multiple values per cell required a small generalization which this PR provides.