### PR TITLE
Use TileDB 2.17.0-rc0

### DIFF
--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -24,11 +24,23 @@ jobs:
         run: |
           install.packages(c("remotes", "rcmdcheck"))
           remotes::install_deps(dependencies = TRUE)
-        shell: Rscript {0}
         env:
           R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
+        shell: Rscript {0}
       - name: Check
         env:
           _R_CHECK_CRAN_INCOMING_: false
         run: rcmdcheck::rcmdcheck(args = c("--no-manual", "--no-vignettes", "--as-cran"), build_args = c("--no-build-vignettes"), error_on = "error", check_dir = "check")
+        shell: Rscript {0}
+      - name: Show install log
+        if: failure()
+        run: |
+          installfile <- "check/tiledb.Rcheck/00install.out"
+          if (file.exists(installfile)) writeLines(readLines(installfile))
+        shell: Rscript {0}
+      - name: Show check log
+        if: failure()
+        run: |
+          checkfile <- "check/tiledb.Rcheck/00check.log"
+          if (file.exists(checkfile)) writeLines(readLines(checkfile))
         shell: Rscript {0}

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tiledb
 Type: Package
-Version: 0.20.3.1
+Version: 0.20.3.2
 Title: Universal Storage Engine for Sparse and Dense Multidimensional Arrays
 Authors@R: c(person("TileDB, Inc.", role = c("aut", "cph")),
  person("Dirk", "Eddelbuettel", email = "dirk@tiledb.com", role = "cre"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,10 @@
 # tiledb ongoing development
 
-* This release of the R package builds against [TileDB 2.16.3](https://github.com/TileDB-Inc/TileDB/releases/tag/2.16.3), and has also been tested against earlier releases as well as the development version (#583)
+* This release of the R package builds against [TileDB 2.17.0](https://github.com/TileDB-Inc/TileDB/releases/tag/2.17.0), and has also been tested against earlier releases as well as the development version (#583)
+
+## Improvements
+
+* Built-time configuration of TileDB Embedded can now be accessed as a JSON string (#584)
 
 
 # tiledb 0.20.3

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -6,7 +6,7 @@ PKG_LIBS = \
 	-L$(RWINLIB)/lib$(subst gcc,,$(COMPILED_BY))$(R_ARCH) \
 	-L$(RWINLIB)/lib$(R_ARCH)$(CRT) \
 	-ltiledbstatic -lbz2 -lzstd -llz4 -lz -lspdlog \
-	-lwebp -lwebpdecoder -lwebpdemux -lwebpmux \
+	-lwebp -lwebpdecoder -lwebpdemux -lwebpmux -lsharpyuv \
         -llibmagic -lpcre2-posix -lpcre2-8 \
 	-laws-cpp-sdk-identity-management -laws-cpp-sdk-cognito-identity -laws-cpp-sdk-sts -laws-cpp-sdk-s3 -laws-cpp-sdk-core -laws-c-event-stream -laws-checksums -laws-c-common \
 	-lShlwapi -lBcrypt -lRpcrt4 -lWininet -lWinhttp -lws2_32 -lVersion -lUserenv

--- a/tools/tiledbVersion.txt
+++ b/tools/tiledbVersion.txt
@@ -1,2 +1,2 @@
-version: 2.16.3
-sha: 194b5ae
+version: 2.17.0-rc0
+sha: 46b9ca5


### PR DESCRIPTION
This PR updates the package preference to TileDB 2.17.0-rc0