### PR TITLE
Robustify test_filter script 

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,9 +8,11 @@
 
 ## Bug Fixes
 
-* Factor level additions ensure the factor is relevelled under the full set of factors (#644)
+* Factor level additions ensure the factor is releveled under the full set of factors (#644)
 
 * The example for `fromDataFrame()` has been updated, along with two other help files (#648)
+
+* Handling of temporary files in one test script has been standardized (#653)
 
 ## Build and Test Systems
 


### PR DESCRIPTION
Nightly job #652 fell over, the error message about 'fragment info' missing a 'group' is misleading, this appears to be due temporary directly handling which we already changed similarly in some other files.

fixes #652 

