### PR TITLE
Emit clearer error when array is needed for parse, update docs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tiledb
 Type: Package
-Version: 0.21.1.5
+Version: 0.21.1.6
 Title: Universal Storage Engine for Sparse and Dense Multidimensional Arrays
 Authors@R: c(person("TileDB, Inc.", role = c("aut", "cph")),
  person("Dirk", "Eddelbuettel", email = "dirk@tiledb.com", role = "cre"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,8 @@
 
 * The included `nanoarrow` header and source file have been updated to release 0.3.0 (#600)
 
+* Query conditions expression parsing requirements are stated and tested more clearly (#601)
+
 ## Bug Fixes
 
 * The DESCRIPTION file now correctly refers to macOS 10.14 (#596)

--- a/R/QueryCondition.R
+++ b/R/QueryCondition.R
@@ -108,11 +108,15 @@ tiledb_query_condition_combine <- function(lhs, rhs, op) {
 #' and \code{"!"} for negation.  Note that we locally define \code{"%nin%"} as \code{Negate()} call
 #' around \code{%in%)} which extends R a little for this use case.
 #'
-#' Expressions are parsed locally by this function. The \code{debug=TRUE} option may help in an issue
-#' has to be diagnosed.
+#' Expressions are parsed locally by this function. The \code{debug=TRUE} option may help if an issue
+#' has to be diagnosed. In most cases of an errroneous parse, it generally helps to supply the
+#' \code{tiledb_array} providing schema information. One example are numeric and integer columns where
+#' the data type is difficult to guess. Also, when using the \code{"%in%"} or \code{"%nin%"} operators,
+#' the argument is mandatory.
 #'
 #' @param expr An expression that is understood by the TileDB grammar for query conditions.
-#' @param ta An optional tiledb_array object that the query condition is applied to
+#' @param ta A tiledb_array object that the query condition is applied to; this argument is optional
+#' in some cases but required in some others.
 #' @param debug A boolean toogle to enable more verbose operations, defaults
 #' to 'FALSE'.
 #' @param strict A boolean toogle to, if set, errors if a non-existing attribute is selected
@@ -142,6 +146,7 @@ parse_query_condition <- function(expr, ta=NULL, debug=FALSE, strict=TRUE, use_i
     .isInOperator <- function(x) tolower(as.character(x)) %in% c("%in%", "%nin%")
     .errorFunction <- if (strict) stop else warning
     .getInd <- function(attr, ta) {
+        if (isFALSE(.hasArray)) stop("The 'ta' argument is required for this type of parse", call. = FALSE)
         ind <- match(attr, ta@sil$names)
         if (!is.finite(ind)) {
             .errorFunction("No attribute '", attr, "' present.", call. = FALSE)

--- a/inst/tinytest/test_dataframe.R
+++ b/inst/tinytest/test_dataframe.R
@@ -144,6 +144,8 @@ suppressMessages({
   library(bit64)
 })
 
+prevTZ <- Sys.getenv("TZ")
+on.exit(Sys.setenv(TZ=prevTZ))
 Sys.setenv(TZ="")
 df <- data.frame(time=round(Sys.time(), "secs") + trunc(cumsum(runif(nobs)*3600)),
                  double_range=seq(-1000, 1000, length=nobs),

--- a/man/parse_query_condition.Rd
+++ b/man/parse_query_condition.Rd
@@ -15,7 +15,8 @@ parse_query_condition(
 \arguments{
 \item{expr}{An expression that is understood by the TileDB grammar for query conditions.}
 
-\item{ta}{An optional tiledb_array object that the query condition is applied to}
+\item{ta}{A tiledb_array object that the query condition is applied to; this argument is optional
+in some cases but required in some others.}
 
 \item{debug}{A boolean toogle to enable more verbose operations, defaults
 to 'FALSE'.}
@@ -37,8 +38,11 @@ and \code{"!"} for negation.  Note that we locally define \code{"\%nin\%"} as \c
 around \code{\%in\%)} which extends R a little for this use case.
 }
 \details{
-Expressions are parsed locally by this function. The \code{debug=TRUE} option may help in an issue
-has to be diagnosed.
+Expressions are parsed locally by this function. The \code{debug=TRUE} option may help if an issue
+has to be diagnosed. In most cases of an errroneous parse, it generally helps to supply the
+\code{tiledb_array} providing schema information. One example are numeric and integer columns where
+the data type is difficult to guess. Also, when using the \code{"\%in\%"} or \code{"\%nin\%"} operators,
+the argument is mandatory.
 }
 \examples{
 \dontshow{ctx <- tiledb_ctx(limitTileDBCores())}


### PR DESCRIPTION
This PR improves the error message when a `tiledb_array` argument is required for the type of parse requested, and improves the documentation of that parsing function.

No new tests.