### PR TITLE
Use TileDB 2.12.1

### DIFF
--- a/tools/tiledbVersion.txt
+++ b/tools/tiledbVersion.txt
@@ -1,2 +1,2 @@
-version: 2.12.0
-sha: ac8a0df
+version: 2.12.1
+sha: 7a66085


### PR DESCRIPTION
This PR updates the package preference to TileDB 2.12.1.

No code changes.