### PR TITLE
Support riskv64 system with an added link instruction

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,8 +10,13 @@
 
 * Treatment of character columns with missing values has been corrected (#454)
 
+* Accessing encrypted arrays has been reverted to the older API accessors (#458)
+
 ## Build and Test Systems
 
+* Sparse matrix conversion used mainly in tests have been updated for version 1.4-2 of the Matrix packages (#457)
+
+* Support builds on the riskv64 platform by adding a missing link instruction (#459)
 
 
 # tiledb 0.15.0

--- a/configure
+++ b/configure
@@ -6033,6 +6033,14 @@ printf %s "checking for Darwin x86_64 use minimum version override... " >&6; }
 printf "%s\n" "${CXX17_MACOS}" >&6; }
 fi
 
+## Take care of riscv64 machines and need for -latomic
+if test x"${machine}" = x"riscv64"; then
+    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for riscv64 linker adjustment" >&5
+printf %s "checking for riscv64 linker adjustment... " >&6; }
+    TILEDB_LIBS="${TILEDB_LIBS} -latomic"
+    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: ${TILEDB_LIBS}" >&5
+printf "%s\n" "${TILEDB_LIBS}" >&6; }
+fi
 
 ## -- Part 3: Check for TileDB --------------------------------------------------
 ##

--- a/configure.ac
+++ b/configure.ac
@@ -153,6 +153,12 @@ if test x"${uname}" = x"Darwin" -a x"${machine}" = x"x86_64"; then
     AC_MSG_RESULT([${CXX17_MACOS}])
 fi
 
+## Take care of riscv64 machines and need for -latomic
+if test x"${machine}" = x"riscv64"; then
+    AC_MSG_CHECKING([for riscv64 linker adjustment])
+    TILEDB_LIBS="${TILEDB_LIBS} -latomic"
+    AC_MSG_RESULT([${TILEDB_LIBS}])
+fi
 
 ## -- Part 3: Check for TileDB --------------------------------------------------
 ##


### PR DESCRIPTION
This PR carries over a tiny patch we added for the Debian builds where on the riskv64 platform an added `-latomic` is needed for linking.  Full details are in the [corresponding Debian bug report](https://bugs.debian.org/1017684).

The change is simple and localised to `configure{,.ac}`.  No new code.