### PR TITLE
Use 2.16.0

### DIFF
--- a/tools/tiledbVersion.txt
+++ b/tools/tiledbVersion.txt
@@ -1,2 +1,2 @@
-version: 2.15.4
-sha: 57c9edf
+version: 2.16.0-rc0
+sha: d4a37a6

--- a/tools/tiledbVersion.txt
+++ b/tools/tiledbVersion.txt
@@ -1,2 +1,2 @@
-version: 2.16.0-rc0
-sha: d4a37a6
+version: 2.16.0-rc1
+sha: 91bd91b

--- a/tools/tiledbVersion.txt
+++ b/tools/tiledbVersion.txt
@@ -1,2 +1,2 @@
-version: 2.16.0-rc1
-sha: 91bd91b
+version: 2.16.0
+sha: d682dd0


### PR DESCRIPTION
This PR updates the package preference to TileDB 2.16.0 (following two tests with release candidates).
