### PR TITLE
Accomodate zero buffer size estimate

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tiledb
 Type: Package
-Version: 0.16.0.1
+Version: 0.16.0.2
 Title: Universal Storage Engine for Sparse and Dense Multidimensional Arrays
 Authors@R: c(person("TileDB, Inc.", role = c("aut", "cph")),
  person("Dirk", "Eddelbuettel", email = "dirk@tiledb.com", role = "cre"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,13 +4,17 @@
 
 * Support for testing group URIs on being relative has been added (#478)
 
+* Logging support at the R and C++ level has been added (#479)
+
 * Use of TileDB Embedded was upgraded to release 2.12.1, and 2.12.2 (#480, #481)
 
 ## Bug Fixes
 
+* Accomodate possible zero sized allocation estimates for attributes (#482)
+
 ## Build and Test Systems
 
-* Update check out action to version three suppressing a warning (#477)
+* Update check-out action to version three suppressing a warning (#477)
 
 
 # tiledb 0.16.0

--- a/R/TileDBArray.R
+++ b/R/TileDBArray.R
@@ -746,7 +746,7 @@ setMethod("[", "tiledb_array",
                          MoreArgs=list(qryptr=qryptr), SIMPLIFY=TRUE)
       ## ensure > 0 for correct handling of zero-length outputs, ensure respecting memory budget
       spdl_debug(paste("['['] result of size estimates is", paste(ressizes, collapse=",")))
-      resrv <- max(1, min(memory_budget/8, ressizes))
+      resrv <- max(1, min(memory_budget/8, ressizes[ressizes > 0]))
       spdl_debug(sprintf("['['] overall estimate %.0f rows", resrv))
 
       ## allocate and set buffers

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -1618,13 +1618,13 @@ BEGIN_RCPP
 END_RCPP
 }
 // libtiledb_query_buffer_var_char_alloc_direct
-XPtr<vlc_buf_t> libtiledb_query_buffer_var_char_alloc_direct(int szoffsets, int szdata, bool nullable, int cols);
+XPtr<vlc_buf_t> libtiledb_query_buffer_var_char_alloc_direct(double szoffsets, double szdata, bool nullable, int cols);
 RcppExport SEXP _tiledb_libtiledb_query_buffer_var_char_alloc_direct(SEXP szoffsetsSEXP, SEXP szdataSEXP, SEXP nullableSEXP, SEXP colsSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< int >::type szoffsets(szoffsetsSEXP);
-    Rcpp::traits::input_parameter< int >::type szdata(szdataSEXP);
+    Rcpp::traits::input_parameter< double >::type szoffsets(szoffsetsSEXP);
+    Rcpp::traits::input_parameter< double >::type szdata(szdataSEXP);
     Rcpp::traits::input_parameter< bool >::type nullable(nullableSEXP);
     Rcpp::traits::input_parameter< int >::type cols(colsSEXP);
     rcpp_result_gen = Rcpp::wrap(libtiledb_query_buffer_var_char_alloc_direct(szoffsets, szdata, nullable, cols));

--- a/src/libtiledb.cpp
+++ b/src/libtiledb.cpp
@@ -2647,16 +2647,16 @@ XPtr<tiledb::Query> libtiledb_query_set_buffer(XPtr<tiledb::Query> query,
 // -- vlc_buf_t functions below
 
 // [[Rcpp::export]]
-XPtr<vlc_buf_t> libtiledb_query_buffer_var_char_alloc_direct(int szoffsets, int szdata,
+XPtr<vlc_buf_t> libtiledb_query_buffer_var_char_alloc_direct(double szoffsets, double szdata,
                                                              bool nullable, int cols=1) {
-  XPtr<vlc_buf_t> buf = make_xptr<vlc_buf_t>(new vlc_buf_t);
-  buf->offsets.resize(szoffsets);
-  buf->str.resize(szdata);
-  buf->rows = szoffsets/cols;           // guess for number of elements
-  buf->cols = cols;
-  buf->nullable = nullable;
-  buf->validity_map.resize(szdata);
-  return buf;
+    XPtr<vlc_buf_t> buf = make_xptr<vlc_buf_t>(new vlc_buf_t);
+    buf->offsets.resize(static_cast<size_t>(szoffsets));
+    buf->str.resize(static_cast<size_t>(szdata));
+    buf->rows = std::round(szoffsets/cols);           // guess for number of elements
+    buf->cols = cols;
+    buf->nullable = nullable;
+    buf->validity_map.resize(static_cast<size_t>(szdata));
+    return buf;
 }
 
 // assigning (for a write) allocates


### PR DESCRIPTION
For attributes added under schema evolution, an estimated buffer size of zero can be returned from TileDB Embedded.  The subsequent calculation for a 'best' buffer size to allocate before submitted a query does not deal gracefully with this, and this PR improves the calculation.  It also protects two allocation size variables from overflow by passing them as double, this matters only if the user has set a very large memory allocation preference via the available setter function.