### PR TITLE
Add parameterized test for SCALE_FLOAT

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -28,6 +28,8 @@
 
 * The test setup was refined for two filter tests (#467, #468)
 
+* A parameterized test for the SCALE_FLOAT filter has been added (#469)
+
 
 # tiledb 0.15.0
 


### PR DESCRIPTION
This micro PR borrows from a just-merged pull request for the Python package and carries its (parameterized) test for the SCALE_FLOAT filter over to the R package.   

No new code, and no changes besides addition of one new test block.