### PR TITLE
Increase micro version, and adjust one test for older version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tiledb
 Type: Package
-Version: 0.19.1.8
+Version: 0.19.1.9
 Title: Universal Storage Engine for Sparse and Dense Multidimensional Arrays
 Authors@R: c(person("TileDB, Inc.", role = c("aut", "cph")),
  person("Dirk", "Eddelbuettel", email = "dirk@tiledb.com", role = "cre"))

--- a/inst/tinytest/test_tiledbarray.R
+++ b/inst/tinytest/test_tiledbarray.R
@@ -1435,7 +1435,7 @@ attrs(arr) <- NA_character_
 expect_true(is.na(attrs(arr)))
 
 v <- tiledb_version()
-if (v[["major"]] == 2L && v[["minor"]] %in% c(4L, 10L, 14L)) exit_file("Skip remainder for 2.{4,10,14}.*")
+if (v[["major"]] == 2L && v[["minor"]] %in% c(4L, 10L, 12L, 14L)) exit_file("Skip remainder for 2.{4,10,14}.*")
 
 ## CI issues at GitHub for r-release on Windows Server 2019
 if (getRversion() < "4.3.0" && Sys.info()[["sysname"]] == "Windows") exit_file("Skip remainder for R 4.2.* on Windows")


### PR DESCRIPTION
PR #564 forgot to increment the micro version, and upset one older release when doing batch testing against older releases.  

This micro-tweak PR adjusts for both those aspect.  No new code.