### PR TITLE
Add release-2.19 branch, shared linkage, curl to nightly valgrind

### DIFF
--- a/.github/workflows/valgrind.yaml
+++ b/.github/workflows/valgrind.yaml
@@ -7,17 +7,17 @@ on:
 
 jobs:
   valgrind:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     name: ${{ matrix.tag }}
 
     strategy:
       fail-fast: false
       matrix:
-        tag: [ release-2.17, release-2.18, dev ]
+        tag: [ release-2.18, release-2.19, dev ]
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Install Dependencies
       run: sudo tools/ci/valgrind/installDependencies.sh

--- a/tools/ci/valgrind/buildAndCheckPackage.sh
+++ b/tools/ci/valgrind/buildAndCheckPackage.sh
@@ -14,5 +14,5 @@ export _RUNNING_UNDER_VALGRIND_=TRUE
 ## tell valgrind to use '-s'
 export VALGRIND_OPTS="-s"
 ## check package
-R CMD check --use-valgrind --as-cran --no-manual --ignore-vignettes tiledb_*.tar.gz
+R CMD check --use-valgrind --as-cran --no-manual --ignore-vignettes $(ls -1t tiledb_*.tar.gz | head -1)
 echo "::endgroup::"

--- a/tools/ci/valgrind/buildTileDB.sh
+++ b/tools/ci/valgrind/buildTileDB.sh
@@ -39,7 +39,7 @@ echo "::group::Build from source"
 mkdir build
 cd build
 export AWSSDK_ROOT_DIR=/usr
-../bootstrap --prefix=/usr/local --enable-s3 --enable-serialization
+../bootstrap --prefix=/usr/local --enable-s3 --enable-serialization --linkage=shared
 make -j 8
 make -C tiledb install
 ldconfig

--- a/tools/ci/valgrind/installDependencies.sh
+++ b/tools/ci/valgrind/installDependencies.sh
@@ -30,6 +30,7 @@ echo "::group::Install Binary Packages"
 # Install and skip recommended packages
 apt install --yes --no-install-recommends \
     cmake \
+    curl \
     git \
     libaws-c-common-dev \
     libaws-c-event-stream-dev \


### PR DESCRIPTION
The nightly `valgrind` job needs a few minor updates to i) extend to release-2.19, and ii) repair build on dev by adding `--linkage=shared` as well as the `curl` binary needed to keep `vcpkg` happy.  Tested in a container.

No new code, no new tests.