### PR TITLE
Minor interface completion at R level allowing nullable and varnum for vec

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,7 +10,7 @@
 
 * Group objects can be opened while supplying a Config object when 2.15.1 or newer is used (#535, #536)
 
-* For character column buffer allocations, the helper function now accepts a `nullable` option (#537)
+* For character column buffer allocations, the R function now accepts a `nullable` option (#537)
 
 ## Build and Test Systems
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,8 @@
 
 * For character column buffer allocations, the R function now accepts a `nullable` option (#537)
 
+* For standard buffer allocations, the R function now accepts `nullable` and `varnum` options (#538)
+
 ## Build and Test Systems
 
 * Testing for Groups reflect the stricter behavior in config setting requiring a close array (#530)

--- a/R/Query.R
+++ b/R/Query.R
@@ -199,13 +199,19 @@ tiledb_query_set_buffer_ptr_char <- function(query, attr, bufptr) {
 #' @param query A TileDB Query object
 #' @param datatype A character value containing the data type
 #' @param ncells A number of elements (not bytes)
+#' @param nullable Optional boolean parameter indicating whether missing values
+#' are allowed (for which another column is allocated), default is FALSE
+#' @param varnum Option intgeter parameter for the number of elemements per variable,
+#' default is one
 #' @return An external pointer to the allocated buffer object
 #' @export
-tiledb_query_buffer_alloc_ptr <- function(query, datatype, ncells) {
-  stopifnot(`Argument 'query' must be a tiledb_query object` = is(query, "tiledb_query"),
-            `Argument 'datatype' must be a character object` = is.character(datatype),
-            `Argument 'ncells' must be numeric` = is.numeric(ncells))
-  bufptr <- libtiledb_query_buffer_alloc_ptr(datatype, ncells)
+tiledb_query_buffer_alloc_ptr <- function(query, datatype, ncells, nullable=FALSE, varnum=1) {
+  stopifnot("Argument 'query' must be a tiledb_query object" = is(query, "tiledb_query"),
+            "Argument 'datatype' must be a character object" = is.character(datatype),
+            "Argument 'ncells' must be numeric" = is.numeric(ncells),
+            "Argument 'nullable' must be logical" = is.logical(nullable),
+            "Argument 'varnum' must be integer or numeric" = is.integer(varnum) || is.numeric(varnum))
+  bufptr <- libtiledb_query_buffer_alloc_ptr(datatype, ncells, nullable, varnum)
   bufptr
 }
 

--- a/man/tiledb_query_buffer_alloc_ptr.Rd
+++ b/man/tiledb_query_buffer_alloc_ptr.Rd
@@ -4,7 +4,13 @@
 \alias{tiledb_query_buffer_alloc_ptr}
 \title{Allocate a Query buffer for a given type}
 \usage{
-tiledb_query_buffer_alloc_ptr(query, datatype, ncells)
+tiledb_query_buffer_alloc_ptr(
+  query,
+  datatype,
+  ncells,
+  nullable = FALSE,
+  varnum = 1
+)
 }
 \arguments{
 \item{query}{A TileDB Query object}
@@ -12,6 +18,12 @@ tiledb_query_buffer_alloc_ptr(query, datatype, ncells)
 \item{datatype}{A character value containing the data type}
 
 \item{ncells}{A number of elements (not bytes)}
+
+\item{nullable}{Optional boolean parameter indicating whether missing values
+are allowed (for which another column is allocated), default is FALSE}
+
+\item{varnum}{Option intgeter parameter for the number of elemements per variable,
+default is one}
 }
 \value{
 An external pointer to the allocated buffer object


### PR DESCRIPTION
Similar to #537 the allocator for normal buffers received two new parameter at the C++ level that we at time time did not carry over to the R interface. This PR completes that and offers two new variables (with defaults) at the R level.

No new code, but a simple test for the new behavior here and in #537.