### PR TITLE
Support XOR filter

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,8 @@
 
 * Use of TileDB Embedded was upgraded to release 2.11.1 and 2.11.2 (#460, #466)
 
+* Support for XOR filters has been added (#472)
+
 ## Bug Fixes
 
 * Treatment of character columns with missing values has been corrected (#454)

--- a/R/Filter.R
+++ b/R/Filter.R
@@ -50,6 +50,7 @@ tiledb_filter.from_ptr <- function(ptr) {
 #'   - "CHECKSUM_SHA256"
 #'   - "DICTIONARY"
 #'   - "SCALE_FLOAT"  (TileDB 2.11.0 or later)
+#'   - "FILTER_XOR"   (TileDB 2.12.0 or later)
 #'
 #' Valid compression options vary depending on the filter used,
 #' consult the TileDB docs for more information.

--- a/inst/tinytest/test_filter.R
+++ b/inst/tinytest/test_filter.R
@@ -184,12 +184,24 @@ if (tiledb_version(TRUE) >= "2.11.0") {
         tiledb_filter_set_option(flt, "SCALE_FLOAT_BYTEWIDTH", pars[i, "bytewidth"])
 
         uri <- file.path(tempdir())
-        fromDataFrame(dat4, uri, filter=name)
+        fromDataFrame(dat4, uri, filter_list=tiledb_filter_list(flt))
         res <- tiledb_array(uri, return_as="data.frame", extended=FALSE)[]
-        expect_equivalent(dat4, res, tolerance=5e-2) # note very high tolerance
-
+        expect_equivalent(dat4, res)
         if (dir.exists(uri)) unlink(uri, recursive=TRUE)
     }
+    if (!dir.exists(tempdir())) dir.create(tempdir())
+}
+
+if (tiledb_version(TRUE) >= "2.12.0") {
+    D <- data.frame(index=sample(100, 26, FALSE),
+                    key=LETTERS,
+                    value=cumsum(runif(26)))
+    uri <- file.path(tempdir())
+    fromDataFrame(D, uri, filter="FILTER_XOR")
+    arr <- tiledb_array(uri, return_as="data.frame", extended=FALSE)[]
+    expect_equal(D$value, arr$value)
+
+    if (dir.exists(uri)) unlink(uri, recursive=TRUE)
     if (!dir.exists(tempdir())) dir.create(tempdir())
 }
 

--- a/src/libtiledb.cpp
+++ b/src/libtiledb.cpp
@@ -305,6 +305,10 @@ tiledb_filter_type_t _string_to_tiledb_filter(std::string filter) {
   } else if (filter == "SCALE_FLOAT") {
     return TILEDB_FILTER_SCALE_FLOAT;
 #endif
+#if TILEDB_VERSION >= TileDB_Version(2,12,0)
+  } else if (filter == "FILTER_XOR") {
+    return TILEDB_FILTER_XOR;
+#endif
   } else {
     Rcpp::stop("Unknown TileDB filter '%s'", filter.c_str());
   }
@@ -345,6 +349,10 @@ const char* _tiledb_filter_to_string(tiledb_filter_type_t filter) {
 #if TILEDB_VERSION >= TileDB_Version(2,11,0)
     case TILEDB_FILTER_SCALE_FLOAT:
       return "SCALE_FLOAT";
+#endif
+#if TILEDB_VERSION >= TileDB_Version(2,12,0)
+  case TILEDB_FILTER_XOR:
+    return "FILTER_XOR";
 #endif
   default: {
       Rcpp::stop("unknown tiledb_filter_t (%d)", filter);


### PR DESCRIPTION
This PR adds support for the `FILTER_XOR` filter (which will be useful mostly as part of larger filter pipelines).  

As with other filters, this is mostly a pass-through to the core library but as simple test was added as well.