### PR TITLE
Use TileDB 2.15.2

### DIFF
--- a/.github/r-ci.sh
+++ b/.github/r-ci.sh
@@ -17,6 +17,7 @@ set -e
 
 CRAN=${CRAN:-"https://cloud.r-project.org"}
 OS=$(uname -s)
+RVER=${RVER:-"4.3.0"}
 
 ## Optional drat repos, unset by default
 DRAT_REPOS=${DRAT_REPOS:-""}
@@ -199,11 +200,11 @@ BootstrapLinuxOptions() {
 
 BootstrapMac() {
     # Install from latest CRAN binary build for OS X
-    wget ${CRAN}/bin/macosx/R-latest.pkg  -O /tmp/R-latest.pkg
+    wget ${CRAN}/bin/macosx/big-sur-x86_64/base/R-${RVER}-x86_64.pkg  -O /tmp/R-latest.pkg
 
     echo "Installing OS X binary package for R"
-    sudo installer -pkg "/tmp/R-latest.pkg" -target /
-    rm "/tmp/R-latest.pkg"
+    sudo installer -pkg /tmp/R-latest.pkg -target /
+    rm /tmp/R-latest.pkg
 
     # Process options
     BootstrapMacOptions

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -11,8 +11,8 @@ jobs:
       fail-fast: false
       matrix:
         include: [
-          { windows: windows-2019, r: release    },
-          { windows: windows-2022, r: devel      }
+          { windows: windows-latest, r: release    },
+          { windows: windows-latest, r: devel      }
         ]
     steps:
       - run: git config --global core.autocrlf false

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -12,8 +12,7 @@ jobs:
       matrix:
         include: [
           { windows: windows-2019, r: release    },
-          { windows: windows-2022, r: devel      },
-          { windows: windows-2022, r: devel-ucrt }
+          { windows: windows-2022, r: devel      }
         ]
     steps:
       - run: git config --global core.autocrlf false

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,7 +6,7 @@
 
 * The startup message now displays the operating system and version (#532)
 
-* Use of TileDB Embedded was upgraded to release 2.15.1 (#534)
+* Use of TileDB Embedded was upgraded to release 2.15.1 and 2.15.2 (#534, #541)
 
 * Group objects can be opened while supplying a Config object when 2.15.1 or newer is used (#535, #536)
 

--- a/tools/tiledbVersion.txt
+++ b/tools/tiledbVersion.txt
@@ -1,2 +1,2 @@
-version: 2.15.1
-sha: 432d4c2
+version: 2.15.2
+sha: 90f30eb


### PR DESCRIPTION
This PR updates the package preference to TileDB 2.15.2.

No code change.  One change to CI setup for macOS where CRAN broke the link along with the R 4.3.0 release.