### PR TITLE
Use TileDB 2.13.1

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,8 @@
 
 * Domain and tile sizes for int64 dimension objects are now internally converted (#500)
 
+* Use of TileDB Embedded was upgraded to release 2.13.1 (#501)
+
 ## Bug Fixes
 
 * Fragment info domain getters now work with ASCII domains (#495)

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -6,6 +6,7 @@ PKG_LIBS = \
 	-L$(RWINLIB)/lib$(subst gcc,,$(COMPILED_BY))$(R_ARCH) \
 	-L$(RWINLIB)/lib$(R_ARCH)$(CRT) \
 	-ltiledbstatic -lbz2 -lzstd -llz4 -lz -lspdlog \
+	-lwebp -lwebpdecoder -lwebpdemux -lwebpmux \
         -llibmagic -lpcre2-posix -lpcre2-8 \
 	-laws-cpp-sdk-identity-management -laws-cpp-sdk-cognito-identity -laws-cpp-sdk-sts -laws-cpp-sdk-s3 -laws-cpp-sdk-core -laws-c-event-stream -laws-checksums -laws-c-common \
 	-lShlwapi -lBcrypt -lRpcrt4 -lWininet -lWinhttp -lws2_32 -lVersion -lUserenv

--- a/tools/tiledbVersion.txt
+++ b/tools/tiledbVersion.txt
@@ -1,2 +1,2 @@
-version: 2.13.0
-sha: db00e70
+version: 2.13.1
+sha: 21c75f9


### PR DESCRIPTION
This PR updates the package preference to TileDB 2.13.1.

No code changes, but the Windows Makefile was updated to include the newly-added Webp libraries in the link step.