### PR TITLE
Silence clang++ by using member variables

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,8 @@
 
 * Attributes can now be created, written and read from in (explicit) UTF8 types (and CHAR and ASCII already behaved correctly with respect to utf8 data) (#510)
 
+* Compilation under `clang++` no longer complains about two unused member variables (#512)
+
 ## Bug Fixes
 
 ## Build and Test Systems

--- a/src/batched.cpp
+++ b/src/batched.cpp
@@ -5,9 +5,10 @@
 class QueryWrapper {
 public:
     QueryWrapper(SEXP qp): qryptr(qp), init(true) {};
+    inline bool is_intialized(void) { return qryptr != R_NilValue && init; }
 private:
-    SEXP qryptr;
-    bool init;
+    SEXP qryptr = R_NilValue;
+    bool init = false;
 };
 
 // [[Rcpp::export]]


### PR DESCRIPTION
When testing different C++ language standard settings under different compilers, it was seen that `clang++` decides to complain about two unused member variable in a helper data structure so this PR adds a simple test accessor in order to give everybody peace and quiet. Even when using `clang++`. 

No other new code.