### PR TITLE
Use TileDB 2.13.0

### DIFF
--- a/.github/workflows/valgrind.yaml
+++ b/.github/workflows/valgrind.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tag: [ release-2.11, release-2.12, dev ]
+        tag: [ release-2.12, release-2.13, dev ]
 #        tag: [ 2.9.5, 2.10.0, dev ]
 
     steps:

--- a/tools/tiledbVersion.txt
+++ b/tools/tiledbVersion.txt
@@ -1,2 +1,2 @@
-version: 2.12.2
-sha: a9d60c8
+version: 2.13.0-rc1
+sha: 390b6e2

--- a/tools/tiledbVersion.txt
+++ b/tools/tiledbVersion.txt
@@ -1,2 +1,2 @@
-version: 2.13.0-rc1
-sha: 390b6e2
+version: 2.13.0-rc2
+sha: 0b2d27a

--- a/tools/tiledbVersion.txt
+++ b/tools/tiledbVersion.txt
@@ -1,2 +1,2 @@
-version: 2.13-rc3
+version: 2.13.0
 sha: db00e70

--- a/tools/tiledbVersion.txt
+++ b/tools/tiledbVersion.txt
@@ -1,2 +1,2 @@
-version: 2.13.0-rc2
-sha: 0b2d27a
+version: 2.13-rc3
+sha: db00e70


### PR DESCRIPTION
This PR updates the package preference to TileDB 2.13.0.

No code changes (but a roll of branches tested in nightly valgrind to 2.12, 2.13, and dev).