### PR TITLE
Move comma in documentation for dimension

### DIFF
--- a/R/Dim.R
+++ b/R/Dim.R
@@ -37,10 +37,10 @@ tiledb_dim.from_ptr <- function(ptr) {
 #'
 #' @param name The dimension name / label string.  This argument is required.
 #' @param domain The dimension (inclusive) domain. The domain of a dimension
-#' is defined by a (lower bound, upper bound) vector. For type, \code{ASCII}
+#' is defined by a (lower bound, upper bound) vector. For type \code{ASCII},
 #' \code{NULL} is expected.
-#' @param tile The tile dimension tile extent. For type,
-#' \code{ASCII} \code{NULL} is expected.
+#' @param tile The tile dimension tile extent. For type
+#' \code{ASCII}, \code{NULL} is expected.
 #' @param type The dimension TileDB datatype string.
 #' @param filter_list An optional \code{tiledb_filter_list} object, default
 #' is no filter

--- a/man/tiledb_dim.Rd
+++ b/man/tiledb_dim.Rd
@@ -17,11 +17,11 @@ tiledb_dim(
 \item{name}{The dimension name / label string.  This argument is required.}
 
 \item{domain}{The dimension (inclusive) domain. The domain of a dimension
-is defined by a (lower bound, upper bound) vector. For type, \code{ASCII}
+is defined by a (lower bound, upper bound) vector. For type \code{ASCII},
 \code{NULL} is expected.}
 
-\item{tile}{The tile dimension tile extent. For type,
-\code{ASCII} \code{NULL} is expected.}
+\item{tile}{The tile dimension tile extent. For type
+\code{ASCII}, \code{NULL} is expected.}
 
 \item{type}{The dimension TileDB datatype string.}
 


### PR DESCRIPTION
A comma in the docstring is confusing, so it makes sense to move it one token forward.