### PR TITLE
Refactor one function to quieten compiler warning

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tiledb
 Type: Package
-Version: 0.22.0.7
+Version: 0.22.0.8
 Title: Modern Database Engine for Multi-Modal Data via Sparse and Dense Multidimensional Arrays
 Authors@R: c(person("TileDB, Inc.", role = c("aut", "cph")),
  person("Dirk", "Eddelbuettel", email = "dirk@tiledb.com", role = "cre"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,8 @@
 
 * Arrays with factor (or ordered) variables now grow their factor levels in appending writes (#639)
 
+* Initialization of object walk order in recursive mode is now more explicit (#640)
+
 ## Bug Fixes
 
 * The read buffer is now correctly sized when implementing VFS serialization (#631)

--- a/R/Config.R
+++ b/R/Config.R
@@ -264,6 +264,13 @@ tiledb_config_as_built_show <- function() {
 #' Return the 'AsBuilt' JSON string
 #'
 #' @return The JSON string containing 'AsBuilt' information
+#' @example
+#' txt <- tiledb::tiledb_config_as_built_json()
+#' ## now eg either one of
+#' ##   sapply(jsonlite::fromJSON(txt)$as_built$parameters$storage_backends, \(x) x[[1]])
+#' ##   sapply(RcppSimdJson::fparse(txt)$as_built$parameters$storage_backends, \(x) x[[1]])
+#' ## will return a named vector such as
+#' ##   c(azure = FALSE, gcs = FALSE, hdfs = FALSE, s3 = TRUE)
 #' @export
 tiledb_config_as_built_json <- function() {
     stopifnot("Accessing 'AsBuilt' requires TileDB 2.17 or newer" = tiledb_version(TRUE) >= "2.17.0")

--- a/R/TileDBArray.R
+++ b/R/TileDBArray.R
@@ -1400,7 +1400,7 @@ setMethod("[<-", "tiledb_array",
       k <- match(colnam, nm)
 
       if (alldictionary[k]) {
-          spdl::debug("[tiledb_array] '[<-' column {} ({}) is factor", colnam, k)
+          spdl::trace("[tiledb_array] '[<-' column {} ({}) is factor", colnam, k)
           new_levels <- levels(value[[k]])
 
           attr <- attrs[[allnames[k]]]
@@ -1415,12 +1415,16 @@ setMethod("[<-", "tiledb_array",
           }
           added_enums <- setdiff(new_levels, dictionary)
           if (length(added_enums) > 0) {
+              spdl::debug("[tiledb_array] '[<-' Adding levels {}", paste(added_enums, collapse=","))
               levels <- unique(c(dictionary, new_levels))
               is_ordered <- tiledb_attribute_is_ordered_enumeration_ptr(attr, arrptr)
               value[[k]] <- factor(value[[k]], levels = levels, ordered = is_ordered)
-              spdl::debug("[tiledb_array] '[<-' releveled column {}", k)
+              spdl::trace("[tiledb_array] '[<-' releveled column {} {}", k, is_ordered)
               ase <- tiledb_array_schema_evolution()
-              arr <- tiledb_array_open(x)
+              if (!tiledb_array_is_open(x))
+                  arr <- tiledb_array_open(x)
+              else
+                  arr <- x
               ase <- tiledb_array_schema_evolution_extend_enumeration(ase, arr, allnames[[k]], added_enums)
               tiledb::tiledb_array_schema_evolution_array_evolve(ase, uri)
           }

--- a/src/libtiledb.cpp
+++ b/src/libtiledb.cpp
@@ -4279,20 +4279,14 @@ tiledb::Object::Type _string_to_object_type(std::string otype) {
 DataFrame libtiledb_object_walk(XPtr<tiledb::Context> ctx,
                                 std::string uri, std::string order, bool recursive = false) {
   check_xptr_tag<tiledb::Context>(ctx);
-  tiledb_walk_order_t walk_order;
-  if (recursive) {
-    if (order == "PREORDER") {
-      walk_order = TILEDB_PREORDER;
-    } else if (order == "POSTORDER") {
-      walk_order = TILEDB_POSTORDER;
-    } else {
-      Rcpp::stop("invalid recursive walk order, must be \"PREORDER\" or \"POSTORDER\"");
-    }
-  }
   std::vector<std::string> uris;
   std::vector<std::string> types;
   tiledb::ObjectIter obj_iter(*ctx.get(), uri);
   if (recursive) {
+    if (!(order == "PREORDER") || (order == "POSTORDER")) {
+      Rcpp::stop("invalid recursive walk order, must be \"PREORDER\" or \"POSTORDER\"");
+    }
+    tiledb_walk_order_t walk_order = (order == "PREORDER") ? TILEDB_PREORDER : TILEDB_POSTORDER;
     obj_iter.set_recursive(walk_order);
   } else {
     obj_iter.set_non_recursive();


### PR DESCRIPTION
This PR improves the dispatching into `tiledb::ObjectIter`. When trying to build under the thread sanitizer (which ultimately did not work) the function tickled a warning about `walk_order` possibly unintialized which is correct as the existing code was co-dependent on recursive mode being set.  This has been improved.

The PR also adds a little usage example to the help page for `built_as` dumper, the code is not exposed as we cannot assume to have a JSON parser loaded, and adds a small improvement to a recent change in enumeration / factor handling in writes.