### PR TITLE
Condition test on newer versions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -26,7 +26,7 @@
 
 * The test setup was tweaked to make a group comparison more resilient to ordering (#462)
 
-* The test setup was refined for two filter tests (#467)
+* The test setup was refined for two filter tests (#467, #468)
 
 
 # tiledb 0.15.0

--- a/inst/tinytest/test_filter.R
+++ b/inst/tinytest/test_filter.R
@@ -124,6 +124,7 @@ for (name in name_list) {
     dat3 <- data.frame(SP=as.character(dat$species),
                        IS=as.character(dat$island),
                        SX=as.character(dat$sex))
+    if (tiledb_version(TRUE) < "2.8.0") next                 # skip if not 2.8.0 or later
     if (name == "DICTIONARY_ENCODING") {
         if (tiledb_version(TRUE) < "2.9.0") next             # skip if not 2.9.0 or later
         dat2 <- dat2[, sapply(dat2, class) == "character"]


### PR DESCRIPTION
This PR adds a one-liner to not run some of the tests refactored in #467 under older TileDB Embedded versions.