### PR TITLE
Release 0.21.2

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tiledb
 Type: Package
-Version: 0.21.1.14
+Version: 0.21.2
 Title: Universal Storage Engine for Sparse and Dense Multidimensional Arrays
 Authors@R: c(person("TileDB, Inc.", role = c("aut", "cph")),
  person("Dirk", "Eddelbuettel", email = "dirk@tiledb.com", role = "cre"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
-# tiledb ongoing development
+# tiledb 0.21.2
 
-* This release of the R package builds against [TileDB 2.17.3](https://github.com/TileDB-Inc/TileDB/releases/tag/2.17.3), and has also been tested against earlier releases as well as the development version (#602)
+* This release of the R package builds against [TileDB 2.17.4](https://github.com/TileDB-Inc/TileDB/releases/tag/2.17.4), and has also been tested against earlier releases as well as the development version (#611)
 
 ## Improvements
 
@@ -25,6 +25,8 @@
 * R objects can be (de-)serialized to and from VFS paths (#608)
 
 * Enumeration support has been extended to some cases only supported by Arrow (#609)
+
+* Use of TileDB Embedded was upgraded to release 2.17.4 (#611)
 
 ## Bug Fixes
 


### PR DESCRIPTION
This PR updates the package to release 0.21.2. From [NEWS.md](https://github.com/TileDB-Inc/TileDB-R/blob/master/NEWS.md) (with 'lowered' headline levels for display here):

## tiledb 0.21.2

* This release of the R package builds against [TileDB 2.17.4](https://github.com/TileDB-Inc/TileDB/releases/tag/2.17.4), and has also been tested against earlier releases as well as the development version (#611)

### Improvements

* Set conditions are supported in query condition expressions (#597)

* Query conditions expression parsing via `parse_query_conditions` was extended simmilarly (#598)

* Array fragment deletions uses a new static method (with TileDB 2.18.0 or later) (#599)

* The included `nanoarrow` header and source file have been updated to release 0.3.0 (#600)

* Query conditions expression parsing requirements are stated and tested more clearly (#601)

* Use of TileDB Embedded was upgraded to release 2.17.2 (#602)

* Enumeration (aka 'factor') support has been extended for 'empty' creation and subsequent extension with new levelss (#605)

* Use of TileDB Embedded was upgraded to release 2.17.3 (#606)

* Factor variables with (unlikely) int64 indices are supported (#607)

* R objects can be (de-)serialized to and from VFS paths (#608)

* Enumeration support has been extended to some cases only supported by Arrow (#609)

* Use of TileDB Embedded was upgraded to release 2.17.4 (#611)

### Bug Fixes

* The DESCRIPTION file now correctly refers to macOS 10.14 (#596)

* The (explicitly) 'batched reader now ensure a correct layout for sparse arrays (#610)

### Build and Test Systems

* The nighly valgrind run was updated to include release 2.17 (#603)

