### PR TITLE
Use TileDB 2.17.1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tiledb
 Type: Package
-Version: 0.21.0.3
+Version: 0.21.0.4
 Title: Universal Storage Engine for Sparse and Dense Multidimensional Arrays
 Authors@R: c(person("TileDB, Inc.", role = c("aut", "cph")),
  person("Dirk", "Eddelbuettel", email = "dirk@tiledb.com", role = "cre"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # tiledb ongoing development
 
-* This release of the R package builds against [TileDB 2.17.0](https://github.com/TileDB-Inc/TileDB/releases/tag/2.17.0), and has also been tested against earlier releases as well as the development version (#583, #587)
+* This release of the R package builds against [TileDB 2.17.1](https://github.com/TileDB-Inc/TileDB/releases/tag/2.17.1), and has also been tested against earlier releases as well as the development version (#593)
 
 ## Improvements
 
@@ -8,12 +8,16 @@
 
 * Conversion to and from `integer64` (and `nanotime`) now use package [RcppInt64](https://cran.r-project.org/package=RcppInt64) (#592)
 
+* Use of TileDB Embedded was upgraded to release 2.17.1 (#593)
+
 
 # tiledb 0.21.0
 
 * This release of the R package builds against [TileDB 2.17.0](https://github.com/TileDB-Inc/TileDB/releases/tag/2.17.0), and has also been tested against earlier releases as well as the development version (#583, #587)
 
 ## Improvements
+
+* Use of TileDB Embedded was upgraded to release 2.17.0 (#583,#587)
 
 * Built-time configuration of TileDB Embedded can now be accessed as a JSON string (#584)
 

--- a/tools/tiledbVersion.txt
+++ b/tools/tiledbVersion.txt
@@ -1,2 +1,2 @@
-version: 2.17.0
-sha: 93c173d
+version: 2.17.1
+sha: 7c8c73b


### PR DESCRIPTION
This PR updates the package preference to TileDB Embedded 2.17.1 tagged last evening.