### PR TITLE
Correct treatment of character columns with missing values

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tiledb
 Type: Package
-Version: 0.15.0.1
+Version: 0.15.0.2
 Title: Universal Storage Engine for Sparse and Dense Multidimensional Arrays
 Authors@R: c(person("TileDB, Inc.", role = c("aut", "cph")),
  person("Dirk", "Eddelbuettel", email = "dirk@tiledb.com", role = "cre"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,17 @@
+# Ongoing Development
+
+## Improvements
+
+* Several deprecated API entry points of TileDB Embedded are no longer used (#452, #453)
+
+## Bug Fixes
+
+* Treatment of character columns with missing values has been corrected (#454)
+
+## Build and Test Systems
+
+
+
 # tiledb 0.15.0
 
 * This release of the R package builds against [TileDB 2.11.0](https://github.com/TileDB-Inc/TileDB/releases/tag/2.11.0), and has also been tested against earlier releases as well as the development version.

--- a/inst/tinytest/test_tiledbarray.R
+++ b/inst/tinytest/test_tiledbarray.R
@@ -1463,3 +1463,14 @@ expect_false(completedBatched(lst))
 res4 <- tiledb:::fetchBatched(arr, lst)
 expect_true(completedBatched(lst))
 expect_equal(nrow(res1) + nrow(res2) + nrow(res3) + nrow(res4), 344)
+
+
+## check NAs in character column
+library(palmerpenguins)
+uri <- tempfile()
+fromDataFrame(penguins, uri, sparse = TRUE, col_index = c("species", "year"))
+pp <- tiledb_array(uri, return_as="data.frame")[]
+oo <- penguins
+expect_equal(sum(is.na(oo$sex)), sum(is.na(pp$sex)))
+expect_equal(sum(oo$sex == "male"), sum(pp$sex == "male"))
+expect_equal(sum(oo$sex == "female"), sum(pp$sex == "female"))

--- a/src/libtiledb.cpp
+++ b/src/libtiledb.cpp
@@ -2689,10 +2689,14 @@ CharacterMatrix libtiledb_query_get_buffer_var_char(XPtr<vlc_buf_t> bufptr,
   // Get the strings
   CharacterMatrix mat(bufptr->rows, bufptr->cols);
   for (size_t i = 0; i < n; i++) {
-      if (!bufptr->nullable || bufptr->validity_map[i] == 1)
+      if (bufptr->nullable) {
+          if (bufptr->validity_map[i] == 0)
+              mat[i] = std::string(&bufptr->str[bufptr->offsets[i]], str_sizes[i]);
+          else
+              mat[i] = R_NaString;
+      } else {
           mat[i] = std::string(&bufptr->str[bufptr->offsets[i]], str_sizes[i]);
-      else
-          mat[i] = R_NaString;
+      }
   }
   return(mat);
 }


### PR DESCRIPTION
This PR addresses a bug highlighted in the referenced Shortcut issue.  In short, the treatment of character columns with missing values had a small logic error which persisted for a while, and should now be addressed.  

The 'in-between releases' micro version counter has been updated to .2, and the NEWS file has been updated as well.  

No new code.