### PR TITLE
Support Date column exports to arrow

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tiledb
 Type: Package
-Version: 0.19.1.4
+Version: 0.19.1.5
 Title: Universal Storage Engine for Sparse and Dense Multidimensional Arrays
 Authors@R: c(person("TileDB, Inc.", role = c("aut", "cph")),
  person("Dirk", "Eddelbuettel", email = "dirk@tiledb.com", role = "cre"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -11,11 +11,15 @@
 
 * Use of TileDB Embedded was upgraded to release 2.15.3 (#551)
 
+* Date columns can now be exported to Arrow as well (#554)
+
 ## Bug Fixes
 
 * Consolidation and vacuum calls now reflect the state of the global context object (#547)
 
 * Pointers to 'Arrow Table' objects representing the table columns are now in external pointers too (#550)
+
+* The documentation for 'Dimensions' was corrected in two spots in its wording / grammar (#552)
 
 ## Build and Test Systems
 

--- a/inst/tinytest/test_arrowio.R
+++ b/inst/tinytest/test_arrowio.R
@@ -193,7 +193,15 @@ for (arg in c("arrow", "arrow_table")) {
     expect_equal(res$num_columns, 8)
 }
 
-
+## test support for return as Date (GH Issue 533)
+uri <- tempfile()
+D <- data.frame(val = 100 + 0:4,
+                dat = Sys.Date() + seq(-4,0))
+fromDataFrame(D, uri, col_index = 1)
+at <- tiledb_array(uri, return_as = "arrow")[]
+expect_true(inherits(at, "Table"))
+chk <- data.frame(at)
+expect_equal(D, chk)
 
 ## detaching arrow should not be necessary as we generally do not need to unload
 ## packages but had been seen as beneficial in some instanced so there is now an option

--- a/src/arrow_adapter.h
+++ b/src/arrow_adapter.h
@@ -185,6 +185,8 @@ class ArrowAdapter {
                 return "tsu:";
             case TILEDB_DATETIME_NS:
                 return "tsn:";
+            case TILEDB_DATETIME_DAY:
+                return "tdD";
             default:
                 break;
         }

--- a/src/arrow_adapter.h
+++ b/src/arrow_adapter.h
@@ -126,6 +126,11 @@ class ArrowAdapter {
         }
 #endif
 
+        /* Workaround for Date column with is 32-bit but treated as 64-bit */
+        if (column->type() == TILEDB_DATETIME_DAY) {
+            column->date_cast();
+        }
+
         return std::pair(std::move(array), std::move(schema));
     }
 

--- a/src/column_buffer.cpp
+++ b/src/column_buffer.cpp
@@ -96,6 +96,16 @@ void ColumnBuffer::to_bitmap(tcb::span<uint8_t> bytemap) {
     }
 }
 
+void ColumnBuffer::date_cast_to_32bit(tcb::span<int64_t> data) {
+    size_t n = data.size();
+    std::vector<int32_t> vec(n);
+    for (size_t i=0; i<n; i++) {
+        vec[i] = static_cast<int32_t>(data[i]);
+    }
+    std::memcpy(data.data(), vec.data(), sizeof(int32_t) * n);
+}
+
+
 //===================================================================
 //= public non-static
 //===================================================================

--- a/src/column_buffer.h
+++ b/src/column_buffer.h
@@ -73,6 +73,12 @@ class ColumnBuffer {
     static void to_bitmap(
         tcb::span<uint8_t> bytemap);
 
+    /**
+     * @brief Cast a 64 bit int down to 32 bit for Date type.
+     *
+     */
+    static void date_cast_to_32bit(tcb::span<int64_t> data);
+
     //===================================================================
     //= public non-static
     //===================================================================
@@ -224,6 +230,16 @@ class ColumnBuffer {
     void validity_to_bitmap() {
         ColumnBuffer::to_bitmap(validity());
     }
+
+    /**
+     * @brief Convert a date column to 32 bit int.
+     *
+     */
+    void date_cast() {
+        ColumnBuffer::date_cast_to_32bit(data<int64_t>());
+    }
+
+
 
    private:
     //===================================================================


### PR DESCRIPTION
Fixes #553 

The R data format 'Date' uses a 32bit integer representation (of days since the epoch).  This can be represented by Arrow as format 'tdD'.  This PR adds export functionality and a simple test.