### PR TITLE
Use TileDB 2.17.4

### DIFF
--- a/tools/tiledbVersion.txt
+++ b/tools/tiledbVersion.txt
@@ -1,2 +1,2 @@
-version: 2.17.3
-sha: 0c2de58
+version: 2.17.4
+sha: a1f648e


### PR DESCRIPTION
This PR updates the package preference to TileDB Embedded 2.17.4 tagged today.