### PR TITLE
Re-enable sudo mode for bspm in CI

### DIFF
--- a/.github/r-ci.sh
+++ b/.github/r-ci.sh
@@ -193,6 +193,7 @@ BootstrapLinuxOptions() {
     #    InstallPandoc 'linux/debian/x86_64'
     #fi
     if [[ "${USE_BSPM}" != "FALSE" ]]; then
+        echo "options(bspm.sudo = TRUE)" | sudo tee --append /etc/R/Rprofile.site >/dev/null
         echo "suppressMessages(bspm::enable())" | sudo tee --append /etc/R/Rprofile.site >/dev/null
         echo "options(bspm.version.check=FALSE)" | sudo tee --append /etc/R/Rprofile.site >/dev/null
     fi


### PR DESCRIPTION
This adds one line back in that was erroneously removed earlier, and has similarly been restored in the corresponding scripts in SOMA and elsewhere.  Adding it does not really change functionality but takes a lot of 'line noise' out of the CI runs as R no longer complains that this should be set but isn't...