### PR TITLE
Move test to *extra.R to avoid valgrind issue from 3rd-party library

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -24,3 +24,4 @@
 ^vignettes/.*\.Rmd
 ^vignettes/Makefile
 ^inst/tinytest/test_timetravel_extra.R
+^inst/tinytest/test_tiledbarray_extra.R

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tiledb
 Type: Package
-Version: 0.15.0.2
+Version: 0.15.0.3
 Title: Universal Storage Engine for Sparse and Dense Multidimensional Arrays
 Authors@R: c(person("TileDB, Inc.", role = c("aut", "cph")),
  person("Dirk", "Eddelbuettel", email = "dirk@tiledb.com", role = "cre"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,8 @@
 
 * Support for DELETE queries has been added (requires TileDB Embedded 2.12.0 or later) (#455, #456)
 
+* Use of TileDB Embedded was upgraded to release 2.11.1 (#460)
+
 ## Bug Fixes
 
 * Treatment of character columns with missing values has been corrected (#454)
@@ -17,6 +19,8 @@
 * Sparse matrix conversion used mainly in tests have been updated for version 1.4-2 of the Matrix packages (#457)
 
 * Support builds on the riskv64 platform by adding a missing link instruction (#459)
+
+* Test setup was tweaked to not trigger a spurious valgrind report from libcrypto (#461)
 
 
 # tiledb 0.15.0

--- a/inst/tinytest/test_tiledbarray.R
+++ b/inst/tinytest/test_tiledbarray.R
@@ -943,34 +943,6 @@ if (requireNamespace("bit64", quietly=TRUE)) {
 if (tiledb_version(TRUE) >= "2.8.0" && tiledb_version(TRUE) < "2.10.0") exit_file("2.8.* and 2.9.* skip remainder")
 
 ## FYI: 101 tests here
-## test encrypted arrays via high-level accessor
-## (lower-level tests in test_densearray and test_arrayschema)
-tmp <- tempfile()
-dir.create(tmp)
-encryption_key <- "0123456789abcdeF0123456789abcdeF"
-
-## create 4x4 with single attribute
-dom <- tiledb_domain(dims = c(tiledb_dim("rows", c(1L, 4L), 4L, "INT32"),
-                              tiledb_dim("cols", c(1L, 4L), 4L, "INT32")))
-schema <- tiledb_array_schema(dom, attrs=c(tiledb_attr("a", type = "INT32")), sparse = TRUE)
-invisible( tiledb_array_create(tmp, schema, encryption_key) )
-
-## write
-I <- c(1, 2, 2)
-J <- c(1, 4, 3)
-data <- c(1L, 2L, 3L)
-A <- tiledb_array(uri = tmp, encryption_key = encryption_key)
-A[I, J] <- data
-
-## read
-A <- tiledb_array(uri = tmp, as.data.frame=TRUE, encryption_key = encryption_key)
-chk <- A[1:2, 2:4]
-expect_equal(nrow(chk), 2)
-expect_equal(chk[,"rows"], c(2L,2L))
-expect_equal(chk[,"cols"], c(3L,4L))
-expect_equal(chk[,"a"], c(3L,2L))
-
-unlink(tmp, recursive = TRUE)
 
 
 ## FYI: 105 tests here

--- a/inst/tinytest/test_tiledbarray_extra.R
+++ b/inst/tinytest/test_tiledbarray_extra.R
@@ -1,0 +1,46 @@
+library(tinytest)
+library(tiledb)
+
+isOldWindows <- Sys.info()[["sysname"]] == "Windows" && grepl('Windows Server 2008', osVersion)
+if (isOldWindows) exit_file("skip this file on old Windows releases")
+isMacOS <- (Sys.info()['sysname'] == "Darwin")
+
+ctx <- tiledb_ctx(limitTileDBCores())
+
+hasDataTable <- requireNamespace("data.table", quietly=TRUE)
+hasTibble <- requireNamespace("tibble", quietly=TRUE)
+
+## GitHub Actions had some jobs killed on the larger data portion so we dial mem use down
+if (Sys.getenv("CI") != "") set_allocation_size_preference(1024*1024*5)
+
+
+
+## this test tickles a valgrind issue 'Conditional jump or move depends on uninitialized value'
+## test encrypted arrays via high-level accessor
+## (lower-level tests in test_densearray and test_arrayschema)
+tmp <- tempfile()
+dir.create(tmp)
+encryption_key <- "0123456789abcdeF0123456789abcdeF"
+
+## create 4x4 with single attribute
+dom <- tiledb_domain(dims = c(tiledb_dim("rows", c(1L, 4L), 4L, "INT32"),
+                              tiledb_dim("cols", c(1L, 4L), 4L, "INT32")))
+schema <- tiledb_array_schema(dom, attrs=c(tiledb_attr("a", type = "INT32")), sparse = TRUE)
+invisible( tiledb_array_create(tmp, schema, encryption_key) )
+
+## write
+I <- c(1, 2, 2)
+J <- c(1, 4, 3)
+data <- c(1L, 2L, 3L)
+A <- tiledb_array(uri = tmp, encryption_key = encryption_key)
+A[I, J] <- data
+
+## read
+A <- tiledb_array(uri = tmp, as.data.frame=TRUE, encryption_key = encryption_key)
+chk <- A[1:2, 2:4]
+expect_equal(nrow(chk), 2)
+expect_equal(chk[,"rows"], c(2L,2L))
+expect_equal(chk[,"cols"], c(3L,4L))
+expect_equal(chk[,"a"], c(3L,2L))
+
+unlink(tmp, recursive = TRUE)


### PR DESCRIPTION
CRAN currently reports a non-leak `valgrind` issue in build and check reports linked from the [package page](https://cran.r-project.org/package=tiledb).  

After quite some time trying to both confirm the source and assess a possible follow-up from CRAN (as the `valgrind` focus is typically on leaks, not 'unconditional jumps') this PR proposes to move one test to another testfile ending in `_extra.R` which is then excluded from the `tar.gz`.  The test remains in the package and is _e.g._ run when calling the test runner in directory or file mode.   But because the actual instruction tickling this appears to come from `libcrypto` the most expedient way forward may be to skip this test at CRAN which is what this PR proposes.  

No new code.
