### PR TITLE
Generalize query condition parsing to allow UTF-8 attributes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tiledb
 Type: Package
-Version: 0.19.0
+Version: 0.19.0.1
 Title: Universal Storage Engine for Sparse and Dense Multidimensional Arrays
 Authors@R: c(person("TileDB, Inc.", role = c("aut", "cph")),
  person("Dirk", "Eddelbuettel", email = "dirk@tiledb.com", role = "cre"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# tiledb ongoing development
+
+## Improvements
+
+* Query conditions can now be expressed for attributes of type UTF-8 (#529)
+
+
 # tiledb 0.19.0
 
 * This release of the R package builds against [TileDB 2.15.0](https://github.com/TileDB-Inc/TileDB/releases/tag/2.15.0), and has also been tested against earlier releases as well as the development

--- a/R/QueryCondition.R
+++ b/R/QueryCondition.R
@@ -196,7 +196,7 @@ parse_query_condition <- function(expr, ta=NULL, debug=FALSE, strict=TRUE, use_i
                            op, " (aka ", .mapOpToCharacter(op), ")",
                            " [",ch, "] ", dtype, "\n", sep="")
             tiledb_query_condition_init(attr = attr,
-                                        value = if (dtype == "ASCII") ch else as.numeric(ch),
+                                        value = if (dtype == "ASCII" || dtype == "UTF8") ch else as.numeric(ch),
                                         dtype = dtype,
                                         op = .mapOpToCharacter(op))
         } else {

--- a/src/libtiledb.cpp
+++ b/src/libtiledb.cpp
@@ -3832,7 +3832,7 @@ void libtiledb_query_condition_init(XPtr<tiledb::QueryCondition> query_cond,
         float v = static_cast<float>(as<double>(condition_value));
         uint64_t cond_val_size = sizeof(float);
         query_cond->init(attr_name, (void*) &v, cond_val_size, op);
-    } else if (cond_val_type == "ASCII") {
+    } else if (cond_val_type == "ASCII" || cond_val_type == "UTF8") {
         std::string v = as<std::string>(condition_value);
         query_cond->init(attr_name, v, op);
     } else {


### PR DESCRIPTION
The PR improves an issue seen in the SOMA work where query conditions would not execute on UTF-8 columns.