### PR TITLE
Additional support for filter lists

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,5 +29,5 @@ LinkingTo: Rcpp
 Suggests: tinytest, simplermarkdown, curl, bit64, Matrix, palmerpenguins, nycflights13, data.table, tibble
 VignetteBuilder: simplermarkdown
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.0
+RoxygenNote: 7.2.1
 Encoding: UTF-8

--- a/R/Attribute.R
+++ b/R/Attribute.R
@@ -38,7 +38,7 @@ tiledb_attr.from_ptr <- function(ptr) {
 #' @param name The dimension name / label string; if missing default `""` is used.
 #' @param type The tiledb_attr TileDB datatype string; if missing the user is alerted
 #' that this is a _required_ parameter.
-#' @param filter_list (default filter_list("NONE")) The tiledb_attr filter_list
+#' @param filter_list (default filter_list("NONE")) An optional tiledb_filter_list object
 #' @param ncells (default 1) The number of cells, use \code{NA} to signal variable length
 #' @param nullable (default FALSE) A logical switch whether the attribute can have missing
 #' values

--- a/R/DataFrame.R
+++ b/R/DataFrame.R
@@ -246,7 +246,6 @@ fromDataFrame <- function(obj, uri, col_index=NULL, sparse=TRUE, allows_dups=spa
                                   coords_filter_list = tiledb_filter_list(sapply(coords_filters, tiledb_filter)),
                                   offsets_filter_list = tiledb_filter_list(sapply(offsets_filters, tiledb_filter)),
                                   validity_filter_list = tiledb_filter_list(sapply(validity_filters, tiledb_filter)),
-
                                   capacity=capacity)
     allows_dups(schema) <- allows_dups
     if (mode != "append")

--- a/R/DataFrame.R
+++ b/R/DataFrame.R
@@ -180,7 +180,6 @@ fromDataFrame <- function(obj, uri, col_index=NULL, sparse=TRUE, allows_dups=spa
                             type = dtype)
 
             if (idxnam %in% names(filter_list)) {
-                cat("Picking index filter for", idxnam, "\n")
                 filter_list(d) <- tiledb_filter_list(sapply(filter_list[[idxnam]], tiledb_filter))
             }
 
@@ -221,7 +220,6 @@ fromDataFrame <- function(obj, uri, col_index=NULL, sparse=TRUE, allows_dups=spa
         else
             stop("Currently unsupported type: ", cl)
         filters <- if (colname %in% names(filter_list)) {
-                       cat("Picking attribute filter for", colname, "\n")
                        tiledb_filter_list(sapply(filter_list[[colname]], tiledb_filter))
                    } else {
                        default_filter_list

--- a/R/Dim.R
+++ b/R/Dim.R
@@ -43,6 +43,7 @@ tiledb_dim.from_ptr <- function(ptr) {
 #' @param tile The tile dimension tile extent. For type,
 #' \code{ASCII} \code{NULL} is expected.
 #' @param type The dimension TileDB datatype string
+#' @param filter_list An optional tiledb_filter_list object, default is no filter
 #' @param ctx tiledb_ctx object (optional)
 #' @return `tiledb_dim` object
 #' @examples
@@ -51,10 +52,11 @@ tiledb_dim.from_ptr <- function(ptr) {
 #'
 #' @importFrom methods new
 #' @export tiledb_dim
-tiledb_dim <- function(name, domain, tile, type, ctx = tiledb_get_context()) {
-  stopifnot(`Argument 'name' must be supplied when creating a dimension object` = !missing(name),
-            `Argument 'name' must be a scalar string when creating a dimension object` = is.scalar(name, "character"),
-            `Argument 'ctx' must be a tiledb_ctx object` = is(ctx, "tiledb_ctx"))
+tiledb_dim <- function(name, domain, tile, type,
+                       filter_list = tiledb_filter_list(), ctx = tiledb_get_context()) {
+  stopifnot("Argument 'name' must be supplied when creating a dimension object" = !missing(name),
+            "Argument 'name' must be a scalar string when creating a dimension object" = is.scalar(name, "character"),
+            "Argument 'ctx' must be a tiledb_ctx object" = is(ctx, "tiledb_ctx"))
   if (missing(type)) {
     type <- ifelse(is.integer(domain), "INT32", "FLOAT64")
   } else if (!type %in% c("INT8", "INT16", "INT32", "INT64",
@@ -90,6 +92,7 @@ tiledb_dim <- function(name, domain, tile, type, ctx = tiledb_get_context()) {
     }
   }
   ptr <- libtiledb_dim(ctx@ptr, name, type, domain, tile)
+  libtiledb_dimension_set_filter_list(ptr, filter_list@ptr)
   return(new("tiledb_dim", ptr = ptr))
 }
 

--- a/man/fromDataFrame.Rd
+++ b/man/fromDataFrame.Rd
@@ -17,6 +17,7 @@ fromDataFrame(
   tile_domain = NULL,
   tile_extent = NULL,
   mode = c("ingest", "schema_only", "append"),
+  filterlist = NULL,
   debug = FALSE
 )
 }
@@ -58,6 +59,9 @@ cannot exceed the tile domain.}
 data ingestion, the default behavior), \sQuote{schema_only} (to create the array schema without
 writing to the newly-created array) and \sQuote{append} (to only append to an already existing
 array).}
+
+\item{filterlist}{A named list specifying filter choices per column, default is an empty
+\code{list} object.}
 
 \item{debug}{Logical flag to select additional output.}
 }

--- a/man/fromDataFrame.Rd
+++ b/man/fromDataFrame.Rd
@@ -17,7 +17,10 @@ fromDataFrame(
   tile_domain = NULL,
   tile_extent = NULL,
   mode = c("ingest", "schema_only", "append"),
-  filterlist = NULL,
+  filter_list = NULL,
+  coords_filters = "ZSTD",
+  offsets_filters = "ZSTD",
+  validity_filters = "RLE",
   debug = FALSE
 )
 }
@@ -60,8 +63,15 @@ data ingestion, the default behavior), \sQuote{schema_only} (to create the array
 writing to the newly-created array) and \sQuote{append} (to only append to an already existing
 array).}
 
-\item{filterlist}{A named list specifying filter choices per column, default is an empty
-\code{list} object.}
+\item{filter_list}{A named list specifying filter choices per column, default is an empty
+\code{list} object. This argument applies for all named arguments and the matchin dimensions
+or attributes. The \code{filter} argument still applies for all unnamed arguments.}
+
+\item{coords_filters}{A character vector with filters for coordinates, default is \code{ZSTD}.}
+
+\item{offsets_filters}{A character vector with filters for coordinates, default is \code{ZSTD}.}
+
+\item{validity_filters}{A character vector with filters for coordinates, default is \code{RLE}.}
 
 \item{debug}{Logical flag to select additional output.}
 }

--- a/man/tiledb_attr.Rd
+++ b/man/tiledb_attr.Rd
@@ -19,7 +19,7 @@ tiledb_attr(
 \item{type}{The tiledb_attr TileDB datatype string; if missing the user is alerted
 that this is a \emph{required} parameter.}
 
-\item{filter_list}{(default filter_list("NONE")) The tiledb_attr filter_list}
+\item{filter_list}{(default filter_list("NONE")) An optional tiledb_filter_list object}
 
 \item{ncells}{(default 1) The number of cells, use \code{NA} to signal variable length}
 

--- a/man/tiledb_dim.Rd
+++ b/man/tiledb_dim.Rd
@@ -4,7 +4,14 @@
 \alias{tiledb_dim}
 \title{Contructs a \code{tiledb_dim} object}
 \usage{
-tiledb_dim(name, domain, tile, type, ctx = tiledb_get_context())
+tiledb_dim(
+  name,
+  domain,
+  tile,
+  type,
+  filter_list = tiledb_filter_list(),
+  ctx = tiledb_get_context()
+)
 }
 \arguments{
 \item{name}{The dimension name / label string.  This argument is required.}
@@ -18,6 +25,8 @@ type \code{integer} or \code{double} (i.e. \code{numeric}). For type,
 \code{ASCII} \code{NULL} is expected.}
 
 \item{type}{The dimension TileDB datatype string}
+
+\item{filter_list}{An optional tiledb_filter_list object, default is no filter}
 
 \item{ctx}{tiledb_ctx object (optional)}
 }

--- a/src/libtiledb.cpp
+++ b/src/libtiledb.cpp
@@ -1083,6 +1083,7 @@ XPtr<tiledb::FilterList> libtiledb_dimension_get_filter_list(XPtr<tiledb::Dimens
 XPtr<tiledb::Dimension> libtiledb_dimension_set_filter_list(XPtr<tiledb::Dimension> dim,
                                                             XPtr<tiledb::FilterList> fltrlst) {
   check_xptr_tag<tiledb::Dimension>(dim);
+  check_xptr_tag<tiledb::FilterList>(fltrlst);
   dim->set_filter_list(*fltrlst);
   return dim;
 }


### PR DESCRIPTION
This PR extends the support for filter lists objects by
- adding a new named lists argument `filter_list` to `fromDataFrame()` 
- supporting an optional argument `filter_list` in `tiledb_dim()` matching `tiledb_attr()`
- also adding support for coords, offset, validity filters to `fromDataFrame()`
