### PR TITLE
Account for integer64 when writing metadata

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -19,6 +19,8 @@
 
 * Attempts to select on dimensions that do not exist now error out with a message (#561)
 
+* Integer64 values can now be written to array metadata (#564)
+
 ## Bug Fixes
 
 * Consolidation and vacuum calls now reflect the state of the global context object (#547)

--- a/inst/tinytest/test_metadata.R
+++ b/inst/tinytest/test_metadata.R
@@ -190,4 +190,11 @@ close_and_reopen(arr, "READ")
 expect_equal(tiledb_num_metadata(arr), 2)
 #})
 
+vals <- bit64::as.integer64(c(10,20,30))
+close_and_reopen(arr, "WRITE")
+expect_true(tiledb_put_metadata(arr, "int64", vals))
+close_and_reopen(arr, "READ")
+expect_equal(tiledb_get_metadata(arr, "int64"), vals)
+
+
 if (dir.exists(tmp)) unlink(tmp, recursive = TRUE, force = TRUE)

--- a/src/libtiledb.cpp
+++ b/src/libtiledb.cpp
@@ -2430,7 +2430,9 @@ SEXP _metadata_to_sexp(const tiledb_datatype_t v_type, const uint32_t v_num, con
   } else if (v_type == TILEDB_UINT32) {
     return copy_int_vector<uint32_t>(v_num, v);
   } else if (v_type == TILEDB_INT64) {
-    return copy_int_vector<int64_t>(v_num, v);
+    std::vector<int64_t> iv(v_num);
+    std::memcpy(&(iv[0]), v, v_num*sizeof(int64_t));
+    return makeInteger64(iv);
   } else if (v_type == TILEDB_UINT64) {
     return copy_int_vector<uint64_t>(v_num, v);
   } else {

--- a/src/libtiledb.cpp
+++ b/src/libtiledb.cpp
@@ -2335,7 +2335,12 @@ bool libtiledb_array_put_metadata(XPtr<tiledb::Array> array,
     }
     case REALSXP: {
       Rcpp::NumericVector v(obj);
-      array->put_metadata(key.c_str(), TILEDB_FLOAT64, v.size(), v.begin());
+      if (isInteger64(v)) {
+          std::vector<int64_t> iv = getInt64Vector(v);
+          array->put_metadata(key.c_str(), TILEDB_INT64, iv.size(), (void*) &iv[0]);
+      } else {
+          array->put_metadata(key.c_str(), TILEDB_FLOAT64, v.size(), v.begin());
+      }
       break;
     }
     case INTSXP: {


### PR DESCRIPTION
This initially reported in the SOMA project as https://github.com/single-cell-data/TileDB-SOMA/issues/1512 but is a tiledb-r issue addressed by this PR.

A small test has been added too.