### PR TITLE
Update valgrind job

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tiledb
 Type: Package
-Version: 0.17.0
+Version: 0.17.0.1
 Title: Universal Storage Engine for Sparse and Dense Multidimensional Arrays
 Authors@R: c(person("TileDB, Inc.", role = c("aut", "cph")),
  person("Dirk", "Eddelbuettel", email = "dirk@tiledb.com", role = "cre"))
@@ -31,4 +31,3 @@ VignetteBuilder: simplermarkdown
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.2.2
 Encoding: UTF-8
-Additional_repositories: https://ghrr.github.io/drat

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,14 @@
+# Ongoing Development
+
+## Improvements
+
+## Bug Fixes
+
+## Build and Test Systems
+
+* The nighhly valgrind job setup was updated to include two new dependencies (#493)
+
+
 # tiledb 0.17.0
 
 * This release of the R package builds against [TileDB 2.13.0](https://github.com/TileDB-Inc/TileDB/releases/tag/2.13.0), and has also been tested against earlier releases as well as the development version (#492).

--- a/tools/ci/valgrind/installDependencies.sh
+++ b/tools/ci/valgrind/installDependencies.sh
@@ -81,7 +81,9 @@ install.r \
     nycflights13 \
     palmerpenguins \
     Rcpp \
+    RcppSpdlog \
     simplermarkdown \
+    spdl \
     tibble \
     tinytest \
     zoo


### PR DESCRIPTION
The setup script for the nightly valgrind job still explicitly enumerates R package dependencies (as opposed to parsing the DESCRIPTION file information) and needs an update for the dependencies `spdl` and `RcppSpdlog` added in 0.17.0.

At the same time we can also remove `Additonal_repositories` which was left in DESCRIPTION but is no longer needed.