### PR TITLE
Use TileDB 2.16.1

### DIFF
--- a/tools/tiledbVersion.txt
+++ b/tools/tiledbVersion.txt
@@ -1,2 +1,2 @@
-version: 2.16.0
-sha: d682dd0
+version: 2.16.1
+sha: 3abc68f


### PR DESCRIPTION
This PR updates the package preference to TileDB 2.16.1 following its release earlier today.