### PR TITLE
Support %in% member condition on ASCII columns

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,8 @@
 
 * Compilation under `clang++` no longer complains about two unused member variables (#512)
 
+* Query conditions for character columns can now be expressed using the `%in%` operator and a vector of values (#513)
+
 ## Bug Fixes
 
 ## Build and Test Systems

--- a/R/QueryCondition.R
+++ b/R/QueryCondition.R
@@ -126,11 +126,12 @@ tiledb_query_condition_combine <- function(lhs, rhs, op) {
 parse_query_condition <- function(expr, ta=NULL, debug=FALSE, strict=TRUE, use_int64=FALSE) {
     .hasArray <- !is.null(ta) && is(ta, "tiledb_array")
     if (.hasArray && length(ta@sil) == 0) ta@sil <- .fill_schema_info_list(ta@uri)
-    .isComparisonOperator <- function(x) as.character(x) %in% c(">", ">=", "<", "<=", "==", "!=")
+    .isComparisonOperator <- function(x) tolower(as.character(x)) %in% c(">", ">=", "<", "<=", "==", "!=", "%in%")
     .isBooleanOperator <- function(x) as.character(x) %in% c("&&", "||", "!")
     .isAscii <- function(x) grepl("^[[:alnum:]_]+$", x)
     .isInteger <- function(x) grepl("^[[:digit:]]+$", as.character(x))
     .isDouble <- function(x) grepl("^[[:digit:]\\.]+$", as.character(x)) && length(grepRaw(".", as.character(x), fixed = TRUE, all = TRUE)) == 1
+    .isInOperator <- function(x) tolower(as.character(x)) == "%in%"
     .errorFunction <- if (strict) stop else warning
     .getType <- function(x, use_int64=FALSE) {
         if (isTRUE(.isInteger(x))) { if (use_int64) "INT64" else "INT32" }
@@ -148,6 +149,11 @@ parse_query_condition <- function(expr, ta=NULL, debug=FALSE, strict=TRUE, use_i
                                               `&&` = "AND",
                                               `||` = "OR",
                                               `!`  = "NOT")
+    .neweqcond <- function(val, attr) {
+        if (debug) cat("   ", attr, "EQ", val, "\n")
+        tiledb_query_condition_init(attr = attr, value = val, dtype = "ASCII", op = "EQ")
+    }
+    .neworcond <- function(op1, op2) tiledb_query_condition_combine(op1, op2, "OR")
     .makeExpr <- function(x, debug=FALSE) {
         if (is.symbol(x)) {
             stop("Unexpected symbol in expression: ", format(x))
@@ -160,7 +166,14 @@ parse_query_condition <- function(expr, ta=NULL, debug=FALSE, strict=TRUE, use_i
             tiledb_query_condition_combine(.makeExpr(x[[2]]),
                                            .makeExpr(x[[3]]),
                                            .mapBoolToCharacter(as.character(x[1])))
-
+        } else if (.isInOperator(x[1])) {
+            if (debug) cat("in: [", as.character(x[2]), "]",
+                           " ", as.character(x[1]),
+                           " [", as.character(x[3]), "]\n", sep="")
+            attr <- as.character(x[2])
+            vals <- eval(parse(text=as.character(x[3])))
+            eqconds <- Map(.neweqcond, vals, attr)
+            orcond <- Reduce(.neworcond, eqconds)
         } else if (.isComparisonOperator(x[1])) {
             op <- as.character(x[1])
             attr <- as.character(x[2])
@@ -169,7 +182,7 @@ parse_query_condition <- function(expr, ta=NULL, debug=FALSE, strict=TRUE, use_i
             if (.hasArray) {
                 ind <- match(attr, ta@sil$names)
                 if (!is.finite(ind)) {
-                    .errorFunction("No attibute '", attr, "' present.", call. = FALSE)
+                    .errorFunction("No attribute '", attr, "' present.", call. = FALSE)
                     return(NULL)
                 }
                 if (ta@sil$status[ind] != 2) {

--- a/inst/tinytest/test_querycondition.R
+++ b/inst/tinytest/test_querycondition.R
@@ -172,6 +172,7 @@ unlink(uri, recursive=TRUE)
 ## parse query condition support
 uri <- tempfile()
 fromDataFrame(penguins, uri, sparse=TRUE)
+arr <- tiledb_array(uri)
 qc <- parse_query_condition(year == 2009)
 arrwithqc <- tiledb_array(uri, as.data.frame=TRUE, query_condition=qc)
 res <- arrwithqc[]
@@ -184,6 +185,21 @@ res <- arrwithqc2[]
 expect_equal(NROW(res), 34L)
 expect_true(all(res$bill_length_mm < 40))
 expect_true(all(res$year == 2009))
+
+qc3 <- parse_query_condition(island %in% c("Dream", "Biscoe"), arr)
+arrwithqc3 <- tiledb_array(uri, as.data.frame=TRUE, strings_as_factors=TRUE, query_condition=qc3)
+res <- arrwithqc3[]
+expect_equal(NROW(res), 168+124)
+expect_true(all(res$island != "Torgersen"))
+expect_true(all(res$island == "Dream" | res$island == "Biscoe"))
+
+qc4 <- parse_query_condition(island %in% c("Dream", "Biscoe") && body_mass_g > 3500, arr)
+arrwithqc4 <- tiledb_array(uri, as.data.frame=TRUE, strings_as_factors=TRUE, query_condition=qc4)
+res <- arrwithqc4[]
+expect_equal(NROW(res), 153+80)
+expect_true(all(res$island != "Torgersen"))
+expect_true(all(res$island == "Dream" | res$island == "Biscoe"))
+expect_true(all(res$body_mass_g > 3500))
 
 unlink(uri, recursive=TRUE)
 


### PR DESCRIPTION
The second attempt at making `foo %in% c("ABC", "DEF", "GHI")` operational takes a different tack and picks up the `%in%` operator and then creates a series of ORed equality constraints.  This is a fairly clean generalisation and extension of the previous code for parsing query conditions.

New tests have been added to show it is working both in isolation and in conjunction with a another constraint.