### PR TITLE
Update valgrind matrix to 2.13, 2.14 and dev

### DIFF
--- a/.github/workflows/valgrind.yaml
+++ b/.github/workflows/valgrind.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tag: [ release-2.12, release-2.13, dev ]
+        tag: [ release-2.13, release-2.14, dev ]
 #        tag: [ 2.9.5, 2.10.0, dev ]
 
     steps:

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,23 @@
+# tiledb 0.17.1.1 (under development)
+
+* This release of the R package builds against [TileDB 2.13.1](https://github.com/TileDB-Inc/TileDB/releases/tag/2.13.1), and has also been tested against earlier releases as well as the development version (#502).
+
+## Improvements
+
+## Bug Fixes
+
+## Build and Test Systems
+
+* The nightly valgrind job matrix was updated to releases 2.13 and 2.14 as well as the branch (#504)
+
+## Deprecations
+
+## Removals
+
+
 # tiledb 0.17.1
 
-* This release of the R package builds against [TileDB 2.13.1](https://github.com/TileDB-Inc/TileDB/releases/tag/2.13.0), and has also been tested against earlier releases as well as the development version (#502).
+* This release of the R package builds against [TileDB 2.13.1](https://github.com/TileDB-Inc/TileDB/releases/tag/2.13.1), and has also been tested against earlier releases as well as the development version (#502).
 
 ## Improvements
 


### PR DESCRIPTION
This PR updates the nightly valgrind matrix to branches 2.13, 2.14 and the dev branch.

No new code.