### PR TITLE
Update manual pages for deletes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,7 @@
 
 * Several deprecated API entry points of TileDB Embedded are no longer used (#452, #453)
 
-* Support for DELETE queries has been added (requires TileDB Embedded 2.12.0 or later) (#455)
+* Support for DELETE queries has been added (requires TileDB Embedded 2.12.0 or later) (#455, #456)
 
 ## Bug Fixes
 

--- a/inst/tinytest/test_tiledbarray.R
+++ b/inst/tinytest/test_tiledbarray.R
@@ -945,7 +945,7 @@ if (tiledb_version(TRUE) >= "2.8.0" && tiledb_version(TRUE) < "2.10.0") exit_fil
 ## FYI: 101 tests here
 ## test encrypted arrays via high-level accessor
 ## (lower-level tests in test_densearray and test_arrayschema)
-if (tiledb_version(TRUE) > "2.4.0") {
+if (tiledb_version(TRUE) > "2.5.0") {
     tmp <- tempfile()
     dir.create(tmp)
     encryption_key <- "0123456789abcdeF0123456789abcdeF"

--- a/man/tiledb_array_open.Rd
+++ b/man/tiledb_array_open.Rd
@@ -4,12 +4,17 @@
 \alias{tiledb_array_open}
 \title{Open a TileDB Array}
 \usage{
-tiledb_array_open(arr, type = c("READ", "WRITE"))
+tiledb_array_open(
+  arr,
+  type = if (tiledb_version(TRUE) >= "2.12.0") c("READ", "WRITE", "DELETE") else
+    c("READ", "WRITE")
+)
 }
 \arguments{
 \item{arr}{A TileDB Array object as for example returned by \code{tiledb_array()}}
 
-\item{type}{A character value that must be either \sQuote{READ} or \sQuote{WRITE}}
+\item{type}{A character value that must be either \sQuote{READ}, \sQuote{WRITE}
+or (for TileDB 2.12.0 or later) \sQuote{DELETE}}
 }
 \value{
 The TileDB Array object but opened for reading or writing

--- a/man/tiledb_query.Rd
+++ b/man/tiledb_query.Rd
@@ -4,12 +4,18 @@
 \alias{tiledb_query}
 \title{Creates a 'tiledb_query' object}
 \usage{
-tiledb_query(array, type = c("READ", "WRITE"), ctx = tiledb_get_context())
+tiledb_query(
+  array,
+  type = if (tiledb_version(TRUE) >= "2.12.0") c("READ", "WRITE", "DELETE") else
+    c("READ", "WRITE"),
+  ctx = tiledb_get_context()
+)
 }
 \arguments{
 \item{array}{A TileDB Array object}
 
-\item{type}{A character value that must be one of 'READ' or 'WRITE'}
+\item{type}{A character value that must be one of 'READ', 'WRITE', or
+'DELETE' (for TileDB >= 2.12.0)}
 
 \item{ctx}{(optional) A TileDB Ctx object}
 }


### PR DESCRIPTION
This PR complements #455 by also updating the two manual pages reflecting the addition of the `DELETE` query type. We also adjust one condition on an older library versions in one test.