### PR TITLE
Reflect global context object when creating config

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tiledb
 Type: Package
-Version: 0.19.1.1
+Version: 0.19.1.2
 Title: Universal Storage Engine for Sparse and Dense Multidimensional Arrays
 Authors@R: c(person("TileDB, Inc.", role = c("aut", "cph")),
  person("Dirk", "Eddelbuettel", email = "dirk@tiledb.com", role = "cre"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,10 @@
 
 * The startup message is now reformated across two shorter lines (#545)
 
+## Bug Fixes
+
+* Consolidation and vacuum calls now reflect the state of the global context object (#547)
+
 
 # tiledb 0.19.1
 

--- a/R/TileDBArray.R
+++ b/R/TileDBArray.R
@@ -1591,7 +1591,7 @@ array_consolidate <- function(uri, cfg = NULL,
                               ctx = tiledb_get_context()) {
     stopifnot(`Argument 'uri' must be character` = is.character(uri))
     if (is.null(cfg)) {
-        cfg <- tiledb_config()
+        cfg <- config(ctx)
     }
 
     if (!missing(start_time)) {
@@ -1635,7 +1635,7 @@ array_vacuum <- function(uri, cfg = NULL,
 
     stopifnot(`Argument 'uri' must be character` = is.character(uri))
     if (is.null(cfg)) {
-        cfg <- tiledb_config()
+        cfg <- config(ctx)
     }
 
     if (!missing(start_time)) {


### PR DESCRIPTION
Fixed #546 

For both consolidation and vacuum, a temporary config was created to set start and end timestamps.  That temporary config was a the default which then skips all possible configuration already set in the global context object.

The simple fix to create the `config` object off the `ctx`, either a givem one or the usual global one.