### PR TITLE
Use TileDB 2.18.0

### DIFF
--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -5,7 +5,7 @@ PKG_CPPFLAGS = -I. -I../inst/include -I$(RWINLIB)/include -I$(RWINLIB)/include/t
 PKG_LIBS = \
 	-L$(RWINLIB)/lib$(subst gcc,,$(COMPILED_BY))$(R_ARCH) \
 	-L$(RWINLIB)/lib$(R_ARCH)$(CRT) \
-	-ltiledbstatic -lbz2 -lzstd -llz4 -lz -lspdlog \
+	-ltiledbstatic -lbz2 -lzstd -llz4 -lz -lspdlog -lfmt \
 	-lwebp -lwebpdecoder -lwebpdemux -lwebpmux -lsharpyuv \
         -llibmagic -lpcre2-posix -lpcre2-8 \
 	-laws-cpp-sdk-identity-management -laws-cpp-sdk-cognito-identity -laws-cpp-sdk-sts -laws-cpp-sdk-s3 -laws-cpp-sdk-core -laws-c-event-stream -laws-checksums -laws-c-common \

--- a/tools/tiledbVersion.txt
+++ b/tools/tiledbVersion.txt
@@ -1,2 +1,2 @@
-version: 2.18.0-rc2
-sha: 3af8017
+version: 2.18.0-rc3
+sha: 925dac8

--- a/tools/tiledbVersion.txt
+++ b/tools/tiledbVersion.txt
@@ -1,2 +1,2 @@
-version: 2.18.0-rc0
-sha: a3c4865
+version: 2.18.0-rc1
+sha: 3af8017

--- a/tools/tiledbVersion.txt
+++ b/tools/tiledbVersion.txt
@@ -1,2 +1,2 @@
-version: 2.18.0-rc1
+version: 2.18.0-rc2
 sha: 3af8017

--- a/tools/tiledbVersion.txt
+++ b/tools/tiledbVersion.txt
@@ -1,2 +1,2 @@
-version: 2.18.0-rc3
-sha: 925dac8
+version: 2.18.0-rc4
+sha: 71ca8b4d

--- a/tools/tiledbVersion.txt
+++ b/tools/tiledbVersion.txt
@@ -1,2 +1,2 @@
 version: 2.18.0-rc4
-sha: 71ca8b4d
+sha: 71ca8b4

--- a/tools/tiledbVersion.txt
+++ b/tools/tiledbVersion.txt
@@ -1,2 +1,2 @@
-version: 2.18.0-rc4
+version: 2.18.0
 sha: 71ca8b4

--- a/tools/tiledbVersion.txt
+++ b/tools/tiledbVersion.txt
@@ -1,2 +1,2 @@
-version: 2.17.4
-sha: a1f648e
+version: 2.18.0-rc0
+sha: a3c4865


### PR DESCRIPTION
This PR updates the package preference to TileDB Embedded 2.18.0 which was released earlier today.