### PR TITLE
Add release-2.20 to valgrind matrix

### DIFF
--- a/.github/workflows/valgrind.yaml
+++ b/.github/workflows/valgrind.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tag: [ release-2.18, release-2.19, dev ]
+        tag: [ release-2.18, release-2.19, release-2.20, dev ]
 
     steps:
     - name: Checkout

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,10 @@
 
 * The example for `fromDataFrame()` has been updated, along with two other help files (#648)
 
+## Build and Test Systems
+
+* The nighly valgrind run was updated to include release 2.20 (#649)
+
 
 # tiledb 0.23.0
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ of TileDB, but should also build against the newest development version.
 
 ## Copyright
 
-The TileDB R package is Copyright 2018-2023 TileDB, Inc
+The TileDB R package is Copyright 2018-2024 TileDB, Inc
 
 ## License
 


### PR DESCRIPTION
This expand the set of TileDB Embedded branches tested nightly with `valgrind`.