### PR TITLE
Use 2.19.0

### DIFF
--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -6,10 +6,15 @@ PKG_LIBS = \
 	-L$(RWINLIB)/lib$(subst gcc,,$(COMPILED_BY))$(R_ARCH) \
 	-L$(RWINLIB)/lib$(R_ARCH)$(CRT) \
 	-ltiledbstatic -lbz2 -lzstd -llz4 -lz -lspdlog -lfmt \
-	-lwebp -lwebpdecoder -lwebpdemux -lwebpmux -lsharpyuv \
-        -llibmagic -lpcre2-posix -lpcre2-8 \
-	-laws-cpp-sdk-identity-management -laws-cpp-sdk-cognito-identity -laws-cpp-sdk-sts -laws-cpp-sdk-s3 -laws-cpp-sdk-core -laws-c-event-stream -laws-checksums -laws-c-common \
-	-lShlwapi -lBcrypt -lRpcrt4 -lWininet -lWinhttp -lws2_32 -lVersion -lUserenv
+	-laws-cpp-sdk-identity-management -laws-cpp-sdk-cognito-identity -laws-cpp-sdk-sts -laws-cpp-sdk-s3 -laws-cpp-sdk-core \
+        -llibmagic -lwebp -lpcre2-posix -lpcre2-8 \
+	-laws-crt-cpp -laws-c-mqtt -laws-c-event-stream -laws-c-s3 -laws-c-auth -laws-c-http -laws-c-io \
+	-lSecur32 -lCrypt32 \
+	-laws-c-compression -laws-c-cal \
+	-lNCrypt \
+	-laws-c-sdkutils -laws-checksums -laws-c-common \
+	-lBCrypt -lKernel32 -lRpcrt4 -lWininet -lWinhttp -lWs2_32 -lShlwapi -lUserenv -lversion -lws2_32 \
+	-lsharpyuv
 
 all: clean winlibs
 

--- a/tools/fetchTileDB.sh
+++ b/tools/fetchTileDB.sh
@@ -41,6 +41,7 @@ if [ ! -d tiledb ]; then
     mkdir tiledb
     tar xzf ${tarball} -C tiledb
     rm ${tarball}
+    test -d tiledb/lib64 && mv tiledb/lib64 tiledb/lib
 fi
 
 ## Copy tiledb/lib/ so that rpath relative path also works from

--- a/tools/tiledbVersion.txt
+++ b/tools/tiledbVersion.txt
@@ -1,2 +1,2 @@
 version: 2.19.0
-sha: fa30a88
+sha: fa30a88a

--- a/tools/tiledbVersion.txt
+++ b/tools/tiledbVersion.txt
@@ -1,2 +1,2 @@
-version: 2.18.3
-sha: 8f8b766
+version: 2.19.0
+sha: fa30a88


### PR DESCRIPTION
This PR updates the package preference to TileDB Embedded 2.19.0 which was released earlier today.