### PR TITLE
Ensure data is returned as data.frame

### DIFF
--- a/inst/tinytest/test_querycondition.R
+++ b/inst/tinytest/test_querycondition.R
@@ -374,9 +374,9 @@ chk <- arr[] 		# everything
 expect_equal(D$key, chk$key)
 
 ## exclude two
-chk <- tiledb_array(uri, query_condition=parse_query_condition(key != "ñ" && key != "Ø"))[]
+chk <- tiledb_array(uri, query_condition=parse_query_condition(key != "ñ" && key != "Ø"), return_as="data.frame")[]
 expect_equal(nrow(D), nrow(chk) + 2)
 
 ## include two
-chk <- tiledb_array(uri, query_condition=parse_query_condition(key == "ñ" || key == "Ø"))[]
+chk <- tiledb_array(uri, query_condition=parse_query_condition(key == "ñ" || key == "Ø"), return_as="data.frame")[]
 expect_equal(nrow(chk), 2)


### PR DESCRIPTION
The PR in #507 overlooked that in order to check the (in)equality by number of rows returned we need to actually ensure we return a data.frame (or data.table) -- which my machine does by a local config variable.  In CI we do not have this, data comes back as a _list_ of columns and `nrow` returns `NULL`.  This corrects this,