### PR TITLE
Update NEWS and roll micro version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tiledb
 Type: Package
-Version: 0.22.0.4
+Version: 0.22.0.5
 Title: Modern Database Engine for Multi-Modal Data via Sparse and Dense Multidimensional Arrays
 Authors@R: c(person("TileDB, Inc.", role = c("aut", "cph")),
  person("Dirk", "Eddelbuettel", email = "dirk@tiledb.com", role = "cre"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,12 @@
 
 * Tests are more careful about using suggested packages only when present (#632)
 
+* When building TileDB Core, shared linking is now requested explicitly (#634)
+
+* Nightly automated checks now include Core release-2.19 and add the 'curl' binary (#635)
+
+* Builds on maOS now set release 11 ('Big Sur') as the required minimum version (#636)
+
 
 # tiledb 0.22.0
 

--- a/cleanup
+++ b/cleanup
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 rm -f  src/Makevars src/*.o src/*.so config.log config.status inst/tiledb-*.tar.gz
-rm -rf tiledb.Rcheck autom4te.cache inst/tiledb/ tiledb/
+rm -rf tiledb.Rcheck autom4te.cache inst/tiledb/ inst/config.log inst/config.status tiledb/


### PR DESCRIPTION
This is a trivial 'no-change' PR keeping up with NEWS, rolling the micro version (useful e.g. at r-universe) and extending the cleanup to remove configure artifacts from another location.

No code changes. 