### PR TITLE
Updates to CI scripts including roll to release 2.21 in nightly

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: System
         run: sysctl -a

--- a/.github/workflows/valgrind.yaml
+++ b/.github/workflows/valgrind.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tag: [ release-2.18, release-2.19, release-2.20, dev ]
+        tag: [ release-2.19, release-2.20, release-2.21, dev ]
 
     steps:
     - name: Checkout

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -16,7 +16,7 @@ jobs:
         ]
     steps:
       - run: git config --global core.autocrlf false
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.r }}

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tiledb
 Type: Package
-Version: 0.24.0.6
+Version: 0.24.0.7
 Title: Modern Database Engine for Multi-Modal Data via Sparse and Dense Multidimensional Arrays
 Authors@R: c(person("TileDB, Inc.", role = c("aut", "cph")),
  person("Dirk", "Eddelbuettel", email = "dirk@tiledb.com", role = "cre"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,11 @@
 
 * The nighly valgrind check now installs to require `nanoarrow` package (#664)
 
+## Build and Test Systems
+
+* The nighly valgrind run was updated to include release 2.21 (#669)
+
+
 
 # tiledb 0.24.0
 


### PR DESCRIPTION
This wins for most boring PR of the year but touches three files. Barely.