### PR TITLE
Use TileDB 2.15.1

### DIFF
--- a/tools/tiledbVersion.txt
+++ b/tools/tiledbVersion.txt
@@ -1,2 +1,2 @@
-version: 2.15.0
-sha: 1fb59c4
+version: 2.15.1
+sha: 432d4c2


### PR DESCRIPTION
This PR updates the package preference to TileDB 2.15.1.

No new code or code changes.