### PR TITLE
Update sparse conversion for Matrix 1.4-2 deprecations

### DIFF
--- a/R/SparseMatrix.R
+++ b/R/SparseMatrix.R
@@ -1,6 +1,6 @@
 #  MIT License
 #
-#  Copyright (c) 2017-2021 TileDB Inc.
+#  Copyright (c) 2017-2022 TileDB Inc.
 #
 #  Permission is hereby granted, free of charge, to any person obtaining a copy
 #  of this software and associated documentation files (the "Software"), to deal
@@ -69,7 +69,7 @@ fromSparseMatrix <- function(obj,
     classIn <- "dgTMatrix"
     if (class(obj)[1] != classIn) {
         classIn <- class(obj)[1]
-        obj <- as(obj, "dgTMatrix")
+        obj <- as(obj, "TsparseMatrix")
     }
 
     dimi <- tiledb_dim(name="i", type = "FLOAT64",  # wider range

--- a/inst/tinytest/test_sparsematrix.R
+++ b/inst/tinytest/test_sparsematrix.R
@@ -18,7 +18,7 @@ nelem <- 0.1 * n * k
 mat[sample(seq_len(n*k), nelem)] <- seq(1, nelem)
 
 ## Convert dense matrix to sparse matrix
-spmat <- as(mat, "dgTMatrix")
+spmat <- as(mat, "TsparseMatrix")
 
 uri <- tempfile()
 if (dir.exists(uri)) unlink(uri, recursive=TRUE)
@@ -36,7 +36,7 @@ mat <- matrix(0, nrow=n, ncol=k, dimnames=list(LETTERS[1:n], letters[1:k]))
 nelem <- 0.2 * n * k
 mat[sample(seq_len(n*k), nelem)] <- seq(1, nelem)
 ## Convert dense matrix to sparse matrix
-spmat <- as(mat, "dgTMatrix")
+spmat <- as(mat, "TsparseMatrix")
 uri <- tempfile()
 if (dir.exists(uri)) unlink(uri, recursive=TRUE)
 fromSparseMatrix(spmat, uri)

--- a/inst/tinytest/test_tiledbarray.R
+++ b/inst/tinytest/test_tiledbarray.R
@@ -1109,6 +1109,7 @@ expect_equal(length(res), 2L)
 expect_equal(res$vals, mat)
 expect_equal(res$vals2, 10*mat)
 
+## FYI: 135 tests here
 ## PR #245 (variant of examples/ex_1.R)
 uri <- tempfile()
 dom <- tiledb_domain(dims = c(tiledb_dim("rows", c(1L, 10L), 10L, "INT32"),
@@ -1192,6 +1193,7 @@ res2 <- arr[]
 expect_equal(nrow(res2), 2)
 expect_equal(res1, res2)
 
+## FYI: 152 tests here
 ## check for strings_as_factors
 arr <- tiledb_array(uri, as.data.frame=TRUE)
 res <- arr[]
@@ -1235,6 +1237,7 @@ schema <- tiledb_array_schema(dom, attrs = c(tiledb_attr("a", type = "INT32"),
                                              tiledb_attr("b", type = "FLOAT64"),
                                              tiledb_attr("c", type = "CHAR", ncells = NA_integer_)))
 
+## FYI: 160 tests here
 uri <- tempfile()
 res <- tiledb_array_create(uri, schema)
 data <- list(a=array(seq(1:100), dim = c(10,5, 2)),
@@ -1259,7 +1262,6 @@ expect_equal(array_vacuum(uri), NULL)
 expect_error(array_vacuum(uri, start_time="abc")) # not a datetime
 expect_error(array_vacuum(uri, end_time="def"))   # not a datetime
 if (tiledb_version(TRUE) >= "2.3.0") expect_equal(array_vacuum(uri, start_time=now-60, end_time=now), NULL)
-
 
 
 


### PR DESCRIPTION
This PR helps the `Matrix` package we use transition to its now-preferred form of coversions by updating the very few conversions we do a) conditionally in code in one place and b) in two places in tests.   No new code.

