### PR TITLE
Generalize query condition parsing to non-INT32 index columns

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,10 @@
-# Ongoing development
+# ongoing development
+
+* This release of the R package builds against [TileDB 2.17.4](https://github.com/TileDB-Inc/TileDB/releases/tag/2.17.4), and has also been tested against earlier releases as well as the development version (#611)
+
+## Improvements
+
+* Query conditioning parsing now supports `factor` index columns other than the standard `integer` type (#614)
 
 ## Documentation
 

--- a/R/QueryCondition.R
+++ b/R/QueryCondition.R
@@ -237,7 +237,7 @@ parse_query_condition <- function(expr, ta=NULL, debug=FALSE, strict=TRUE, use_i
                            " [",ch, "] ", dtype, "\n", sep="")
 
             ## take care of factor (aka "enum" case) and set the data type to ASCII
-            if (dtype == "INT32" && is_enum) {
+            if (dtype %in% c("INT8", "INT16", "INT32", "INT64", "UINT8", "UINT16", "UINT32", "UINT64") && is_enum) {
                 if (debug) cat("   [factor column] ", ch, " ", attr, " ", dtype, " --> ASCII", " ", is_enum, "\n")
                 dtype <- "ASCII"
             }


### PR DESCRIPTION
This PR generalized support for parsing of query condition from user supplied text to arrays not created from R `factors` and using indices with types different from `int32_t`.