### PR TITLE
Use TileDB 2.18.3

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tiledb
 Type: Package
-Version: 0.22.0.5
+Version: 0.22.0.6
 Title: Modern Database Engine for Multi-Modal Data via Sparse and Dense Multidimensional Arrays
 Authors@R: c(person("TileDB, Inc.", role = c("aut", "cph")),
  person("Dirk", "Eddelbuettel", email = "dirk@tiledb.com", role = "cre"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # Ongoing development
 
+* This release of the R package builds against [TileDB 2.18.3](https://github.com/TileDB-Inc/TileDB/releases/tag/2.18.3), and has also been tested against earlier releases as well as the development version (#638)
+
 ## Improvements
 
 * A TileDB Array can now be opened in 'keep open' mode for subsequent use without re-opening (#630)

--- a/tools/tiledbVersion.txt
+++ b/tools/tiledbVersion.txt
@@ -1,2 +1,2 @@
-version: 2.18.2
-sha: 9ae6e1a
+version: 2.18.3
+sha: 8f8b766


### PR DESCRIPTION
This PR updates the package preference to TileDB Embedded 2.18.3 which was tagged earlier.