### PR TITLE
Revert a sorting of factor levels and process as given by user

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tiledb
 Type: Package
-Version: 0.21.0.4
+Version: 0.21.0.5
 Title: Universal Storage Engine for Sparse and Dense Multidimensional Arrays
 Authors@R: c(person("TileDB, Inc.", role = c("aut", "cph")),
  person("Dirk", "Eddelbuettel", email = "dirk@tiledb.com", role = "cre"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,10 @@
 
 * Use of TileDB Embedded was upgraded to release 2.17.1 (#593)
 
+## Bug Fixes
+
+* An added sorting of factor levels insert has been reverted (#594)
+
 
 # tiledb 0.21.0
 

--- a/R/ArraySchemaEvolution.R
+++ b/R/ArraySchemaEvolution.R
@@ -101,11 +101,6 @@ tiledb_array_schema_evolution_add_enumeration <- function(object, name, enums, o
               "The 'enumlist' argument must be a character object" = is.character(enums),
               "This function needs TileDB 2.17.0 or later" = tiledb_version(TRUE) >= "2.17.0",
               "The 'ctx' argument must be a Context object" = is(ctx, "tiledb_ctx"))
-    srted <- sort(enums)
-    if (!isTRUE(all.equal(enums, srted))) {
-        warning("Enumeration levels were not sorted so rearranging.")
-        enums <- srted
-    }
     object@ptr <- libtiledb_array_schema_evolution_add_enumeration(ctx@ptr, object@ptr, name,
                                                                    enums, FALSE, ordered)
     invisible(object)


### PR DESCRIPTION
This reverts a small addition that aimed to be helpful but wasn't.   More details in [SC 34672](https://app.shortcut.com/tiledb-inc/story/34672/tiledb-r-reorders-factor-levels-during-schema-evolution).