### PR TITLE
Correct postorder walk argument check

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tiledb
 Type: Package
-Version: 0.24.0.8
+Version: 0.24.0.9
 Title: Modern Database Engine for Multi-Modal Data via Sparse and Dense Multidimensional Arrays
 Authors@R: c(person("TileDB, Inc.", role = c("aut", "cph")),
  person("Dirk", "Eddelbuettel", email = "dirk@tiledb.com", role = "cre"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -16,10 +16,13 @@
 
 * Variable cell numbers can now set consistently for all attribute types (#670)
 
+* Object walk traversal order detection has been corrected (#671)
+
 ## Build and Test Systems
 
 * The nighly valgrind run was updated to include release 2.21 (#669)
 
+* Unit tests have been added for the TileDB 'object' functions (#671)
 
 
 # tiledb 0.24.0

--- a/R/Object.R
+++ b/R/Object.R
@@ -1,6 +1,6 @@
 #  MIT License
 #
-#  Copyright (c) 2017-2022 TileDB Inc.
+#  Copyright (c) 2017-2024 TileDB Inc.
 #
 #  Permission is hereby granted, free of charge, to any person obtaining a copy
 #  of this software and associated documentation files (the "Software"), to deal
@@ -33,8 +33,9 @@
 #'
 #' @export
 tiledb_object_type <- function(uri, ctx = tiledb_get_context()) {
-    stopifnot(`The 'ctx' argument must a tiledb_ctx` = is(ctx, "tiledb_ctx"),
-              `The 'uri' argument must be a string scalar` = !missing(uri) && is.scalar(uri,"character"))
+    stopifnot("The 'ctx' argument must a tiledb_ctx" = is(ctx, "tiledb_ctx"),
+              "The 'uri' argument must be a string scalar" =
+                  !missing(uri) && is.scalar(uri,"character"))
     libtiledb_object_type(ctx@ptr, uri)
 }
 
@@ -47,8 +48,9 @@ tiledb_object_type <- function(uri, ctx = tiledb_get_context()) {
 #' @return uri of removed TileDB resource
 #' @export
 tiledb_object_rm <- function(uri, ctx = tiledb_get_context()) {
-    stopifnot(`The 'ctx' argument must a tiledb_ctx` = is(ctx, "tiledb_ctx"),
-              `The 'uri' argument must be a string scalar` = !missing(uri) && is.scalar(uri,"character"))
+    stopifnot("The 'ctx' argument must a tiledb_ctx" = is(ctx, "tiledb_ctx"),
+              "The 'uri' argument must be a string scalar" =
+                  !missing(uri) && is.scalar(uri,"character"))
     libtiledb_object_remove(ctx@ptr, uri)
 }
 
@@ -62,9 +64,9 @@ tiledb_object_rm <- function(uri, ctx = tiledb_get_context()) {
 #' @return new uri of moved tiledb resource
 #' @export
 tiledb_object_mv <- function(old_uri, new_uri, ctx = tiledb_get_context()) {
-    stopifnot(`The 'ctx' argument must a tiledb_ctx` = is(ctx, "tiledb_ctx"),
-              `The 'old_uri' argument must be a string scalar` = !missing(old_uri) && is.scalar(old_uri,"character"),
-              `The 'new_uri' argument must be a string scalar` = !missing(new_uri) && is.scalar(new_uri,"character"))
+    stopifnot("The 'ctx' argument must a tiledb_ctx" = is(ctx, "tiledb_ctx"),
+              "The 'old_uri' argument must be a string scalar" = !missing(old_uri) && is.scalar(old_uri,"character"),
+              "The 'new_uri' argument must be a string scalar" = !missing(new_uri) && is.scalar(new_uri,"character"))
     libtiledb_object_move(ctx@ptr, old_uri, new_uri)
 }
 
@@ -76,20 +78,24 @@ tiledb_object_mv <- function(old_uri, new_uri, ctx = tiledb_get_context()) {
 #' @return a dataframe with object type, object uri string columns
 #' @export
 tiledb_object_ls <- function(uri, filter = NULL, ctx = tiledb_get_context()) {
-    stopifnot(`The 'ctx' argument must a tiledb_ctx` = is(ctx, "tiledb_ctx"),
-              `The 'uri' argument must be a string scalar` = !missing(uri) && is.scalar(uri,"character"))
+    stopifnot("The 'ctx' argument must a tiledb_ctx" = is(ctx, "tiledb_ctx"),
+              "The 'uri' argument must be a string scalar" =
+                  !missing(uri) && is.scalar(uri,"character"))
     libtiledb_object_walk(ctx@ptr, uri, order = "PREORDER")
 }
 
 #' Recursively discover TileDB resources at a given root URI path
 #'
 #' @param uri root uri path to walk
-#' @param order (default "PREORDER") specify "POSTORDER" for "POSTORDER" traversal
+#' @param order traversal order, one of "PREORDER" and "POSTORDER" (default "PREORDER")
 #' @param ctx tiledb_ctx object (optional)
 #' @return a dataframe with object type, object uri string columns
 #' @export
-tiledb_object_walk <- function(uri, order = "PREORDER", ctx = tiledb_get_context()) {
-    stopifnot(`The 'ctx' argument must a tiledb_ctx` = is(ctx, "tiledb_ctx"),
-              `The 'uri' argument must be a string scalar` = !missing(uri) && is.scalar(uri,"character"))
+tiledb_object_walk <- function(uri, order = c("PREORDER", "POSTORDER"), ctx = tiledb_get_context()) {
+    order <- match.arg(order)
+    stopifnot("The 'ctx' argument must a tiledb_ctx" = is(ctx, "tiledb_ctx"),
+              "The 'order' argument must be a string scalar" = is.scalar(order,"character"),
+              "The 'uri' argument must be a string scalar" =
+                  !missing(uri) && is.scalar(uri,"character"))
     libtiledb_object_walk(ctx@ptr, uri, order = order, recursive = TRUE)
 }

--- a/inst/tinytest/test_group.R
+++ b/inst/tinytest/test_group.R
@@ -169,3 +169,21 @@ expect_true(is(grp@ptr, "externalptr"))
 expect_true(tiledb_group_is_open(grp))
 expect_equal(tiledb_group_member_count(grp), 2)
 grp <- tiledb_group_close(grp)
+
+
+## Some 'Object' tests
+expect_equal(tiledb_object_type(uri), "GROUP")
+for (name in c("anny", "bob", "chloe", "dave"))
+    expect_equal(tiledb_object_type(file.path(uri, name)), "ARRAY")
+expect_equal(tiledb_object_type(file.path(uri, "NOPE")), "INVALID")
+
+old_uri <- file.path(uri, "bob")
+new_uri <- file.path(uri, "bill")
+expect_equal(tiledb_object_mv(old_uri, new_uri), new_uri)
+expect_equal(tiledb_object_type(new_uri), "ARRAY")
+expect_equal(tiledb_object_type(old_uri), "INVALID")
+dir_info <- tiledb_object_ls(uri)
+expect_equal(dim(dir_info), c(4,2))
+dir_info <- tiledb_object_walk(uri, "POSTORDER")
+expect_equal(dim(dir_info), c(4,2))
+expect_error(tiledb_object_walk(uri, "FRODO"))

--- a/src/libtiledb.cpp
+++ b/src/libtiledb.cpp
@@ -4292,29 +4292,25 @@ tiledb::Object::Type _string_to_object_type(std::string otype) {
 // [[Rcpp::export]]
 DataFrame libtiledb_object_walk(XPtr<tiledb::Context> ctx,
                                 std::string uri, std::string order, bool recursive = false) {
-  check_xptr_tag<tiledb::Context>(ctx);
-  std::vector<std::string> uris;
-  std::vector<std::string> types;
-  tiledb::ObjectIter obj_iter(*ctx.get(), uri);
-  if (recursive) {
-    if (!(order == "PREORDER") || (order == "POSTORDER")) {
-      Rcpp::stop("invalid recursive walk order, must be \"PREORDER\" or \"POSTORDER\"");
+    check_xptr_tag<tiledb::Context>(ctx);
+    std::vector<std::string> uris;
+    std::vector<std::string> types;
+    tiledb::ObjectIter obj_iter(*ctx.get(), uri);
+    if (recursive) {
+        if (! ((order == "PREORDER") || (order == "POSTORDER"))) {
+            Rcpp::stop("invalid recursive walk order, must be \"PREORDER\" or \"POSTORDER\"");
+        }
+        tiledb_walk_order_t walk_order = (order == "PREORDER") ? TILEDB_PREORDER : TILEDB_POSTORDER;
+        obj_iter.set_recursive(walk_order);
+    } else {
+        obj_iter.set_non_recursive();
     }
-    tiledb_walk_order_t walk_order = (order == "PREORDER") ? TILEDB_PREORDER : TILEDB_POSTORDER;
-    obj_iter.set_recursive(walk_order);
-  } else {
-    obj_iter.set_non_recursive();
-  }
-  for (const auto& object : obj_iter) {
-    uris.push_back(object.uri());
-    types.push_back(_object_type_to_string(object.type()));
-  }
-  Rcpp::StringVector r_uris(uris.size());
-  r_uris = uris;
-  Rcpp::StringVector r_types(types.size());
-  r_types = types;
-  return Rcpp::DataFrame::create(Rcpp::Named("TYPE") = r_types,
-                                 Rcpp::Named("URI") = r_uris);
+    for (const auto& object : obj_iter) {
+        uris.push_back(object.uri());
+        types.push_back(_object_type_to_string(object.type()));
+    }
+    return Rcpp::DataFrame::create(Rcpp::Named("TYPE") = uris,
+                                   Rcpp::Named("URI") = types);
 }
 
 /**


### PR DESCRIPTION
@nickvigilante found another bug in (really old code mostly going back to Jake and Pete (!!) -- but this specific one was mine) where the argument check for POSTORDER and PREORDER was bungled by a lack of parenthesis.

At this opportunity the argument checks were all `tiledb_object_*` functions were polished, the `tiledb_object_walk` return object was simplified (taking advantage of Rcpp here) and new tests were added for this section of the API.