### PR TITLE
Safer check for NAs in `tiledb_config()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # tiledb 0.18.0.2 (Development)
 
 * This release of the R package builds against [TileDB 2.14.1](https://github.com/TileDB-Inc/TileDB/releases/tag/2.14.1), and has also been tested against earlier releases as well as the development version (#502).
+* Safer checking of `NAs` in `tiledb_config()` to support R 4.2 conditional lengths (#518, #519)
 
 ## Improvements
 

--- a/R/Config.R
+++ b/R/Config.R
@@ -55,7 +55,8 @@ tiledb_config.from_ptr <- function(ptr) {
 #' @importFrom methods new
 #' @export tiledb_config
 tiledb_config <- function(config = NA_character_) {
-  if (!is.na(config)) {
+  config <- config[!is.na(x = config)]
+  if (length(x = config)) {
     stopifnot(`If given, the 'config' argument must be a name, value character vector` = is.character(config) && !is.null(names(config)))
     ptr <- libtiledb_config(config)
   } else {

--- a/inst/tinytest/test_config.R
+++ b/inst/tinytest/test_config.R
@@ -20,6 +20,15 @@ expect_error(tiledb_config(1))
 expect_error(tiledb_config(c(foo = 1)))
 #})
 
+## handle cases with NAs
+expect_silent(cfg <- tiledb_config(c(a = "1")))
+expect_equal(cfg["a"], c(a = "1"))
+expect_silent(cfg <- tiledb_config(c(a = "1", b = "2")))
+expect_equal(cfg["b"], c(b = "2"))
+expect_equal(head(names(as.vector(cfg)), 2L), c("a", "b"))
+expect_silent(cfg <- tiledb_config(c(a = "1", c = NA_character_, b = "2")))
+expect_equal(head(names(as.vector(cfg)), 2L), c("a", "b"))
+
 #test_that("tiledb_config indexing works", {
 cfg <- tiledb_config()
 cfg["foo"] <- "bar"


### PR DESCRIPTION
Replace `if(is.na())` as R 4.2 errors when conditions > 1L Instead, removes NAs from `config`
Then, checks the length of `config`; if there is a length, adds it to the TileDB config

fixes #518