### PR TITLE
Support POSIXct and Date in QueryCondition

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tiledb
 Type: Package
-Version: 0.19.1.10
+Version: 0.19.1.11
 Title: Universal Storage Engine for Sparse and Dense Multidimensional Arrays
 Authors@R: c(person("TileDB, Inc.", role = c("aut", "cph")),
  person("Dirk", "Eddelbuettel", email = "dirk@tiledb.com", role = "cre"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -21,6 +21,8 @@
 
 * Integer64 values can now be written to array metadata (#564)
 
+* Date and POSIXct attributes are now supported in query conditions (#568)
+
 ## Bug Fixes
 
 * Consolidation and vacuum calls now reflect the state of the global context object (#547)

--- a/R/QueryCondition.R
+++ b/R/QueryCondition.R
@@ -63,7 +63,10 @@ tiledb_query_condition <- function(ctx = tiledb_get_context()) {
 tiledb_query_condition_init <- function(attr, value, dtype, op, qc = tiledb_query_condition()) {
     stopifnot("Argument 'qc' with query condition object required" = is(qc, "tiledb_query_condition"),
               "Argument 'attr' must be character" = is.character(attr),
-              "Argument 'value' must be of length one" = (is.vector(value) || bit64::is.integer64(value)) && all.equal(length(value),1),
+              "Argument 'value' must be of length one" = (is.vector(value) ||
+                                                          bit64::is.integer64(value) ||
+                                                          inherits(value, "POSIXt") ||
+                                                          inherits(value, "Date")) && all.equal(length(value),1),
               "Argument 'dtype' must be character" = is.character(dtype),
               "Argument 'op' must be character" = is.character(op))
     op <- match.arg(op, c("LT", "LE", "GT", "GE", "EQ", "NE"))
@@ -200,6 +203,8 @@ parse_query_condition <- function(expr, ta=NULL, debug=FALSE, strict=TRUE, use_i
                                                        ASCII = ch,
                                                        UTF8 = ch,
                                                        BOOL = as.logical(ch),
+                                                       DATETIME_MS = as.POSIXct(ch),
+                                                       DATETIME_DAY = as.Date(ch),
                                                        as.numeric(ch)),
                                         dtype = dtype,
                                         op = .mapOpToCharacter(op))

--- a/inst/tinytest/test_querycondition.R
+++ b/inst/tinytest/test_querycondition.R
@@ -352,7 +352,9 @@ sch <- tiledb_array_schema(dom,
                                      tiledb_attr("int64",  type="INT64"),
                                      tiledb_attr("uint64", type="UINT64"),
                                      tiledb_attr("float32",type="FLOAT32"),
-                                     tiledb_attr("float64",type="FLOAT64")),
+                                     tiledb_attr("float64",type="FLOAT64"),
+                                     tiledb_attr("posixct",type="DATETIME_MS"),
+                                     tiledb_attr("date",   type="DATETIME_DAY")),
                            sparse = TRUE)
 tiledb_array_create(tmp, sch)
 arr <- tiledb_array(tmp)
@@ -367,11 +369,17 @@ arr[] <- data.frame(rows = 1:n,
                     int64 = as.integer64(1:n),
                     uint64 = as.integer64(1:n),
                     float32 = 1:n,
-                    float64 = 1:n)
+                    float64 = 1:n,
+                    posixct = as.POSIXct(1:n, origin="1970-01-01"),
+                    date = as.Date(1:n))
 
 for (col in c("int8", "uint8", "int16", "uint16", "int32", "uint32",
               "int64", "uint64", "float32", "float64")) {
-    val <- if (grepl("int64", col)) as.integer64(10) else 10
+    val <- switch(col,
+                  int64 = as.integer64(10),
+                  posixct = as.POSIXct(10),
+                  date = as.Date(10),
+                  10)
     expect_silent(qc <- tiledb_query_condition_init(col, val, toupper(col), "GT"))
     arr <- tiledb_array(tmp, return_as="data.frame", query_condition = qc)
     expect_equal( NROW(arr[]), 10)      # ten rows if we restrict to 'value' > 10
@@ -423,3 +431,14 @@ query_condition(arr) <- parse_query_condition(labs == TRUE, ta=arr)
 expect_equal(nrow(arr[]), 2L)
 query_condition(arr) <- parse_query_condition(labs == FALSE, ta=arr)
 expect_equal(nrow(arr[]), 3L)
+
+## Parse query condition on POSIXct ('datetime') and Date
+uri <- tempfile()
+D <- data.frame(datetime=as.POSIXct(as.Date("2023-01-01") + 0:99),
+                date=as.Date("2023-01-01") + 0:99,
+                value=cumsum(1:100))
+fromDataFrame(D, uri)
+arr <- tiledb_array(uri, extended=FALSE, return_as="data.frame")
+qc <- parse_query_condition(datetime > "2023-01-05 00:00:00" && date <= "2023-01-10", ta=arr)
+query_condition(arr) <- qc
+expect_equal(nrow(arr[]), 5)

--- a/src/libtiledb.cpp
+++ b/src/libtiledb.cpp
@@ -3849,6 +3849,14 @@ void libtiledb_query_condition_init(XPtr<tiledb::QueryCondition> query_cond,
         bool v = as<bool>(condition_value);
         uint64_t cond_val_size = sizeof(bool);
         query_cond->init(attr_name, (void*) &v, cond_val_size, op);
+    } else if (cond_val_type == "DATETIME_MS") {
+        int64_t v = static_cast<int64_t>(as<double>(condition_value) * 1000);
+        uint64_t cond_val_size = sizeof(int64_t);
+        query_cond->init(attr_name, (void*) &v, cond_val_size, op);
+    } else if (cond_val_type == "DATETIME_DAY") {
+        int64_t v = static_cast<int64_t>(as<double>(condition_value));
+        uint64_t cond_val_size = sizeof(int64_t);
+        query_cond->init(attr_name, (void*) &v, cond_val_size, op);
     } else {
         Rcpp::stop("Currently unsupported type: %s", cond_val_type);
     }


### PR DESCRIPTION
During a recent exchange on the [TileDB Community Slack](https://join.slack.com/t/tiledb-community/shared_invite/zt-ndq1ipwl-QcithaWG6j1BImtuQGSpag) it became clear that query conditions did not support attributes of type `POSIXct` or `Date`.  

This PR adds support for these two column types.  New tests have been added as well. 