### PR TITLE
One word fix for nightly.yaml

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -33,7 +33,7 @@ jobs:
     permissions:
       issues: write
     runs-on: ubuntu-latest
-    needs: test
+    needs: dev
     if: failure() || cancelled()
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Downloads](https://cranlogs.r-pkg.org/badges/grand-total/tiledb?color=brightgreen)](https://cran.r-project.org/package=tiledb)
 [![CRAN](https://www.r-pkg.org/badges/version/tiledb)](https://cran.r-project.org/package=tiledb)
 [![r-universe](https://tiledb-inc.r-universe.dev/badges/tiledb)](https://tiledb-inc.r-universe.dev/tiledb)
+[![r-universe dev](https://eddelbuettel.r-universe.dev/badges/tiledb)](https://eddelbuettel.r-universe.dev/tiledb)
 
 # <a href="https://tiledb.com/"><img src="https://github.com/TileDB-Inc/TileDB/raw/dev/doc/source/_static/tiledb-logo_color_no_margin_@4x.png" alt="TileDB logo" width="400"></a>
 


### PR DESCRIPTION
By a standard convention of some universal law, when I copied in the stanza that @jdblischak recommended to me I promptly forget to update _its_ dependency on `test` to the one named `dev` we use here.  Fix is a one word substitution.