### PR TITLE
Correct nullable string validity map treatment

### DIFF
--- a/inst/tinytest/test_query.R
+++ b/inst/tinytest/test_query.R
@@ -263,12 +263,13 @@ uri <- tempfile()
 pp <- palmerpenguins::penguins
 fromDataFrame(pp, uri, sparse = TRUE, col_index = c("species", "year"))
 
-qc <- parse_query_condition(body_mass_g > 4000 && sex == "male")
+qc <- parse_query_condition(body_mass_g > 4000 || island == "Biscoe" || sex == "male")
 arr <- tiledb_array(uri)
 qry <- tiledb_query(arr, "DELETE")
 qry <- tiledb_query_set_condition(qry, qc)
 tiledb_query_submit(qry)
 tiledb_query_finalize(qry)
 
-oo <- tiledb_array(uri, return_as="data.frame")[]
-expect_equal(nrow(oo), 177)             # instead of 344 pre-deletion
+oo <- tiledb_array(uri, return_as="data.frame", strings_as_factors=TRUE)[]
+
+expect_equal(nrow(oo), 84)             # instead of 344 pre-deletion

--- a/src/libtiledb.cpp
+++ b/src/libtiledb.cpp
@@ -2710,7 +2710,7 @@ XPtr<vlc_buf_t> libtiledb_query_buffer_var_char_create(CharacterVector vec, bool
         bufptr->str += s;
         cumlen += s.length();
         if (nullable) {
-          bufptr->validity_map[i] = vec[i] == NA_STRING;
+          bufptr->validity_map[i] = vec[i] != R_NaString;
         }
     }
     bufptr->rows = bufptr->cols = 0; // signal unassigned for the write case
@@ -2763,7 +2763,7 @@ CharacterMatrix libtiledb_query_get_buffer_var_char(XPtr<vlc_buf_t> bufptr,
   CharacterMatrix mat(bufptr->rows, bufptr->cols);
   for (size_t i = 0; i < n; i++) {
       if (bufptr->nullable) {
-          if (bufptr->validity_map[i] == 0)
+          if (bufptr->validity_map[i] != 0)
               mat[i] = std::string(&bufptr->str[bufptr->offsets[i]], str_sizes[i]);
           else
               mat[i] = R_NaString;


### PR DESCRIPTION
Work on the TileDB SOMA package and its indepedent implementation of the read-path (relying on Arrow buffers) revealed that we encoded missingness incorrectly for nullable strings.  (This happened for read and write so round-turn tests passed.  This is also not a concern for numeric values were encoded correctly but only concerns strings.)

This PR corrects this.  It also tightens one test on deletion by switching to a triple || condition.

