### PR TITLE
Update to release-2.17, add new dependencies, add dispatch

### DIFF
--- a/.github/workflows/valgrind.yaml
+++ b/.github/workflows/valgrind.yaml
@@ -3,7 +3,7 @@ name: valgrind
 on:
   schedule:
     - cron: "17 01 * * *"
-  # push:
+  workflow_dispatch:
 
 jobs:
   valgrind:
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tag: [ release-2.15, release-2.16, dev ]
+        tag: [ release-2.17, dev ]
 
     steps:
     - name: Checkout

--- a/NEWS.md
+++ b/NEWS.md
@@ -20,6 +20,11 @@
 
 * The DESCRIPTION file now correctly refers to macOS 10.14 (#596)
 
+## Build and Test Systems
+
+* The nighly valgrind run was updated to include release 2.17 (#603)
+
+
 
 # tiledb 0.21.1
 

--- a/tools/ci/valgrind/installDependencies.sh
+++ b/tools/ci/valgrind/installDependencies.sh
@@ -81,6 +81,7 @@ install.r \
     nycflights13 \
     palmerpenguins \
     Rcpp \
+    RcppInt64 \
     RcppSpdlog \
     simplermarkdown \
     spdl \


### PR DESCRIPTION
This PR updates the nightly `valgrind` job to use the `release-2.17` branch along with `dev` and updates the lists of packages installed for the tests.  It also adds a `workflow_dispatch` trigger to run this outside of the scheduler.