### PR TITLE
Ensure factor additions do not overflow index type

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tiledb
 Type: Package
-Version: 0.23.0
+Version: 0.23.0.1
 Title: Modern Database Engine for Multi-Modal Data via Sparse and Dense Multidimensional Arrays
 Authors@R: c(person("TileDB, Inc.", role = c("aut", "cph")),
  person("Dirk", "Eddelbuettel", email = "dirk@tiledb.com", role = "cre"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,14 @@
+# Ongoing development
+
+## Improvements
+
+* Factor level additions now check for possible over in the index type (#645)
+
+## Bug Fixes
+
+* Factor level additions ensure the factor is relevelled under the full set of factors (#644)
+
+
 # tiledb 0.23.0
 
 * This release of the R package builds against [TileDB 2.19.0](https://github.com/TileDB-Inc/TileDB/releases/tag/2.19.0), and has also been tested against earlier releases as well as the development version (#641)

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -82,6 +82,10 @@ libtiledb_version <- function() {
     .Call(`_tiledb_libtiledb_version`)
 }
 
+tiledb_datatype_max_value <- function(datatype) {
+    .Call(`_tiledb_tiledb_datatype_max_value`, datatype)
+}
+
 libtiledb_ctx <- function(config = NULL) {
     .Call(`_tiledb_libtiledb_ctx`, config)
 }

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -216,6 +216,17 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// tiledb_datatype_max_value
+size_t tiledb_datatype_max_value(const std::string& datatype);
+RcppExport SEXP _tiledb_tiledb_datatype_max_value(SEXP datatypeSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< const std::string& >::type datatype(datatypeSEXP);
+    rcpp_result_gen = Rcpp::wrap(tiledb_datatype_max_value(datatype));
+    return rcpp_result_gen;
+END_RCPP
+}
 // libtiledb_ctx
 XPtr<tiledb::Context> libtiledb_ctx(Nullable<XPtr<tiledb::Config>> config);
 RcppExport SEXP _tiledb_libtiledb_ctx(SEXP configSEXP) {
@@ -3589,6 +3600,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_tiledb_tiledb_datatype_string_to_sizeof", (DL_FUNC) &_tiledb_tiledb_datatype_string_to_sizeof, 1},
     {"_tiledb_tiledb_datatype_R_type", (DL_FUNC) &_tiledb_tiledb_datatype_R_type, 1},
     {"_tiledb_libtiledb_version", (DL_FUNC) &_tiledb_libtiledb_version, 0},
+    {"_tiledb_tiledb_datatype_max_value", (DL_FUNC) &_tiledb_tiledb_datatype_max_value, 1},
     {"_tiledb_libtiledb_ctx", (DL_FUNC) &_tiledb_libtiledb_ctx, 1},
     {"_tiledb_libtiledb_ctx_config", (DL_FUNC) &_tiledb_libtiledb_ctx_config, 1},
     {"_tiledb_libtiledb_ctx_is_supported_fs", (DL_FUNC) &_tiledb_libtiledb_ctx_is_supported_fs, 2},

--- a/src/libtiledb.cpp
+++ b/src/libtiledb.cpp
@@ -1,6 +1,6 @@
 //  MIT License
 //
-//  Copyright (c) 2017-2023 TileDB Inc.
+//  Copyright (c) 2017-2024 TileDB Inc.
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal
@@ -491,6 +491,21 @@ NumericVector libtiledb_version() {
                                Named("patch") = std::get<2>(ver));
 }
 
+// [[Rcpp::export]]
+size_t tiledb_datatype_max_value(const std::string& datatype) {
+    tiledb_datatype_t dtype = _string_to_tiledb_datatype(datatype);
+    switch (dtype) {
+    case TILEDB_INT8:    return std::numeric_limits<int8_t>::max();
+    case TILEDB_UINT8:   return std::numeric_limits<uint8_t>::max();
+    case TILEDB_INT16:   return std::numeric_limits<int16_t>::max();
+    case TILEDB_UINT16:  return std::numeric_limits<uint16_t>::max();
+    case TILEDB_INT32:   return std::numeric_limits<int32_t>::max();
+    case TILEDB_UINT32:  return std::numeric_limits<uint32_t>::max();
+    case TILEDB_INT64:   return std::numeric_limits<int64_t>::max();
+    case TILEDB_UINT64:  return std::numeric_limits<uint64_t>::max();
+    default: Rcpp::stop("currently unsupported datatype (%s)", datatype);
+    }
+}
 
 /**
  * TileDB Context


### PR DESCRIPTION
This PR adds a check for possible overflow in factor index level values when data is appended and factor levels grow.  This arguably a corner case as most arrays (at least when created from R) will have an int32_t index.  But as schemas can of course be based on factors with int8_t (and uint8_t, ...) it is possible.   A unit test has been adding trying to write 130 distinct factor values which correctly errors with int8_t (max is 127 and lower) but passes with uint8_t.