### PR TITLE
Correct the incorrectly scaled down buffer size

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tiledb
 Type: Package
-Version: 0.22.0.2
+Version: 0.22.0.3
 Title: Modern Database Engine for Multi-Modal Data via Sparse and Dense Multidimensional Arrays
 Authors@R: c(person("TileDB, Inc.", role = c("aut", "cph")),
  person("Dirk", "Eddelbuettel", email = "dirk@tiledb.com", role = "cre"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,10 @@
 
 * A TileDB Array can now be opened in 'keep open' mode for subsequent use without re-opening (#630)
 
+## Bug Fixes
+
+* The read buffer is now correctly sized when implementing VFS serialization (#631)
+
 ## Build and Test Systems
 
 * Builds from TileDB Core non-release tarballs are now supported via new configure option (#627)

--- a/inst/tinytest/test_tiledbarray.R
+++ b/inst/tinytest/test_tiledbarray.R
@@ -1580,3 +1580,5 @@ expect_false(tiledb_array_is_open(arr))
 arr <- tiledb_array(uri, keep_open=TRUE)
 res <- arr[]
 expect_true(tiledb_array_is_open(arr))
+arr <- tiledb_array_close(arr)
+expect_false(tiledb_array_is_open(arr))

--- a/src/libtiledb.cpp
+++ b/src/libtiledb.cpp
@@ -4467,7 +4467,7 @@ Rcpp::IntegerVector libtiledb_vfs_read(XPtr<tiledb::Context> ctxxp, XPtr<vfs_fh_
   std::shared_ptr<tiledb_ctx_t> ctx = ctxxp.get()->ptr();
   std::int64_t offs = fromInteger64(offset);
   std::int64_t nb = fromInteger64(nbytes);
-  Rcpp::IntegerVector buf(nb/4);
+  Rcpp::IntegerVector buf(nb);
   tiledb_vfs_read(ctx.get(), fh->fh, offs, &(buf[0]), nb);
   return buf;
 }


### PR DESCRIPTION
This PR corrects an incorrectly size read buffer when doing a VFS serialization of a serialized R object.  This is fairly new code (suggested/requested by a client) and likely not in wide use yet. 