### PR TITLE
Re-level 'factor' and 'ordered' variables with new levels

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tiledb
 Type: Package
-Version: 0.22.0.6
+Version: 0.22.0.7
 Title: Modern Database Engine for Multi-Modal Data via Sparse and Dense Multidimensional Arrays
 Authors@R: c(person("TileDB, Inc.", role = c("aut", "cph")),
  person("Dirk", "Eddelbuettel", email = "dirk@tiledb.com", role = "cre"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,8 @@
 
 * A TileDB Array can now be opened in 'keep open' mode for subsequent use without re-opening (#630)
 
+* Arrays with factor (or ordered) variables now grow their factor levels in appending writes (#639)
+
 ## Bug Fixes
 
 * The read buffer is now correctly sized when implementing VFS serialization (#631)

--- a/R/TileDBArray.R
+++ b/R/TileDBArray.R
@@ -1413,12 +1413,16 @@ setMethod("[<-", "tiledb_array",
           } else {
               stop("Unsupported enumeration vector payload of type '%s'", tpstr, call. = FALSE)
           }
-          if (length(setdiff(dictionary, new_levels)) > 0) {
+          added_enums <- setdiff(new_levels, dictionary)
+          if (length(added_enums) > 0) {
+              levels <- unique(c(dictionary, new_levels))
               is_ordered <- tiledb_attribute_is_ordered_enumeration_ptr(attr, arrptr)
-              value[[k]] <- factor(value[[k]],
-                                   levels = unique(c(dictionary, new_levels)),
-                                   ordered = is_ordered)
+              value[[k]] <- factor(value[[k]], levels = levels, ordered = is_ordered)
               spdl::debug("[tiledb_array] '[<-' releveled column {}", k)
+              ase <- tiledb_array_schema_evolution()
+              arr <- tiledb_array_open(x)
+              ase <- tiledb_array_schema_evolution_extend_enumeration(ase, arr, allnames[[k]], added_enums)
+              tiledb::tiledb_array_schema_evolution_array_evolve(ase, uri)
           }
       }
 

--- a/inst/tinytest/test_arrayschemaevolution.R
+++ b/inst/tinytest/test_arrayschemaevolution.R
@@ -112,11 +112,10 @@ run_int_col_test <- function(coltype) {
     tiledb_array_create(uri, schema)
 
     set.seed(42)
-    df <- data.frame(dim = 1:10, fct = sample(1:length(enums), 10, replace=TRUE) - 1, dbl = rnorm(10))
+    df <- data.frame(dim = 1:10, fct = sample(enums, 10, replace=TRUE), dbl = rnorm(10))
     arr <- tiledb_array(uri)
     arr[] <- df
 
-    qc <-
     res <- tiledb_array(uri, return_as="data.frame", query_condition = parse_query_condition(fct == blue, arr))[]
     expect_equal(nrow(res), 5)
 

--- a/inst/tinytest/test_arrayschemaevolution.R
+++ b/inst/tinytest/test_arrayschemaevolution.R
@@ -64,7 +64,6 @@ expect_equal(levels(res$val), enums)
 expect_equal(as.integer(res$val), c(1:5,5:1))
 
 
-
 ## -- testing 'create empty following by extending'
 if (tiledb_version(TRUE) < "2.17.3") exit_file("Needs TileDB 2.17.3 or later")
 uri <- tempfile()
@@ -104,6 +103,7 @@ expect_equal(levels(arr[, "b"]), c("red", "green", "blue", "orange"))
 ## -- testing query condition on non int32 columns
 run_int_col_test <- function(coltype) {
     uri <- tempfile()
+
     enums <- c("blue", "green", "red")
     dom <- tiledb_domain(dims = tiledb_dim(name="dim", domain=c(0L,100L), tile=10L, type="INT32"))
     attrs <- c(tiledb_attr(name="fct", type = coltype, enumeration=enums),
@@ -112,7 +112,7 @@ run_int_col_test <- function(coltype) {
     tiledb_array_create(uri, schema)
 
     set.seed(42)
-    df <- data.frame(dim = 1:10, fct = sample(enums, 10, replace=TRUE), dbl = rnorm(10))
+    df <- data.frame(dim = 1:10, fct = sample(length(enums), 10, replace=TRUE) - 1, dbl = rnorm(10))
     arr <- tiledb_array(uri)
     arr[] <- df
 
@@ -133,3 +133,49 @@ run_int_col_test <- function(coltype) {
     unlink(uri)
 }
 sapply(c("INT8", "INT16", "INT32", "UINT8", "UINT16", "UINT32"), run_int_col_test)
+
+
+## test that factor levels can grow without overlap
+uri <- tempfile()
+df1 <- data.frame(id = 1:3, obs = factor(c("A", "B", "A")))
+fromDataFrame(df1, uri, col_index=1, tile_domain=c(1L, 6L))
+
+## write with a factor with two elements but without one of the initial ones
+## while factor(c("B", "C", "B")) gets encoded as c(1,2,1) it should really
+## encoded as c(2,3,2) under levels that are c("A", "B", "C") -- and the
+## write method now does that
+df2 <- data.frame(id = 4:6, obs = factor(c("B", "C", "B")))
+fromDataFrame(df2, uri, col_index=1, mode="append")
+
+res <- tiledb_array(uri, return_as="data.frame")[]
+
+expect_equal(nrow(res), 6)
+expect_equal(nlevels(res[["obs"]]), 3)
+expect_equal(levels(res[["obs"]]), c("A", "B", "C"))
+expect_equal(as.integer(res[["obs"]]), c(1L, 2L, 1L, 2L, 3L, 2L))
+
+ref <- rbind(df1, df2)
+expect_equivalent(res, ref) # equivalent because of query status attribute
+
+
+## test that ordered factor levels can grow without overlap
+uri <- tempfile()
+df1 <- data.frame(id = 1:3, obs = ordered(c("A", "B", "A")))
+fromDataFrame(df1, uri, col_index=1, tile_domain=c(1L, 6L))
+
+## write with a factor with two elements but without one of the initial ones
+## while factor(c("B", "C", "B")) gets encoded as c(1,2,1) it should really
+## encoded as c(2,3,2) under levels that are c("A", "B", "C") -- and the
+## write method now does that
+df2 <- data.frame(id = 4:6, obs = ordered(c("B", "C", "B")))
+fromDataFrame(df2, uri, col_index=1, mode="append")
+
+res <- tiledb_array(uri, return_as="data.frame")[]
+
+expect_equal(nrow(res), 6)
+expect_equal(nlevels(res[["obs"]]), 3)
+expect_equal(levels(res[["obs"]]), c("A", "B", "C"))
+expect_equal(as.integer(res[["obs"]]), c(1L, 2L, 1L, 2L, 3L, 2L))
+
+ref <- rbind(df1, df2)
+expect_equivalent(res, ref) # equivalent because of query status attribute

--- a/inst/tinytest/test_arrayschemaevolution.R
+++ b/inst/tinytest/test_arrayschemaevolution.R
@@ -103,7 +103,6 @@ expect_equal(levels(arr[, "b"]), c("red", "green", "blue", "orange"))
 ## -- testing query condition on non int32 columns
 run_int_col_test <- function(coltype) {
     uri <- tempfile()
-
     enums <- c("blue", "green", "red")
     dom <- tiledb_domain(dims = tiledb_dim(name="dim", domain=c(0L,100L), tile=10L, type="INT32"))
     attrs <- c(tiledb_attr(name="fct", type = coltype, enumeration=enums),


### PR DESCRIPTION
This PR adds the ability for schemas to grow the stored factor levels when new levels are submitted in append mode from either `factor` or `ordered` variables.  

New tests are added.