### PR TITLE
Skip parts of a test file under 2.14.*

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -22,6 +22,8 @@
 
 * The use of binary packages in continuous integration has been made a little more robust (#531)
 
+* A small subset of tests are skipped if testing against the older release 2.14.* (#542)
+
 
 # tiledb 0.19.0
 

--- a/inst/tinytest/test_tiledbarray.R
+++ b/inst/tinytest/test_tiledbarray.R
@@ -1435,7 +1435,7 @@ attrs(arr) <- NA_character_
 expect_true(is.na(attrs(arr)))
 
 v <- tiledb_version()
-if (v[["major"]] == 2L && v[["minor"]] %in% c(4L, 10L)) exit_file("Skip remainder for 2.4.* and 2.10.*")
+if (v[["major"]] == 2L && v[["minor"]] %in% c(4L, 10L, 14L)) exit_file("Skip remainder for 2.{4,10,14}.*")
 
 ## CI issues at GitHub for r-release on Windows Server 2019
 if (getRversion() < "4.3.0" && Sys.info()[["sysname"]] == "Windows") exit_file("Skip remainder for R 4.2.* on Windows")


### PR DESCRIPTION
The related test battery shows a minor wrinkle under 2.14.*; this is likely not worth fixing as it is fine under 2.15.* and 2.16.0.  