### PR TITLE
Use TileDB 2.12.0

### DIFF
--- a/.github/workflows/valgrind.yaml
+++ b/.github/workflows/valgrind.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tag: [ release-2.10, release-2.11, dev ]
+        tag: [ release-2.11, release-2.12, dev ]
 #        tag: [ 2.9.5, 2.10.0, dev ]
 
     steps:

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -1,7 +1,6 @@
 on:
-  #push:
-  #pull_request:
-  release:
+  push:
+  pull_request:
 
 name: windows
 

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -1,6 +1,7 @@
 on:
-  push:
-  pull_request:
+  #push:
+  #pull_request:
+  release:
 
 name: windows
 

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,7 +1,7 @@
 CXX_STD = CXX17
 RWINLIB = ../windows/rwinlib-tiledb
 
-PKG_CPPFLAGS = -I../inst/include -I$(RWINLIB)/include -DTILEDB_STATIC_DEFINE
+PKG_CPPFLAGS = -I../inst/include -I$(RWINLIB)/include -I$(RWINLIB)/include/tiledb -DTILEDB_STATIC_DEFINE
 PKG_LIBS = \
 	-L$(RWINLIB)/lib$(subst gcc,,$(COMPILED_BY))$(R_ARCH) \
 	-L$(RWINLIB)/lib$(R_ARCH)$(CRT) \

--- a/tools/ci/valgrind/installDependencies.sh
+++ b/tools/ci/valgrind/installDependencies.sh
@@ -16,7 +16,7 @@ wget -qO- https://cloud.r-project.org/bin/linux/ubuntu/marutter_pubkey.asc | tee
 echo "deb [arch=amd64] https://cloud.r-project.org/bin/linux/ubuntu $(lsb_release -sc)-cran40/" > /etc/apt/sources.list.d/cranubuntu.list
 # edd key and cranapt / r2u for CRAN binaries
 wget -q -O- https://eddelbuettel.github.io/r2u/assets/dirk_eddelbuettel_key.asc | tee -a /etc/apt/trusted.gpg.d/cranapt_key.asc
-echo "deb [arch=amd64] https://dirk.eddelbuettel.com/cranapt $(lsb_release -sc) main" > /etc/apt/sources.list.d/cranapt.list
+echo "deb [arch=amd64] https://r2u.stat.illinois.edu/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/cranapt.list
 # edd launchpad key and launchpad PPA for AWS packages
 wget -q -O- https://eddelbuettel.github.io/r2u/assets/dirk_eddelbuettel_launchpad_ppa_key.asc | tee -a /etc/apt/trusted.gpg.d/eddppa_key.asc
 echo "deb [arch=amd64] http://ppa.launchpad.net/edd/misc/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/eddppa.list

--- a/tools/tiledbVersion.txt
+++ b/tools/tiledbVersion.txt
@@ -1,2 +1,2 @@
-version: 2.11.3
-sha: a55a910
+version: 2.12.0-rc0
+sha: 97b7d23

--- a/tools/tiledbVersion.txt
+++ b/tools/tiledbVersion.txt
@@ -1,2 +1,2 @@
-version: 2.12.0-rc1
-sha: c8b41a7
+version: 2.12.0-rc2
+sha: ac8a0df

--- a/tools/tiledbVersion.txt
+++ b/tools/tiledbVersion.txt
@@ -1,2 +1,2 @@
-version: 2.12.0-rc2
+version: 2.12.0
 sha: ac8a0df

--- a/tools/tiledbVersion.txt
+++ b/tools/tiledbVersion.txt
@@ -1,2 +1,2 @@
-version: 2.12.0-rc0
-sha: 97b7d23
+version: 2.12.0-rc1
+sha: c8b41a7


### PR DESCRIPTION
This PR updates the package preference to TileDB 2.12.0.

No code changes (but a roll of branches tested in nightly valgrind to 2.12, and minor tweak to one Makefile and the CI setup).
