### PR TITLE
Use TileDB 2.15.0

### DIFF
--- a/.github/workflows/valgrind.yaml
+++ b/.github/workflows/valgrind.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tag: [ release-2.13, release-2.14, dev ]
+        tag: [ release-2.14, release-2.15, dev ]
 #        tag: [ 2.9.5, 2.10.0, dev ]
 
     steps:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tiledb
 Type: Package
-Version: 0.18.0.2
+Version: 0.18.0.3
 Title: Universal Storage Engine for Sparse and Dense Multidimensional Arrays
 Authors@R: c(person("TileDB, Inc.", role = c("aut", "cph")),
  person("Dirk", "Eddelbuettel", email = "dirk@tiledb.com", role = "cre"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,8 +3,6 @@
 * This release of the R package builds against [TileDB 2.15.0](https://github.com/TileDB-Inc/TileDB/releases/tag/2.15.0), and has also been tested against earlier releases as well as the development
   version (#516, #521).
 
-* Safer checking of `NAs` in `tiledb_config()` to support R 4.2 conditional lengths (#518, #519)
-
 ## Breaking Changes
 
 * The validity map coding of nullable strings has been corrected: validity map values of one are now interpreted as valid/non-null for full compatibility with other TileDB projects. Previously written arrays with nullable strings can be read by setting the config option `r.legacy_validity_mode` to `true`; the option also permits to write to an older installation. A conversion helper script is provided in `scripts/legacy_validity_convert.r`. (#517)
@@ -19,6 +17,8 @@
 
 * Use of TileDB Embedded was upgraded to releases 2.14.1 and 2.15.0 (#516, #521)
 
+* Safer checking of `NAs` in `tiledb_config()` to support R 4.2 conditional lengths (#519)
+
 ## Bug Fixes
 
 * The access to JSON-formatted performance statistics has been simplified (#514)
@@ -26,6 +26,8 @@
 ## Build and Test Systems
 
 * The TileDB Embedded version is now used to determine whether a dampener is needed for the deprecation warning (#511)
+
+* One of the test data sets included with #517 has been regenerated under an older TileDB version in order to test on more systems (#523)
 
 ## Deprecations
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
-# tiledb 0.18.0.2 (Development)
+# tiledb 0.18.0.3 (Development)
 
-* This release of the R package builds against [TileDB 2.14.1](https://github.com/TileDB-Inc/TileDB/releases/tag/2.14.1), and has also been tested against earlier releases as well as the development version (#502).
+* This release of the R package builds against [TileDB 2.15.0](https://github.com/TileDB-Inc/TileDB/releases/tag/2.15.0), and has also been tested against earlier releases as well as the development
+  version (#516, #521).
+
 * Safer checking of `NAs` in `tiledb_config()` to support R 4.2 conditional lengths (#518, #519)
 
 ## Breaking Changes
@@ -15,7 +17,7 @@
 
 * Query conditions for character columns can now be expressed using the `%in%` operator and a vector of values (#513)
 
-* Use of TileDB Embedded was upgraded to release 2.14.1 (#516)
+* Use of TileDB Embedded was upgraded to releases 2.14.1 and 2.15.0 (#516, #521)
 
 ## Bug Fixes
 

--- a/tools/tiledbVersion.txt
+++ b/tools/tiledbVersion.txt
@@ -1,2 +1,2 @@
-version: 2.15.0-rc2
+version: 2.15.0
 sha: 1fb59c4

--- a/tools/tiledbVersion.txt
+++ b/tools/tiledbVersion.txt
@@ -1,2 +1,2 @@
-version: 2.15.0-rc1
-sha: 5b3d42d
+version: 2.15.0-rc2
+sha: 1fb59c4

--- a/tools/tiledbVersion.txt
+++ b/tools/tiledbVersion.txt
@@ -1,2 +1,2 @@
-version: 2.14.1
-sha: 0c9da0a
+version: 2.15.0-rc0
+sha: 442d128

--- a/tools/tiledbVersion.txt
+++ b/tools/tiledbVersion.txt
@@ -1,2 +1,2 @@
-version: 2.15.0-rc0
-sha: 442d128
+version: 2.15.0-rc1
+sha: 5b3d42d


### PR DESCRIPTION
This PR updates the package preference to TileDB 2.15.0 (currently at rc0).

We also rolled the valgrind test matrix to the release-2.15 branch, and increased the release version to 0.18.0.3 to signal a new rc snapshot.