### PR TITLE
Add code coverage

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,3 +30,7 @@ jobs:
 
       - name: Test
         run: ./.github/r-ci.sh run_tests
+
+      - name: Coverage
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        run: ./.github/r-ci.sh coverage

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+ignore:
+  - "inst/tiledb/"  	# ignore headers from TileDB Core brought in via artifact

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,2 +1,4 @@
+comment: false
+
 ignore:
-  - "inst/tiledb/"  	# ignore headers from TileDB Core brought in via artifact
+  - "inst/tiledb/"


### PR DESCRIPTION
This very simple PR adds coverage. This worked in the first commit, but oddly not in the second which tried to limit which directories to include (i.e. to ignore headers from TileDB Embedded which we only access to build).

No new code.