### PR TITLE
Remove deprecated 'timestamp' argument to tiledb_array

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tiledb
 Type: Package
-Version: 0.19.1.9
+Version: 0.19.1.10
 Title: Universal Storage Engine for Sparse and Dense Multidimensional Arrays
 Authors@R: c(person("TileDB, Inc.", role = c("aut", "cph")),
  person("Dirk", "Eddelbuettel", email = "dirk@tiledb.com", role = "cre"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -35,6 +35,10 @@
 
 * Compilation on Linux systems as old as Ubuntu 18.04 without a `filesystem` header is now possible (#556)
 
+## Removals
+
+* The `timestamp` argument to `tiledb_array`, deprecated in favor of `timestamp_end` (and `timestamp_start`) in July 2021, has been removed (#566).
+
 
 # tiledb 0.19.1
 

--- a/R/BatchedQuery.R
+++ b/R/BatchedQuery.R
@@ -34,7 +34,7 @@ createBatched <- function(x) {
     layout <- x@query_layout
     asint64 <- x@datetimes_as_int64
     enckey <- x@encryption_key
-    tstamp <- x@timestamp
+    tstamp <- x@timestamp_end
 
     sparse <- libtiledb_array_schema_sparse(sch@ptr)
 

--- a/inst/tinytest/test_tiledbarray.R
+++ b/inst/tinytest/test_tiledbarray.R
@@ -961,10 +961,7 @@ if (requireNamespace("bit64", quietly=TRUE)) {
 
 if (tiledb_version(TRUE) >= "2.8.0" && tiledb_version(TRUE) < "2.10.0") exit_file("2.8.* and 2.9.* skip remainder")
 
-## FYI: 101 tests here
-
-
-## FYI: 105 tests here
+## n=104
 ## non-empty domain, var and plain
 tmp <- tempfile()
 dir.create(tmp)
@@ -999,6 +996,7 @@ schema3 <- tiledb::schema(arr)
 expect_true(is(schema3, "tiledb_array_schema"))
 expect_equal(schema, schema3)
 
+## n=114
 ## time travel
 tmp <- tempfile()
 dir.create(tmp)
@@ -1033,15 +1031,6 @@ if (tiledb_version(TRUE) >= "2.10.0") {
     A <- tiledb_array(uri = tmp, as.data.frame=TRUE, timestamp_end=now2 - onet)
     expect_equal(nrow(A[]), 3)
     A <- tiledb_array(uri = tmp, as.data.frame=TRUE, timestamp_end=now2 + onet)
-    expect_equal(nrow(A[]), 6)
-} else if (tiledb_version(TRUE) >= "2.8.0") {
-    A <- tiledb_array(uri = tmp, as.data.frame=TRUE, timestamp=now1 - onet)
-    expect_equal(nrow(A[]), 0)
-    A <- tiledb_array(uri = tmp, as.data.frame=TRUE, timestamp=now1 + onet)
-    expect_equal(nrow(A[]), 3)
-    A <- tiledb_array(uri = tmp, as.data.frame=TRUE, timestamp=now2 - onet)
-    expect_equal(nrow(A[]), 3)
-    A <- tiledb_array(uri = tmp, as.data.frame=TRUE, timestamp=now2 + onet)
     expect_equal(nrow(A[]), 6)
 }
 
@@ -1303,6 +1292,7 @@ if (hasTibble) {
     expect_true(inherits(res, "tbl"))
 }
 
+## n=178
 ## test return_as for array and matrix
 uri <- tempfile()
 dir.create(uri)
@@ -1359,6 +1349,7 @@ expect_true(min(res$bill_length_mm) > 50)
 expect_equal(colnames(res), c("species", "island", "body_mass_g", "bill_length_mm", "year", "sex"))
 
 
+## n=186
 ## new 3d index, and int64 domain conversion
 uri <- tempfile()
 dom <- tiledb_domain(dims = c(tiledb_dim("rows", c(1L, 4L), 4L, "INT32"),
@@ -1392,6 +1383,7 @@ selected_ranges(A) <- list(cbind(2,2), cbind(2,3), cbind(2,2))
 res <- A[]
 expect_equal(res[, "a", drop=TRUE], c(22,26))
 
+## n=196
 if (requireNamespace("bit64", quietly=TRUE)) {
   suppressMessages(library(bit64))
   uri <- tempfile()
@@ -1437,6 +1429,7 @@ expect_true(is.na(attrs(arr)))
 v <- tiledb_version()
 if (v[["major"]] == 2L && v[["minor"]] %in% c(4L, 10L, 12L, 14L)) exit_file("Skip remainder for 2.{4,10,14}.*")
 
+## n=204
 ## CI issues at GitHub for r-release on Windows Server 2019
 if (getRversion() < "4.3.0" && Sys.info()[["sysname"]] == "Windows") exit_file("Skip remainder for R 4.2.* on Windows")
 

--- a/man/tiledb_array-class.Rd
+++ b/man/tiledb_array-class.Rd
@@ -39,8 +39,6 @@ describes the selected points for dimension i}
 
 \item{\code{encryption_key}}{A character value}
 
-\item{\code{timestamp}}{A POSIXct datetime variable (deprecated, use timestamp_start)}
-
 \item{\code{as.matrix}}{A logical value}
 
 \item{\code{as.array}}{A logical value}

--- a/man/tiledb_array.Rd
+++ b/man/tiledb_array.Rd
@@ -18,7 +18,6 @@ tiledb_array(
   query_layout = character(),
   datetimes_as_int64 = FALSE,
   encryption_key = character(),
-  timestamp = as.POSIXct(double(), origin = "1970-01-01"),
   as.matrix = FALSE,
   as.array = FALSE,
   query_condition = new("tiledb_query_condition"),
@@ -68,9 +67,6 @@ representation as \sQuote{raw} \code{integer64} and not as \code{Date},
 
 \item{encryption_key}{optional A character value with an AES-256 encryption key
 in case the array was written with encryption.}
-
-\item{timestamp}{optional A POSIXct Datetime value determining where in time the array is
-to be openened. Deprecated, use \sQuote{timestamp_start} instead}
 
 \item{as.matrix}{optional logical switch, defaults to "FALSE"; currently limited to dense
 matrices; in the case of multiple attributes in query a list of matrices is returned}


### PR DESCRIPTION
The `timestamp` argument has been deprecated in favor of the `timestamp_start` and `timestamp_end` pair on 23 July 2021, or nearly two years ago.  It can now be removed per this PR.

No new code.