### PR TITLE
Use api functions with encryption key and type

### DIFF
--- a/inst/tinytest/test_tiledbarray.R
+++ b/inst/tinytest/test_tiledbarray.R
@@ -945,34 +945,33 @@ if (tiledb_version(TRUE) >= "2.8.0" && tiledb_version(TRUE) < "2.10.0") exit_fil
 ## FYI: 101 tests here
 ## test encrypted arrays via high-level accessor
 ## (lower-level tests in test_densearray and test_arrayschema)
-if (tiledb_version(TRUE) > "2.5.0") {
-    tmp <- tempfile()
-    dir.create(tmp)
-    encryption_key <- "0123456789abcdeF0123456789abcdeF"
+tmp <- tempfile()
+dir.create(tmp)
+encryption_key <- "0123456789abcdeF0123456789abcdeF"
 
-    ## create 4x4 with single attribute
-    dom <- tiledb_domain(dims = c(tiledb_dim("rows", c(1L, 4L), 4L, "INT32"),
-                                  tiledb_dim("cols", c(1L, 4L), 4L, "INT32")))
-    schema <- tiledb_array_schema(dom, attrs=c(tiledb_attr("a", type = "INT32")), sparse = TRUE)
-    invisible( tiledb_array_create(tmp, schema, encryption_key) )
+## create 4x4 with single attribute
+dom <- tiledb_domain(dims = c(tiledb_dim("rows", c(1L, 4L), 4L, "INT32"),
+                              tiledb_dim("cols", c(1L, 4L), 4L, "INT32")))
+schema <- tiledb_array_schema(dom, attrs=c(tiledb_attr("a", type = "INT32")), sparse = TRUE)
+invisible( tiledb_array_create(tmp, schema, encryption_key) )
 
-    ## write
-    I <- c(1, 2, 2)
-    J <- c(1, 4, 3)
-    data <- c(1L, 2L, 3L)
-    A <- tiledb_array(uri = tmp, encryption_key = encryption_key)
-    A[I, J] <- data
+## write
+I <- c(1, 2, 2)
+J <- c(1, 4, 3)
+data <- c(1L, 2L, 3L)
+A <- tiledb_array(uri = tmp, encryption_key = encryption_key)
+A[I, J] <- data
 
-    ## read
-    A <- tiledb_array(uri = tmp, as.data.frame=TRUE, encryption_key = encryption_key)
-    chk <- A[1:2, 2:4]
-    expect_equal(nrow(chk), 2)
-    expect_equal(chk[,"rows"], c(2L,2L))
-    expect_equal(chk[,"cols"], c(3L,4L))
-    expect_equal(chk[,"a"], c(3L,2L))
+## read
+A <- tiledb_array(uri = tmp, as.data.frame=TRUE, encryption_key = encryption_key)
+chk <- A[1:2, 2:4]
+expect_equal(nrow(chk), 2)
+expect_equal(chk[,"rows"], c(2L,2L))
+expect_equal(chk[,"cols"], c(3L,4L))
+expect_equal(chk[,"a"], c(3L,2L))
 
-    unlink(tmp, recursive = TRUE)
-}
+unlink(tmp, recursive = TRUE)
+
 
 ## FYI: 105 tests here
 ## non-empty domain, var and plain

--- a/src/libtiledb.cpp
+++ b/src/libtiledb.cpp
@@ -1626,11 +1626,8 @@ XPtr<tiledb::ArraySchema> libtiledb_array_schema_load_with_key(XPtr<tiledb::Cont
                                                                std::string uri,
                                                                std::string key) {
     check_xptr_tag<tiledb::Context>(ctx);
-    XPtr<tiledb::Config> cfg = libtiledb_ctx_config(ctx);
-    (*cfg)["sm.encryption_type"] = "AES_256_GCM";
-    (*cfg)["sm.encryption_key"] = key;
-    XPtr<tiledb::Context> newctx = libtiledb_ctx(cfg);
-    auto p = new tiledb::ArraySchema(*newctx.get(), uri);
+    auto p = new tiledb::ArraySchema(*ctx.get(), uri, TILEDB_AES_256_GCM,
+                                     key.data(), (uint32_t) key.size());
     return make_xptr<tiledb::ArraySchema>(p);
 }
 
@@ -1965,13 +1962,9 @@ XPtr<tiledb::Array> libtiledb_array_open_with_key(XPtr<tiledb::Context> ctx, std
                                                   std::string enc_key) {
     check_xptr_tag<tiledb::Context>(ctx);
     auto query_type = _string_to_tiledb_query_type(type);
-
-    XPtr<tiledb::Config> cfg = libtiledb_ctx_config(ctx);
-    (*cfg)["sm.encryption_type"] = "AES_256_GCM";
-    (*cfg)["sm.encryption_key"] = enc_key;
-    XPtr<tiledb::Context> newctx = libtiledb_ctx(cfg);
-    auto p = new tiledb::Array(*newctx.get(), uri, query_type);
-    return make_xptr<tiledb::Array>(p);
+    return make_xptr<tiledb::Array>(new tiledb::Array(tiledb::Array(*ctx.get(), uri, query_type,
+                                                                    TILEDB_AES_256_GCM, enc_key.data(),
+                                                                    (uint32_t)enc_key.size())));
 }
 
 // [[Rcpp::export]]
@@ -1981,17 +1974,9 @@ XPtr<tiledb::Array> libtiledb_array_open_at_with_key(XPtr<tiledb::Context> ctx, 
     check_xptr_tag<tiledb::Context>(ctx);
     auto query_type = _string_to_tiledb_query_type(type);
     uint64_t ts_ms = static_cast<uint64_t>(std::round(tstamp.getFractionalTimestamp() * 1000));
-    XPtr<tiledb::Config> cfg = libtiledb_ctx_config(ctx);
-    (*cfg)["sm.encryption_type"] = "AES_256_GCM";
-    (*cfg)["sm.encryption_key"] = enc_key;
-    XPtr<tiledb::Context> newctx = libtiledb_ctx(cfg);
-#if TILEDB_VERSION >= TileDB_Version(2,3,0)
-    auto p = new tiledb::Array(*newctx.get(), uri, query_type);
-    p->set_open_timestamp_start(ts_ms);
-#else
-    auto p = new tiledb::Array(*ctx.get(), uri, query_type, ts_ms);
-#endif
-    return make_xptr<tiledb::Array>(p);
+    return make_xptr<tiledb::Array>(new tiledb::Array(*ctx.get(), uri, query_type,
+                                                      TILEDB_AES_256_GCM, enc_key.data(),
+                                                      (uint32_t)enc_key.size(), ts_ms));
 }
 
 // [[Rcpp::export]]


### PR DESCRIPTION
This PR reverts parts of the recent PR #452 as using Config objects to pass encryption key and types has object lifespan implications that are not easily accomodated here by the R package.  The change also permits us to remove one test conditioner.

No new code.