### PR TITLE
Use TileDB 2.10.2

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tiledb
 Type: Package
-Version: 0.14.0.2
+Version: 0.14.0.3
 Title: Universal Storage Engine for Sparse and Dense Multidimensional Arrays
 Authors@R: c(person("TileDB, Inc.", role = c("aut", "cph")),
  person("Dirk", "Eddelbuettel", email = "dirk@tiledb.com", role = "cre"))

--- a/tools/tiledbVersion.txt
+++ b/tools/tiledbVersion.txt
@@ -1,2 +1,2 @@
-version: 2.10.2-rc0
+version: 2.10.2
 sha: 9ab84f9

--- a/tools/tiledbVersion.txt
+++ b/tools/tiledbVersion.txt
@@ -1,2 +1,2 @@
-version: 2.10.1
-sha: 6535d4c
+version: 2.10.2-rc0
+sha: 9ab84f9


### PR DESCRIPTION
This PR updates the package preference to TileDB 2.10.2.