### PR TITLE
Use TileDB 2.15.4

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tiledb
 Type: Package
-Version: 0.19.1.6
+Version: 0.19.1.7
 Title: Universal Storage Engine for Sparse and Dense Multidimensional Arrays
 Authors@R: c(person("TileDB, Inc.", role = c("aut", "cph")),
  person("Dirk", "Eddelbuettel", email = "dirk@tiledb.com", role = "cre"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 # tilebd 0.19.* -- Ongoing development
 
-* This release of the R package builds against [TileDB 2.15.3](https://github.com/TileDB-Inc/TileDB/releases/tag/2.15.3), and has also been tested against earlier releases as well as the development
-  version (#551).
+* This release of the R package builds against [TileDB 2.15.4](https://github.com/TileDB-Inc/TileDB/releases/tag/2.15.4), and has also been tested against earlier releases as well as the development
+  version (#551, #559)
 
 ## Improvements
 

--- a/tools/tiledbVersion.txt
+++ b/tools/tiledbVersion.txt
@@ -1,2 +1,2 @@
-version: 2.15.3
-sha: 689bea0
+version: 2.15.4
+sha: 57c9edf


### PR DESCRIPTION
This PR updates the package preference to TileDB 2.15.4.

No code change.