### PR TITLE
Refine filter tests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tiledb
 Type: Package
-Version: 0.15.0.3
+Version: 0.15.0.4
 Title: Universal Storage Engine for Sparse and Dense Multidimensional Arrays
 Authors@R: c(person("TileDB, Inc.", role = c("aut", "cph")),
  person("Dirk", "Eddelbuettel", email = "dirk@tiledb.com", role = "cre"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -22,9 +22,11 @@
 
 * Support builds on the riskv64 platform by adding a missing link instruction (#459)
 
-* Test setup was tweaked to not trigger a spurious valgrind report from libcrypto (#461)
+* The test setup was tweaked to not trigger a spurious valgrind report from libcrypto (#461)
 
-* Test setup was tweaked to make a group comparison more resilient to ordering (#462)
+* The test setup was tweaked to make a group comparison more resilient to ordering (#462)
+
+* The test setup was refined for two filter tests (#467)
 
 
 # tiledb 0.15.0

--- a/inst/tinytest/test_filter.R
+++ b/inst/tinytest/test_filter.R
@@ -74,7 +74,6 @@ tiledb_filter_set_option(flt, "POSITIVE_DELTA_MAX_WINDOW", 10)
 expect_equal(tiledb_filter_get_option(flt, "POSITIVE_DELTA_MAX_WINDOW"), 10)
 #})
 
-
 ## add some bulk checking for filters
 name_list <- c("NONE",
                "GZIP",
@@ -87,9 +86,10 @@ name_list <- c("NONE",
                "BITSHUFFLE",
                "BYTESHUFFLE",
                "CHECKSUM_MD5",
-               "CHECKSUM_SHA256",
-               "DICTIONARY_ENCODING",
-               "SCALE_FLOAT")
+               "CHECKSUM_SHA256"
+               #"DICTIONARY_ENCODING",  # cannot be used below
+               #"SCALE_FLOAT"            # cannot be used below
+               )
 
 if (!requireNamespace("palmerpenguins", quietly=TRUE)) exit_file("remainder needs 'palmerpenguins'")
 dat <- palmerpenguins::penguins
@@ -108,7 +108,6 @@ for (name in name_list) {
     if (name == "SCALE_FLOAT") {
         if (tiledb_version(TRUE) < "2.11.0") next            # skip if not 2.11.0 or later
     }
-
     basepath <- file.path(tempdir())
     uri <- file.path(basepath, name)
     fromDataFrame(dat2, uri, filter=name)
@@ -123,4 +122,58 @@ for (name in name_list) {
         #message("None ", size_none, " vs ", name, " ", size_curr)
     }
 }
+
+## add some bulk checking for filters on character data
+name_list <- c("NONE",
+               "RLE",
+               "DICTIONARY_ENCODING")
+for (name in name_list) {
+    dat3 <- data.frame(SP=as.character(dat$species),
+                       IS=as.character(dat$island),
+                       SX=as.character(dat$sex))
+    if (name == "DICTIONARY_ENCODING") {
+        if (tiledb_version(TRUE) < "2.9.0") next             # skip if not 2.9.0 or later
+        dat2 <- dat2[, sapply(dat2, class) == "character"]
+    }
+    basepath <- file.path(tempdir())
+    uri <- file.path(basepath, name)
+    if (dir.exists(uri)) unlink(uri, recursive=TRUE)
+    fromDataFrame(dat3, uri, filter=name)
+
+    if (is.na(match(name, c("NONE")))) {
+        size_none <- tiledb_vfs_dir_size(file.path(basepath, "NONE"), vfs)
+        expect_true(size_none > 0)
+        size_curr <- tiledb_vfs_dir_size(uri, vfs)
+        expect_true(size_curr > 0)
+        expect_true(size_curr < size_none)
+        #message("None ", size_none, " vs ", name, " ", size_curr)
+    }
+}
+
+## add some bulk checking for filters on float/double
+name_list <- c("NONE",
+               "SCALE_FLOAT")
+for (name in name_list) {
+    dat4 <- data.frame(BL=dat$bill_length_mm,
+                       BD=dat$bill_depth_mm,
+                       FL=as.double(dat$flipper_length_mm),
+                       BM=as.double(dat$body_mass_g))
+    if (name == "SCALE_FLOAT") {
+        if (tiledb_version(TRUE) < "2.11.0") next            # skip if not 2.11.0 or later
+    }
+    basepath <- file.path(tempdir())
+    uri <- file.path(basepath, name)
+    if (dir.exists(uri)) unlink(uri, recursive=TRUE)
+    fromDataFrame(dat4, uri, filter=name)
+
+    if (is.na(match(name, c("NONE")))) {
+        size_none <- tiledb_vfs_dir_size(file.path(basepath, "NONE"), vfs)
+        expect_true(size_none > 0)
+        size_curr <- tiledb_vfs_dir_size(uri, vfs)
+        expect_true(size_curr > 0)
+        #expect_true(size_curr < size_none)
+        #message("None ", size_none, " vs ", name, " ", size_curr)
+    }
+}
+
 rm(vfs)

--- a/inst/tinytest/test_filter.R
+++ b/inst/tinytest/test_filter.R
@@ -87,8 +87,8 @@ name_list <- c("NONE",
                "BYTESHUFFLE",
                "CHECKSUM_MD5",
                "CHECKSUM_SHA256"
-               #"DICTIONARY_ENCODING",  # cannot be used below
-               #"SCALE_FLOAT"            # cannot be used below
+               #"DICTIONARY_ENCODING",  # cannot be used here, see below for explicit block
+               #"SCALE_FLOAT"           # cannot be used here, see below for explicit block
                )
 
 if (!requireNamespace("palmerpenguins", quietly=TRUE)) exit_file("remainder needs 'palmerpenguins'")
@@ -101,13 +101,6 @@ if (Sys.info()[["sysname"]]=="Linux" && isFALSE(any(grepl("avx2", readLines("/pr
 vfs <- tiledb_vfs()                     # use an explicit VFS instance for the ops in loop over filters
 for (name in name_list) {
     dat2 <- dat
-    if (name == "DICTIONARY_ENCODING") {
-        if (tiledb_version(TRUE) < "2.9.0") next             # skip if not 2.9.0 or later
-        dat2 <- dat2[, sapply(dat2, class) == "character"]
-    }
-    if (name == "SCALE_FLOAT") {
-        if (tiledb_version(TRUE) < "2.11.0") next            # skip if not 2.11.0 or later
-    }
     basepath <- file.path(tempdir())
     uri <- file.path(basepath, name)
     fromDataFrame(dat2, uri, filter=name)

--- a/src/libtiledb.cpp
+++ b/src/libtiledb.cpp
@@ -1017,8 +1017,8 @@ SEXP libtiledb_dim_get_tile_extent(XPtr<tiledb::Dimension> dim) {
       using DataType = tiledb::impl::tiledb_to_type<TILEDB_INT64>::type;
       auto t = dim->tile_extent<DataType>();
       if (t <= R_NaInt || t > std::numeric_limits<int32_t>::max()) {
-          std::vector<int64_t> v{t};          // return as int64
-          return makeInteger64(v);            // which 'travels' as a double
+          std::vector<int64_t> v{t};         // return as int64
+          return makeInteger64(v);           // which 'travels' as a double
       }
       // 'else' i.e. default cast to int32
       return IntegerVector({static_cast<int32_t>(t),});
@@ -1030,8 +1030,9 @@ SEXP libtiledb_dim_get_tile_extent(XPtr<tiledb::Dimension> dim) {
           Rcpp::stop("tiledb_dim tile UINT64 value not representable as an INT64");
       }
       if (t > std::numeric_limits<int32_t>::max()) {
-          std::vector<int64_t> v{t};          // return as int64
-          return makeInteger64(v);            // which 'travels' as a double
+          auto tt = static_cast<int64_t>(t); // avoids a 'narrowing' watnings
+          std::vector<int64_t> v{ tt };      // return as int64
+          return makeInteger64(v);           // which 'travels' as a double
       }
       return IntegerVector({static_cast<int32_t>(t),});
     }


### PR DESCRIPTION
This small PR brings changes needed for 2.12 concerning two filter tests requiring, respectively, character or float inputs. It also adds a cast from uint64 to int64 to suppress a 'narrowing' compiler warning (and this is after an explicit test for overflow).

No new code.
