### PR TITLE
Use TileDB 2.17.3

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tiledb
 Type: Package
-Version: 0.21.1.9
+Version: 0.21.1.10
 Title: Universal Storage Engine for Sparse and Dense Multidimensional Arrays
 Authors@R: c(person("TileDB, Inc.", role = c("aut", "cph")),
  person("Dirk", "Eddelbuettel", email = "dirk@tiledb.com", role = "cre"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # tiledb ongoing development
 
-* This release of the R package builds against [TileDB 2.17.2](https://github.com/TileDB-Inc/TileDB/releases/tag/2.17.2), and has also been tested against earlier releases as well as the development version (#602)
+* This release of the R package builds against [TileDB 2.17.3](https://github.com/TileDB-Inc/TileDB/releases/tag/2.17.3), and has also been tested against earlier releases as well as the development version (#602)
 
 ## Improvements
 
@@ -17,6 +17,8 @@
 * Use of TileDB Embedded was upgraded to release 2.17.2 (#602)
 
 * Enumeration (aka 'factor') support has been extended for 'empty' creation and subsequent extension with new levelss (#605)
+
+* Use of TileDB Embedded was upgraded to release 2.17.3 (#606)
 
 ## Bug Fixes
 

--- a/tools/tiledbVersion.txt
+++ b/tools/tiledbVersion.txt
@@ -1,2 +1,2 @@
-version: 2.17.2
-sha: 06a09ae
+version: 2.17.3
+sha: 0c2de58


### PR DESCRIPTION
This PR updates the package preference to TileDB Embedded 2.17.3 tagged today.