### PR TITLE
Resize in lieu of just reserving

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tiledb
 Type: Package
-Version: 0.20.1
+Version: 0.20.1.1
 Title: Universal Storage Engine for Sparse and Dense Multidimensional Arrays
 Authors@R: c(person("TileDB, Inc.", role = c("aut", "cph")),
  person("Dirk", "Eddelbuettel", email = "dirk@tiledb.com", role = "cre"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# tiledb - ongoing development
+
+## Improvements
+
+* The column buffer allocation is now robust to container overflow sanitizer checks (#574)
+
+
 # tilebd 0.20.1
 
 * This release of the R package builds against [TileDB 2.16.0](https://github.com/TileDB-Inc/TileDB/releases/tag/2.16.0), and has also been tested against earlier releases as well as the development version

--- a/src/column_buffer.cpp
+++ b/src/column_buffer.cpp
@@ -139,12 +139,12 @@ ColumnBuffer::ColumnBuffer(
     // Call reserve() to allocate memory without initializing the contents.
     // This reduce the time to allocate the buffer and reduces the
     // resident memory footprint of the buffer.
-    data_.reserve(num_bytes);
+    data_.resize(num_bytes);
     if (is_var_) {
-        offsets_.reserve(num_cells + 1);  // extra offset for arrow
+        offsets_.resize(num_cells + 1);  // extra offset for arrow
     }
     if (is_nullable_) {
-        validity_.reserve(num_cells);
+        validity_.resize(num_cells);
     }
 }
 


### PR DESCRIPTION
Recent ASAN checking involved checks for [Container Overflow](https://github.com/google/sanitizers/wiki/AddressSanitizerContainerOverflow) which requires actual _allocation_ and not just _reservation_.  This small PR contains the update for the column buffer class.