### PR TITLE
When (u)int64 dimensions are created optionally upcast to integer64 type

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tiledb
 Type: Package
-Version: 0.17.0.3
+Version: 0.17.0.4
 Title: Universal Storage Engine for Sparse and Dense Multidimensional Arrays
 Authors@R: c(person("TileDB, Inc.", role = c("aut", "cph")),
  person("Dirk", "Eddelbuettel", email = "dirk@tiledb.com", role = "cre"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,7 +6,9 @@
 
 * Deprecated Core API functions for Array access and range setting are longer used (#496)
 
-* TileDB Group objects now have a default `show()` method (#498)
+* TileDB Group objects now have a default `show()` method (#498, #499)
+
+* Domain and tile sizes for int64 dimension objects are now internally converted (#500)
 
 ## Bug Fixes
 
@@ -27,7 +29,7 @@
 ## Removals
 
 * Functions `libtiledb_query_set_coordinates()` and `libtiledb_coords()`
-  which have been deprecated since June 2000 have been remove. (#497)
+  which have been deprecated since June 2000 have been removed. (#497)
 
 
 # tiledb 0.17.0

--- a/inst/tinytest/test_tiledbarray.R
+++ b/inst/tinytest/test_tiledbarray.R
@@ -413,9 +413,9 @@ if (requireNamespace("bit64", quietly=TRUE)) {
 
   unlink(tmp, recursive = TRUE)
 
-  ## test for error on non integer64 arguments
-  expect_error(tiledb_dim("rows", c(1L,4L), as.integer64(4), "INT64"))
-  expect_error(tiledb_dim("rows", as.integer64(c(1,4)), 4L, "INT64"))
+  ## test for no error on non integer64 arguments
+  expect_silent(tiledb_dim("rows", c(1L,4L), as.integer64(4), "INT64"))
+  expect_silent(tiledb_dim("rows", as.integer64(c(1,4)), 4L, "INT64"))
 }
 
 #test_that("test uint64 dimension for sparse arrays", {
@@ -447,9 +447,9 @@ if (requireNamespace("bit64", quietly=TRUE)) {
 
   unlink(tmp, recursive = TRUE)
 
-  ## test for error on non integer64 arguments
-  expect_error(tiledb_dim("rows", c(1L,4L), as.integer64(4), "UINT64"))
-  expect_error(tiledb_dim("rows", as.integer64(c(1,4)), 4L, "UINT64"))
+  ## test no error on non integer64 arguments
+  expect_silent(tiledb_dim("rows", c(1L,4L), as.integer64(4), "UINT64"))
+  expect_silent(tiledb_dim("rows", as.integer64(c(1,4)), 4L, "UINT64"))
 }
 
 #test_that("test uint32 dimension for sparse arrays", {


### PR DESCRIPTION
This PR offers an ease-of-use adjustment by converting domain ranges or tile size to `int64_t` if the domain is of type UINT64 or INT64, thus freeing the user having to use `bit64::as.integer64()` on each of the values.

Two pairs of tests that previously failed (when the requirement 'must be int64' was not met) were converted to silent as this is no longer an error due to the added internal conversion.