### PR TITLE
Correct one example, update roxygen2 use in two other spots

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,5 +30,5 @@ LinkingTo: Rcpp, RcppInt64
 Suggests: tinytest, simplermarkdown, curl, bit64, Matrix, palmerpenguins, nycflights13, data.table, tibble, arrow
 VignetteBuilder: simplermarkdown
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.0
 Encoding: UTF-8

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tiledb
 Type: Package
-Version: 0.23.0.1
+Version: 0.23.0.2
 Title: Modern Database Engine for Multi-Modal Data via Sparse and Dense Multidimensional Arrays
 Authors@R: c(person("TileDB, Inc.", role = c("aut", "cph")),
  person("Dirk", "Eddelbuettel", email = "dirk@tiledb.com", role = "cre"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,11 +2,13 @@
 
 ## Improvements
 
-* Factor level additions now check for possible over in the index type (#645)
+* Factor level additions now check for possible over in the index type (#645, #646)
 
 ## Bug Fixes
 
 * Factor level additions ensure the factor is relevelled under the full set of factors (#644)
+
+* The example for `fromDataFrame()` has been updated, along with two other help files (#648)
 
 
 # tiledb 0.23.0

--- a/R/Config.R
+++ b/R/Config.R
@@ -264,7 +264,7 @@ tiledb_config_as_built_show <- function() {
 #' Return the 'AsBuilt' JSON string
 #'
 #' @return The JSON string containing 'AsBuilt' information
-#' @example
+#' @examples
 #' txt <- tiledb::tiledb_config_as_built_json()
 #' ## now eg either one of
 #' ##   sapply(jsonlite::fromJSON(txt)$as_built$parameters$storage_backends, \(x) x[[1]])

--- a/R/DataFrame.R
+++ b/R/DataFrame.R
@@ -1,6 +1,6 @@
 #  MIT License
 #
-#  Copyright (c) 2017-2023 TileDB Inc.
+#  Copyright (c) 2017-2024 TileDB Inc.
 #
 #  Permission is hereby granted, free of charge, to any person obtaining a copy
 #  of this software and associated documentation files (the "Software"), to deal
@@ -71,15 +71,12 @@
 ##' @return Null, invisibly.
 ##' @examples
 ##' \dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
-##' \dontrun{
 ##' uri <- tempfile()
-##' ## turn factor into character
-##' irisdf <- within(iris, Species <- as.character(Species))
-##' fromDataFrame(irisdf, uri)
-##' arr <- tiledb_array(uri, return_as="data.frame", sparse=FALSE)
+##' fromDataFrame(iris, uri)
+##' arr <- tiledb_array(uri, return_as="data.frame", extended=FALSE)
 ##' newdf <- arr[]
-##' all.equal(iris, newdf)
-##' }
+##' all.equal(iris, newdf, check.attributes=FALSE)  # extra attribute on query in newdf
+##' all.equal(as.matrix(iris), as.matrix(newdf))	# also strips attribute
 ##' @export
 fromDataFrame <- function(obj, uri, col_index=NULL, sparse=TRUE, allows_dups=sparse,
                           cell_order = "COL_MAJOR", tile_order = "COL_MAJOR", filter="ZSTD",

--- a/R/TileDB-Package.R
+++ b/R/TileDB-Package.R
@@ -27,8 +27,10 @@
 #" dense and sparse array data with support for fast updates and
 #' reads. It features excellent compression, an efficient parallel I/O
 #' system which also scales well, and bindings to multiple languages.
-#'
-#' @docType package
+
+#' @keywords internal
+"_PACKAGE"
+
 #' @name tiledb-package
 #' @useDynLib tiledb, .registration = TRUE
 #' @importFrom Rcpp sourceCpp

--- a/man/fromDataFrame.Rd
+++ b/man/fromDataFrame.Rd
@@ -92,13 +92,10 @@ At present, factor variable are converted to character.
 }
 \examples{
 \dontshow{ctx <- tiledb_ctx(limitTileDBCores())}
-\dontrun{
 uri <- tempfile()
-## turn factor into character
-irisdf <- within(iris, Species <- as.character(Species))
-fromDataFrame(irisdf, uri)
-arr <- tiledb_array(uri, return_as="data.frame", sparse=FALSE)
+fromDataFrame(iris, uri)
+arr <- tiledb_array(uri, return_as="data.frame", extended=FALSE)
 newdf <- arr[]
-all.equal(iris, newdf)
-}
+all.equal(iris, newdf, check.attributes=FALSE)  # extra attribute on query in newdf
+all.equal(as.matrix(iris), as.matrix(newdf))	# also strips attribute
 }

--- a/man/tiledb-package.Rd
+++ b/man/tiledb-package.Rd
@@ -2,6 +2,7 @@
 % Please edit documentation in R/TileDB-Package.R
 \docType{package}
 \name{tiledb-package}
+\alias{tiledb}
 \alias{tiledb-package}
 \title{tiledb - Interface to the TileDB Storage Manager API}
 \description{
@@ -10,3 +11,21 @@ The efficient multi-dimensional array management system
 reads. It features excellent compression, an efficient parallel I/O
 system which also scales well, and bindings to multiple languages.
 }
+\seealso{
+Useful links:
+\itemize{
+  \item \url{https://github.com/TileDB-Inc/TileDB-R}
+  \item Report bugs at \url{https://github.com/TileDB-Inc/TileDB-R/issues}
+}
+
+}
+\author{
+\strong{Maintainer}: Dirk Eddelbuettel \email{dirk@tiledb.com}
+
+Authors:
+\itemize{
+  \item TileDB, Inc. [copyright holder]
+}
+
+}
+\keyword{internal}

--- a/man/tiledb_config_as_built_json.Rd
+++ b/man/tiledb_config_as_built_json.Rd
@@ -12,3 +12,11 @@ The JSON string containing 'AsBuilt' information
 \description{
 Return the 'AsBuilt' JSON string
 }
+\examples{
+txt <- tiledb::tiledb_config_as_built_json()
+## now eg either one of
+##   sapply(jsonlite::fromJSON(txt)$as_built$parameters$storage_backends, \(x) x[[1]])
+##   sapply(RcppSimdJson::fparse(txt)$as_built$parameters$storage_backends, \(x) x[[1]])
+## will return a named vector such as
+##   c(azure = FALSE, gcs = FALSE, hdfs = FALSE, s3 = TRUE)
+}


### PR DESCRIPTION
As #647 points out, the `fromDataFrame()` example was a little stale and needed an update provided here.

Using current `roxygen2` 7.3.0 also leads to two changes: a correctly identified typo, and a forced change because that's how opinionated packages roll.