### PR TITLE
Add (for now) required --linkage=shared

### DIFF
--- a/tools/buildTileDB.sh
+++ b/tools/buildTileDB.sh
@@ -46,7 +46,7 @@ fi
 ## Build
 mkdir build
 cd build
-../tiledb-src/bootstrap --force-build-all-deps --enable-s3 --enable-serialization
+../tiledb-src/bootstrap --force-build-all-deps --enable-s3 --enable-serialization --linkage=shared
 make -j 2
 make -C tiledb install
 cd ..


### PR DESCRIPTION
The nightly is currently borked (see [the most recent run](https://github.com/TileDB-Inc/TileDB-R/actions/runs/7148197239)) because the dev branch (inadvertently) switched from default builds of shared libraries to static libraries.  So this PR adds the (at least currently) required `--linkage=shared`.  Tested locally in a container, it is indeed the difference maker.

@teo-tsirpanis is working on restoring core to the prior behaviour, once that is merged we can likely revert this.