### PR TITLE
Show (brief) git log after cloning release branch in valgrind run

### DIFF
--- a/tools/ci/valgrind/buildTileDB.sh
+++ b/tools/ci/valgrind/buildTileDB.sh
@@ -19,6 +19,7 @@ isrelease=$?
 echo "::group::Setup sources"
 if [ ${isrelease} -eq 0 ]; then
     git clone --single-branch --branch ${version} https://github.com/TileDB-Inc/TileDB.git TileDB-${version}
+    git log --graph --pretty=format:'%h - %d %s (%cr) <%an>' --abbrev-commit | head
 elif [ ${version} = "dev" ]; then
     wget https://github.com/TileDB-Inc/TileDB/archive/refs/heads/${version}.zip
     unzip ${version}.zip


### PR DESCRIPTION
This PR expands the reporting in the nightly valgrind run by also displaying the recent git log and sha1 after cloning.

SC-24719