### PR TITLE
Account for one-based arrays in R when comparing for max capacity

### DIFF
--- a/R/TileDBArray.R
+++ b/R/TileDBArray.R
@@ -1415,7 +1415,7 @@ setMethod("[<-", "tiledb_array",
           }
           added_enums <- setdiff(new_levels, dictionary)
           if (length(added_enums) > 0) {
-              maxval <- tiledb_datatype_max_value(alltypes[k])
+              maxval <- tiledb_datatype_max_value(alltypes[k]) + 1 # R vectors are 1-indexed
               spdl::debug("[tiledb_array] '[<-' Adding levels '{}' at '{}' {} ({} + {} ? {})",
                           paste(added_enums, collapse=","), allnames[k], alltypes[k], length(dictionary), length(added_enums), maxval);
               if (length(dictionary) + length(added_enums) > maxval) {


### PR DESCRIPTION
This accounts for a minor off-by-one: when looking at array length in R, 128 is the critical value and not the reported 127.  Usual old story of C/C++ being zero based whereas R is one-based.  This updates yesterday's PR #645.