### PR TITLE
Correction to Metadata argument 'arr' description

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -31,6 +31,8 @@
 
 * One of the test data sets included with #517 has been regenerated under an older TileDB version in order to test on more systems (#523)
 
+* Documentation for Metadata accessors no longer states URIs strings are accepted (#527)
+
 ## Deprecations
 
 ## Removals

--- a/R/Metadata.R
+++ b/R/Metadata.R
@@ -37,7 +37,7 @@ tiledb_has_metadata <- function(arr, key) {
 
 ##' Return count of TileDB Array Metadata objects
 ##'
-##' @param arr A TileDB Array object, or a character URI describing one
+##' @param arr A TileDB Array object
 ##' @return A integer variable with the number of Metadata objects
 ##' @export
 tiledb_num_metadata <- function(arr) {
@@ -48,7 +48,7 @@ tiledb_num_metadata <- function(arr) {
 
 ##' Return a TileDB Array Metadata object given by key
 ##'
-##' @param arr A TileDB Array object, or a character URI describing one
+##' @param arr A TileDB Array object
 ##' @param key A character value describing a metadata key
 ##' @return A object stored in the Metadata under the given key,
 ##' or \sQuote{NULL} if none found.
@@ -65,7 +65,7 @@ tiledb_get_metadata <- function(arr, key) {
 
 ##' Store an object in TileDB Array Metadata under given key
 ##'
-##' @param arr A TileDB Array object, or a character URI describing one
+##' @param arr A TileDB Array object
 ##' @param key A character value describing a metadata key
 ##' @param val An object to be stored
 ##' @return A boolean value indicating success
@@ -79,7 +79,7 @@ tiledb_put_metadata <- function(arr, key, val) {
 
 ##' Return all TileDB Array Metadata objects as a named list
 ##'
-##' @param arr A TileDB Array object, or a character URI describing one
+##' @param arr A TileDB Array object
 ##' @return A named list with all Metadata objects indexed by the given key
 ##' @export
 tiledb_get_all_metadata <- function(arr) {

--- a/man/parse_query_condition.Rd
+++ b/man/parse_query_condition.Rd
@@ -13,8 +13,7 @@ parse_query_condition(
 )
 }
 \arguments{
-\item{expr}{An expression that is understood by the TileDB grammar for
-query conditions.}
+\item{expr}{An expression that is understood by the TileDB grammar for query conditions.}
 
 \item{ta}{An optional tiledb_array object that the query condition is applied to}
 

--- a/man/tiledb_get_all_metadata.Rd
+++ b/man/tiledb_get_all_metadata.Rd
@@ -7,7 +7,7 @@
 tiledb_get_all_metadata(arr)
 }
 \arguments{
-\item{arr}{A TileDB Array object, or a character URI describing one}
+\item{arr}{A TileDB Array object}
 }
 \value{
 A named list with all Metadata objects indexed by the given key

--- a/man/tiledb_get_metadata.Rd
+++ b/man/tiledb_get_metadata.Rd
@@ -7,7 +7,7 @@
 tiledb_get_metadata(arr, key)
 }
 \arguments{
-\item{arr}{A TileDB Array object, or a character URI describing one}
+\item{arr}{A TileDB Array object}
 
 \item{key}{A character value describing a metadata key}
 }

--- a/man/tiledb_num_metadata.Rd
+++ b/man/tiledb_num_metadata.Rd
@@ -7,7 +7,7 @@
 tiledb_num_metadata(arr)
 }
 \arguments{
-\item{arr}{A TileDB Array object, or a character URI describing one}
+\item{arr}{A TileDB Array object}
 }
 \value{
 A integer variable with the number of Metadata objects

--- a/man/tiledb_put_metadata.Rd
+++ b/man/tiledb_put_metadata.Rd
@@ -7,7 +7,7 @@
 tiledb_put_metadata(arr, key, val)
 }
 \arguments{
-\item{arr}{A TileDB Array object, or a character URI describing one}
+\item{arr}{A TileDB Array object}
 
 \item{key}{A character value describing a metadata key}
 


### PR DESCRIPTION
This PR provides a small correction to the documentation for the main argument for 'metadata' accessor which does have to be a `tiledb_array` -- and not also a URI as the docs were still saying.

No new code.