### PR TITLE
Support BOOL in query conditions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,8 @@
 
 * For standard buffer allocations, the R function now accepts `nullable` and `varnum` options (#538)
 
+* Query conditions can now be expressed on boolean attributes (#540)
+
 ## Build and Test Systems
 
 * Testing for Groups reflect the stricter behavior in config setting requiring a close array (#530)

--- a/R/QueryCondition.R
+++ b/R/QueryCondition.R
@@ -196,7 +196,11 @@ parse_query_condition <- function(expr, ta=NULL, debug=FALSE, strict=TRUE, use_i
                            op, " (aka ", .mapOpToCharacter(op), ")",
                            " [",ch, "] ", dtype, "\n", sep="")
             tiledb_query_condition_init(attr = attr,
-                                        value = if (dtype == "ASCII" || dtype == "UTF8") ch else as.numeric(ch),
+                                        value = switch(dtype,
+                                                       ASCII = ch,
+                                                       UTF0 = ch,
+                                                       BOOL = as.logical(ch),
+                                                       as.numeric(ch)),
                                         dtype = dtype,
                                         op = .mapOpToCharacter(op))
         } else {

--- a/R/QueryCondition.R
+++ b/R/QueryCondition.R
@@ -198,7 +198,7 @@ parse_query_condition <- function(expr, ta=NULL, debug=FALSE, strict=TRUE, use_i
             tiledb_query_condition_init(attr = attr,
                                         value = switch(dtype,
                                                        ASCII = ch,
-                                                       UTF0 = ch,
+                                                       UTF8 = ch,
                                                        BOOL = as.logical(ch),
                                                        as.numeric(ch)),
                                         dtype = dtype,

--- a/inst/tinytest/test_querycondition.R
+++ b/inst/tinytest/test_querycondition.R
@@ -406,3 +406,20 @@ expect_equal(nrow(D), nrow(chk) + 2)
 ## include two
 chk <- tiledb_array(uri, query_condition=parse_query_condition(key == "ñ" || key == "Ø"), return_as="data.frame")[]
 expect_equal(nrow(chk), 2)
+
+
+## Test minimal version
+if (tiledb_version(TRUE) < "2.16.0") exit_file("Remainder needs 2.16.* or later")
+
+## BOOL in query condition
+D <- data.frame(rows=1:5,
+                vals=100+cumsum(rnorm(5)),
+                labs=c(TRUE, FALSE, FALSE, TRUE, FALSE))
+uri <- tempfile()
+expect_silent(fromDataFrame(D, uri, col_index=1))
+arr <- tiledb_array(uri, return_as="data.frame")
+expect_equal(nrow(arr[]), 5L)
+query_condition(arr) <- parse_query_condition(labs == TRUE, ta=arr)
+expect_equal(nrow(arr[]), 2L)
+query_condition(arr) <- parse_query_condition(labs == FALSE, ta=arr)
+expect_equal(nrow(arr[]), 3L)

--- a/src/libtiledb.cpp
+++ b/src/libtiledb.cpp
@@ -3835,6 +3835,10 @@ void libtiledb_query_condition_init(XPtr<tiledb::QueryCondition> query_cond,
     } else if (cond_val_type == "ASCII" || cond_val_type == "UTF8") {
         std::string v = as<std::string>(condition_value);
         query_cond->init(attr_name, v, op);
+    } else if (cond_val_type == "BOOL") {
+        bool v = as<bool>(condition_value);
+        uint64_t cond_val_size = sizeof(bool);
+        query_cond->init(attr_name, (void*) &v, cond_val_size, op);
     } else {
         Rcpp::stop("Currently unsupported type: %s", cond_val_type);
     }


### PR DESCRIPTION
Query conditions can use BOOL types (though these are internally masked to UINT8).  A [pending PR in Core](https://github.com/TileDB-Inc/TileDB/pull/4046) smoothes two edges on schema creation and query processing.  With that change we can easily extend processing of query conditions and admit BOOL as a type.

~This should remain as a draft until the change has been merged in Core.~  Done as https://github.com/TileDB-Inc/TileDB/pull/4046 is now merged