### PR TITLE
Accomodate deprecation of delete_fragments in 2.18.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tiledb
 Type: Package
-Version: 0.21.1.3
+Version: 0.21.1.4
 Title: Universal Storage Engine for Sparse and Dense Multidimensional Arrays
 Authors@R: c(person("TileDB, Inc.", role = c("aut", "cph")),
  person("Dirk", "Eddelbuettel", email = "dirk@tiledb.com", role = "cre"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,8 @@
 
 * Query conditions expression parsing via `parse_query_conditions` was extended simmilarly (#598)
 
+* Array fragment deletions uses a new static method (with TileDB 2.18.0 or later) (#599)
+
 ## Bug Fixes
 
 * The DESCRIPTION file now correctly refers to macOS 10.14 (#596)

--- a/R/Array.R
+++ b/R/Array.R
@@ -152,13 +152,14 @@ tiledb_array_is_heterogeneous <- function(arr) {
 ##' @param arr A TileDB Array object as for example returned by \code{tiledb_array()}
 ##' @param ts_start A Datetime object that will be converted to millisecond granularity
 ##' @param ts_end A Datetime object that will be converted to millisecond granularity
+##' @param ctx A tiledb_ctx object (optional)
 ##' @return A boolean indicating success
 ##' @export
-tiledb_array_delete_fragments <- function(arr, ts_start, ts_end) {
+tiledb_array_delete_fragments <- function(arr, ts_start, ts_end, ctx = tiledb_get_context()) {
     stopifnot("The 'arr' argument must be a tiledb_array object" = .isArray(arr),
               "The 'ts_start' argument must a time object" = inherits(ts_start, "POSIXct"),
               "The 'ts_end' argument must a time object" = inherits(ts_end, "POSIXct"))
-    libtiledb_array_delete_fragments(arr@ptr, ts_start, ts_end)
+    libtiledb_array_delete_fragments(ctx@ptr, arr@ptr, ts_start, ts_end)
     invisible(TRUE)
 }
 

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -590,8 +590,8 @@ libtiledb_array_open_timestamp_end <- function(array) {
     .Call(`_tiledb_libtiledb_array_open_timestamp_end`, array)
 }
 
-libtiledb_array_delete_fragments <- function(array, tstamp_start, tstamp_end) {
-    invisible(.Call(`_tiledb_libtiledb_array_delete_fragments`, array, tstamp_start, tstamp_end))
+libtiledb_array_delete_fragments <- function(ctx, array, tstamp_start, tstamp_end) {
+    invisible(.Call(`_tiledb_libtiledb_array_delete_fragments`, ctx, array, tstamp_start, tstamp_end))
 }
 
 libtiledb_array_has_enumeration <- function(ctx, arr, name) {

--- a/man/tiledb_array_delete_fragments.Rd
+++ b/man/tiledb_array_delete_fragments.Rd
@@ -4,7 +4,12 @@
 \alias{tiledb_array_delete_fragments}
 \title{Delete fragments written between the start and end times given}
 \usage{
-tiledb_array_delete_fragments(arr, ts_start, ts_end)
+tiledb_array_delete_fragments(
+  arr,
+  ts_start,
+  ts_end,
+  ctx = tiledb_get_context()
+)
 }
 \arguments{
 \item{arr}{A TileDB Array object as for example returned by \code{tiledb_array()}}
@@ -12,6 +17,8 @@ tiledb_array_delete_fragments(arr, ts_start, ts_end)
 \item{ts_start}{A Datetime object that will be converted to millisecond granularity}
 
 \item{ts_end}{A Datetime object that will be converted to millisecond granularity}
+
+\item{ctx}{A tiledb_ctx object (optional)}
 }
 \value{
 A boolean indicating success

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -1710,14 +1710,15 @@ BEGIN_RCPP
 END_RCPP
 }
 // libtiledb_array_delete_fragments
-void libtiledb_array_delete_fragments(XPtr<tiledb::Array> array, Rcpp::Datetime tstamp_start, Rcpp::Datetime tstamp_end);
-RcppExport SEXP _tiledb_libtiledb_array_delete_fragments(SEXP arraySEXP, SEXP tstamp_startSEXP, SEXP tstamp_endSEXP) {
+void libtiledb_array_delete_fragments(XPtr<tiledb::Context> ctx, XPtr<tiledb::Array> array, Rcpp::Datetime tstamp_start, Rcpp::Datetime tstamp_end);
+RcppExport SEXP _tiledb_libtiledb_array_delete_fragments(SEXP ctxSEXP, SEXP arraySEXP, SEXP tstamp_startSEXP, SEXP tstamp_endSEXP) {
 BEGIN_RCPP
     Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< XPtr<tiledb::Context> >::type ctx(ctxSEXP);
     Rcpp::traits::input_parameter< XPtr<tiledb::Array> >::type array(arraySEXP);
     Rcpp::traits::input_parameter< Rcpp::Datetime >::type tstamp_start(tstamp_startSEXP);
     Rcpp::traits::input_parameter< Rcpp::Datetime >::type tstamp_end(tstamp_endSEXP);
-    libtiledb_array_delete_fragments(array, tstamp_start, tstamp_end);
+    libtiledb_array_delete_fragments(ctx, array, tstamp_start, tstamp_end);
     return R_NilValue;
 END_RCPP
 }
@@ -3602,7 +3603,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_tiledb_libtiledb_array_open_timestamp_start", (DL_FUNC) &_tiledb_libtiledb_array_open_timestamp_start, 1},
     {"_tiledb_libtiledb_array_set_open_timestamp_end", (DL_FUNC) &_tiledb_libtiledb_array_set_open_timestamp_end, 2},
     {"_tiledb_libtiledb_array_open_timestamp_end", (DL_FUNC) &_tiledb_libtiledb_array_open_timestamp_end, 1},
-    {"_tiledb_libtiledb_array_delete_fragments", (DL_FUNC) &_tiledb_libtiledb_array_delete_fragments, 3},
+    {"_tiledb_libtiledb_array_delete_fragments", (DL_FUNC) &_tiledb_libtiledb_array_delete_fragments, 4},
     {"_tiledb_libtiledb_array_has_enumeration", (DL_FUNC) &_tiledb_libtiledb_array_has_enumeration, 3},
     {"_tiledb_libtiledb_array_get_enumeration", (DL_FUNC) &_tiledb_libtiledb_array_get_enumeration, 3},
     {"_tiledb_libtiledb_array_has_enumeration_vector", (DL_FUNC) &_tiledb_libtiledb_array_has_enumeration_vector, 2},

--- a/src/libtiledb.cpp
+++ b/src/libtiledb.cpp
@@ -2605,14 +2605,19 @@ Rcpp::Datetime libtiledb_array_open_timestamp_end(XPtr<tiledb::Array> array) {
 }
 
 // [[Rcpp::export]]
-void libtiledb_array_delete_fragments(XPtr<tiledb::Array> array,
+void libtiledb_array_delete_fragments(XPtr<tiledb::Context> ctx, XPtr<tiledb::Array> array,
                                       Rcpp::Datetime tstamp_start, Rcpp::Datetime tstamp_end) {
 #if TILEDB_VERSION >= TileDB_Version(2,12,0)
+    check_xptr_tag<tiledb::Context>(ctx);
     check_xptr_tag<tiledb::Array>(array);
     const std::string uri = array->uri();
     uint64_t ts_ms_st = static_cast<uint64_t>(std::round(tstamp_start.getFractionalTimestamp() * 1000));
     uint64_t ts_ms_en = static_cast<uint64_t>(std::round(tstamp_end.getFractionalTimestamp() * 1000));
+#if TILEDB_VERSION >= TileDB_Version(2,18,0)
+    tiledb::Array::delete_fragments(*ctx.get(), uri, ts_ms_st, ts_ms_en);
+#else
     array->delete_fragments(uri, ts_ms_st, ts_ms_en);
+#endif
 #endif
 }
 


### PR DESCRIPTION
This PR switched `array->delete_fragments(...)` to the new static method `Array::delete_fragments()`  (when TileDB 2.18.0 or later is found) to suppress a new deprecation warning.

No new code, no new tests.