### PR TITLE
Use TileDB 2.21.0-rc1 (reverting previous tweaks)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tiledb
 Type: Package
-Version: 0.24.0.5
+Version: 0.24.0.6
 Title: Modern Database Engine for Multi-Modal Data via Sparse and Dense Multidimensional Arrays
 Authors@R: c(person("TileDB, Inc.", role = c("aut", "cph")),
  person("Dirk", "Eddelbuettel", email = "dirk@tiledb.com", role = "cre"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,8 @@
 # Ongoing Development
 
 * This release of the R package builds against both [TileDB 2.20.1](https://github.com/TileDB-Inc/TileDB/releases/tag/2.20.1)
-  and [TileDB 2.21.0-rc0](https://github.com/TileDB-Inc/TileDB/releases/tag/2.21.0-rc0),
-  and has also been tested against earlier releases as well as the development version (#661, #666)
+  and [TileDB 2.21.0-rc1](https://github.com/TileDB-Inc/TileDB/releases/tag/2.21.0-rc1),
+  and has also been tested against earlier releases as well as the development version (#661, #666, @668)
 
 ## Improvements
 

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -7,7 +7,7 @@ PKG_LIBS = \
 	-L$(RWINLIB)/lib$(R_ARCH)$(CRT) \
 	-ltiledbstatic -lbz2 -lzstd -llz4 -lz -lspdlog -lfmt \
 	-laws-cpp-sdk-identity-management -laws-cpp-sdk-cognito-identity -laws-cpp-sdk-sts -laws-cpp-sdk-s3 -laws-cpp-sdk-core \
-	-lwebp -lmagic -ltre \
+	-llibmagic -lwebp -lpcre2-posix -lpcre2-8 \
 	-laws-crt-cpp -laws-c-mqtt -laws-c-event-stream -laws-c-s3 -laws-c-auth -laws-c-http -laws-c-io \
 	-lSecur32 -lCrypt32 \
 	-laws-c-compression -laws-c-cal \

--- a/tools/fetchTileDBLib.R
+++ b/tools/fetchTileDBLib.R
@@ -28,7 +28,6 @@ if (!file.exists(dcffile)) {
 }
 dcf <- read.dcf(dcffile)
 ver <- dcf[[1, "version"]]
-shrtver <- gsub("-rc0$", "", ver)
 sha <- dcf[[1, "sha"]]
 
 ## on linux, we need to consider AVX2 vs non-AVX2 capabilities on the build machine
@@ -38,10 +37,8 @@ avx2 <- if (osarg == "linux" && any(grepl("avx2", readLines("/proc/cpuinfo")))) 
 baseurl <- "https://github.com/TileDB-Inc/TileDB/releases/download"
 ## now switch based on macOS or Linux, using version, architecture, avx2 if needed, version and sha
 dlurl <- switch(osarg,
-                #linux = file.path(baseurl,sprintf("%s/tiledb-linux-%s%s-%s-%s.tar.gz", ver, arch, avx2, ver, sha)),
-                #macos = file.path(baseurl,sprintf("%s/tiledb-macos-%s-%s-%s.tar.gz", ver, arch, ver, sha)),
-                linux = file.path(baseurl,sprintf("%s/tiledb-linux-%s%s-%s.tar.gz", ver, arch, avx2, shrtver)),
-                macos = file.path(baseurl,sprintf("%s/tiledb-macos-%s-%s.tar.gz", ver, arch, shrtver)),
+                linux = file.path(baseurl,sprintf("%s/tiledb-linux-%s%s-%s-%s.tar.gz", ver, arch, avx2, ver, sha)),
+                macos = file.path(baseurl,sprintf("%s/tiledb-macos-%s-%s-%s.tar.gz", ver, arch, ver, sha)),
                 url = urlarg)
 cat("downloading", dlurl, "\n")
 op <- options()

--- a/tools/tiledbVersion.txt
+++ b/tools/tiledbVersion.txt
@@ -1,2 +1,2 @@
-version: 2.21.0-rc0
-sha: 5e75f71
+version: 2.21.0-rc1
+sha: 0ea9c13


### PR DESCRIPTION
Changes in #666 accomodating the libmagic and CPack-induced changes have been reverted