### PR TITLE
Accomodate tighter check in group_set_config by moving close up

### DIFF
--- a/inst/tinytest/test_group.R
+++ b/inst/tinytest/test_group.R
@@ -30,10 +30,10 @@ expect_true(tiledb_group_is_open(grp))
 
 cfg <- tiledb_group_get_config(grp)
 expect_true(is(cfg, "tiledb_config"))
+grp <- tiledb_group_close(grp)
 grp <- tiledb_group_set_config(grp, cfg)
 
 ## close, re-open to write
-grp <- tiledb_group_close(grp)
 expect_false(tiledb_group_is_open(grp))
 grp <- tiledb_group_open(grp, "WRITE")
 expect_true(tiledb_group_is_open(grp))


### PR DESCRIPTION
[PR #3878 in Core](https://github.com/TileDB-Inc/TileDB/pull/3878) adds stricter behavior on groups setting configs so the tiledb-r unit test needs to move a single `close()` statement from just _after_ testing this function to just _before_.

No new code, no new tests.