### PR TITLE
Extend parse_query_condition to use new 'IN' and 'NOT_IN' queries

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tiledb
 Type: Package
-Version: 0.21.1.2
+Version: 0.21.1.3
 Title: Universal Storage Engine for Sparse and Dense Multidimensional Arrays
 Authors@R: c(person("TileDB, Inc.", role = c("aut", "cph")),
  person("Dirk", "Eddelbuettel", email = "dirk@tiledb.com", role = "cre"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,8 @@
 
 * Set conditions are supported in query condition expressions (#597)
 
+* Query conditions expression parsing via `parse_query_conditions` was extended simmilarly (#598)
+
 ## Bug Fixes
 
 * The DESCRIPTION file now correctly refers to macOS 10.14 (#596)

--- a/inst/tinytest/test_querycondition.R
+++ b/inst/tinytest/test_querycondition.R
@@ -184,7 +184,9 @@ expect_equal(NROW(res), 34L)
 expect_true(all(res$bill_length_mm < 40))
 expect_true(all(res$year == 2009))
 
-if (tiledb_version(TRUE) >= "2.10.0") { # the OR operator is more recent than query conditions overall
+## the OR operator is more recent than query conditions overall
+## and this translates to the new-in-2.17.0 set version
+if (tiledb_version(TRUE) >= "2.17.0") {
     qc3 <- parse_query_condition(island %in% c("Dream", "Biscoe"), arr)
     arrwithqc3 <- tiledb_array(uri, return_as="data.frame", strings_as_factors=TRUE, query_condition=qc3)
     res <- arrwithqc3[]

--- a/inst/tinytest/test_querycondition.R
+++ b/inst/tinytest/test_querycondition.R
@@ -166,6 +166,7 @@ expect_true(all(res$year == 2009))
 
 unlink(uri, recursive=TRUE)
 
+## n=15
 ## parse query condition support
 uri <- tempfile()
 fromDataFrame(penguins, uri, sparse=TRUE)
@@ -319,17 +320,17 @@ arr <- tiledb_array(uri, return_as="data.frame", query_condition=qc)
 expect_equal(NROW(arr[]),
              sum(with(penguins, year == 2009)))
 
-qc <- parse_query_condition(year < 2009 || year < 2010)
+qc <- parse_query_condition(year < 2009 || year < 2010, arr)
 arr <- tiledb_array(uri, return_as="data.frame", query_condition=qc)
 expect_equal(NROW(arr[]),
              sum(with(penguins, year < 2010)))
 
 ## Last two with single & or |
-qc <- parse_query_condition(year <= 2009 & year >= 2009)
+qc <- parse_query_condition(year <= 2009 & year >= 2009, arr)
 arr <- tiledb_array(uri, return_as="data.frame", query_condition=qc)
 expect_equal(NROW(arr[]), sum(with(penguins, year == 2009)))
 
-qc <- parse_query_condition(year < 2009 | year < 2010)
+qc <- parse_query_condition(year < 2009 | year < 2010, arr)
 arr <- tiledb_array(uri, return_as="data.frame", query_condition=qc)
 expect_equal(NROW(arr[]), sum(with(penguins, year < 2010)))
 

--- a/inst/tinytest/test_querycondition.R
+++ b/inst/tinytest/test_querycondition.R
@@ -484,3 +484,55 @@ expect_true(all(res$val >= as.integer64(6)))
 qc <- tiledb_query_condition_create("val", as.integer64(6:10), "NOT_IN")
 res <- tiledb_array(uri, return_as="data.frame", query_condition=qc)[]
 expect_true(all(res$val <= as.integer64(5)))
+
+## new parse tests
+uri <- tempfile()
+fromDataFrame(penguins, uri)
+## %in% and %nin%
+arr <- tiledb_array(uri) # to get the types correct we need array info
+res <- tiledb_array(uri, return_as="data.frame",
+                    query_condition=parse_query_condition(year %in% c(2007, 2009), arr))[]
+expect_true(all(res$year != "2008"))
+
+res <- tiledb_array(uri, return_as="data.frame",
+                    query_condition=parse_query_condition(year %nin% c(2007, 2009), arr))[]
+expect_true(all(res$year == "2008"))
+
+## double
+res <- tiledb_array(uri, return_as="data.frame",
+                    query_condition=parse_query_condition(bill_length_mm %in% c(32.1,33.1,33.5),arr))[]
+expect_true(all(res$bill_length_mm <= 33.5))
+expect_equal(nrow(res), 3)
+
+## Character (automagically converted from factor)
+res <- tiledb_array(uri, return_as="data.frame",
+                    query_condition=parse_query_condition(island %in% c("Biscoe", "Dream"), arr))[]
+tt <- table(res$island)
+expect_equal(tt[["Biscoe"]], 168)
+expect_equal(tt[["Dream"]], 124)
+
+## Character (automagically converted from factor)
+res <- tiledb_array(uri, return_as="data.frame",
+                    query_condition=parse_query_condition(island %nin% c("Biscoe", "Dream"), arr))[]
+tt <- table(res$island)
+expect_equal(tt[["Torgersen"]], 52)
+
+## Combo
+qc <- parse_query_condition(year %in% c(2007, 2009) && island %nin% c("Biscoe", "Dream"), arr)
+res <- tiledb_array(uri, return_as="data.frame", query_condition=qc)[]
+expect_true(all(res$year != "2008"))
+expect_true(all(res$island == "Torgersen"))
+
+
+## int64
+df <- data.frame(ind=1:10, val=as.integer64(1:10))
+uri <- tempfile()
+fromDataFrame(df, uri)
+arr <- tiledb_array(uri)
+qc <- parse_query_condition(val %in% as.integer64(6:10), arr)
+res <- tiledb_array(uri, return_as="data.frame", query_condition=qc)[]
+expect_true(all(res$val >= as.integer64(6)))
+
+qc <- parse_query_condition(val %nin% as.integer64(6:10), arr)
+res <- tiledb_array(uri, return_as="data.frame", query_condition=qc)[]
+expect_true(all(res$val <= as.integer64(5)))

--- a/inst/tinytest/test_querycondition.R
+++ b/inst/tinytest/test_querycondition.R
@@ -320,17 +320,17 @@ arr <- tiledb_array(uri, return_as="data.frame", query_condition=qc)
 expect_equal(NROW(arr[]),
              sum(with(penguins, year == 2009)))
 
-qc <- parse_query_condition(year < 2009 || year < 2010, arr)
+qc <- parse_query_condition(year < 2009 || year < 2010)
 arr <- tiledb_array(uri, return_as="data.frame", query_condition=qc)
 expect_equal(NROW(arr[]),
              sum(with(penguins, year < 2010)))
 
 ## Last two with single & or |
-qc <- parse_query_condition(year <= 2009 & year >= 2009, arr)
+qc <- parse_query_condition(year <= 2009 & year >= 2009)
 arr <- tiledb_array(uri, return_as="data.frame", query_condition=qc)
 expect_equal(NROW(arr[]), sum(with(penguins, year == 2009)))
 
-qc <- parse_query_condition(year < 2009 | year < 2010, arr)
+qc <- parse_query_condition(year < 2009 | year < 2010)
 arr <- tiledb_array(uri, return_as="data.frame", query_condition=qc)
 expect_equal(NROW(arr[]), sum(with(penguins, year < 2010)))
 

--- a/man/parse_query_condition.Rd
+++ b/man/parse_query_condition.Rd
@@ -30,8 +30,15 @@ default is false to remain as a default four-byte \code{int}}
 A \code{tiledb_query_condition} object
 }
 \description{
-The grammar for query conditions is at present constraint to six operators
-and three boolean types.
+The grammar for query conditions is at present constraint to eight operators (\code{">"},
+\code{">="}, \code{"<"}, \code{"<="}, \code{"=="}, \code{"!="}, \code{"\%in\%"}, \code{"\%nin\%"}),
+and three boolean operators (\code{"&&"}, also as \code{"&"}, (\code{"||"}, also as \code{"|"},
+and \code{"!"} for negation.  Note that we locally define \code{"\%nin\%"} as \code{Negate()} call
+around \code{\%in\%)} which extends R a little for this use case.
+}
+\details{
+Expressions are parsed locally by this function. The \code{debug=TRUE} option may help in an issue
+has to be diagnosed.
 }
 \examples{
 \dontshow{ctx <- tiledb_ctx(limitTileDBCores())}


### PR DESCRIPTION
This PR extend #597 but adding support for the new (faster) vector set comparisons to `parse_query_conditions`.  

As `parse_query_conditions` starts of with a _syntactially valid_ R expression, we cannot use `IN` and `NOT_IN` which are not known operators.  So we reuse the existing `%in%` and, as commonly done, locally define

     `%nin%` <- Negate(`%in%`)

A few new tests ~will be~ have been added too ~but~ and it (of course) passes all existing tests in `test_querycondion.R`.

