### PR TITLE
Ensure the per-session temporary directory persists

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -30,6 +30,8 @@
 
 * A parameterized test for the SCALE_FLOAT filter has been added (#469)
 
+* The test setup ensures that the per-session directory remains accessible (#470)
+
 
 # tiledb 0.15.0
 

--- a/inst/tinytest/test_filter.R
+++ b/inst/tinytest/test_filter.R
@@ -190,6 +190,7 @@ if (tiledb_version(TRUE) >= "2.11.0") {
 
         if (dir.exists(uri)) unlink(uri, recursive=TRUE)
     }
+    if (!dir.exists(tempdir())) dir.create(tempdir())
 }
 
 rm(vfs)


### PR DESCRIPTION
The test added in #469 appears to in some circumstances, but of course not the machine where I wrote it ..., take out the per-session temporary directory which interferes with subsequent tests.  This PR adds one line to rectify this.  

No other changes.