### PR TITLE
Extend nightly valgrind run to 2.18

### DIFF
--- a/.github/workflows/valgrind.yaml
+++ b/.github/workflows/valgrind.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tag: [ release-2.17, dev ]
+        tag: [ release-2.17, release-2.18, dev ]
 
     steps:
     - name: Checkout

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,10 @@
 
 * Query conditioning parsing now supports `factor` index columns other than the standard `integer` type (#614)
 
+## Build and Test Systems
+
+* The nighly valgrind run was updated to include release 2.18 (#615)
+
 ## Documentation
 
 * The pkgdown documentation has been updated for release 0.21.2 (#613)


### PR DESCRIPTION
This PR extends the nightly valgrind run to the release-2.18 branch of Core.

No new code.