### PR TITLE
Default sparse read via tiledb_array to UNORDERED

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -25,3 +25,4 @@
 ^vignettes/Makefile
 ^inst/tinytest/test_timetravel_extra.R
 ^inst/tinytest/test_tiledbarray_extra.R
+^codecov.yml

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tiledb
 Type: Package
-Version: 0.16.0.2
+Version: 0.16.0.3
 Title: Universal Storage Engine for Sparse and Dense Multidimensional Arrays
 Authors@R: c(person("TileDB, Inc.", role = c("aut", "cph")),
  person("Dirk", "Eddelbuettel", email = "dirk@tiledb.com", role = "cre"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,8 @@
 
 * Use of TileDB Embedded was upgraded to release 2.12.1, and 2.12.2 (#480, #481)
 
+* Sparse array queries via tiledb_array and '[]' access use an UNORDERED query layout (#488)
+
 ## Bug Fixes
 
 * Accomodate possible zero sized allocation estimates for attributes (#482)

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,7 @@
 
 * Support for testing group URIs on being relative has been added (#478)
 
-* Logging support at the R and C++ level has been added (#479)
+* Logging support at the R and C++ level has been added (#479, #487)
 
 * Use of TileDB Embedded was upgraded to release 2.12.1, and 2.12.2 (#480, #481)
 
@@ -12,9 +12,15 @@
 
 * Accomodate possible zero sized allocation estimates for attributes (#482)
 
+* Detect missing columns in a write-attempt with partial data (#483)
+
 ## Build and Test Systems
 
 * Update check-out action to version three suppressing a warning (#477)
+
+* Code Coverage reports are now generated and available at codecov.io (#484)
+
+* Small internal changes renaming two files and conditioning tests under two older releases (#485)
 
 
 # tiledb 0.16.0

--- a/R/TileDBArray.R
+++ b/R/TileDBArray.R
@@ -593,7 +593,7 @@ setMethod("[", "tiledb_array",
   ## open query
   qryptr <- libtiledb_query(ctx@ptr, arrptr, "READ")
   qryptr <- libtiledb_query_set_layout(qryptr,
-                                       if (length(layout) > 0) layout
+                                       if (isTRUE(nchar(layout) > 0)) layout
                                        else { if (sparse) "UNORDERED" else "COL_MAJOR" })
 
   ## ranges seem to interfere with the byte/element adjustment below so set up toggle
@@ -1157,7 +1157,7 @@ setMethod("[<-", "tiledb_array",
 
     qryptr <- libtiledb_query(ctx@ptr, arrptr, "WRITE")
     qryptr <- libtiledb_query_set_layout(qryptr,
-                                         if (length(layout) > 0) layout
+                                         if (isTRUE(nchar(layout) > 0)) layout
                                          else { if (sparse) "UNORDERED" else "COL_MAJOR" })
 
     buflist <- vector(mode="list", length=nc)

--- a/R/TileDBArray.R
+++ b/R/TileDBArray.R
@@ -592,7 +592,9 @@ setMethod("[", "tiledb_array",
   nonemptydom <- mapply(getDomain, dimnames, dimtypes, SIMPLIFY=FALSE)
   ## open query
   qryptr <- libtiledb_query(ctx@ptr, arrptr, "READ")
-  if (length(layout) > 0) libtiledb_query_set_layout(qryptr, layout)
+  qryptr <- libtiledb_query_set_layout(qryptr,
+                                       if (length(layout) > 0) layout
+                                       else { if (sparse) "UNORDERED" else "COL_MAJOR" })
 
   ## ranges seem to interfere with the byte/element adjustment below so set up toggle
   rangeunset <- TRUE

--- a/inst/tinytest/test_arrayschemaevolution.R
+++ b/inst/tinytest/test_arrayschemaevolution.R
@@ -6,7 +6,7 @@ if (Sys.info()[["sysname"]] == "Windows") exit_file("Skip on Windows")
 
 ctx <- tiledb_ctx(limitTileDBCores())
 
-if (tiledb_version(TRUE) < "2.4.0") exit_file("Needs TileDB 2.4.* or later")
+if (tiledb_version(TRUE) < "2.11.0") exit_file("Needs TileDB 2.11.* or later")
 
 df <- data.frame(key=letters[1:10],
                  val=1:10)

--- a/inst/tinytest/test_matrix.R
+++ b/inst/tinytest/test_matrix.R
@@ -8,11 +8,11 @@ if (isOldWindows) exit_file("skip this file on old Windows releases")
 ctx <- tiledb_ctx(limitTileDBCores())
 
 uri <- tempfile()
-M <- matrix(1:12, 3, 4, dimnames=list(LETTERS[1:3], letters[1:4]))
+M <- matrix(1:16, 4, 4, dimnames=list(LETTERS[1:4], letters[1:4]))
 fromMatrix(M, uri)
 
 M2 <- toMatrix(uri)
-expect_equivalent(M, M2)
+expect_equivalent(M, t(M2))             # because we now default to UNORDERED we need to transpose
 
 
 uri <- tempfile()
@@ -21,7 +21,6 @@ fromMatrix(M, uri)
 
 M2 <- toMatrix(uri)
 expect_equivalent(M, M2)
-
 
 
 uri <- tempfile()

--- a/inst/tinytest/test_tiledbarray.R
+++ b/inst/tinytest/test_tiledbarray.R
@@ -599,7 +599,7 @@ if (requireNamespace("bit64", quietly=TRUE)) {
   ## or with indices
   #A[rep(1:4,each=4), rep(1:4,4)] <- data
 
-  A <- tiledb_array(uri = tmp, as.data.frame=TRUE)
+  A <- tiledb_array(uri = tmp, as.data.frame=TRUE, query_layout="ROW_MAJOR")
   newdata <- A[1:2, 2:3]
   expect_equal(newdata[,"a"], c(2L, 3L, 6L, 7L))
   expect_equal(newdata[,"rows"], c(1L, 1L, 2L, 2L))
@@ -630,7 +630,7 @@ if (requireNamespace("bit64", quietly=TRUE)) {
   ## or with indices
   #A[rep(1:4,each=4), rep(1:4,4)] <- data
 
-  A <- tiledb_array(uri = tmp, as.data.frame=TRUE)
+  A <- tiledb_array(uri = tmp, as.data.frame=TRUE, query_layout="ROW_MAJOR")
   newdata <- A[1:2, 2:3]
   expect_equal(newdata[,"a"], c(2L, 3L, 6L, 7L))
   expect_equal(newdata[,"rows"], c(1L, 1L, 2L, 2L))
@@ -661,7 +661,7 @@ if (requireNamespace("bit64", quietly=TRUE)) {
   ## or with indices
   #A[rep(1:4,each=4), rep(1:4,4)] <- data
 
-  A <- tiledb_array(uri = tmp, as.data.frame=TRUE)
+  A <- tiledb_array(uri = tmp, as.data.frame=TRUE, query_layout="ROW_MAJOR")
   newdata <- A[1:2, 2:3]
   expect_equal(newdata[,"a"], c(2L, 3L, 6L, 7L))
   expect_equal(newdata[,"rows"], c(1L, 1L, 2L, 2L))
@@ -692,7 +692,7 @@ if (requireNamespace("bit64", quietly=TRUE)) {
   ## or with indices
   #A[rep(1:4,each=4), rep(1:4,4)] <- data
 
-  A <- tiledb_array(uri = tmp, as.data.frame=TRUE)
+  A <- tiledb_array(uri = tmp, as.data.frame=TRUE, query_layout="ROW_MAJOR")
   newdata <- A[1:2, 2:3]
   expect_equal(newdata[,"a"], c(2L, 3L, 6L, 7L))
   expect_equal(newdata[,"rows"], c(1L, 1L, 2L, 2L))
@@ -723,7 +723,7 @@ if (requireNamespace("bit64", quietly=TRUE)) {
   ## or with indices
   #A[rep(1:4,each=4), rep(1:4,4)] <- data
 
-  A <- tiledb_array(uri = tmp, as.data.frame=TRUE)
+  A <- tiledb_array(uri = tmp, as.data.frame=TRUE, query_layout="ROW_MAJOR")
   newdata <- A[1:2, 2:3]
   expect_equal(newdata[,"a"], c(2L, 3L, 6L, 7L))
   expect_equal(newdata[,"rows"], c(1L, 1L, 2L, 2L))
@@ -754,7 +754,7 @@ if (requireNamespace("bit64", quietly=TRUE)) {
   ## or with indices
   #A[rep(1:4,each=4), rep(1:4,4)] <- data
 
-  A <- tiledb_array(uri = tmp, as.data.frame=TRUE)
+  A <- tiledb_array(uri = tmp, as.data.frame=TRUE, query_layout="ROW_MAJOR")
   newdata <- A[1:2, 2:3]
   expect_equal(newdata[,"a"], c(2L, 3L, 6L, 7L))
   expect_equal(newdata[,"rows"], c(1L, 1L, 2L, 2L))
@@ -785,7 +785,7 @@ if (requireNamespace("bit64", quietly=TRUE)) {
   ## or with indices
   #A[as.integer64(rep(1:4,each=4)), as.integer64(rep(1:4,4))] <- data
 
-  A <- tiledb_array(uri = tmp, as.data.frame=TRUE)
+  A <- tiledb_array(uri = tmp, as.data.frame=TRUE, query_layout="ROW_MAJOR")
   newdata <- A[as.integer64(1:2), as.integer64(2:3)]
   expect_equal(newdata[,"a"], c(2L, 3L, 6L, 7L))
   expect_equal(newdata[,"rows"], as.integer64(c(1L, 1L, 2L, 2L)))
@@ -817,7 +817,7 @@ if (requireNamespace("bit64", quietly=TRUE)) {
   ## or with indices
   #A[as.integer64(rep(1:4,each=4)), as.integer64(rep(1:4,4))] <- data
 
-  A <- tiledb_array(uri = tmp, as.data.frame=TRUE)
+  A <- tiledb_array(uri = tmp, as.data.frame=TRUE, query_layout="ROW_MAJOR")
   newdata <- A[as.integer64(1:2), as.integer64(2:3)]
   expect_equal(newdata[,"a"], c(2L, 3L, 6L, 7L))
   expect_equal(newdata[,"rows"], c(1L, 1L, 2L, 2L))
@@ -868,7 +868,7 @@ if (requireNamespace("bit64", quietly=TRUE)) {
   ## or with indices
   #A[rep(1:4,each=4), rep(1:4,4)] <- data
 
-  A <- tiledb_array(uri = tmp, as.data.frame=TRUE)
+  A <- tiledb_array(uri = tmp, as.data.frame=TRUE, query_layout="ROW_MAJOR")
   newdata <- A[1:2, 2:3]
   expect_equal(newdata[,"rows"], c(1L, 1L, 2L, 2L))
   expect_equal(newdata[,"cols"], c(2L, 3L, 2L, 3L))
@@ -924,7 +924,7 @@ if (requireNamespace("bit64", quietly=TRUE)) {
   ## or with indices
   A[rep(1:4,each=4), rep(1:4,4)] <- data
 
-  A <- tiledb_array(uri = tmp, as.data.frame=TRUE)
+  A <- tiledb_array(uri = tmp, as.data.frame=TRUE, query_layout="ROW_MAJOR")
   newdata <- A[1:2, 2:3]
   expect_equal(newdata[,"rows"], c(1L, 1L, 2L, 2L))
   expect_equal(newdata[,"cols"], c(2L, 3L, 2L, 3L))
@@ -1351,7 +1351,7 @@ data <- array(1:64, dim = c(4,4,4))
 A <- tiledb_array(uri = uri)
 A[] <- data
 
-A <- tiledb_array(uri = uri, return_as="data.frame")
+A <- tiledb_array(uri = uri, return_as="data.frame", query_layout="ROW_MAJOR")
 res <- A[2,2,2]
 expect_equal(res[, "a", drop=TRUE], 22)
 res <- A[2,2:3,2]
@@ -1421,7 +1421,7 @@ if (v[["major"]] == 2L && v[["minor"]] %in% c(4L, 10L)) exit_file("Skip remainde
 
 ## check for incomplete status on unsuccessful query
 set_allocation_size_preference(256)     # too low for penguins to return something
-array <- tiledb_array(uri, as.data.frame=TRUE)
+array <- tiledb_array(uri, as.data.frame=TRUE, query_layout="ROW_MAJOR")
 expect_warning(res <- array[])          # warning emitted
 expect_equal(attr(res, "query_status"), "INCOMPLETE") # and query status reported
 


### PR DESCRIPTION
This PR changes the default query layout for read access via `tiledb_array()` and the `[` accessor to 'UNORDERED' for sparse matrices (and 'ROW_MAJOR' for dense).  The read setting now matches the `[<-` write access implementation.

Unordered generally performs better, motivating the change.  This is a change in behavior as seen by the handful of tests which needed updating.

As an illustration, here is a approximately seven-fold gain with a (local disk) array using the Deutsche Boerse (csv to sparse array) data set from a tutorial from last year:

```sh
$ ./exampleDBoerse.R        
                 test replications elapsed relative                                                      
1      a <- resNone[]           10  10.663    7.451                                                      
2 b <- resUnordered[]           10   1.431    1.000                                                      
$ 
```