### PR TITLE
Add release-2.11 to valgrind test matrix

### DIFF
--- a/.github/workflows/valgrind.yaml
+++ b/.github/workflows/valgrind.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tag: [ release-2.10, dev ]
+        tag: [ release-2.10, release-2.11, dev ]
 #        tag: [ 2.9.5, 2.10.0, dev ]
 
     steps:

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,14 @@
+# Ongoing
+
+## Improvements
+
+## Bug Fixes
+
+## Build and Test Systems
+
+* The nightly `valgrind` check has been extended to the release-2.11 branch (#446)
+
+
 # tiledb 0.14.1
 
 * This release of the R package builds against [TileDB 2.10.2](https://github.com/TileDB-Inc/TileDB/releases/tag/2.10.2), and has also been tested against earlier releases as well as the development version.


### PR DESCRIPTION
This PR expands the valgrind test matrix by adding the release-2.11 branch.   No new code.