### PR TITLE
Use TileDB 2.11.2

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,7 +6,7 @@
 
 * Support for DELETE queries has been added (requires TileDB Embedded 2.12.0 or later) (#455, #456)
 
-* Use of TileDB Embedded was upgraded to release 2.11.1 (#460)
+* Use of TileDB Embedded was upgraded to release 2.11.1 and 2.11.2 (#460, #466)
 
 ## Bug Fixes
 

--- a/tools/tiledbVersion.txt
+++ b/tools/tiledbVersion.txt
@@ -1,2 +1,2 @@
-version: 2.11.1
-sha: 15a1161
+version: 2.11.2
+sha: 6ad6f76


### PR DESCRIPTION
This PR updates the package preference to TileDB 2.11.2.

No code changes.