### PR TITLE
Update valgrind test matrix and standardize tests

### DIFF
--- a/.github/workflows/valgrind.yaml
+++ b/.github/workflows/valgrind.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tag: [ 2.9.5, release-2.10, dev ]
+        tag: [ release-2.10, dev ]
 #        tag: [ 2.9.5, 2.10.0, dev ]
 
     steps:

--- a/R/Utils.R
+++ b/R/Utils.R
@@ -49,7 +49,7 @@ save_return_as_preference <- function(value = c("asis", "array", "matrix", "data
     value <- match.arg(value)
 
     cfgdir <- tools::R_user_dir(packageName())
-    if (!dir.exists(cfgdir)) dir.create(cfgdir)
+    if (!dir.exists(cfgdir)) dir.create(cfgdir, recursive = TRUE)
     fname <- file.path(cfgdir, "config.dcf")
     con <- file(fname, "a+")
     cat("return_as:", value, "\n", file=con)
@@ -124,7 +124,7 @@ save_allocation_size_preference <- function(value) {
               `The 'value' has to be numeric` = is.numeric(value))
 
     cfgdir <- tools::R_user_dir(packageName())
-    if (!dir.exists(cfgdir)) dir.create(cfgdir)
+    if (!dir.exists(cfgdir)) dir.create(cfgdir, recursive = TRUE)
     fname <- file.path(cfgdir, "config.dcf")
     con <- file(fname, "a+")
     cat("allocation_size:", value, "\n", file=con)

--- a/inst/tinytest/test_querycondition.R
+++ b/inst/tinytest/test_querycondition.R
@@ -4,7 +4,10 @@ library(tiledb)
 isOldWindows <- Sys.info()[["sysname"]] == "Windows" && grepl('Windows Server 2008', osVersion)
 if (isOldWindows) exit_file("skip this file on old Windows releases")
 
-if (Sys.getenv("_RUNNING_UNDER_VALGRIND_", "FALSE") == "TRUE" && Sys.Date() < as.Date("2022-08-06")) exit_file("Skipping under valgrind until Aug 6")
+#if (Sys.getenv("_RUNNING_UNDER_VALGRIND_", "FALSE") == "TRUE" && Sys.Date() < as.Date("2022-08-06")) exit_file("Skipping under valgrind until Aug 6")
+
+## GitHub Actions had some jobs killed on the larger data portion so we dial mem use down
+if (Sys.getenv("CI") != "") set_allocation_size_preference(1024*1024*5)
 
 ctx <- tiledb_ctx(limitTileDBCores())
 

--- a/inst/tinytest/test_tiledbarray.R
+++ b/inst/tinytest/test_tiledbarray.R
@@ -11,7 +11,7 @@ hasDataTable <- requireNamespace("data.table", quietly=TRUE)
 hasTibble <- requireNamespace("tibble", quietly=TRUE)
 
 ## GitHub Actions had some jobs killed on the larger data portion so we dial mem use down
-if (Sys.getenv("CI") != "") set_allocation_size_preference(1024*1014)
+if (Sys.getenv("CI") != "") set_allocation_size_preference(1024*1024*5)
 
 #test_that("test tiledb_array read/write sparse array with heterogenous date domains", {
 op <- options()

--- a/tests/tinytest.R
+++ b/tests/tinytest.R
@@ -1,14 +1,4 @@
 
 if (requireNamespace("tinytest", quietly=TRUE))  {
-
-    ## Set a seed to make the test deterministic
-    set.seed(42)
-
-    ## R makes us to this
-    Sys.setenv("R_TESTS"="")
-
-    ## there are several more granular ways to test files in a tinytest directory,
-    ## see its package vignette; tests can also run once the package is installed
-    ## using the same command `test_package(pkgName)`, or by director or file
     tinytest::test_package("tiledb")
 }


### PR DESCRIPTION
The nightly valgrind test is operational and signals the (known) leak in 2.9.* which is now fixed in 2.10.2 and later (and no longer triggered in the 2.10 release branch).  This PR removes the test for 2.9.5 as 2.9.* is essentially frozen.  

It also standardizes the memory budget allocation to just two test files which need it (as opposed to effectively all by setting it when the test runner is called, also removing some old setup code no longer needed with current versions of `tinytest`), and a common value of 5mb.  The setting is conditional on use within CI as it only appears to 'bite' in CI use on machines with their limited memory resource allocation.  

Lastly, it corrects a small bug in setting of default value by ensuring directory creation is rercursive.  This was seen as needed when we set the value in the test runner setup script as a user-preference.