### PR TITLE
Update tile_extent getter

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tiledb
 Type: Package
-Version: 0.20.1.2
+Version: 0.20.1.3
 Title: Universal Storage Engine for Sparse and Dense Multidimensional Arrays
 Authors@R: c(person("TileDB, Inc.", role = c("aut", "cph")),
  person("Dirk", "Eddelbuettel", email = "dirk@tiledb.com", role = "cre"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,10 +1,16 @@
 # tiledb - ongoing development
 
+* This release of the R package builds against [TileDB 2.16.1](https://github.com/TileDB-Inc/TileDB/releases/tag/2.16.1), and has also been tested against earlier releases as well as the development version
+
 ## Improvements
 
 * The column buffer allocation is now robust to container overflow sanitizer checks (#574)
 
 * The array schema version is now accessible via a function (#575)
+
+* Use of TileDB Embedded was upgraded to release 2.15.3 (#576)
+
+* The tile extend getter function is now able to access a wider range of possible values (#577)
 
 
 # tilebd 0.20.1
@@ -19,7 +25,7 @@
 
 ## Build and Test Systems
 
-* The valgrind nightly test was rolled to branches 2.15 and 2.15 to 2.15 and 2.15 of the TileDB Embedded library.
+* The valgrind nightly test was rolled from branches 2.14 and 2.15 to 2.15 and 2.16 of the TileDB Embedded library.
 
 
 # tilebd 0.20.0

--- a/inst/tinytest/test_filter.R
+++ b/inst/tinytest/test_filter.R
@@ -82,7 +82,7 @@ name_list <- c("NONE",
                "RLE",
                "BZIP2",
                #"DOUBLE_DELTA",			# cannot be used with floating point data
-               "BIT_WIDTH_REDUCTION",
+               #"BIT_WIDTH_REDUCTION",  # cannot be used with floating point data
                "BITSHUFFLE",
                "BYTESHUFFLE",
                "CHECKSUM_MD5",
@@ -94,6 +94,7 @@ name_list <- c("NONE",
 if (!requireNamespace("palmerpenguins", quietly=TRUE)) exit_file("remainder needs 'palmerpenguins'")
 dat <- palmerpenguins::penguins
 
+## n=20
 ## we have seen some test setups fail and suspect lack of AVX2
 if (Sys.info()[["sysname"]]=="Linux" && isFALSE(any(grepl("avx2", readLines("/proc/cpuinfo")))))
     exit_file("Skipping remainder on Linux systems without AVX2")

--- a/src/libtiledb.cpp
+++ b/src/libtiledb.cpp
@@ -970,7 +970,7 @@ SEXP libtiledb_dim_get_tile_extent(XPtr<tiledb::Dimension> dim) {
   switch (dim_type) {
     case TILEDB_FLOAT32: {
       using DataType = tiledb::impl::tiledb_to_type<TILEDB_FLOAT32>::type;
-      return NumericVector({dim->tile_extent<DataType>(),});
+      return Rcpp::wrap(static_cast<double>(dim->tile_extent<DataType>()));
     }
     case TILEDB_FLOAT64: {
       using DataType = tiledb::impl::tiledb_to_type<TILEDB_FLOAT64>::type;
@@ -978,23 +978,23 @@ SEXP libtiledb_dim_get_tile_extent(XPtr<tiledb::Dimension> dim) {
       if (t == R_NaReal) {
         Rcpp::stop("tiledb_dim tile FLOAT64 value not representable as an R double");
       }
-      return NumericVector({t});
+      return Rcpp::wrap(static_cast<double>(dim->tile_extent<DataType>()));
     }
     case TILEDB_INT8: {
       using DataType = tiledb::impl::tiledb_to_type<TILEDB_INT8>::type;
-      return IntegerVector({dim->tile_extent<DataType>()});
+      return Rcpp::wrap(static_cast<int32_t>(dim->tile_extent<DataType>()));
     }
     case TILEDB_UINT8: {
       using DataType = tiledb::impl::tiledb_to_type<TILEDB_UINT8>::type;
-      return IntegerVector({dim->tile_extent<DataType>()});
+      return Rcpp::wrap(static_cast<int32_t>(dim->tile_extent<DataType>()));
     }
     case TILEDB_INT16: {
       using DataType = tiledb::impl::tiledb_to_type<TILEDB_INT16>::type;
-      return IntegerVector({dim->tile_extent<DataType>()});
+      return Rcpp::wrap(static_cast<int32_t>(dim->tile_extent<DataType>()));
     }
     case TILEDB_UINT16: {
       using DataType = tiledb::impl::tiledb_to_type<TILEDB_INT16>::type;
-      return IntegerVector({dim->tile_extent<DataType>()});
+      return Rcpp::wrap(static_cast<int32_t>(dim->tile_extent<DataType>()));
     }
     case TILEDB_INT32: {
       using DataType = tiledb::impl::tiledb_to_type<TILEDB_INT32>::type;
@@ -1002,15 +1002,17 @@ SEXP libtiledb_dim_get_tile_extent(XPtr<tiledb::Dimension> dim) {
       if (t == R_NaInt) {
         Rcpp::stop("tiledb_dim tile INT32 value not representable as an R integer");
       }
-      return IntegerVector({t,});
+      return Rcpp::wrap(static_cast<int32_t>(t));
     }
     case TILEDB_UINT32: {
       using DataType = tiledb::impl::tiledb_to_type<TILEDB_UINT32>::type;
       auto t = dim->tile_extent<DataType>();
       if (t > std::numeric_limits<int32_t>::max()) {
-        Rcpp::stop("tiledb_dim tile UINT32 value not representable as an R integer");
+        Rcpp::warning("tiledb_dim tile UINT32 value not representable as an R integer, returning double");
+        return Rcpp::wrap(static_cast<double>(t));
+      } else {
+        return Rcpp::wrap(static_cast<int32_t>(t));
       }
-      return IntegerVector({static_cast<int32_t>(t),});
     }
     case TILEDB_DATETIME_YEAR:
     case TILEDB_DATETIME_MONTH:
@@ -1033,20 +1035,21 @@ SEXP libtiledb_dim_get_tile_extent(XPtr<tiledb::Dimension> dim) {
           return makeInteger64(v);           // which 'travels' as a double
       }
       // 'else' i.e. default cast to int32
-      return IntegerVector({static_cast<int32_t>(t),});
+      return Rcpp::wrap(static_cast<int32_t>(t));
     }
     case TILEDB_UINT64: {
       using DataType = tiledb::impl::tiledb_to_type<TILEDB_UINT64>::type;
       auto t = dim->tile_extent<DataType>();
       if (t > std::numeric_limits<int64_t>::max()) {
-          Rcpp::stop("tiledb_dim tile UINT64 value not representable as an INT64");
+          Rcpp::warning("tiledb_dim tile UINT32 value not representable as an INT64, returning double");
+          return Rcpp::wrap(static_cast<double>(t));
       }
       if (t > std::numeric_limits<int32_t>::max()) {
           auto tt = static_cast<int64_t>(t); // avoids a 'narrowing' watnings
           std::vector<int64_t> v{ tt };      // return as int64
           return makeInteger64(v);           // which 'travels' as a double
       }
-      return IntegerVector({static_cast<int32_t>(t),});
+      return Rcpp::wrap(static_cast<int32_t>(t));
     }
     default:
       Rcpp::stop("invalid tiledb_dim domain type (%s)", _tiledb_datatype_to_string(dim_type));


### PR DESCRIPTION
When accessing a VCF array it was observed that a perfectly valid uint32_t tile extent could not be retrieved to an existing and somewhat overly restrictive check in the extent getter.  This PR updates it by switching to larger data types (with warning) as needed allowing processing of such arrays.   

The PR also removes one filter test which cannot be applied to float data, this is unrelated to the change above and more likely to a change in TileDB Embedded.