### PR TITLE
Correct treatment of ncells=NA for non-character columns

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tiledb
 Type: Package
-Version: 0.24.0.7
+Version: 0.24.0.8
 Title: Modern Database Engine for Multi-Modal Data via Sparse and Dense Multidimensional Arrays
 Authors@R: c(person("TileDB, Inc.", role = c("aut", "cph")),
  person("Dirk", "Eddelbuettel", email = "dirk@tiledb.com", role = "cre"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,8 @@
 
 * The nighly valgrind check now installs to require `nanoarrow` package (#664)
 
+* Variable cell numbers can now set consistently for all attribute types (#670)
+
 ## Build and Test Systems
 
 * The nighly valgrind run was updated to include release 2.21 (#669)

--- a/R/Attribute.R
+++ b/R/Attribute.R
@@ -63,10 +63,13 @@ tiledb_attr <- function(name,
                         ctx = tiledb_get_context()
                         ) {
     if (missing(name)) name <- ""
-    stopifnot(`The 'type' argument for is mandatory` = !missing(type),
-              `The 'ctx' argument must be a tiledb_ctx` = is(ctx, "tiledb_ctx"),
-              `The 'name' argument must be a scalar string` = is.scalar(name, "character"),
-              `The 'filter_list' argument must be a tiledb_filter_list instance` = is(filter_list, "tiledb_filter_list"))
+    if (is.na(ncells)) ncells <- NA_integer_ 		# the specific NA for ints (as basic NA is bool)
+    stopifnot("The 'name' argument must be a scalar string" = is.scalar(name, "character"),
+              "The 'type' argument is mandatory" = !missing(type),
+              "The 'ncells' argument must be numeric or NA" = is.numeric(ncells) || is.na(ncells),
+              "The 'filter_list' argument must be a tiledb_filter_list instance" =
+                  is(filter_list, "tiledb_filter_list"),
+              "The 'ctx' argument must be a tiledb_ctx" = is(ctx, "tiledb_ctx"))
     ptr <- libtiledb_attribute(ctx@ptr, name, type, filter_list@ptr, ncells, nullable)
     attr <- new("tiledb_attr", ptr = ptr)
     if (!is.null(enumeration))


### PR DESCRIPTION
@nickvigilante noticed that `ncells=NA` mishaves in attributes settings for non-character columns ... and a bit of inspection reveals that its treatment was only done in character columns.

This is now fixed, and the parameter setting checks at the main R interface have been beefed up too.