### PR TITLE
Update macosx-version-min to 11 aka 'Big Sur'

### DIFF
--- a/configure
+++ b/configure
@@ -6047,11 +6047,11 @@ origLDFLAGS="${LDFLAGS}"
 CPPFLAGS="${origCPPFLAGS} ${TILEDB_INCLUDE}"
 LDFLAGS="${origLDFLAGS} ${TILEDB_LIBS} ${TILEDB_RPATH}"
 
-## Take care of 10.14 requirement for Intel macOS
+## Take care of 11 (aka 'Big Sur') requirement for Intel macOS, automatic on arm
 if test x"${uname}" = x"Darwin" -a x"${machine}" = x"x86_64"; then
     { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for Darwin x86_64 use minimum version override" >&5
 printf %s "checking for Darwin x86_64 use minimum version override... " >&6; }
-    CXX17_MACOS="-mmacosx-version-min=10.14"
+    CXX17_MACOS="-mmacosx-version-min=11"
     { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: ${CXX17_MACOS}" >&5
 printf "%s\n" "${CXX17_MACOS}" >&6; }
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -160,10 +160,10 @@ origLDFLAGS="${LDFLAGS}"
 CPPFLAGS="${origCPPFLAGS} ${TILEDB_INCLUDE}"
 LDFLAGS="${origLDFLAGS} ${TILEDB_LIBS} ${TILEDB_RPATH}"
 
-## Take care of 10.14 requirement for Intel macOS
+## Take care of 11 (aka 'Big Sur') requirement for Intel macOS, automatic on arm
 if test x"${uname}" = x"Darwin" -a x"${machine}" = x"x86_64"; then
     AC_MSG_CHECKING([for Darwin x86_64 use minimum version override])
-    CXX17_MACOS="-mmacosx-version-min=10.14"
+    CXX17_MACOS="-mmacosx-version-min=11"
     AC_MSG_RESULT([${CXX17_MACOS}])
 fi
 


### PR DESCRIPTION
This follows discussions both internally at TileDB and on the r-package-devel list; the stated minimum for macOS builds (per e.g. https://mac.r-project.org/) is now version 11 ('Big Sur') and old-rel builds on x86_64 appear to be quietly suspended.

Version 11 works for us as it allows for `std::filesystem`.   The corresponding change in Core has not (yet ?) been backported to release-2.19 but the R package can use it either way.