### PR TITLE
Minor cleanup on group show method and README

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tiledb
 Type: Package
-Version: 0.17.0.2
+Version: 0.17.0.3
 Title: Universal Storage Engine for Sparse and Dense Multidimensional Arrays
 Authors@R: c(person("TileDB, Inc.", role = c("aut", "cph")),
  person("Dirk", "Eddelbuettel", email = "dirk@tiledb.com", role = "cre"))

--- a/R/Group.R
+++ b/R/Group.R
@@ -319,10 +319,12 @@ tiledb_group_member <- function(grp, idx) {
 ##' Dump the TileDB Group to String
 ##'
 ##' @param grp A TileDB Group object as for example returned by \code{tiledb_group()}
-##' @param recursive A logical value indicating whether a recursive dump is desired
+##' @param recursive A logical value indicating whether a recursive dump is desired, defaults
+##' to \sQuote{FALSE}. Note that recursive listings on remote object may be an expensive or
+##' slow operation.
 ##' @return A character string
 ##' @export
-tiledb_group_member_dump <- function(grp, recursive = TRUE) {
+tiledb_group_member_dump <- function(grp, recursive = FALSE) {
     stopifnot("The 'grp' argument must be a tiledb_group object" = is(grp, "tiledb_group"),
               "This function needs TileDB 2.8.*" = .tiledb28())
     libtiledb_group_dump(grp@ptr, recursive)
@@ -346,5 +348,5 @@ tiledb_group_is_relative <- function(grp, name) {
 #' @param object `tiledb_group` object
 #' @export
 setMethod("show", signature(object = "tiledb_group"), function(object) {
-    cat(libtiledb_group_dump(object@ptr, TRUE))
+    cat(libtiledb_group_dump(object@ptr, FALSE))
 })

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -1075,3 +1075,4 @@ querybuf_from_shmem <- function(path, dtype) {
 vlcbuf_from_shmem <- function(datapath, dtype) {
     .Call(`_tiledb_vlcbuf_from_shmem`, datapath, dtype)
 }
+

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
-[![Build Status](https://img.shields.io/azure-devops/build/tiledb-inc/836549eb-f74a-4986-a18f-7fbba6bbb5f0/24/master?label=Azure%20Pipelines&logo=azure-pipelines&style=flat-square)](https://dev.azure.com/TileDB-Inc/CI/_build/latest?definitionId=24&branchName=master)
-[![R-CMD-check](https://github.com/TileDB-Inc/TileDB-R/workflows/R-CMD-check/badge.svg)](https://github.com/TileDB-Inc/TileDB-R/actions/workflows/R-CMD-check.yaml)
+[![ci](https://github.com/TileDB-Inc/TileDB-R/actions/workflows/ci.yaml/badge.svg)](https://github.com/TileDB-Inc/TileDB-R/actions/workflows/ci.yaml)
+[![windows](https://github.com/TileDB-Inc/TileDB-R/actions/workflows/windows.yaml/badge.svg)](https://github.com/TileDB-Inc/TileDB-R/actions/workflows/windows.yaml)
+[![valgrind](https://github.com/TileDB-Inc/TileDB-R/actions/workflows/valgrind.yaml/badge.svg)](https://github.com/TileDB-Inc/TileDB-R/actions/workflows/valgrind.yaml)
 [![Downloads](https://cranlogs.r-pkg.org/badges/grand-total/tiledb?color=brightgreen)](https://cran.r-project.org/package=tiledb)
 [![CRAN](https://www.r-pkg.org/badges/version/tiledb)](https://cran.r-project.org/package=tiledb)
 
@@ -36,9 +37,8 @@ The most recent released version can be installed from
     > if (!requireNamespace("remotes",quietly=TRUE)) install.packages("remotes")
     > remotes::install_github("TileDB-Inc/TileDB-R")
     ...
-    > tiledb::tiledb_version()
-    major minor patch
-        2    10     0
+    > library(tiledb)
+    TileDB R 0.17.0 with TileDB Embedded 2.13.0. See https://tiledb.com for more information.
     > help(package=tiledb)
 
 If the TileDB library is installed in a custom location, you need to pass the explicit path:

--- a/man/tiledb_group_member_dump.Rd
+++ b/man/tiledb_group_member_dump.Rd
@@ -4,12 +4,14 @@
 \alias{tiledb_group_member_dump}
 \title{Dump the TileDB Group to String}
 \usage{
-tiledb_group_member_dump(grp, recursive = TRUE)
+tiledb_group_member_dump(grp, recursive = FALSE)
 }
 \arguments{
 \item{grp}{A TileDB Group object as for example returned by \code{tiledb_group()}}
 
-\item{recursive}{A logical value indicating whether a recursive dump is desired}
+\item{recursive}{A logical value indicating whether a recursive dump is desired, defaults
+to \sQuote{FALSE}. Note that recursive listings on remote object may be an expensive or
+slow operation.}
 }
 \value{
 A character string


### PR DESCRIPTION
This PR ensures we use a less-costly-on-remote-or-large groups setting for the new `show()` value for recursion (thanks to a suggestion by @aaronwolen), and (belatedly) adjusts the README.md to changes in CI by showing all current badges from GitHub Actions.

No new code.