### PR TITLE
Switch two allocations from ArrowMalloc to new to match later delete

### DIFF
--- a/src/arrowio.cpp
+++ b/src/arrowio.cpp
@@ -33,7 +33,7 @@
 
 
 ArrowSchema* schema_owning_ptr(void) {
-  struct ArrowSchema* schema = (struct ArrowSchema*)ArrowMalloc(sizeof(struct ArrowSchema));
+  struct ArrowSchema* schema = new struct ArrowSchema;
   if (schema == nullptr) Rcpp::stop("Failed to allocate ArrowSchema");
   schema->release = NULL;
   spdl::debug("[schema_owning_ptr] created");
@@ -41,7 +41,7 @@ ArrowSchema* schema_owning_ptr(void) {
 }
 
 ArrowArray* array_owning_ptr(void) {
-  struct ArrowArray* array = (struct ArrowArray*)ArrowMalloc(sizeof(struct ArrowArray));
+  struct ArrowArray* array = new struct ArrowArray;
   if (array == nullptr) Rcpp::stop("Failed to allocate ArrowArray");
   array->release = NULL;
   spdl::debug("[array_owning_ptr] created");


### PR DESCRIPTION
This PR corrects the issue identified by CRAN's ASAN check in which the new/delete and malloc/free pairings were crossed in one instance of Arrow schema and array structure allocation.

Using a [suitable container](https://github.com/wch/r-debug) and its `RDcsan` build we were ablt to reproduce to finding, set up an appropropriate fix and assert no issues remained under this setup.