### PR TITLE
Test if data.table and tibble installed, rewrite one for data.frame

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tiledb
 Type: Package
-Version: 0.22.0.3
+Version: 0.22.0.4
 Title: Modern Database Engine for Multi-Modal Data via Sparse and Dense Multidimensional Arrays
 Authors@R: c(person("TileDB, Inc.", role = c("aut", "cph")),
  person("Dirk", "Eddelbuettel", email = "dirk@tiledb.com", role = "cre"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,8 @@
 
 * Builds from TileDB Core non-release tarballs are now supported via new configure option (#627)
 
+* Tests are more careful about using suggested packages only when present (#632)
+
 
 # tiledb 0.22.0
 

--- a/inst/tinytest/test_arrayschemaevolution.R
+++ b/inst/tinytest/test_arrayschemaevolution.R
@@ -117,19 +117,19 @@ run_int_col_test <- function(coltype) {
     arr[] <- df
 
     qc <-
-    res <- tiledb_array(uri, return_as="data.table", query_condition = parse_query_condition(fct == blue, arr))[]
+    res <- tiledb_array(uri, return_as="data.frame", query_condition = parse_query_condition(fct == blue, arr))[]
     expect_equal(nrow(res), 5)
 
-    res <- tiledb_array(uri, return_as="data.table", query_condition = parse_query_condition(fct == green, arr))[]
+    res <- tiledb_array(uri, return_as="data.frame", query_condition = parse_query_condition(fct == green, arr))[]
     expect_equal(nrow(res), 3)
 
-    res <- tiledb_array(uri, return_as="data.table", query_condition = parse_query_condition(fct == red, arr))[]
+    res <- tiledb_array(uri, return_as="data.frame", query_condition = parse_query_condition(fct == red, arr))[]
     expect_equal(nrow(res), 2)
 
-    res <- tiledb_array(uri, return_as="data.table", query_condition = parse_query_condition(fct != blue, arr))[]
+    res <- tiledb_array(uri, return_as="data.frame", query_condition = parse_query_condition(fct != blue, arr))[]
     expect_equal(nrow(res), 5)
 
-    expect_error(tiledb_array(uri, return_as="data.table", query_condition = parse_query_condition(fct > blue, arr))[])
+    expect_error(tiledb_array(uri, return_as="data.frame", query_condition = parse_query_condition(fct > blue, arr))[])
 
     unlink(uri)
 }

--- a/inst/tinytest/test_ordered.R
+++ b/inst/tinytest/test_ordered.R
@@ -85,17 +85,21 @@ expect_false(is.ordered(dfval$sex))
 expect_true(is.factor(dfval$sex))
 expect_equivalent(et, dfval)
 
-dtval <- tiledb_array(uri, return_as="data.table", extended=FALSE)[]
-expect_true(is.ordered(dtval$pclass))
-expect_false(is.ordered(dtval$sex))
-expect_true(is.factor(dtval$sex))
-expect_equivalent(et, dtval)
+if (requireNamespace("data.table", quietly=TRUE)) {
+    dtval <- tiledb_array(uri, return_as="data.table", extended=FALSE)[]
+    expect_true(is.ordered(dtval$pclass))
+    expect_false(is.ordered(dtval$sex))
+    expect_true(is.factor(dtval$sex))
+    expect_equivalent(et, dtval)
+}
 
-tbval <- tiledb_array(uri, return_as="tibble", extended=FALSE)[]
-expect_true(is.ordered(tbval$pclass))
-expect_false(is.ordered(tbval$sex))
-expect_true(is.factor(tbval$sex))
-expect_equivalent(et, tbval)
+if (requireNamespace("tibble", quietly=TRUE)) {
+    tbval <- tiledb_array(uri, return_as="tibble", extended=FALSE)[]
+    expect_true(is.ordered(tbval$pclass))
+    expect_false(is.ordered(tbval$sex))
+    expect_true(is.factor(tbval$sex))
+    expect_equivalent(et, tbval)
+}
 
 if (Sys.getenv("CI", "") != "" && requireNamespace("arrow", quietly=TRUE)) {
     arval <- tiledb_array(uri, return_as="arrow", extended=FALSE)[]


### PR DESCRIPTION
This is a small 'quality of life' improvement:  when testing (on a reduced installation) for the now-fixed ASAN error, tests errored out trying to use `data.table` which is in fact a suggested and hence optional package.  This PR rewrites on test file to use `data.frame` (a builtin) in one case, and test in another.

No new code, no new tests.