### PR TITLE
Install req'd nanoarrow for valgrind nightlies, also install arrow

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tiledb
 Type: Package
-Version: 0.24.0.3
+Version: 0.24.0.4
 Title: Modern Database Engine for Multi-Modal Data via Sparse and Dense Multidimensional Arrays
 Authors@R: c(person("TileDB, Inc.", role = c("aut", "cph")),
  person("Dirk", "Eddelbuettel", email = "dirk@tiledb.com", role = "cre"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,8 @@
 
 * The `tiledb_get_query_range_var()` accessor now correctly calls the range getter for variable-sized dimensions (#662)
 
+* The nighly valgrind check now installs to require `nanoarrow` package (#664)
+
 
 # tiledb 0.24.0
 

--- a/src/libtiledb.cpp
+++ b/src/libtiledb.cpp
@@ -4376,8 +4376,7 @@ std::string libtiledb_vfs_create_dir(XPtr<tiledb::VFS> vfs, std::string uri) {
 // [[Rcpp::export]]
 bool libtiledb_vfs_is_dir(XPtr<tiledb::VFS> vfs, std::string uri) {
     check_xptr_tag<tiledb::VFS>(vfs);
-    auto ptr = vfs.get();
-    return ptr->is_dir(uri);
+    return vfs->is_dir(uri);
 }
 
 // [[Rcpp::export]]

--- a/tools/ci/valgrind/installDependencies.sh
+++ b/tools/ci/valgrind/installDependencies.sh
@@ -74,11 +74,13 @@ echo "::endgroup::"
 echo "::group::Install R Packages"
 # This relies on bspm and installs binaries (i.e. r-cran-* packages)
 install.r \
+    arrow \
     bit64 \
     curl \
     data.table \
     Matrix \
     nanotime \
+    nanoarrow \
     nycflights13 \
     palmerpenguins \
     Rcpp \


### PR DESCRIPTION
The recent PR #663 makes `nanoarrow` a requirement.  But the older of the two nightlies still uses an explicit package list which did not include it.   As we rely on easy to install binaries, we add `arrow` as (which is only a `Suggests:`) to widen the test coverage.

Also fix a minor 'style bug' noticed today in one VFS function.