### PR TITLE
Use TileDB 2.17.2

### DIFF
--- a/.github/r-ci.sh
+++ b/.github/r-ci.sh
@@ -114,7 +114,8 @@ BootstrapLinux() {
     ## from r2u setup script
     sudo apt update -qq && sudo apt install --yes --no-install-recommends wget ca-certificates dirmngr gnupg gpg-agent
     wget -q -O- https://eddelbuettel.github.io/r2u/assets/dirk_eddelbuettel_key.asc | sudo tee -a /etc/apt/trusted.gpg.d/cranapt_key.asc
-    echo "deb [arch=amd64] https://r2u.stat.illinois.edu/ubuntu $(lsb_release -cs) main" | sudo tee -a /etc/apt/sources.list.d/cranapt.list
+#    echo "deb [arch=amd64] https://r2u.stat.illinois.edu/ubuntu $(lsb_release -cs) main" | sudo tee -a /etc/apt/sources.list.d/cranapt.list
+    echo "deb [arch=amd64] https://dirk.eddelbuettel.com/cranapt $(lsb_release -cs) main" | sudo tee -a /etc/apt/sources.list.d/cranapt.list
     wget -q -O- https://cloud.r-project.org/bin/linux/ubuntu/marutter_pubkey.asc  | sudo tee -a /etc/apt/trusted.gpg.d/cran_ubuntu_key.asc
     echo "deb [arch=amd64] https://cloud.r-project.org/bin/linux/ubuntu $(lsb_release -cs)-cran40/" | sudo tee -a /etc/apt/sources.list.d/cran_r.list
     echo "Package: *" | sudo tee -a /etc/apt/preferences.d/99cranapt

--- a/.github/r-ci.sh
+++ b/.github/r-ci.sh
@@ -114,8 +114,8 @@ BootstrapLinux() {
     ## from r2u setup script
     sudo apt update -qq && sudo apt install --yes --no-install-recommends wget ca-certificates dirmngr gnupg gpg-agent
     wget -q -O- https://eddelbuettel.github.io/r2u/assets/dirk_eddelbuettel_key.asc | sudo tee -a /etc/apt/trusted.gpg.d/cranapt_key.asc
-#    echo "deb [arch=amd64] https://r2u.stat.illinois.edu/ubuntu $(lsb_release -cs) main" | sudo tee -a /etc/apt/sources.list.d/cranapt.list
-    echo "deb [arch=amd64] https://dirk.eddelbuettel.com/cranapt $(lsb_release -cs) main" | sudo tee -a /etc/apt/sources.list.d/cranapt.list
+    echo "deb [arch=amd64] https://r2u.stat.illinois.edu/ubuntu $(lsb_release -cs) main" | sudo tee -a /etc/apt/sources.list.d/cranapt.list
+#    echo "deb [arch=amd64] https://dirk.eddelbuettel.com/cranapt $(lsb_release -cs) main" | sudo tee -a /etc/apt/sources.list.d/cranapt.list
     wget -q -O- https://cloud.r-project.org/bin/linux/ubuntu/marutter_pubkey.asc  | sudo tee -a /etc/apt/trusted.gpg.d/cran_ubuntu_key.asc
     echo "deb [arch=amd64] https://cloud.r-project.org/bin/linux/ubuntu $(lsb_release -cs)-cran40/" | sudo tee -a /etc/apt/sources.list.d/cran_r.list
     echo "Package: *" | sudo tee -a /etc/apt/preferences.d/99cranapt

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tiledb
 Type: Package
-Version: 0.21.1.6
+Version: 0.21.1.7
 Title: Universal Storage Engine for Sparse and Dense Multidimensional Arrays
 Authors@R: c(person("TileDB, Inc.", role = c("aut", "cph")),
  person("Dirk", "Eddelbuettel", email = "dirk@tiledb.com", role = "cre"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # tiledb ongoing development
 
-* This release of the R package builds against [TileDB 2.17.1](https://github.com/TileDB-Inc/TileDB/releases/tag/2.17.1), and has also been tested against earlier releases as well as the development version (#593)
+* This release of the R package builds against [TileDB 2.17.2](https://github.com/TileDB-Inc/TileDB/releases/tag/2.17.2), and has also been tested against earlier releases as well as the development version (#602)
 
 ## Improvements
 
@@ -13,6 +13,8 @@
 * The included `nanoarrow` header and source file have been updated to release 0.3.0 (#600)
 
 * Query conditions expression parsing requirements are stated and tested more clearly (#601)
+
+* Use of TileDB Embedded was upgraded to release 2.17.2 (#602)
 
 ## Bug Fixes
 

--- a/tools/tiledbVersion.txt
+++ b/tools/tiledbVersion.txt
@@ -1,2 +1,2 @@
-version: 2.17.1
-sha: 7c8c73b
+version: 2.17.2
+sha: 06a09ae


### PR DESCRIPTION
This PR updates the package preference to TileDB Embedded 2.17.2 tagged yesterday.