### PR TITLE
Refactor test for remaining group elements after partial removal

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -22,6 +22,8 @@
 
 * Test setup was tweaked to not trigger a spurious valgrind report from libcrypto (#461)
 
+* Test setup was tweaked to make a group comparison more resilient to ordering (#462)
+
 
 # tiledb 0.15.0
 


### PR DESCRIPTION
This PR makes one (occassionally failing) tests for comparison of groups following removal a little more resilient by comparing against "all" possible values (here: two).  The underlying issue may well be that we are "writing too much too fast" without an explicit `sleep()` making the timestamp-ordered retrieval undeterminstic. In our different setups the issue was never reliably reproducible, so the more defensive approach in value comparison is appropriate.

No new code.