### PR TITLE
Ensure sparse arrays are read UNORDERED if no default was set

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tiledb
 Type: Package
-Version: 0.21.1.13
+Version: 0.21.1.14
 Title: Universal Storage Engine for Sparse and Dense Multidimensional Arrays
 Authors@R: c(person("TileDB, Inc.", role = c("aut", "cph")),
  person("Dirk", "Eddelbuettel", email = "dirk@tiledb.com", role = "cre"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -30,6 +30,8 @@
 
 * The DESCRIPTION file now correctly refers to macOS 10.14 (#596)
 
+* The (explicitly) 'batched reader now ensure a correct layout for sparse arrays (#610)
+
 ## Build and Test Systems
 
 * The nighly valgrind run was updated to include release 2.17 (#603)

--- a/R/BatchedQuery.R
+++ b/R/BatchedQuery.R
@@ -119,8 +119,8 @@ createBatched <- function(x) {
 
     ## open query
     qryptr <- libtiledb_query(ctx@ptr, arrptr, "READ")
-    if (length(layout) > 0) libtiledb_query_set_layout(qryptr, layout)
-
+    qryptr <- libtiledb_query_set_layout(qryptr, if (isTRUE(nzchar(layout))) layout
+                                                 else { if (sparse) "UNORDERED" else "COL_MAJOR" })
 
     ## ranges seem to interfere with the byte/element adjustment below so set up toggle
     rangeunset <- TRUE

--- a/R/TileDBArray.R
+++ b/R/TileDBArray.R
@@ -647,9 +647,8 @@ setMethod("[", "tiledb_array",
 
   ## open query
   qryptr <- libtiledb_query(ctx@ptr, arrptr, "READ")
-  qryptr <- libtiledb_query_set_layout(qryptr,
-                                       if (isTRUE(nchar(layout) > 0)) layout
-                                       else { if (sparse) "UNORDERED" else "COL_MAJOR" })
+  qryptr <- libtiledb_query_set_layout(qryptr, if (isTRUE(nzchar(layout))) layout
+                                               else { if (sparse) "UNORDERED" else "COL_MAJOR" })
 
   ## ranges seem to interfere with the byte/element adjustment below so set up toggle
   rangeunset <- TRUE

--- a/inst/tinytest/test_tiledbarray.R
+++ b/inst/tinytest/test_tiledbarray.R
@@ -1460,10 +1460,8 @@ if (Sys.getenv("IS_COVR", "no") == "no") {
     res2 <- tiledb:::fetchBatched(arr, lst)
     expect_false(completedBatched(lst))
     res3 <- tiledb:::fetchBatched(arr, lst)
-    expect_false(completedBatched(lst))
-    res4 <- tiledb:::fetchBatched(arr, lst)
     expect_true(completedBatched(lst))
-    expect_equal(nrow(res1) + nrow(res2) + nrow(res3) + nrow(res4), 344)
+    expect_equal(nrow(res1) + nrow(res2) + nrow(res3), 344)
     set_allocation_size_preference(1024*1024)
 }
 


### PR DESCRIPTION
This PR carries a required check over from the default reader to the (slightly older and simpler) 'batched' reader and ensures that sparse arrays are not read in row or col order with the legacy reader.

[SC 36351](https://app.shortcut.com/tiledb-inc/story/36351/segfault-with-batched-reader)