### PR TITLE
Add badges for r-universe and anaconda

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tiledb
 Type: Package
-Version: 0.21.3
+Version: 0.21.3.1
 Title: Universal Storage Engine for Sparse and Dense Multidimensional Arrays
 Authors@R: c(person("TileDB, Inc.", role = c("aut", "cph")),
  person("Dirk", "Eddelbuettel", email = "dirk@tiledb.com", role = "cre"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# ongoing development
+
+## Documentation
+
+* The README now contains badges for the r-universe and Anaconda versions (in addition to CRAN) (#617)
+
+
 # tiledb 0.21.3
 
 * This release of the R package builds against [TileDB 2.17.4](https://github.com/TileDB-Inc/TileDB/releases/tag/2.17.4), and has also been tested against earlier releases as well as the development version (#611)

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 [![valgrind](https://github.com/TileDB-Inc/TileDB-R/actions/workflows/valgrind.yaml/badge.svg)](https://github.com/TileDB-Inc/TileDB-R/actions/workflows/valgrind.yaml)
 [![Downloads](https://cranlogs.r-pkg.org/badges/grand-total/tiledb?color=brightgreen)](https://cran.r-project.org/package=tiledb)
 [![CRAN](https://www.r-pkg.org/badges/version/tiledb)](https://cran.r-project.org/package=tiledb)
+[![r-universe](https://tiledb-inc.r-universe.dev/badges/tiledb)](https://tiledb-inc.r-universe.dev/tiledb)
+[![Anaconda](https://anaconda.org/conda-forge/r-tiledb/badges/version.svg)](https://anaconda.org/conda-forge/r-tiledb)
 
 # <a href="https://tiledb.com/"><img src="https://github.com/TileDB-Inc/TileDB/raw/dev/doc/source/_static/tiledb-logo_color_no_margin_@4x.png" alt="TileDB logo" width="400"></a>
 
@@ -38,7 +40,7 @@ The most recent released version can be installed from
     > remotes::install_github("TileDB-Inc/TileDB-R")
     ...
     > library(tiledb)
-    TileDB R 0.21.1 with TileDB Embedded 2.17.1 on Ubuntu 22.04.
+    TileDB R 0.21.3 with TileDB Embedded 2.17.4 on Ubuntu 22.04.
     See https://tiledb.com for more information about TileDB.
     > help(package=tiledb)
 


### PR DESCRIPTION
This PR adds, respectively, a badge for the (TileDB) r-universe builds and for Anaconda given that their version numbers may now differ from the CRAN version.

Previewing the proposed change in a live markdown viewer (with a dark theme) yields the expected outcome:
![image](https://github.com/TileDB-Inc/TileDB-R/assets/673121/93cb7072-ec42-40b3-af60-300d671d3713)

No new code.