### PR TITLE
Correct filehandle use in VFS serialization

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tiledb
 Type: Package
-Version: 0.21.3.2
+Version: 0.21.3.3
 Title: Universal Storage Engine for Sparse and Dense Multidimensional Arrays
 Authors@R: c(person("TileDB, Inc.", role = c("aut", "cph")),
  person("Dirk", "Eddelbuettel", email = "dirk@tiledb.com", role = "cre"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # ongoing development
 
+## Bug Fixes
+
+* When using serializing via VFS (as added in #608) the filehandles is now properly released (#619)
+
 ## Build and Test Systems
 
 * Some tests were refactored slightly for greater robustness (#618)

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -954,6 +954,10 @@ libtiledb_vfs_copy_file <- function(vfs, old_uri, new_uri) {
     .Call(`_tiledb_libtiledb_vfs_copy_file`, vfs, old_uri, new_uri)
 }
 
+libtiledb_vfs_fh_free <- function(fhxp) {
+    invisible(.Call(`_tiledb_libtiledb_vfs_fh_free`, fhxp))
+}
+
 libtiledb_stats_enable <- function() {
     invisible(.Call(`_tiledb_libtiledb_stats_enable`))
 }

--- a/inst/include/tiledb.h
+++ b/inst/include/tiledb.h
@@ -76,7 +76,11 @@ typedef std::unordered_map<std::string, std::shared_ptr<tiledb::ColumnBuffer>> m
 
 // C++ compiler complains about missing delete functionality when we use tiledb_vfs_fh_t directly
 struct vfs_fh {
-   void *fh;
+#if TILEDB_VERSION_MAJOR == 2 && TILEDB_VERSION_MINOR >= 15
+    tiledb_vfs_fh_handle_t* fh;
+#else
+    tiledb_vfs_fh_t* fh;
+#endif
 };
 typedef struct vfs_fh vfs_fh_t;
 

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -2847,6 +2847,16 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// libtiledb_vfs_fh_free
+void libtiledb_vfs_fh_free(XPtr<vfs_fh_t> fhxp);
+RcppExport SEXP _tiledb_libtiledb_vfs_fh_free(SEXP fhxpSEXP) {
+BEGIN_RCPP
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< XPtr<vfs_fh_t> >::type fhxp(fhxpSEXP);
+    libtiledb_vfs_fh_free(fhxp);
+    return R_NilValue;
+END_RCPP
+}
 // libtiledb_stats_enable
 void libtiledb_stats_enable();
 RcppExport SEXP _tiledb_libtiledb_stats_enable() {
@@ -3783,6 +3793,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_tiledb_libtiledb_vfs_dir_size", (DL_FUNC) &_tiledb_libtiledb_vfs_dir_size, 2},
     {"_tiledb_libtiledb_vfs_ls", (DL_FUNC) &_tiledb_libtiledb_vfs_ls, 2},
     {"_tiledb_libtiledb_vfs_copy_file", (DL_FUNC) &_tiledb_libtiledb_vfs_copy_file, 3},
+    {"_tiledb_libtiledb_vfs_fh_free", (DL_FUNC) &_tiledb_libtiledb_vfs_fh_free, 1},
     {"_tiledb_libtiledb_stats_enable", (DL_FUNC) &_tiledb_libtiledb_stats_enable, 0},
     {"_tiledb_libtiledb_stats_disable", (DL_FUNC) &_tiledb_libtiledb_stats_disable, 0},
     {"_tiledb_libtiledb_stats_reset", (DL_FUNC) &_tiledb_libtiledb_stats_reset, 0},


### PR DESCRIPTION
The recently added VFS serialization example uses the C API handle to open an VFS resources, but did not properly release the resource which our good friend `valgrind` noticed.  This PR corrects this.