### PR TITLE
Update scale filter option setter

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -192,8 +192,8 @@ libtiledb_filter_get_option <- function(filter, filter_option_str) {
     .Call(`_tiledb_libtiledb_filter_get_option`, filter, filter_option_str)
 }
 
-libtiledb_filter_set_option <- function(filter, filter_option_str, value) {
-    .Call(`_tiledb_libtiledb_filter_set_option`, filter, filter_option_str, value)
+libtiledb_filter_set_option <- function(filter, filter_option_str, valuesxp) {
+    .Call(`_tiledb_libtiledb_filter_set_option`, filter, filter_option_str, valuesxp)
 }
 
 libtiledb_filter_list <- function(ctx, filters) {

--- a/inst/tinytest/test_filter.R
+++ b/inst/tinytest/test_filter.R
@@ -176,7 +176,9 @@ if (tiledb_version(TRUE) >= "2.11.0") {
                        BD=dat$bill_depth_mm,
                        FL=as.double(dat$flipper_length_mm),
                        BM=as.double(dat$body_mass_g))
-    pars <- expand.grid(factor=c(1,0.5,2), offset=0, bytewidth=c(1,0))
+    pars <- expand.grid(factor=c(1.0,0.5,2.0),
+                        offset=0.0,
+                        bytewidth=bit64::as.integer64(c(1,2)))
     for (i in seq_len(nrow(pars))) {
         flt <- tiledb_filter("SCALE_FLOAT")
         tiledb_filter_set_option(flt, "SCALE_FLOAT_FACTOR", pars[i, "factor"])

--- a/inst/tinytest/test_filter.R
+++ b/inst/tinytest/test_filter.R
@@ -178,7 +178,7 @@ if (tiledb_version(TRUE) >= "2.11.0") {
                        BM=as.double(dat$body_mass_g))
     pars <- expand.grid(factor=c(1.0,0.5,2.0),
                         offset=0.0,
-                        bytewidth=bit64::as.integer64(c(1,2)))
+                        bytewidth=bit64::as.integer64(c(1,8)))
     for (i in seq_len(nrow(pars))) {
         flt <- tiledb_filter("SCALE_FLOAT")
         tiledb_filter_set_option(flt, "SCALE_FLOAT_FACTOR", pars[i, "factor"])

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -534,15 +534,15 @@ BEGIN_RCPP
 END_RCPP
 }
 // libtiledb_filter_set_option
-XPtr<tiledb::Filter> libtiledb_filter_set_option(XPtr<tiledb::Filter> filter, std::string filter_option_str, int value);
-RcppExport SEXP _tiledb_libtiledb_filter_set_option(SEXP filterSEXP, SEXP filter_option_strSEXP, SEXP valueSEXP) {
+XPtr<tiledb::Filter> libtiledb_filter_set_option(XPtr<tiledb::Filter> filter, std::string filter_option_str, SEXP valuesxp);
+RcppExport SEXP _tiledb_libtiledb_filter_set_option(SEXP filterSEXP, SEXP filter_option_strSEXP, SEXP valuesxpSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< XPtr<tiledb::Filter> >::type filter(filterSEXP);
     Rcpp::traits::input_parameter< std::string >::type filter_option_str(filter_option_strSEXP);
-    Rcpp::traits::input_parameter< int >::type value(valueSEXP);
-    rcpp_result_gen = Rcpp::wrap(libtiledb_filter_set_option(filter, filter_option_str, value));
+    Rcpp::traits::input_parameter< SEXP >::type valuesxp(valuesxpSEXP);
+    rcpp_result_gen = Rcpp::wrap(libtiledb_filter_set_option(filter, filter_option_str, valuesxp));
     return rcpp_result_gen;
 END_RCPP
 }

--- a/src/libtiledb.cpp
+++ b/src/libtiledb.cpp
@@ -1310,14 +1310,14 @@ XPtr<tiledb::Filter> libtiledb_filter_set_option(XPtr<tiledb::Filter> filter, st
     // For scale_float filters we need either a double, or an
     if (filter_option == TILEDB_SCALE_FLOAT_FACTOR || filter_option == TILEDB_SCALE_FLOAT_OFFSET) {
         double value = Rcpp::as<double>(valuesxp);
-        spdl::warn("[libtiledb_filter_set_option] setting {} to {}", filter_option_str, value);
+        spdl::debug("[libtiledb_filter_set_option] setting {} to {}", filter_option_str, value);
         filter->set_option(filter_option, &value);
         return filter;
     } else if (filter_option == TILEDB_SCALE_FLOAT_BYTEWIDTH) {
         double dblval = Rcpp::as<double>(valuesxp);
         int64_t int64val = makeScalarInteger64(dblval);
         uint64_t value = static_cast<uint64_t>(int64val);
-        spdl::warn("[libtiledb_filter_set_option] setting {} to {}", filter_option_str, value);
+        spdl::debug("[libtiledb_filter_set_option] setting {} to {}", filter_option_str, value);
         filter->set_option(filter_option, &value);
         return filter;
     }

--- a/src/libtiledb.cpp
+++ b/src/libtiledb.cpp
@@ -1303,11 +1303,29 @@ R_xlen_t libtiledb_filter_get_option(XPtr<tiledb::Filter> filter, std::string fi
 }
 
 //[[Rcpp::export]]
-XPtr<tiledb::Filter> libtiledb_filter_set_option(XPtr<tiledb::Filter> filter, std::string filter_option_str, int value) {
-  check_xptr_tag<tiledb::Filter>(filter);
-  tiledb_filter_option_t filter_option = _string_to_tiledb_filter_option(filter_option_str);
-  filter->set_option(filter_option, &value);
-  return filter;
+XPtr<tiledb::Filter> libtiledb_filter_set_option(XPtr<tiledb::Filter> filter, std::string filter_option_str, SEXP valuesxp) {
+    check_xptr_tag<tiledb::Filter>(filter);
+    tiledb_filter_option_t filter_option = _string_to_tiledb_filter_option(filter_option_str);
+#if TILEDB_VERSION >= TileDB_Version(2,11,0)
+    // For scale_float filters we need either a double, or an
+    if (filter_option == TILEDB_SCALE_FLOAT_FACTOR || filter_option == TILEDB_SCALE_FLOAT_OFFSET) {
+        double value = Rcpp::as<double>(valuesxp);
+        spdl::warn("[libtiledb_filter_set_option] setting {} to {}", filter_option_str, value);
+        filter->set_option(filter_option, &value);
+        return filter;
+    } else if (filter_option == TILEDB_SCALE_FLOAT_BYTEWIDTH) {
+        double dblval = Rcpp::as<double>(valuesxp);
+        int64_t int64val = makeScalarInteger64(dblval);
+        uint64_t value = static_cast<uint64_t>(int64val);
+        spdl::warn("[libtiledb_filter_set_option] setting {} to {}", filter_option_str, value);
+        filter->set_option(filter_option, &value);
+        return filter;
+    }
+#endif
+    // all others set an int value
+    int32_t value = Rcpp::as<int32_t>(valuesxp);
+    filter->set_option(filter_option, &value);
+    return filter;
 }
 
 


### PR DESCRIPTION
This PR corrects the filter option setter for the float scale filter which had previously failed to correctly use the `double` and `uint64_t` types for its three options.  This was revealed when testing with the latest merges to `dev` in TileDB Core.

No other code changes.