### PR TITLE
Correct 'raw' stats export to json string interface

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -860,8 +860,8 @@ libtiledb_stats_dump <- function(path = "") {
     invisible(.Call(`_tiledb_libtiledb_stats_dump`, path))
 }
 
-libtiledb_stats_raw_dump <- function(path = "") {
-    invisible(.Call(`_tiledb_libtiledb_stats_raw_dump`, path))
+libtiledb_stats_raw_dump <- function() {
+    .Call(`_tiledb_libtiledb_stats_raw_dump`)
 }
 
 libtiledb_stats_raw_get <- function() {

--- a/R/Stats.R
+++ b/R/Stats.R
@@ -1,6 +1,6 @@
 #  MIT License
 #
-#  Copyright (c) 2017-2021 TileDB Inc.
+#  Copyright (c) 2017-2023 TileDB Inc.
 #
 #  Permission is hereby granted, free of charge, to any person obtaining a copy
 #  of this software and associated documentation files (the "Software"), to deal
@@ -44,7 +44,7 @@ tiledb_stats_reset <- function() {
   libtiledb_stats_reset()
 }
 
-#' Dumps internal TileDB statistics to file
+#' Dumps internal TileDB statistics to file or stdout
 #'
 #' @param path Character variable with path to stats file;
 #' if the empty string is passed then the result is displayed on stdout.
@@ -68,23 +68,20 @@ tiledb_stats_print <- function() {
   libtiledb_stats_dump("")
 }
 
-#' Dumps internal TileDB statistics as JSON to file
+#' Dumps internal TileDB statistics as JSON to a string
 #'
 #' This function requires TileDB Embedded 2.0.3 or later.
-#' @param path Character variable with path to stats file;
-#' if the empty string is passed then the result is displayed on stdout.
 #' @examples
 #' \dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
 #' if (tiledb_version(TRUE) >= "2.0.3") {
-#'   pth <- tempfile()
-#'   tiledb_stats_raw_dump(pth)
-#'   cat(readLines(pth)[1:10], sep = "\n")
+#'   txt <- tiledb_stats_raw_dump()
+#'   cat(txt, "\n")
 #' }
 #' @export
-tiledb_stats_raw_dump <- function(path) {
-  stopifnot(`Argument 'path' must be character` = is.character(path),
-            `Raw statistics are available with TileDB Embedded verion 2.0.3 or later` = tiledb_version(TRUE) >= "2.0.3")
-  libtiledb_stats_raw_dump(path)
+tiledb_stats_raw_dump <- function() {
+    stopifnot("Raw statistics are available with TileDB Embedded verion 2.0.3 or later" =
+                  tiledb_version(TRUE) >= "2.0.3")
+    libtiledb_stats_raw_dump()
 }
 
 #' Print internal TileDB statistics as JSON
@@ -93,17 +90,20 @@ tiledb_stats_raw_dump <- function(path) {
 #' It required TileDB Embedded 2.0.3 or later.
 #' @export
 tiledb_stats_raw_print <- function() {
-  stopifnot(`Raw statistics are available with TileDB Embedded verion 2.0.3 or later` = tiledb_version(TRUE) >= "2.0.3")
-  libtiledb_stats_raw_dump("")
+    stopifnot("Raw statistics are available with TileDB Embedded verion 2.0.3 or later"
+              = tiledb_version(TRUE) >= "2.0.3")
+    cat(libtiledb_stats_raw_dump(), "\n")
 }
 
 #' Gets internal TileDB statistics as JSON string
 #'
-#' This function is a convenience wrapper for \code{tiledb_stats_raw_dump}
+#' This function is a (now deprecated) convenience wrapper for \code{tiledb_stats_raw_dump}
 #' and returns the result as a JSON string.
 #' It required TileDB Embedded 2.0.3 or later.
 #' @export
 tiledb_stats_raw_get <- function() {
-  stopifnot(`Raw statistics are available with TileDB Embedded verion 2.0.3 or later` = tiledb_version(TRUE) >= "2.0.3")
-  libtiledb_stats_raw_get()
-}
+    stopifnot("Raw statistics are available with TileDB Embedded verion 2.0.3 or later"
+              = tiledb_version(TRUE) >= "2.0.3")
+    .Deprecated(msg="Use 'tiledb_stats_raw_dump' instead of 'tiledb_stats_raw_get'.")
+    libtiledb_stats_raw_get()
+ }

--- a/inst/tinytest/test_querycondition.R
+++ b/inst/tinytest/test_querycondition.R
@@ -186,20 +186,22 @@ expect_equal(NROW(res), 34L)
 expect_true(all(res$bill_length_mm < 40))
 expect_true(all(res$year == 2009))
 
-qc3 <- parse_query_condition(island %in% c("Dream", "Biscoe"), arr)
-arrwithqc3 <- tiledb_array(uri, as.data.frame=TRUE, strings_as_factors=TRUE, query_condition=qc3)
-res <- arrwithqc3[]
-expect_equal(NROW(res), 168+124)
-expect_true(all(res$island != "Torgersen"))
-expect_true(all(res$island == "Dream" | res$island == "Biscoe"))
+if (tiledb_version(TRUE) >= "2.10.0") { # the OR operator is more recent than query conditions overall
+    qc3 <- parse_query_condition(island %in% c("Dream", "Biscoe"), arr)
+    arrwithqc3 <- tiledb_array(uri, as.data.frame=TRUE, strings_as_factors=TRUE, query_condition=qc3)
+    res <- arrwithqc3[]
+    expect_equal(NROW(res), 168+124)
+    expect_true(all(res$island != "Torgersen"))
+    expect_true(all(res$island == "Dream" | res$island == "Biscoe"))
 
-qc4 <- parse_query_condition(island %in% c("Dream", "Biscoe") && body_mass_g > 3500, arr)
-arrwithqc4 <- tiledb_array(uri, as.data.frame=TRUE, strings_as_factors=TRUE, query_condition=qc4)
-res <- arrwithqc4[]
-expect_equal(NROW(res), 153+80)
-expect_true(all(res$island != "Torgersen"))
-expect_true(all(res$island == "Dream" | res$island == "Biscoe"))
-expect_true(all(res$body_mass_g > 3500))
+    qc4 <- parse_query_condition(island %in% c("Dream", "Biscoe") && body_mass_g > 3500, arr)
+    arrwithqc4 <- tiledb_array(uri, as.data.frame=TRUE, strings_as_factors=TRUE, query_condition=qc4)
+    res <- arrwithqc4[]
+    expect_equal(NROW(res), 153+80)
+    expect_true(all(res$island != "Torgersen"))
+    expect_true(all(res$island == "Dream" | res$island == "Biscoe"))
+    expect_true(all(res$body_mass_g > 3500))
+}
 
 unlink(uri, recursive=TRUE)
 

--- a/man/tiledb_dim.Rd
+++ b/man/tiledb_dim.Rd
@@ -16,17 +16,17 @@ tiledb_dim(
 \arguments{
 \item{name}{The dimension name / label string.  This argument is required.}
 
-\item{domain}{The dimension (inclusive) domain. The dimension’s domain is
-defined by a (lower bound, upper bound) vector, and is usually either of
-type \code{integer} or \code{double} (i.e. \code{numeric}). For type,
-\code{ASCII} \code{NULL} is expected.}
+\item{domain}{The dimension (inclusive) domain. The domain of a dimension
+is defined by a (lower bound, upper bound) vector. For type, \code{ASCII}
+\code{NULL} is expected.}
 
 \item{tile}{The tile dimension tile extent. For type,
 \code{ASCII} \code{NULL} is expected.}
 
-\item{type}{The dimension TileDB datatype string}
+\item{type}{The dimension TileDB datatype string.}
 
-\item{filter_list}{An optional tiledb_filter_list object, default is no filter}
+\item{filter_list}{An optional \code{tiledb_filter_list} object, default
+is no filter}
 
 \item{ctx}{tiledb_ctx object (optional)}
 }

--- a/man/tiledb_stats_dump.Rd
+++ b/man/tiledb_stats_dump.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/Stats.R
 \name{tiledb_stats_dump}
 \alias{tiledb_stats_dump}
-\title{Dumps internal TileDB statistics to file}
+\title{Dumps internal TileDB statistics to file or stdout}
 \usage{
 tiledb_stats_dump(path)
 }
@@ -11,7 +11,7 @@ tiledb_stats_dump(path)
 if the empty string is passed then the result is displayed on stdout.}
 }
 \description{
-Dumps internal TileDB statistics to file
+Dumps internal TileDB statistics to file or stdout
 }
 \examples{
 \dontshow{ctx <- tiledb_ctx(limitTileDBCores())}

--- a/man/tiledb_stats_raw_dump.Rd
+++ b/man/tiledb_stats_raw_dump.Rd
@@ -2,13 +2,9 @@
 % Please edit documentation in R/Stats.R
 \name{tiledb_stats_raw_dump}
 \alias{tiledb_stats_raw_dump}
-\title{Dumps internal TileDB statistics as JSON to file}
+\title{Dumps internal TileDB statistics as JSON to a string}
 \usage{
-tiledb_stats_raw_dump(path)
-}
-\arguments{
-\item{path}{Character variable with path to stats file;
-if the empty string is passed then the result is displayed on stdout.}
+tiledb_stats_raw_dump()
 }
 \description{
 This function requires TileDB Embedded 2.0.3 or later.
@@ -16,8 +12,7 @@ This function requires TileDB Embedded 2.0.3 or later.
 \examples{
 \dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
 if (tiledb_version(TRUE) >= "2.0.3") {
-  pth <- tempfile()
-  tiledb_stats_raw_dump(pth)
-  cat(readLines(pth)[1:10], sep = "\n")
+  txt <- tiledb_stats_raw_dump()
+  cat(txt, "\n")
 }
 }

--- a/man/tiledb_stats_raw_get.Rd
+++ b/man/tiledb_stats_raw_get.Rd
@@ -7,7 +7,7 @@
 tiledb_stats_raw_get()
 }
 \description{
-This function is a convenience wrapper for \code{tiledb_stats_raw_dump}
+This function is a (now deprecated) convenience wrapper for \code{tiledb_stats_raw_dump}
 and returns the result as a JSON string.
 It required TileDB Embedded 2.0.3 or later.
 }

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -2524,13 +2524,13 @@ BEGIN_RCPP
 END_RCPP
 }
 // libtiledb_stats_raw_dump
-void libtiledb_stats_raw_dump(std::string path);
-RcppExport SEXP _tiledb_libtiledb_stats_raw_dump(SEXP pathSEXP) {
+std::string libtiledb_stats_raw_dump();
+RcppExport SEXP _tiledb_libtiledb_stats_raw_dump() {
 BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< std::string >::type path(pathSEXP);
-    libtiledb_stats_raw_dump(path);
-    return R_NilValue;
+    rcpp_result_gen = Rcpp::wrap(libtiledb_stats_raw_dump());
+    return rcpp_result_gen;
 END_RCPP
 }
 // libtiledb_stats_raw_get
@@ -3385,7 +3385,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_tiledb_libtiledb_stats_disable", (DL_FUNC) &_tiledb_libtiledb_stats_disable, 0},
     {"_tiledb_libtiledb_stats_reset", (DL_FUNC) &_tiledb_libtiledb_stats_reset, 0},
     {"_tiledb_libtiledb_stats_dump", (DL_FUNC) &_tiledb_libtiledb_stats_dump, 1},
-    {"_tiledb_libtiledb_stats_raw_dump", (DL_FUNC) &_tiledb_libtiledb_stats_raw_dump, 1},
+    {"_tiledb_libtiledb_stats_raw_dump", (DL_FUNC) &_tiledb_libtiledb_stats_raw_dump, 0},
     {"_tiledb_libtiledb_stats_raw_get", (DL_FUNC) &_tiledb_libtiledb_stats_raw_get, 0},
     {"_tiledb_libtiledb_fragment_info", (DL_FUNC) &_tiledb_libtiledb_fragment_info, 2},
     {"_tiledb_libtiledb_fragment_info_uri", (DL_FUNC) &_tiledb_libtiledb_fragment_info_uri, 2},

--- a/src/libtiledb.cpp
+++ b/src/libtiledb.cpp
@@ -4165,33 +4165,24 @@ void libtiledb_stats_dump(std::string path = "") {
 }
 
 // [[Rcpp::export]]
-void libtiledb_stats_raw_dump(std::string path = "") {
+std::string libtiledb_stats_raw_dump() {
 #if TILEDB_VERSION < TileDB_Version(2,0,3)
-  Rcpp::stop("This function requires TileDB Embedded 2.0.3 or later.");
+    Rcpp::stop("This function requires TileDB Embedded 2.0.3 or later.");
 #else
-  if (path == "") {
-    tiledb::Stats::raw_dump();
-  } else {
-    FILE* fptr = nullptr;
-    fptr = fopen(path.c_str(), "w");
-    if (fptr == nullptr) {
-      Rcpp::stop("error opening stats dump file for writing");
-    }
-    tiledb::Stats::raw_dump(fptr);
-    fclose(fptr);
-  }
+    std::string txt;
+    tiledb::Stats::raw_dump(&txt);
+    return txt;
 #endif
 }
 
 // [[Rcpp::export]]
 std::string libtiledb_stats_raw_get() {
 #if TILEDB_VERSION < TileDB_Version(2,0,3)
-  Rcpp::stop("This function requires TileDB Embedded 2.0.3 or later.");
-  return(std::string());//not reached
+    Rcpp::stop("This function requires TileDB Embedded 2.0.3 or later.");
+    return(std::string());//not reached
 #else
-  std::string result;
-  tiledb::Stats::raw_dump(&result);
-  return result;
+    Rcpp::message(Rcpp::wrap("This function is deprecated, please use 'libtiledb_stats_raw_dump'."));
+    return libtiledb_stats_raw_dump();
 #endif
 }
 


### PR DESCRIPTION
This PR is a small cleanup.  When we added 'raw' stats export, I at first did not switch to the functionality of exporting as a string. I had at first approximated that by writing to file and re-reading.

While working on the SOMA stats functionality it became a little clearer that this is a wart.  So now the `*_dump()` function as before emits to _either_ stdout or a file (if filename is given), and `*_raw_dump()`  returns a JSON string.  The existing extra accessors remain but are marked deprecated and will be removed after a suitable time period.

The PR also adds a small cleanup for the PR #513 that went in this morning as using OR on query conditions has only been available since 2.10.0.

No new code, no new tests.