### PR TITLE
Extend enumeration support to non-string levels

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tiledb
 Type: Package
-Version: 0.21.1.12
+Version: 0.21.1.13
 Title: Universal Storage Engine for Sparse and Dense Multidimensional Arrays
 Authors@R: c(person("TileDB, Inc.", role = c("aut", "cph")),
  person("Dirk", "Eddelbuettel", email = "dirk@tiledb.com", role = "cre"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -24,6 +24,8 @@
 
 * R objects can be (de-)serialized to and from VFS paths (#608)
 
+* Enumeration support has been extended to some cases only supported by Arrow (#609)
+
 ## Bug Fixes
 
 * The DESCRIPTION file now correctly refers to macOS 10.14 (#596)

--- a/R/ArraySchemaEvolution.R
+++ b/R/ArraySchemaEvolution.R
@@ -123,7 +123,7 @@ tiledb_array_schema_evolution_drop_enumeration <- function(object, attrname) {
 
 #' Evolve an Array Schema by adding an empty Enumeration
 #'
-#' @param asc An ArraySchemaEvolution object
+#' @param ase An ArraySchemaEvolution object
 #' @param enum_name A character value with the Enumeration name
 #' @param type_str A character value with the TileDB type, defaults to \sQuote{ASCII}
 #' @param cell_val_num An integer with number values per cell, defaults to \code{NA_integer_} to
@@ -137,7 +137,7 @@ tiledb_array_schema_evolution_add_enumeration_empty <- function(ase, enum_name, 
                                                                 ordered = FALSE,
                                                                 ctx = tiledb_get_context()) {
     stopifnot("Argument 'ase' must be an Array Schema Evolution object" =
-                  is(object, "tiledb_array_schema_evolution"),
+                  is(ase, "tiledb_array_schema_evolution"),
               "Argument 'enum_name' must be character" = is.character(enum_name),
               "Argument 'type_str' must be character" = is.character(type_str),
               "Argument 'cell_val_num' must be integer" = is.integer(cell_val_num),

--- a/R/Attribute.R
+++ b/R/Attribute.R
@@ -388,6 +388,30 @@ tiledb_attribute_set_enumeration_name <- function(attr, enum_name, ctx = tiledb_
 #' @export
 tiledb_attribute_is_ordered_enumeration_ptr <- function(attr, arrptr, ctx = tiledb_get_context()) {
     stopifnot("The 'attr' argument must be an attribute" = is(attr, "tiledb_attr"),
-              "The 'arr' argument must be an external pointer" = is(arrptr, "externalptr"))
+              "The 'arrptr' argument must be an external pointer" = is(arrptr, "externalptr"))
     libtiledb_attribute_is_ordered_enumeration(ctx@ptr, attr@ptr, arrptr)
+}
+
+# internal function to access enumeration data type
+#' @noRd
+tiledb_attribute_get_enumeration_type <- function(attr, arr, ctx = tiledb_get_context()) {
+    stopifnot("The 'attr' argument must be an attribute" = is(attr, "tiledb_attr"),
+              "The 'arr' argument must be an array" = is(arr, "tiledb_array"))
+    libtiledb_attribute_get_enumeration_type(ctx@ptr, attr@ptr, arr@ptr)
+}
+
+# internal function to access enumeration data type
+#' @noRd
+tiledb_attribute_get_enumeration_type_ptr <- function(attr, arrptr, ctx = tiledb_get_context()) {
+    stopifnot("The 'attr' argument must be an attribute" = is(attr, "tiledb_attr"),
+              "The 'arrptr' argument must be an external pointer" = is(arrptr, "externalptr"))
+    libtiledb_attribute_get_enumeration_type(ctx@ptr, attr@ptr, arrptr)
+}
+
+# internal function to get (non-string) enumeration vector
+#' @noRd
+tiledb_attribute_get_enumeration_vector_ptr <- function(attr, arrptr, ctx = tiledb_get_context()) {
+    stopifnot("The 'attr' argument must be an attribute" = is(attr, "tiledb_attr"),
+              "The 'arrptr' argument must be an external pointer" = is(arrptr, "externalptr"))
+    libtiledb_attribute_get_enumeration_vector(ctx@ptr, attr@ptr, arrptr)
 }

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -302,6 +302,14 @@ libtiledb_attribute_has_enumeration <- function(ctx, attr) {
     .Call(`_tiledb_libtiledb_attribute_has_enumeration`, ctx, attr)
 }
 
+libtiledb_attribute_get_enumeration_type <- function(ctx, attr, arr) {
+    .Call(`_tiledb_libtiledb_attribute_get_enumeration_type`, ctx, attr, arr)
+}
+
+libtiledb_attribute_get_enumeration_vector <- function(ctx, attr, arr) {
+    .Call(`_tiledb_libtiledb_attribute_get_enumeration_vector`, ctx, attr, arr)
+}
+
 libtiledb_attribute_get_enumeration <- function(ctx, attr, arr) {
     .Call(`_tiledb_libtiledb_attribute_get_enumeration`, ctx, attr, arr)
 }

--- a/man/tiledb_array_schema_evolution_add_enumeration_empty.Rd
+++ b/man/tiledb_array_schema_evolution_add_enumeration_empty.Rd
@@ -14,6 +14,8 @@ tiledb_array_schema_evolution_add_enumeration_empty(
 )
 }
 \arguments{
+\item{ase}{An ArraySchemaEvolution object}
+
 \item{enum_name}{A character value with the Enumeration name}
 
 \item{type_str}{A character value with the TileDB type, defaults to \sQuote{ASCII}}
@@ -25,8 +27,6 @@ flag the \code{NA} value use for character values}
 or \code{ordered} (when \code{TRUE})}
 
 \item{ctx}{Optional tiledb_ctx object}
-
-\item{asc}{An ArraySchemaEvolution object}
 }
 \description{
 Evolve an Array Schema by adding an empty Enumeration

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -847,6 +847,32 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// libtiledb_attribute_get_enumeration_type
+Rcpp::String libtiledb_attribute_get_enumeration_type(XPtr<tiledb::Context> ctx, XPtr<tiledb::Attribute> attr, XPtr<tiledb::Array> arr);
+RcppExport SEXP _tiledb_libtiledb_attribute_get_enumeration_type(SEXP ctxSEXP, SEXP attrSEXP, SEXP arrSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< XPtr<tiledb::Context> >::type ctx(ctxSEXP);
+    Rcpp::traits::input_parameter< XPtr<tiledb::Attribute> >::type attr(attrSEXP);
+    Rcpp::traits::input_parameter< XPtr<tiledb::Array> >::type arr(arrSEXP);
+    rcpp_result_gen = Rcpp::wrap(libtiledb_attribute_get_enumeration_type(ctx, attr, arr));
+    return rcpp_result_gen;
+END_RCPP
+}
+// libtiledb_attribute_get_enumeration_vector
+SEXP libtiledb_attribute_get_enumeration_vector(XPtr<tiledb::Context> ctx, XPtr<tiledb::Attribute> attr, XPtr<tiledb::Array> arr);
+RcppExport SEXP _tiledb_libtiledb_attribute_get_enumeration_vector(SEXP ctxSEXP, SEXP attrSEXP, SEXP arrSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< XPtr<tiledb::Context> >::type ctx(ctxSEXP);
+    Rcpp::traits::input_parameter< XPtr<tiledb::Attribute> >::type attr(attrSEXP);
+    Rcpp::traits::input_parameter< XPtr<tiledb::Array> >::type arr(arrSEXP);
+    rcpp_result_gen = Rcpp::wrap(libtiledb_attribute_get_enumeration_vector(ctx, attr, arr));
+    return rcpp_result_gen;
+END_RCPP
+}
 // libtiledb_attribute_get_enumeration
 std::vector<std::string> libtiledb_attribute_get_enumeration(XPtr<tiledb::Context> ctx, XPtr<tiledb::Attribute> attr, XPtr<tiledb::Array> arr);
 RcppExport SEXP _tiledb_libtiledb_attribute_get_enumeration(SEXP ctxSEXP, SEXP attrSEXP, SEXP arrSEXP) {
@@ -3594,6 +3620,8 @@ static const R_CallMethodDef CallEntries[] = {
     {"_tiledb_libtiledb_attribute_set_nullable", (DL_FUNC) &_tiledb_libtiledb_attribute_set_nullable, 2},
     {"_tiledb_libtiledb_attribute_get_nullable", (DL_FUNC) &_tiledb_libtiledb_attribute_get_nullable, 1},
     {"_tiledb_libtiledb_attribute_has_enumeration", (DL_FUNC) &_tiledb_libtiledb_attribute_has_enumeration, 2},
+    {"_tiledb_libtiledb_attribute_get_enumeration_type", (DL_FUNC) &_tiledb_libtiledb_attribute_get_enumeration_type, 3},
+    {"_tiledb_libtiledb_attribute_get_enumeration_vector", (DL_FUNC) &_tiledb_libtiledb_attribute_get_enumeration_vector, 3},
     {"_tiledb_libtiledb_attribute_get_enumeration", (DL_FUNC) &_tiledb_libtiledb_attribute_get_enumeration, 3},
     {"_tiledb_libtiledb_attribute_set_enumeration", (DL_FUNC) &_tiledb_libtiledb_attribute_set_enumeration, 3},
     {"_tiledb_libtiledb_attribute_is_ordered_enumeration", (DL_FUNC) &_tiledb_libtiledb_attribute_is_ordered_enumeration, 3},


### PR DESCRIPTION
This PR adds support for reads of enumeration types possible in arrow but not in the stricter R `factor` setup.  For other types we collapse the levels information into the actual data (i.e. converting from factor to vector).  One such example where the last two columns were written from arrow as dictionaries with, respectively, `float64` and `bool` levels:

```
$ Rscript -e 'tiledb::tiledb_array("/some/uri/some/where", return_as="tibble")[]'
# A tibble: 5 × 5
  soma_joinid   int string `enum-float64` `enum-bool`
      <int64> <int> <chr>           <dbl> <lgl>      
1           0   100 red               1.2 TRUE       
2           1   101 yellow            3.4 TRUE       
3           2   102 green             5.6 FALSE      
4           3   103 red               1.2 TRUE       
5           4   104 green             5.6 FALSE      
$ 
```

[SC 36358](https://app.shortcut.com/tiledb-inc/story/36358/extend-enumeration-support)