### PR TITLE
Use more newlines in schema print for improved readability

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,8 @@
 
 * Array writes which set timestamps now take advantage of the new temporal policy API (#558)
 
+* Displaying a schema is now more readable with additional linebreaks (#560)
+
 ## Bug Fixes
 
 * Consolidation and vacuum calls now reflect the state of the global context object (#547)

--- a/R/ArraySchema.R
+++ b/R/ArraySchema.R
@@ -145,7 +145,7 @@ setMethod("show", signature(object = "tiledb_array_schema"),
     nfo <- nfilters(fl$offsets)
     nfv <- if (tiledb_version(TRUE) >= "2.6.0") nfilters(fl$validity) else 0
     cat("tiledb_array_schema(\n    domain=", .as_text_domain(domain(object)), ",\n",
-        "    attrs=c(", paste(sapply(attrs(object), .as_text_attribute), collapse=", "), "),\n",
+        "    attrs=c(\n        ", paste(sapply(attrs(object), .as_text_attribute), collapse=",\n        "), "\n    ),\n",
         "    cell_order=\"", cell_order(object), "\", ",
         "tile_order=\"", tile_order(object), "\", ",
         "capacity=", capacity(object), ", ",

--- a/R/Attribute.R
+++ b/R/Attribute.R
@@ -1,6 +1,6 @@
 #  MIT License
 #
-#  Copyright (c) 2017-2022 TileDB Inc.
+#  Copyright (c) 2017-2023 TileDB Inc.
 #
 #  Permission is hereby granted, free of charge, to any person obtaining a copy
 #  of this software and associated documentation files (the "Software"), to deal

--- a/R/Domain.R
+++ b/R/Domain.R
@@ -73,12 +73,12 @@ setMethod("raw_dump",
 
 # internal function returning text use here and in other higher-level show() methods
 .as_text_domain <- function(object) {
-    txt <- "tiledb_domain(c("
+    txt <- "tiledb_domain(c(\n"
     dims <- dimensions(object)
     nd <- length(dims)
     for (i in seq_len(nd)) {
-        txt <- paste0(txt, .as_text_dimension(dims[[i]]),
-                      if (i == nd) "))" else ", ")
+        txt <- paste0(txt, "        ", .as_text_dimension(dims[[i]]),
+                      if (i == nd) "\n    ))" else ",\n")
     }
     txt
 }


### PR DESCRIPTION
This PR updates the 'show' methods for schema, domain and attributes to add extra newlines so that each dimension and attribute is on a separate line easing readibility. For example, `quickstart_sparse` becomes

```r
tiledb_array_schema(
    domain=tiledb_domain(c(
        tiledb_dim(name="rows", domain=c(1L,4L), tile=4L, type="INT32"),
        tiledb_dim(name="cols", domain=c(1L,4L), tile=4L, type="INT32")
    )),
    attrs=c(
        tiledb_attr(name="a", type="INT32", ncells=1, nullable=FALSE)
    ),
    cell_order="COL_MAJOR", tile_order="COL_MAJOR", capacity=10000, sparse=TRUE, allows_dups=FALSE,
    coords_filter_list=tiledb_filter_list(c(tiledb_filter_set_option(tiledb_filter("ZSTD"),"COMPRESSION_LEVEL",-1))),
    offsets_filter_list=tiledb_filter_list(c(tiledb_filter_set_option(tiledb_filter("ZSTD"),"COMPRESSION_LEVEL",-1))),
    validity_filter_list=tiledb_filter_list(c(tiledb_filter_set_option(tiledb_filter("RLE"),"COMPRESSION_LEVEL",-1)))
)
```

No new code.



