### PR TITLE
Also show utils::osVersion

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,9 +4,13 @@
 
 * Query conditions can now be expressed for attributes of type UTF-8 (#529)
 
+* The startup message now displays the operating system and version (#532)
+
 ## Build and Test Systems
 
 * Testing for Groups reflect the stricter behavior in config setting requiring a close array (#530)
+
+* The use of binary packages in continuous integration has been made a little more robust (#531)
 
 
 # tiledb 0.19.0

--- a/R/Init.R
+++ b/R/Init.R
@@ -61,6 +61,7 @@
     if (interactive()) {
         packageStartupMessage("TileDB R ", packageVersion("tiledb"),
                               " with TileDB Embedded ", format(tiledb_version(TRUE)),
+                              " on ", utils::osVersion,
                               ". See https://tiledb.com for more information.")
     }
 }

--- a/inst/tinytest/test_filestore.R
+++ b/inst/tinytest/test_filestore.R
@@ -4,6 +4,8 @@ library(tiledb)
 isOldWindows <- Sys.info()[["sysname"]] == "Windows" && grepl('Windows Server 2008', osVersion)
 if (isOldWindows) exit_file("skip this file on old Windows releases")
 
+isWindows <- Sys.info()[["sysname"]] == "Windows"
+
 ctx <- tiledb_ctx(limitTileDBCores())
 
 if (tiledb_version(TRUE) < "2.9.0") exit_file("Needs TileDB 2.9.* or later")
@@ -18,6 +20,7 @@ expect_true(inherits(tiledb_filestore_schema_create(), "tiledb_array_schema"))
 expect_true(inherits(tiledb_filestore_schema_create(text_file), "tiledb_array_schema"))
 expect_error(tiledb_filestore_schema_create("does_not_exist"))
 
+if (isWindows) exit_file("Skip remainder as tests randomly fail")
 
 tempuri <- tempfile()
 res <- tiledb_filestore_schema_create(text_file) 					# schema from text_file


### PR DESCRIPTION
Small 'quality of life' improvement changing the startup message from

```r
> library(tiledb)
TileDB R 0.19.0.2 with TileDB Embedded 2.16.0. See https://tiledb.com for more information.
> 
```

to

```r
> library(tiledb)
TileDB R 0.19.0.2 with TileDB Embedded 2.16.0 on Ubuntu 22.10. See https://tiledb.com for more information.
>
```

(The message is only shown if interactive use is detected.)