### PR TITLE
Adjust startup message, minor update to README.md

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tiledb
 Type: Package
-Version: 0.19.1
+Version: 0.19.1.1
 Title: Universal Storage Engine for Sparse and Dense Multidimensional Arrays
 Authors@R: c(person("TileDB, Inc.", role = c("aut", "cph")),
  person("Dirk", "Eddelbuettel", email = "dirk@tiledb.com", role = "cre"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,13 @@
+# tilebd 0.19.* -- Ongoing development
+
+* This release of the R package builds against [TileDB 2.15.2](https://github.com/TileDB-Inc/TileDB/releases/tag/2.15.2), and has also been tested against earlier releases as well as the development
+  version (#534, #541).
+
+## Improvements
+
+* The startup message is now reformated across two shorter lines (#545)
+
+
 # tiledb 0.19.1
 
 * This release of the R package builds against [TileDB 2.15.2](https://github.com/TileDB-Inc/TileDB/releases/tag/2.15.2), and has also been tested against earlier releases as well as the development

--- a/R/Init.R
+++ b/R/Init.R
@@ -1,6 +1,6 @@
 #  MIT License
 #
-#  Copyright (c) 2017-2022 TileDB Inc.
+#  Copyright (c) 2017-2023 TileDB Inc.
 #
 #  Permission is hereby granted, free of charge, to any person obtaining a copy
 #  of this software and associated documentation files (the "Software"), to deal
@@ -62,7 +62,7 @@
         packageStartupMessage("TileDB R ", packageVersion("tiledb"),
                               " with TileDB Embedded ", format(tiledb_version(TRUE)),
                               " on ", utils::osVersion,
-                              ". See https://tiledb.com for more information.")
+                              ".\nSee https://tiledb.com for more information about TileDB.")
     }
 }
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ The most recent released version can be installed from
     > remotes::install_github("TileDB-Inc/TileDB-R")
     ...
     > library(tiledb)
-    TileDB R 0.17.0 with TileDB Embedded 2.13.0. See https://tiledb.com for more information.
+    TileDB R 0.19.1 with TileDB Embedded 2.15.2 on Ubuntu 22.04.
+    See https://tiledb.com for more information about TileDB.
     > help(package=tiledb)
 
 If the TileDB library is installed in a custom location, you need to pass the explicit path:
@@ -46,7 +47,7 @@ If the TileDB library is installed in a custom location, you need to pass the ex
     > remotes::install_github("TileDB-Inc/TileDB-R",
           args="--configure-args='--with-tiledb=/path/to/tiledb'")
 
-Note that the TileDB R package is developed and tested against the latest stable (`v2.6.x`) version
+Note that the TileDB R package is always developed and tested against the latest stable version
 of TileDB, but should also build against the newest development version.
 
 ## Quick Links
@@ -58,7 +59,7 @@ of TileDB, but should also build against the newest development version.
 
 ## Copyright
 
-The TileDB R package is Copyright 2018-2022 TileDB, Inc
+The TileDB R package is Copyright 2018-2023 TileDB, Inc
 
 ## License
 


### PR DESCRIPTION
This is small cosmetic PR adjusting the startup message to be a little narrow and across two lines:

```r
> library(tiledb)
TileDB R 0.19.1 with TileDB Embedded 2.15.2 on Ubuntu 22.04.
See https://tiledb.com for more information about TileDB.
> 
```

It also updates the referenced version information in the README.md and updates the copyright year.
