### PR TITLE
Error out when attempts to set dimensions selection beyond number of dimension

### DIFF
--- a/R/TileDBArray.R
+++ b/R/TileDBArray.R
@@ -552,6 +552,7 @@ setMethod("[", "tiledb_array",
   use_arrow <- x@return_as == "arrow"
 
   dims <- tiledb::dimensions(dom)
+  ndims <- length(dims)
   dimnames <- sapply(dims, function(d) libtiledb_dim_get_name(d@ptr))
   dimtypes <- sapply(dims, function(d) libtiledb_dim_get_datatype(d@ptr))
   dimvarnum <- sapply(dims, function(d) libtiledb_dim_get_cell_val_num(d@ptr))
@@ -711,6 +712,9 @@ setMethod("[", "tiledb_array",
   }
 
   if (!is.null(j)) {
+      if (ndims == 1) {
+          stop("Setting dimension 'j' requires at least two dimensions.", call. = FALSE)
+      }
       if (!is.null(x@selected_ranges[[2]])) {
           stop("Cannot set both 'j' and second element of 'selected_ranges'.", call. = FALSE)
       }
@@ -718,6 +722,9 @@ setMethod("[", "tiledb_array",
   }
 
   if (!is.null(k)) {
+      if (ndims <= 2) {
+          stop("Setting dimension 'k' requires at least three dimensions.", call. = FALSE)
+      }
       if (!is.null(x@selected_ranges[[3]])) {
           stop("Cannot set both 'k' and second element of 'selected_ranges'.", call. = FALSE)
       }

--- a/inst/tinytest/test_tiledbarray.R
+++ b/inst/tinytest/test_tiledbarray.R
@@ -1540,3 +1540,17 @@ revert <- tiledb_array(rvturi, strings_as_factors=TRUE)[]
 expect_equal(sum(is.na(revert$sex)), 333)
 for (col in colnames(before)[-c(1,8)]) # exclude __tiledb_rows
     expect_equal(before[[col]], revert[[col]])
+
+## check for error when setting on N+1 dims
+D <- data.frame(i=1:10, j=101:110, k=letters[1:10])
+uri <- tempfile()
+fromDataFrame(D, uri, col_index=1)
+arr <- tiledb_array(uri, return_as="data.frame")
+expect_error(arr[, 103:105])   # error: indexing on second dim on one-dim array
+expect_equal(nrow(arr[]), 10)
+
+uri <- tempfile()
+fromDataFrame(D, uri, col_index=1:2)
+arr <- tiledb_array(uri, return_as="data.frame")
+expect_error(arr[, , 103:105]) # error: indexing on third dim on two-dim array
+expect_equal(nrow(arr[]), 10)


### PR DESCRIPTION
This simple PR catches a simple error when e.g. on an one-dimensional array a request is made such as

```r
res <- arr[, 10:20]
```

trying to select on _j_ which otherwise results in an error.  Ditto for attempting to set _k_ on a two-dimensional array.

Simple tests have been added.