### PR TITLE
Ensure factors reset when levels grow in appending writes

### DIFF
--- a/R/TileDBArray.R
+++ b/R/TileDBArray.R
@@ -1415,7 +1415,9 @@ setMethod("[<-", "tiledb_array",
           }
           added_enums <- setdiff(new_levels, dictionary)
           if (length(added_enums) > 0) {
-              spdl::debug("[tiledb_array] '[<-' Adding levels {}", paste(added_enums, collapse=","))
+              spdl::debug("[tiledb_array] '[<-' Adding levels '{}' at '{}' ({} + {})",
+                         paste(added_enums, collapse=","), allnames[[k]],
+                         length(dictionary), length(added_enums))
               levels <- unique(c(dictionary, new_levels))
               is_ordered <- tiledb_attribute_is_ordered_enumeration_ptr(attr, arrptr)
               value[[k]] <- factor(value[[k]], levels = levels, ordered = is_ordered)
@@ -1427,6 +1429,7 @@ setMethod("[<-", "tiledb_array",
                   arr <- x
               ase <- tiledb_array_schema_evolution_extend_enumeration(ase, arr, allnames[[k]], added_enums)
               tiledb::tiledb_array_schema_evolution_array_evolve(ase, uri)
+              value[[k]] <- factor(value[[k]], levels = unique(c(dictionary, added_enums)), ordered=is.ordered(value[[k]]))
           }
       }
 
@@ -1441,7 +1444,7 @@ setMethod("[<-", "tiledb_array",
             col <- unname(do.call(c, col))
         }
         if (is.factor(col)) {
-            col <- as.integer(col) - 1 		# zero based in C++ so offsetting
+            col <- as.integer(col) - 1L 		# zero based in C++ so offsetting
         }
         nr <- NROW(col)
         spdl::debug("[tiledb_array] '[<-' alloc buf {} '{}': {}, rows: {} null: {} asint64: {}", k, colnam, alltypes[k], nr, allnullable[k], asint64)

--- a/inst/tinytest/test_arrayschemaevolution.R
+++ b/inst/tinytest/test_arrayschemaevolution.R
@@ -178,3 +178,14 @@ expect_equal(as.integer(res[["obs"]]), c(1L, 2L, 1L, 2L, 3L, 2L))
 
 ref <- rbind(df1, df2)
 expect_equivalent(res, ref) # equivalent because of query status attribute
+
+
+## another test for growing
+uri <- tempfile()
+df1 <- data.frame(rows=11:14, a=200+0:3, b=factor(rep(c("blue", "ornage"), each=2)))
+expect_silent(fromDataFrame(df1, uri, col_index=1, tile_domain=c(1L, 30L)))
+df2 <- data.frame(rows=21:24, a=300+0:3, b=factor(rep(c("brown", "yellow"), each=2)))
+expect_silent(fromDataFrame(df2, uri, mode="append", col_index=1))
+
+res <- tiledb_array(uri, return_as="data.frame")[]
+expect_equivalent(res, rbind(df1, df2))   # factors in data.frame get releveled too


### PR DESCRIPTION
This carries over a small fix first made for the SOMA package where it is ensured that in appending writes with expanding factor levels, the factor variable is 'reset' to the expanded set.  This was the initial 'A,B,A' adding 'B,C,B' -- each data.frame contains a factors with (integer) values 1, 2, 1 (in R, and 0, 1, 0 in C++) but because they form a new factor with three levels 'A, B, C' the second one has be recoded as 2, 3, 2. 

CI has passed on reasonable operating systems and is currently awaiting resources for the fancier one.

