### PR TITLE
Minor interface completion at R level allowing nullable for char vec

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,8 @@
 
 * Group objects can be opened while supplying a Config object when 2.15.1 or newer is used (#535, #536)
 
+* For character column buffer allocations, the helper function now accepts a `nullable` option (#537)
+
 ## Build and Test Systems
 
 * Testing for Groups reflect the stricter behavior in config setting requiring a close array (#530)

--- a/R/Query.R
+++ b/R/Query.R
@@ -148,12 +148,13 @@ tiledb_query_create_buffer_ptr_char <- function(query, varvec) {
 #'
 #' @param sizeoffsets A numeric value with the size of the offsets vector
 #' @param sizedata A numeric value of the size of the data string
+#' @param nullable An optional boolean indicating whether the column can have NULLs
 #' @return An external pointer to the allocated buffer object
 #' @export
-tiledb_query_alloc_buffer_ptr_char <- function(sizeoffsets, sizedata) {
+tiledb_query_alloc_buffer_ptr_char <- function(sizeoffsets, sizedata, nullable=FALSE) {
   stopifnot(`Argument 'sizeoffset' must be numeric` = is.numeric(sizeoffsets),
             `Argument 'sizedata' must be numeric` = is.numeric(sizedata))
-  bufptr <- libtiledb_query_buffer_var_char_alloc_direct(sizeoffsets, sizedata)
+  bufptr <- libtiledb_query_buffer_var_char_alloc_direct(sizeoffsets, sizedata, nullable)
   bufptr
 }
 

--- a/man/tiledb_group.Rd
+++ b/man/tiledb_group.Rd
@@ -4,7 +4,12 @@
 \alias{tiledb_group}
 \title{Creates a 'tiledb_group' object}
 \usage{
-tiledb_group(uri, type = c("READ", "WRITE"), ctx = tiledb_get_context())
+tiledb_group(
+  uri,
+  type = c("READ", "WRITE"),
+  ctx = tiledb_get_context(),
+  cfg = NULL
+)
 }
 \arguments{
 \item{uri}{Character variable with the URI of the new group object}
@@ -12,8 +17,10 @@ tiledb_group(uri, type = c("READ", "WRITE"), ctx = tiledb_get_context())
 \item{type}{Character variable with the query type value: one of \dQuote{READ}
 or \dQuote{WRITE}}
 
-\item{ctx}{(optional) A TileDB Ctx object; if not supplied the default
+\item{ctx}{(optional) A TileDB Context object; if not supplied the default
 context object is retrieved}
+
+\item{cfg}{(optional) A TileConfig object}
 }
 \value{
 A 'group' object

--- a/man/tiledb_query_alloc_buffer_ptr_char.Rd
+++ b/man/tiledb_query_alloc_buffer_ptr_char.Rd
@@ -4,12 +4,14 @@
 \alias{tiledb_query_alloc_buffer_ptr_char}
 \title{Allocate a Query buffer for reading a character attribute}
 \usage{
-tiledb_query_alloc_buffer_ptr_char(sizeoffsets, sizedata)
+tiledb_query_alloc_buffer_ptr_char(sizeoffsets, sizedata, nullable = FALSE)
 }
 \arguments{
 \item{sizeoffsets}{A numeric value with the size of the offsets vector}
 
 \item{sizedata}{A numeric value of the size of the data string}
+
+\item{nullable}{An optional boolean indicating whether the column can have NULLs}
 }
 \value{
 An external pointer to the allocated buffer object


### PR DESCRIPTION
The allocator for variable cell sized character buffers received a new parameter at the C++ level that we at time time did not carry over to the R interface.  This PR completes that and offers a new variable (with default) at the R level.

No new code.  One Rd file from a recent PR got updated in the `roxygen2` run.