### PR TITLE
Add option to select tiledb core source tarball for download

### DIFF
--- a/configure
+++ b/configure
@@ -649,6 +649,7 @@ LIBOBJS
 FILESYSTEM_HEADER_MISSSING
 CXX17_MACOS
 have_git
+have_curl
 have_cmake
 TILEDB_LIB_URL
 TILEDB_SILENT_BUILD
@@ -6210,6 +6211,52 @@ fi
             as_fn_error $? "please install 'cmake'" "$LINENO" 5
         fi
 
+        # Extract the first word of "curl", so it can be a program name with args.
+set dummy curl; ac_word=$2
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+printf %s "checking for $ac_word... " >&6; }
+if test ${ac_cv_prog_have_curl+y}
+then :
+  printf %s "(cached) " >&6
+else $as_nop
+  if test -n "$have_curl"; then
+  ac_cv_prog_have_curl="$have_curl" # Let the user override the test.
+else
+as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
+for as_dir in $PATH
+do
+  IFS=$as_save_IFS
+  case $as_dir in #(((
+    '') as_dir=./ ;;
+    */) ;;
+    *) as_dir=$as_dir/ ;;
+  esac
+    for ac_exec_ext in '' $ac_executable_extensions; do
+  if as_fn_executable_p "$as_dir$ac_word$ac_exec_ext"; then
+    ac_cv_prog_have_curl="yes"
+    printf "%s\n" "$as_me:${as_lineno-$LINENO}: found $as_dir$ac_word$ac_exec_ext" >&5
+    break 2
+  fi
+done
+  done
+IFS=$as_save_IFS
+
+fi
+fi
+have_curl=$ac_cv_prog_have_curl
+if test -n "$have_curl"; then
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $have_curl" >&5
+printf "%s\n" "$have_curl" >&6; }
+else
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
+printf "%s\n" "no" >&6; }
+fi
+
+
+        if test x"${have_curl}" != x"yes"; then
+            as_fn_error $? "please install 'curl'" "$LINENO" 5
+        fi
+
         # Extract the first word of "git", so it can be a program name with args.
 set dummy git; ac_word=$2
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
@@ -6257,7 +6304,15 @@ fi
         fi
         { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: installing TileDB via building locally..." >&5
 printf "%s\n" "installing TileDB via building locally..." >&6; }
-        tools/buildTileDB.sh
+        if test x"${TILEDB_LIB_URL}" != x; then
+            { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: using ${TILEDB_LIB_URL} ..." >&5
+printf "%s\n" "using ${TILEDB_LIB_URL} ..." >&6; }
+            tools/buildTileDB.sh ${TILEBD_LIB_URL}
+        else
+            { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: using default url ..." >&5
+printf "%s\n" "using default url ..." >&6; }
+            tools/buildTileDB.sh default
+        fi
 
     ## case two: download considered
     ##   - on macOS or Linux a 'fast and slim' build with external (pinned) library

--- a/configure.ac
+++ b/configure.ac
@@ -215,13 +215,24 @@ if test x"${have_tiledb}" = x"no"; then
         if test x"${have_cmake}" != x"yes"; then
             AC_MSG_ERROR([please install 'cmake'])
         fi
+        AC_DEFUN([AC_PROG_CURL], [AC_CHECK_PROG(have_curl,curl,yes)])
+        AC_PROG_CURL
+        if test x"${have_curl}" != x"yes"; then
+            AC_MSG_ERROR([please install 'curl'])
+        fi
         AC_DEFUN([AC_PROG_GIT], [AC_CHECK_PROG(have_git,git,yes)])
         AC_PROG_GIT
         if test x"${have_git}" != x"yes"; then
             AC_MSG_ERROR([please install 'git'])
         fi
         AC_MSG_RESULT([installing TileDB via building locally...])
-        tools/buildTileDB.sh
+        if test x"${TILEDB_LIB_URL}" != x; then
+            AC_MSG_RESULT([using ${TILEDB_LIB_URL} ...])
+            tools/buildTileDB.sh ${TILEBD_LIB_URL}
+        else
+            AC_MSG_RESULT([using default url ...])
+            tools/buildTileDB.sh default
+        fi
 
     ## case two: download considered
     ##   - on macOS or Linux a 'fast and slim' build with external (pinned) library

--- a/tools/buildTileDB.sh
+++ b/tools/buildTileDB.sh
@@ -1,19 +1,27 @@
 #!/bin/bash
 
+set -eu
+
+if [ $# -lt 1 ]; then
+    echo "Usage: buildTileDB.sh (default|url_to_tarball)"
+    echo "where 'default' leads to use of default version, which a given url can override"
+    exit 1
+fi
+url="${1}"
+
 if [ ! -d src ]; then
     echo "No src/ directory. Script should be invoked from top-level."
     exit 1
 fi
 
+## CRAN wants us permit different R binaries via different PATHs
+: ${R_HOME=`R RHOME`}
+
 cd src
 
 if [ ! -f tiledb.tar.gz ]; then
     echo "Downloading ${url} as tiledb.tar.gz ..."
-    ## CRAN wants us permit different R binaries via different PATHs
-    if [ x"${R_HOME}" = x ]; then
-        R_HOME=`R RHOME`
-    fi
-    ${R_HOME}/bin/Rscript ../tools/fetchTileDBSrc.R
+    ${R_HOME}/bin/Rscript ../tools/fetchTileDBSrc.R ${url}
 fi
 
 if [ ! -d tiledb-src ]; then
@@ -47,9 +55,9 @@ cd ..
 
 ## Install
 mkdir -p ../inst/tiledb
-cp -ax tiledb-src/dist/* ../inst/tiledb/
+cp -ax build/dist/* ../inst/tiledb/
 mkdir -p ../tiledb
-cp -ax tiledb-src/dist/* ../tiledb/
+cp -ax build/dist/* ../tiledb/
 
 if [ ! -f .keep_build_dirs ]; then
     rm -rf build tiledb-src

--- a/tools/fetchTileDBSrc.R
+++ b/tools/fetchTileDBSrc.R
@@ -1,18 +1,40 @@
 #!/usr/bin/Rscript
 
-dcffile <- "../tools/tiledbVersion.txt"
-if (!file.exists(dcffile)) {
-    message("TileDB Version file not found.")
+## Require one command arg
+args <- commandArgs(TRUE)
+if (length(args) != 1) {
+    message("Usage: fetchTileDBSrc.R (default|url)")
+    message("where 'default' select the given default URL")
+    message("      'url' provides an alternative URL to download from")
     q()
 }
-dcf <- read.dcf(dcffile)
-ver <- dcf[[1, "version"]]
+arg <- args[1]
 
-## by default we download the source from the given release
-url <- paste0("https://github.com/TileDB-Inc/TileDB/archive/", ver, ".tar.gz")
+if (arg == "default") {
+    ## Determin the 'default' download from the pin
 
-cat("Downloading ", url, "\n")
-op <- options()
-options(timeout=60)
-download.file(url, "tiledb.tar.gz", quiet=TRUE)
-options(op)
+    ## This is an R script to make it easy to read the dcf format file
+    dcffile <- "../tools/tiledbVersion.txt"
+    if (!file.exists(dcffile)) {
+        message("TileDB Version file not found.")
+        q()
+    }
+    dcf <- read.dcf(dcffile)
+    ver <- dcf[[1, "version"]]
+
+    ## by default we download the source from the given release
+    url <- paste0("https://github.com/TileDB-Inc/TileDB/archive/", ver, ".tar.gz")
+
+} else {
+    ## use the given url
+    url <- arg
+}
+
+if (!file.exists("tiledb.tar,gz")) {
+    cat("Downloading", url, "\n")
+    op <- options()
+    options(timeout=60)
+    download.file(url, "tiledb.tar.gz", quiet=TRUE)
+    options(op)
+}
+q()


### PR DESCRIPTION
This PR covers some small updates to the build system that go along with with #620 , #621 and the TileDB Core changes for `vcpkg`.  We now ensure / check that `curl` is installed (as `vcpkg` needs it) and support a `configure` option `--with-download=url` to supply a URL (the option itself may have come in with #620) for which the `url` argument, when given, is passed on to the worker scripts managing the download.  The fallback remains the pinned default version, but a given url could e.g. point to nighly tarballs (once produced).