### PR TITLE
Update windows ci

### DIFF
--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -23,9 +23,9 @@ jobs:
           r-version: ${{ matrix.r }}
       - name: Install dependencies
         run: |
+          setRepositories(ind = 1:2)
           install.packages(c("remotes", "rcmdcheck"))
-          remotes::install_deps(dependencies = NA)
-          install.packages(c("palmerpenguins", "nycflights13", "tibble", "data.table"))
+          remotes::install_deps(dependencies = TRUE)
         shell: Rscript {0}
         env:
           R_REMOTES_NO_ERRORS_FROM_WARNINGS: true

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -23,7 +23,6 @@ jobs:
           r-version: ${{ matrix.r }}
       - name: Install dependencies
         run: |
-          setRepositories(ind = 1:2)
           install.packages(c("remotes", "rcmdcheck"))
           remotes::install_deps(dependencies = TRUE)
         shell: Rscript {0}
@@ -32,6 +31,5 @@ jobs:
       - name: Check
         env:
           _R_CHECK_CRAN_INCOMING_: false
-          _R_CHECK_FORCE_SUGGESTS_: false
         run: rcmdcheck::rcmdcheck(args = c("--no-manual", "--no-vignettes", "--as-cran"), build_args = c("--no-build-vignettes"), error_on = "error", check_dir = "check")
         shell: Rscript {0}


### PR DESCRIPTION
This PR updates the continuous integration setup for Windows.  We still run three variants while R-oldrel is R 4.1.*, the last release series with 32 bit as well as non-UCRT 64 bit, which will change by April.

No new code.