### PR TITLE
Use temporal policy when setting array timestamp on write

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tiledb
 Type: Package
-Version: 0.19.1.5
+Version: 0.19.1.6
 Title: Universal Storage Engine for Sparse and Dense Multidimensional Arrays
 Authors@R: c(person("TileDB, Inc.", role = c("aut", "cph")),
  person("Dirk", "Eddelbuettel", email = "dirk@tiledb.com", role = "cre"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,8 @@
 
 * Date columns can now be exported to Arrow as well (#554)
 
+* Array writes which set timestamps now take advantage of the new temporal policy API (#558)
+
 ## Bug Fixes
 
 * Consolidation and vacuum calls now reflect the state of the global context object (#547)

--- a/R/TileDBArray.R
+++ b/R/TileDBArray.R
@@ -610,9 +610,11 @@ setMethod("[", "tiledb_array",
     }
   }
   if (length(x@timestamp_start) > 0) {
+      spdl::debug("['['] set open_timestamp_start to {}", x@timestamp_start)
       arrptr <- libtiledb_array_set_open_timestamp_start(arrptr, x@timestamp_start)
   }
   if (length(x@timestamp_end) > 0) {
+      spdl::debug("['['] set open_timestamp_end to {}", x@timestamp_end)
       arrptr <- libtiledb_array_set_open_timestamp_end(arrptr, x@timestamp_end)
   }
   if (length(x@timestamp_start) > 0 || length(x@timestamp_end) > 0) {
@@ -1269,6 +1271,9 @@ setMethod("[<-", "tiledb_array",
     if (libtiledb_array_is_open_for_writing(x@ptr)) { 			# if open for writing
       arrptr <- x@ptr                                           #   use array
     } else {                                                    # else open appropriately
+      if (length(x@timestamp_end) > 0) {
+        tstamp <- x@timestamp_end
+      }
       if (length(enckey) > 0) {
         if (length(tstamp) > 0) {
           arrptr <- libtiledb_array_open_at_with_key(ctx@ptr, uri, "WRITE", enckey, tstamp)
@@ -1277,8 +1282,10 @@ setMethod("[<-", "tiledb_array",
         }
       } else {
         if (length(tstamp) > 0) {
+          spdl::debug("['[<-'] openning for WRITE at {}", tstamp)
           arrptr <- libtiledb_array_open_at(ctx@ptr, uri, "WRITE", tstamp)
         } else {
+          spdl::debug("['[<-'] openning for WRITE")
           arrptr <- libtiledb_array_open(ctx@ptr, uri, "WRITE")
         }
       }

--- a/inst/tinytest/test_timetravel.R
+++ b/inst/tinytest/test_timetravel.R
@@ -130,7 +130,7 @@ expect_true(length(ndircons2) < length(ndircons))
 if (tiledb_version(TRUE) < "2.15.0") exit_file("Needs TileDB 2.15.* or later")
 
 uri <- tempfile()
-ts <- function(x) as.POSIXct(x/1000, tz="UTC")
+ts <- function(x) as.POSIXct(x/1000, tz="UTC", origin="1970-01-01")
 D <- data.frame(ind = 1L, val = 1.0)
 fromDataFrame(D, uri, col_index = 1, mode = "schema_only")
 for (tstamp in 1:3) {

--- a/src/libtiledb.cpp
+++ b/src/libtiledb.cpp
@@ -2005,7 +2005,7 @@ XPtr<tiledb::Array> libtiledb_array_open_at(XPtr<tiledb::Context> ctx, std::stri
     auto ptr = new tiledb::Array(*ctx.get(), uri, query_type, tiledb::TemporalPolicy(tiledb::TimeTravel, ts_ms));
     ptr->set_open_timestamp_end(ts_ms);
 #elif TILEDB_VERSION >= TileDB_Version(2,3,0)
-    auto ptr = new tiledb::Array(*ctx.get(), uri, query_type, ts_ms);
+    auto ptr = new tiledb::Array(*ctx.get(), uri, query_type);
     ptr->set_open_timestamp_end(ts_ms);
 #else
     auto ptr = new tiledb::Array(*ctx.get(), uri, query_type, ts_ms);

--- a/src/libtiledb.cpp
+++ b/src/libtiledb.cpp
@@ -2001,8 +2001,11 @@ XPtr<tiledb::Array> libtiledb_array_open_at(XPtr<tiledb::Context> ctx, std::stri
     auto query_type = _string_to_tiledb_query_type(type);
     // get timestamp as seconds since epoch (plus fractional seconds, returns double), scale to millisec
     uint64_t ts_ms = static_cast<uint64_t>(std::round(tstamp.getFractionalTimestamp() * 1000));
-#if TILEDB_VERSION >= TileDB_Version(2,3,0)
-    auto ptr = new tiledb::Array(*ctx.get(), uri, query_type);
+#if TILEDB_VERSION >= TileDB_Version(2,15,0)
+    auto ptr = new tiledb::Array(*ctx.get(), uri, query_type, tiledb::TemporalPolicy(tiledb::TimeTravel, ts_ms));
+    ptr->set_open_timestamp_end(ts_ms);
+#elif TILEDB_VERSION >= TileDB_Version(2,3,0)
+    auto ptr = new tiledb::Array(*ctx.get(), uri, query_type, ts_ms);
     ptr->set_open_timestamp_end(ts_ms);
 #else
     auto ptr = new tiledb::Array(*ctx.get(), uri, query_type, ts_ms);


### PR DESCRIPTION
This PR switches to the new TemporalPolicy-using interface when writing arrays.  

A set of tests has been added as well.