### PR TITLE
Use TileDB 2.16.3

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tiledb
 Type: Package
-Version: 0.20.3
+Version: 0.20.3.1
 Title: Universal Storage Engine for Sparse and Dense Multidimensional Arrays
 Authors@R: c(person("TileDB, Inc.", role = c("aut", "cph")),
  person("Dirk", "Eddelbuettel", email = "dirk@tiledb.com", role = "cre"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# tiledb ongoing development
+
+* This release of the R package builds against [TileDB 2.16.3](https://github.com/TileDB-Inc/TileDB/releases/tag/2.16.3), and has also been tested against earlier releases as well as the development version (#583)
+
+
 # tiledb 0.20.3
 
 * This release of the R package builds against [TileDB 2.16.2](https://github.com/TileDB-Inc/TileDB/releases/tag/2.16.2), and has also been tested against earlier releases as well as the development version (#582)

--- a/tools/tiledbVersion.txt
+++ b/tools/tiledbVersion.txt
@@ -1,2 +1,2 @@
-version: 2.16.2
-sha: 07b65de
+version: 2.16.3
+sha: 194b5ae


### PR DESCRIPTION
This PR updates the package preference to TileDB 2.16.3 following its release earlier today.