### PR TITLE
Use TileDB 2.11.3

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tiledb
 Type: Package
-Version: 0.15.0.4
+Version: 0.15.0.5
 Title: Universal Storage Engine for Sparse and Dense Multidimensional Arrays
 Authors@R: c(person("TileDB, Inc.", role = c("aut", "cph")),
  person("Dirk", "Eddelbuettel", email = "dirk@tiledb.com", role = "cre"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,7 +6,7 @@
 
 * Support for DELETE queries has been added (requires TileDB Embedded 2.12.0 or later) (#455, #456)
 
-* Use of TileDB Embedded was upgraded to release 2.11.1 and 2.11.2 (#460, #466)
+* Use of TileDB Embedded was upgraded to release 2.11.1, 2.11.2, and 2.11.3 (#460, #466, #474)
 
 * Support for XOR filters has been added (#472)
 

--- a/tools/tiledbVersion.txt
+++ b/tools/tiledbVersion.txt
@@ -1,2 +1,2 @@
-version: 2.11.2
-sha: 6ad6f76
+version: 2.11.3
+sha: a55a910


### PR DESCRIPTION
This PR updates the package preference to TileDB 2.11.3.

No code changes.