### PR TITLE
Use TileDB 2.11.1

### DIFF
--- a/tools/ci/valgrind/buildAndCheckPackage.sh
+++ b/tools/ci/valgrind/buildAndCheckPackage.sh
@@ -11,6 +11,8 @@ echo "::group::Check TileDB R package"
 export _R_CHECK_FORCE_SUGGESTS_=FALSE
 ## set an 'under valgrind' variable (see SC-19185)
 export _RUNNING_UNDER_VALGRIND_=TRUE
+## tell valgrind to use '-s'
+export VALGRIND_OPTS="-s"
 ## check package
 R CMD check --use-valgrind --as-cran --no-manual --ignore-vignettes tiledb_*.tar.gz
 echo "::endgroup::"

--- a/tools/tiledbVersion.txt
+++ b/tools/tiledbVersion.txt
@@ -1,2 +1,2 @@
-version: 2.11.0
-sha: 34e5dbc
+version: 2.11.1
+sha: 15a1161


### PR DESCRIPTION
This PR updates the package preference to TileDB 2.11.1.

It also updates the nightly `valgrind` check to use the `-s` option to show a more detailed error list on the run summary.

No code changes.