### PR TITLE
Additional minor memory (and test) refactoring

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -26,3 +26,4 @@
 ^inst/tinytest/test_timetravel_extra.R
 ^inst/tinytest/test_tiledbarray_extra.R
 ^codecov.yml
+^notes.md

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tiledb
 Type: Package
-Version: 0.21.3.1
+Version: 0.21.3.2
 Title: Universal Storage Engine for Sparse and Dense Multidimensional Arrays
 Authors@R: c(person("TileDB, Inc.", role = c("aut", "cph")),
  person("Dirk", "Eddelbuettel", email = "dirk@tiledb.com", role = "cre"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # ongoing development
 
+## Build and Test Systems
+
+* Some tests were refactored slightly for greater robustness (#618)
+
 ## Documentation
 
 * The README now contains badges for the r-universe and Anaconda versions (in addition to CRAN) (#617)

--- a/inst/tinytest/test_arrayschemaevolution.R
+++ b/inst/tinytest/test_arrayschemaevolution.R
@@ -63,14 +63,6 @@ expect_true(is.factor(res$val))
 expect_equal(levels(res$val), enums)
 expect_equal(as.integer(res$val), c(1:5,5:1))
 
-## check as arrow
-if (!requireNamespace("arrow", quietly=TRUE)) exit_file("No 'arrow' package.")
-arr <- tiledb_array(uri, return_as="arrow")
-res <- arr[]
-v <- res[["val"]]$as_vector()
-expect_true(is.factor(v))
-expect_equal(levels(v), enums)
-expect_equal(as.integer(v), c(1:5,5:1))
 
 
 ## -- testing 'create empty following by extending'

--- a/inst/tinytest/test_arrayschemaevolution_arrow.R
+++ b/inst/tinytest/test_arrayschemaevolution_arrow.R
@@ -1,0 +1,48 @@
+library(tinytest)
+library(tiledb)
+
+if (Sys.info()[["sysname"]] == "Windows") exit_file("Skip on Windows")
+if (Sys.getenv("CI", "") == "") exit_file("Skip unextended test run")
+
+ctx <- tiledb_ctx(limitTileDBCores())
+
+if (tiledb_version(TRUE) < "2.17.0") exit_file("Needs TileDB 2.17.* or later")
+
+df <- data.frame(key=letters[1:10], val=c(1:5,5:1))
+uri <- tempfile()
+arr <- fromDataFrame(df, uri)
+
+sch <- schema(uri)
+attrs <- attrs(sch)
+attr <- attrs$val   # copy of attribute
+
+## First drop existing attribute
+ase <- tiledb_array_schema_evolution()
+ase <- tiledb_array_schema_evolution_drop_attribute(ase, "val")
+tiledb_array_schema_evolution_array_evolve(ase, uri)
+
+## Second add enumeration under a name
+ase <- tiledb_array_schema_evolution()
+enums <- c("blue", "green", "orange", "pink", "red")
+ase <- tiledb_array_schema_evolution_add_enumeration(ase, "frobo", enums)
+
+## Third connect the attribute to the enum and add it back in
+attr <- tiledb_attribute_set_enumeration_name(attr, "frobo")
+ase <- tiledb_array_schema_evolution_add_attribute(ase, attr)
+tiledb_array_schema_evolution_array_evolve(ase, uri)
+
+## check as data.frame
+arr <- tiledb_array(uri, return_as="data.frame")
+res <- arr[]
+expect_true(is.factor(res$val))
+expect_equal(levels(res$val), enums)
+expect_equal(as.integer(res$val), c(1:5,5:1))
+
+## check as arrow
+if (!requireNamespace("arrow", quietly=TRUE)) exit_file("No 'arrow' package.")
+arr <- tiledb_array(uri, return_as="arrow")
+res <- arr[]
+v <- res[["val"]]$as_vector()
+expect_true(is.factor(v))
+expect_equal(levels(v), enums)
+expect_equal(as.integer(v), c(1:5,5:1))

--- a/inst/tinytest/test_arrowio.R
+++ b/inst/tinytest/test_arrowio.R
@@ -4,10 +4,13 @@ library(tiledb)
 isOldWindows <- Sys.info()[["sysname"]] == "Windows" && grepl('Windows Server 2008', osVersion)
 if (isOldWindows) exit_file("skip this file on old Windows releases")
 
+if (Sys.getenv("CI", "") == "") exit_file("Skip unextended test run")
+
 ctx <- tiledb_ctx(limitTileDBCores())
 
 if (!requireNamespace("arrow", quietly=TRUE)) exit_file("No 'arrow' package.")
 suppressMessages(library(arrow))
+
 
 if (get_return_as_preference() != "asis") set_return_as_preference("asis") 		# baseline value
 

--- a/inst/tinytest/test_ordered.R
+++ b/inst/tinytest/test_ordered.R
@@ -97,8 +97,7 @@ expect_false(is.ordered(tbval$sex))
 expect_true(is.factor(tbval$sex))
 expect_equivalent(et, tbval)
 
-if (Sys.getenv("CI", "") != "") {
-    if (!requireNamespace("arrow", quietly=TRUE)) exit_file("No 'arrow' package.")
+if (Sys.getenv("CI", "") != "" && requireNamespace("arrow", quietly=TRUE)) {
     arval <- tiledb_array(uri, return_as="arrow", extended=FALSE)[]
     tbval <- tibble::as_tibble(arval)
     expect_true(is.ordered(tbval$pclass))

--- a/inst/tinytest/test_ordered.R
+++ b/inst/tinytest/test_ordered.R
@@ -97,10 +97,12 @@ expect_false(is.ordered(tbval$sex))
 expect_true(is.factor(tbval$sex))
 expect_equivalent(et, tbval)
 
-if (!requireNamespace("arrow", quietly=TRUE)) exit_file("No 'arrow' package.")
-arval <- tiledb_array(uri, return_as="arrow", extended=FALSE)[]
-tbval <- tibble::as_tibble(arval)
-expect_true(is.ordered(tbval$pclass))
-expect_false(is.ordered(tbval$sex))
-expect_true(is.factor(tbval$sex))
-expect_equivalent(et, tbval)
+if (Sys.getenv("CI", "") != "") {
+    if (!requireNamespace("arrow", quietly=TRUE)) exit_file("No 'arrow' package.")
+    arval <- tiledb_array(uri, return_as="arrow", extended=FALSE)[]
+    tbval <- tibble::as_tibble(arval)
+    expect_true(is.ordered(tbval$pclass))
+    expect_false(is.ordered(tbval$sex))
+    expect_true(is.factor(tbval$sex))
+    expect_equivalent(et, tbval)
+}

--- a/src/arrowio.cpp
+++ b/src/arrowio.cpp
@@ -223,6 +223,7 @@ bool check_arrow_array_tag(Rcpp::XPtr<ArrowArray> xp) {
 }
 
 
+
 // (Adapted) helper functions from nanoarrow
 //
 // Create an external pointer with the proper class and that will release any
@@ -230,6 +231,7 @@ bool check_arrow_array_tag(Rcpp::XPtr<ArrowArray> xp) {
 // but do not set an XPtr finalizer
 Rcpp::XPtr<ArrowSchema> schema_owning_xptr(void) {
     struct ArrowSchema* schema = (struct ArrowSchema*)ArrowMalloc(sizeof(struct ArrowSchema));
+    spdl::trace(tfm::format("[schema_owning_xptr] Allocating %d bytes", sizeof(struct ArrowSchema)));
     if (schema == NULL) Rcpp::stop("Failed to allocate ArrowSchema");
     schema->release = NULL;
     Rcpp::XPtr<ArrowSchema> schema_xptr = make_xptr(schema, false);
@@ -240,6 +242,7 @@ Rcpp::XPtr<ArrowSchema> schema_owning_xptr(void) {
 // but do not set an XPtr finalizer
 Rcpp::XPtr<ArrowArray> array_owning_xptr(void) {
     struct ArrowArray* array = (struct ArrowArray*)ArrowMalloc(sizeof(struct ArrowArray));
+    spdl::trace(tfm::format("[array_owning_xptr] Allocating %d bytes", sizeof(struct ArrowArray)));
     if (array == NULL) Rcpp::stop("Failed to allocate ArrowArray");
     array->release = NULL;
     Rcpp::XPtr<ArrowArray> array_xptr = make_xptr(array, false);
@@ -250,13 +253,19 @@ Rcpp::XPtr<ArrowArray> array_owning_xptr(void) {
 inline void registerXptrFinalizer(SEXP s, R_CFinalizer_t f, bool onexit = true) {
     R_RegisterCFinalizerEx(s, f, onexit ? TRUE : FALSE);
 }
+extern "C" {
+    void ArrowArrayRelease(struct ArrowArray *array); 		// made non-static in nanoarrow.c
+    ArrowErrorCode ArrowArraySetStorageType(struct ArrowArray* array,	// ditto
+                                            enum ArrowType storage_type);
+    ArrowErrorCode localArrowSchemaSetType(struct ArrowSchema* schema, enum ArrowType type);
+}
 
 Rcpp::XPtr<ArrowSchema> schema_setup_struct(Rcpp::XPtr<ArrowSchema> schxp, int64_t n_children) {
     ArrowSchema* schema = schxp.get();
     auto type = NANOARROW_TYPE_STRUCT;
 
     ArrowSchemaInit(schema);    					// modified from ArrowSchemaInitFromType()
-    int result = ArrowSchemaSetType(schema, type);
+    int result = localArrowSchemaSetType(schema, type); // modified to call func with XPtr
     if (result != NANOARROW_OK) {
         schema->release(schema);
         Rcpp::stop("Error setting struct schema");
@@ -281,12 +290,6 @@ Rcpp::XPtr<ArrowSchema> schema_setup_struct(Rcpp::XPtr<ArrowSchema> schxp, int64
         }
     }
     return schxp;
-}
-
-extern "C" {
-    void ArrowArrayRelease(struct ArrowArray *array); 		// made non-static in nanoarrow.c
-    ArrowErrorCode ArrowArraySetStorageType(struct ArrowArray* array,	// ditto
-                                            enum ArrowType storage_type);
 }
 
 Rcpp::XPtr<ArrowArray> array_setup_struct(Rcpp::XPtr<ArrowArray> arrxp, int64_t n_children) {
@@ -350,7 +353,6 @@ Rcpp::XPtr<ArrowArray> array_setup_struct(Rcpp::XPtr<ArrowArray> arrxp, int64_t 
     array->n_children = n_children;
     return arrxp;
 }
-
 
 
 // [[Rcpp::export]]
@@ -470,4 +472,47 @@ Rcpp::XPtr<tiledb::ArrayBuffers> libtiledb_allocate_column_buffers(Rcpp::XPtr<ti
                                 name, cbsp.use_count(), memory_budget));
     }
     return make_xptr<tiledb::ArrayBuffers>(abp);
+}
+
+// added two local copies to inject xptr for format
+extern "C" {
+    const char* ArrowSchemaFormatTemplate(enum ArrowType type);  // remove static in nanoarrow
+    int ArrowSchemaInitChildrenIfNeeded(struct ArrowSchema* schema, enum ArrowType type); // ditto
+}
+ArrowErrorCode localArrowSchemaSetFormat(struct ArrowSchema* schema, const char* format) {
+    if (schema->format != NULL) {
+        ArrowFree((void*)schema->format);
+    }
+
+    if (format != NULL) {
+        size_t format_size = strlen(format) + 1;
+        schema->format = (const char*)ArrowMalloc(format_size);
+        if (schema->format == NULL) {
+            return ENOMEM;
+        }
+        Rcpp::XPtr<const char> schema_fmt_xp = make_xptr(schema->format, false);
+
+        memcpy((void*)schema->format, format, format_size);
+    } else {
+        schema->format = NULL;
+    }
+
+    return NANOARROW_OK;
+}
+ArrowErrorCode localArrowSchemaSetType(struct ArrowSchema* schema, enum ArrowType type) {
+    // We don't allocate the dictionary because it has to be nullptr
+    // for non-dictionary-encoded arrays.
+
+    // Set the format to a valid format string for type
+    const char* template_format = ArrowSchemaFormatTemplate(type);
+
+    // If type isn't recognized and not explicitly unset
+    if (template_format == NULL && type != NANOARROW_TYPE_UNINITIALIZED) {
+        return EINVAL;
+    }
+
+    NANOARROW_RETURN_NOT_OK(localArrowSchemaSetFormat(schema, template_format));
+
+    // For types with an umabiguous child structure, allocate children
+    return ArrowSchemaInitChildrenIfNeeded(schema, type);
 }

--- a/src/arrowio.cpp
+++ b/src/arrowio.cpp
@@ -223,7 +223,6 @@ bool check_arrow_array_tag(Rcpp::XPtr<ArrowArray> xp) {
 }
 
 
-
 // (Adapted) helper functions from nanoarrow
 //
 // Create an external pointer with the proper class and that will release any

--- a/src/nanoarrow.c
+++ b/src/nanoarrow.c
@@ -296,7 +296,8 @@ static void ArrowSchemaRelease(struct ArrowSchema* schema) {
   schema->release = NULL;
 }
 
-static const char* ArrowSchemaFormatTemplate(enum ArrowType type) {
+//static
+const char* ArrowSchemaFormatTemplate(enum ArrowType type) {
   switch (type) {
     case NANOARROW_TYPE_UNINITIALIZED:
       return NULL;
@@ -363,7 +364,8 @@ static const char* ArrowSchemaFormatTemplate(enum ArrowType type) {
   }
 }
 
-static int ArrowSchemaInitChildrenIfNeeded(struct ArrowSchema* schema,
+//static
+int ArrowSchemaInitChildrenIfNeeded(struct ArrowSchema* schema,
                                            enum ArrowType type) {
   switch (type) {
     case NANOARROW_TYPE_LIST:


### PR DESCRIPTION
This PR tries to ensure we remain on the good side of CRAN with respect to valgrind testing.  We do now a small fixed set of 216 bytes being 'lost definitely' when the AWS SDK initializes, this was may be unavoidable.  We saw in some tests that a `char*` holding the arrow format string was not recovered, this PR addresses this.

A somewhat less tractable problem is that R at shutdown and in its garbage collection does not _guarentee_ it will visit all remaining external pointers.  So we can observer different test behavior just by moving test blocks in a file, or to a different.  And when we started to separate test files so they test in isolation .. we got back to square one because running all may again lead to false positives.  So the only viable strategy is to be more careful about which tests run where.  This PR keeps the test surface maximal at CI but smaller in other places like CRAN where some arrow related tests may be skipped.

[SC 36872](https://app.shortcut.com/tiledb-inc/story/36872/additional-care-for-memory-checks-in-the-context-of-arrow)