### PR TITLE
Support group construction with optional config

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tiledb
 Type: Package
-Version: 0.19.0.2
+Version: 0.19.0.3
 Title: Universal Storage Engine for Sparse and Dense Multidimensional Arrays
 Authors@R: c(person("TileDB, Inc.", role = c("aut", "cph")),
  person("Dirk", "Eddelbuettel", email = "dirk@tiledb.com", role = "cre"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,10 @@
 
 * The startup message now displays the operating system and version (#532)
 
+* Use of TileDB Embedded was upgraded to release 2.15.1 (#534)
+
+* Group objects can be opened while supplying a Config object when 2.15.1 or newer is used (#535)
+
 ## Build and Test Systems
 
 * Testing for Groups reflect the stricter behavior in config setting requiring a close array (#530)

--- a/R/Group.R
+++ b/R/Group.R
@@ -34,16 +34,24 @@ setClass("tiledb_group",
 #' @param uri Character variable with the URI of the new group object
 #' @param type Character variable with the query type value: one of \dQuote{READ}
 #' or \dQuote{WRITE}
-#' @param ctx (optional) A TileDB Ctx object; if not supplied the default
+#' @param ctx (optional) A TileDB Context object; if not supplied the default
 #' context object is retrieved
+#' @param cfg (optional) A TileConfig object
 #' @return A 'group' object
 #' @export
-tiledb_group <- function(uri, type = c("READ", "WRITE"), ctx = tiledb_get_context()) {
+tiledb_group <- function(uri, type = c("READ", "WRITE"),
+                         ctx = tiledb_get_context(), cfg = NULL) {
     stopifnot("The 'ctx' argument must be a Context object" = is(ctx, "tiledb_ctx"),
               "The 'uri' argument must be character" = is.character(uri),
-              "This function needs TileDB 2.8.*" = .tiledb28())
+              "This function needs TileDB 2.8.*" = .tiledb28(),
+              "The 'config argument must be a Config object" =
+                  is.null(cfg) || is(cfg, "tiledb_config"))
     type <- match.arg(type)
-    ptr <- libtiledb_group(ctx@ptr, uri, type)
+    if (is.null(cfg)) {
+        ptr <- libtiledb_group(ctx@ptr, uri, type)
+    } else {
+        ptr <- libtiledb_group_with_config(ctx@ptr, uri, type, cfg@ptr)
+    }
     group <- new("tiledb_group", ptr = ptr)
     invisible(group)
 }

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -956,6 +956,10 @@ libtiledb_group <- function(ctx, uri, querytypestr) {
     .Call(`_tiledb_libtiledb_group`, ctx, uri, querytypestr)
 }
 
+libtiledb_group_with_config <- function(ctx, uri, querytypestr, cfg) {
+    .Call(`_tiledb_libtiledb_group_with_config`, ctx, uri, querytypestr, cfg)
+}
+
 libtiledb_group_open <- function(grp, querytypestr) {
     .Call(`_tiledb_libtiledb_group_open`, grp, querytypestr)
 }

--- a/inst/tinytest/test_group.R
+++ b/inst/tinytest/test_group.R
@@ -159,3 +159,13 @@ expect_true(tiledb_group_is_relative(grp, "name_is_chloe"))
 expect_error(tiledb_group_is_relative(uri, "name_is_chloe"))	# wrong type errors
 expect_error(tiledb_group_is_relative(grp, "does_not_exist"))	# non-group errors
 expect_error(tiledb_group_is_relative(grp, TRUE)) 				# not a char, errors
+
+if (tiledb_version(TRUE) < "2.16.0") exit_file("Remainder requires TileDB 2.16.* or later")
+grp <- tiledb_group_close(grp)
+cfg <- tiledb_config(c("sm.tile_cache_size" = "100"))
+grp <- tiledb_group(uri, "READ", cfg=cfg)
+expect_true(is(grp, "tiledb_group"))
+expect_true(is(grp@ptr, "externalptr"))
+expect_true(tiledb_group_is_open(grp))
+expect_equal(tiledb_group_member_count(grp), 2)
+grp <- tiledb_group_close(grp)

--- a/inst/tinytest/test_group.R
+++ b/inst/tinytest/test_group.R
@@ -160,7 +160,7 @@ expect_error(tiledb_group_is_relative(uri, "name_is_chloe"))	# wrong type errors
 expect_error(tiledb_group_is_relative(grp, "does_not_exist"))	# non-group errors
 expect_error(tiledb_group_is_relative(grp, TRUE)) 				# not a char, errors
 
-if (tiledb_version(TRUE) < "2.16.0") exit_file("Remainder requires TileDB 2.16.* or later")
+if (tiledb_version(TRUE) < "2.15.1") exit_file("Remainder requires TileDB 2.15.1 or later")
 grp <- tiledb_group_close(grp)
 cfg <- tiledb_config(c("sm.tile_cache_size" = "100"))
 grp <- tiledb_group(uri, "READ", cfg=cfg)

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -2810,6 +2810,20 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// libtiledb_group_with_config
+XPtr<tiledb::Group> libtiledb_group_with_config(XPtr<tiledb::Context> ctx, const std::string& uri, const std::string& querytypestr, XPtr<tiledb::Config> cfg);
+RcppExport SEXP _tiledb_libtiledb_group_with_config(SEXP ctxSEXP, SEXP uriSEXP, SEXP querytypestrSEXP, SEXP cfgSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< XPtr<tiledb::Context> >::type ctx(ctxSEXP);
+    Rcpp::traits::input_parameter< const std::string& >::type uri(uriSEXP);
+    Rcpp::traits::input_parameter< const std::string& >::type querytypestr(querytypestrSEXP);
+    Rcpp::traits::input_parameter< XPtr<tiledb::Config> >::type cfg(cfgSEXP);
+    rcpp_result_gen = Rcpp::wrap(libtiledb_group_with_config(ctx, uri, querytypestr, cfg));
+    return rcpp_result_gen;
+END_RCPP
+}
 // libtiledb_group_open
 XPtr<tiledb::Group> libtiledb_group_open(XPtr<tiledb::Group> grp, const std::string& querytypestr);
 RcppExport SEXP _tiledb_libtiledb_group_open(SEXP grpSEXP, SEXP querytypestrSEXP) {
@@ -3435,6 +3449,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_tiledb_libtiledb_fragment_info_dump", (DL_FUNC) &_tiledb_libtiledb_fragment_info_dump, 1},
     {"_tiledb_libtiledb_error_message", (DL_FUNC) &_tiledb_libtiledb_error_message, 1},
     {"_tiledb_libtiledb_group", (DL_FUNC) &_tiledb_libtiledb_group, 3},
+    {"_tiledb_libtiledb_group_with_config", (DL_FUNC) &_tiledb_libtiledb_group_with_config, 4},
     {"_tiledb_libtiledb_group_open", (DL_FUNC) &_tiledb_libtiledb_group_open, 2},
     {"_tiledb_libtiledb_group_set_config", (DL_FUNC) &_tiledb_libtiledb_group_set_config, 2},
     {"_tiledb_libtiledb_group_get_config", (DL_FUNC) &_tiledb_libtiledb_group_get_config, 1},

--- a/src/libtiledb.cpp
+++ b/src/libtiledb.cpp
@@ -4586,7 +4586,7 @@ XPtr<tiledb::Group> libtiledb_group_with_config(XPtr<tiledb::Context> ctx,
                                                 XPtr<tiledb::Config> cfg) {
     check_xptr_tag<tiledb::Context>(ctx);
     check_xptr_tag<tiledb::Config>(cfg);
-#if TILEDB_VERSION >= TileDB_Version(2,16,0)
+#if TILEDB_VERSION >= TileDB_Version(2,15,1)
     tiledb_query_type_t querytype = _string_to_tiledb_query_type(querytypestr);
     auto p = new tiledb::Group(*ctx.get(), uri, querytype, *cfg.get());
     XPtr<tiledb::Group> ptr = make_xptr<tiledb::Group>(p);

--- a/src/libtiledb.cpp
+++ b/src/libtiledb.cpp
@@ -4578,6 +4578,25 @@ XPtr<tiledb::Group> libtiledb_group(XPtr<tiledb::Context> ctx,
     return ptr;
 }
 
+// Interfaces to R are C-based so we cannot overload just on signature
+// [[Rcpp::export]]
+XPtr<tiledb::Group> libtiledb_group_with_config(XPtr<tiledb::Context> ctx,
+                                                const std::string& uri,
+                                                const std::string& querytypestr,
+                                                XPtr<tiledb::Config> cfg) {
+    check_xptr_tag<tiledb::Context>(ctx);
+    check_xptr_tag<tiledb::Config>(cfg);
+#if TILEDB_VERSION >= TileDB_Version(2,16,0)
+    tiledb_query_type_t querytype = _string_to_tiledb_query_type(querytypestr);
+    auto p = new tiledb::Group(*ctx.get(), uri, querytype, *cfg.get());
+    XPtr<tiledb::Group> ptr = make_xptr<tiledb::Group>(p);
+#else
+    XPtr<tiledb::Group> ptr(new tiledb::Group()); // placeholder
+#endif
+    return ptr;
+}
+
+
 // [[Rcpp::export]]
 XPtr<tiledb::Group> libtiledb_group_open(XPtr<tiledb::Group> grp,
                                          const std::string& querytypestr) {


### PR DESCRIPTION
This PR adds support for opening a TileDB group object with a config object (as made possible by release 2.15.1). 

This of interest to the SOMA project (where group reads still go through the tiledb-r package) as groups can now be queried directly reflecting a configuration option.