### PR TITLE
In a distant past we needed to avoid tests on Windows Server 2008

### DIFF
--- a/inst/tinytest/test_arrayschema.R
+++ b/inst/tinytest/test_arrayschema.R
@@ -1,8 +1,6 @@
 library(tinytest)
 library(tiledb)
 
-isOldWindows <- Sys.info()[["sysname"]] == "Windows" && grepl('Windows Server 2008', osVersion)
-
 ctx <- tiledb_ctx(limitTileDBCores())
 
 if (get_return_as_preference() != "asis") set_return_as_preference("asis") 		# baseline value
@@ -97,28 +95,21 @@ expect_error(tiledb:::libtiledb_array_schema_set_capacity(sch@ptr, -10))
 
 
 #test_that("tiledb_array_schema created with encryption",  {
-if (!(isOldWindows)) {
-  dir.create(uri <- tempfile())
-  key <- "0123456789abcdeF0123456789abcdeF"
+dir.create(uri <- tempfile())
+key <- "0123456789abcdeF0123456789abcdeF"
 
-  dom <- tiledb_domain(dims = c(tiledb_dim("rows", c(1L, 4L), 4L, "INT32"),
-                                tiledb_dim("cols", c(1L, 4L), 4L, "INT32")))
-  schema <- tiledb_array_schema(dom, attrs = c(tiledb_attr("a", type = "INT32")))
+dom <- tiledb_domain(dims = c(tiledb_dim("rows", c(1L, 4L), 4L, "INT32"),
+                              tiledb_dim("cols", c(1L, 4L), 4L, "INT32")))
+schema <- tiledb_array_schema(dom, attrs = c(tiledb_attr("a", type = "INT32")))
 
-  ##tiledb_array_create_with_key(uri, schema, key)
-  ## for now calling into function
-  tiledb:::libtiledb_array_create_with_key(uri, schema@ptr, key)
+##tiledb_array_create_with_key(uri, schema, key)
+## for now calling into function
+tiledb:::libtiledb_array_create_with_key(uri, schema@ptr, key)
 
-#  ctx <- tiledb_ctx()
-#  arrptr <- tiledb:::libtiledb_array_open_with_key(ctx@ptr, uri, "WRITE", key)
-#  A <- new("tiledb_dense", ctx=ctx, uri=uri, as.data.frame=FALSE, ptr=arrptr)
+##expect_true(is(schema(A), "tiledb_dense"))
+## can't yet read / write as scheme getter not generalized for encryption
 
-#  expect_true(is(A, "tiledb_dense"))
-  ##expect_true(is(schema(A), "tiledb_dense"))
-  ## can't yet read / write as scheme getter not generalized for encryption
-
-  unlink(uri, recursive=TRUE)
-}
+unlink(uri, recursive=TRUE)
 #})
 
 #test_that("tiledb_array_schema dups setter/getter",  {

--- a/inst/tinytest/test_arrayschemaevolution.R
+++ b/inst/tinytest/test_arrayschemaevolution.R
@@ -1,7 +1,6 @@
 library(tinytest)
 library(tiledb)
 
-#isOldWindows <- Sys.info()[["sysname"]] == "Windows" && grepl('Windows Server 2008', osVersion)
 if (Sys.info()[["sysname"]] == "Windows") exit_file("Skip on Windows")
 
 ctx <- tiledb_ctx(limitTileDBCores())

--- a/inst/tinytest/test_arrowio.R
+++ b/inst/tinytest/test_arrowio.R
@@ -1,9 +1,6 @@
 library(tinytest)
 library(tiledb)
 
-isOldWindows <- Sys.info()[["sysname"]] == "Windows" && grepl('Windows Server 2008', osVersion)
-if (isOldWindows) exit_file("skip this file on old Windows releases")
-
 if (Sys.getenv("CI", "") == "") exit_file("Skip unextended test run")
 
 ctx <- tiledb_ctx(limitTileDBCores())

--- a/inst/tinytest/test_attr.R
+++ b/inst/tinytest/test_attr.R
@@ -3,7 +3,6 @@ library(tiledb)
 
 ctx <- tiledb_ctx(limitTileDBCores())
 
-isOldWindows <- Sys.info()[["sysname"]] == "Windows" && grepl('Windows Server 2008', osVersion)
 isWindows <- Sys.info()[["sysname"]] == "Windows"
 
 #test_that("tiledb_attr constructor works", {
@@ -54,7 +53,6 @@ expect_true(is.na(tiledb::cell_val_num(attrs)))
 #})
 
 #test_that("tiledb_attr set fill", {
-if (isOldWindows) exit_file("skip remainder of this file on old Windows releases")
 
 ## test for default
 dom <- tiledb_domain(dims = tiledb_dim("rows", c(1L, 4L), 4L, "INT32"))

--- a/inst/tinytest/test_ctx.R
+++ b/inst/tinytest/test_ctx.R
@@ -1,9 +1,6 @@
 library(tinytest)
 library(tiledb)
 
-isOldWindows <- Sys.info()[["sysname"]] == "Windows" && grepl('Windows Server 2008', osVersion)
-if (isOldWindows) exit_file("skip this file on old Windows releases")
-
 tiledb_ctx(limitTileDBCores())
 
 #test_that("tiledb_ctx default constructor", {

--- a/inst/tinytest/test_dataframe.R
+++ b/inst/tinytest/test_dataframe.R
@@ -1,9 +1,6 @@
 library(tinytest)
 library(tiledb)
 
-isOldWindows <- Sys.info()[["sysname"]] == "Windows" && grepl('Windows Server 2008', osVersion)
-if (isOldWindows) exit_file("skip this file on old Windows releases")
-
 ctx <- tiledb_ctx(limitTileDBCores())
 
 #test_that("tiledb_fromdataframe", {

--- a/inst/tinytest/test_datetime.R
+++ b/inst/tinytest/test_datetime.R
@@ -1,9 +1,6 @@
 library(tinytest)
 library(tiledb)
 
-isOldWindows <- Sys.info()[["sysname"]] == "Windows" && grepl('Windows Server 2008', osVersion)
-if (isOldWindows) exit_file("skip this file on old Windows releases")
-
 isMacOS <- (Sys.info()['sysname'] == "Darwin")
 
 ctx <- tiledb_ctx(limitTileDBCores())

--- a/inst/tinytest/test_dim.R
+++ b/inst/tinytest/test_dim.R
@@ -1,9 +1,6 @@
 library(tinytest)
 library(tiledb)
 
-isOldWindows <- Sys.info()[["sysname"]] == "Windows" && grepl('Windows Server 2008', osVersion)
-if (isOldWindows) exit_file("skip this file on old Windows releases")
-
 ctx <- tiledb_ctx(limitTileDBCores())
 
 #test_that("tiledb_dim default constructor", {

--- a/inst/tinytest/test_dimsubset.R
+++ b/inst/tinytest/test_dimsubset.R
@@ -5,9 +5,6 @@ library(tinytest)
 library(tiledb)
 library(RcppSpdlog)                     # use logging for some informal profiling
 
-isOldWindows <- Sys.info()[["sysname"]] == "Windows" && grepl('Windows Server 2008', osVersion)
-if (isOldWindows) exit_file("skip this file on old Windows releases")
-
 if (!requireNamespace("nycflights13", quietly=TRUE)) exit_file("Needed 'nycflights13' package missing")
 
 log_setup("test_dimsubset", "warn")     # but set the default level to 'warn' -> silent, activate via 'info'

--- a/inst/tinytest/test_domain.R
+++ b/inst/tinytest/test_domain.R
@@ -1,9 +1,6 @@
 library(tinytest)
 library(tiledb)
 
-isOldWindows <- Sys.info()[["sysname"]] == "Windows" && grepl('Windows Server 2008', osVersion)
-if (isOldWindows) exit_file("skip this file on old Windows releases")
-
 ctx <- tiledb_ctx(limitTileDBCores())
 
 #test_that("tiledb_domain basic constructor", {

--- a/inst/tinytest/test_filestore.R
+++ b/inst/tinytest/test_filestore.R
@@ -1,9 +1,6 @@
 library(tinytest)
 library(tiledb)
 
-isOldWindows <- Sys.info()[["sysname"]] == "Windows" && grepl('Windows Server 2008', osVersion)
-if (isOldWindows) exit_file("skip this file on old Windows releases")
-
 isWindows <- Sys.info()[["sysname"]] == "Windows"
 
 ctx <- tiledb_ctx(limitTileDBCores())

--- a/inst/tinytest/test_filterlist.R
+++ b/inst/tinytest/test_filterlist.R
@@ -1,9 +1,6 @@
 library(tinytest)
 library(tiledb)
 
-isOldWindows <- Sys.info()[["sysname"]] == "Windows" && grepl('Windows Server 2008', osVersion)
-if (isOldWindows) exit_file("skip this file on old Windows releases")
-
 ctx <- tiledb_ctx(limitTileDBCores())
 
 #test_that("tiledb_filter_list default constructor", {

--- a/inst/tinytest/test_fragmentinfo.R
+++ b/inst/tinytest/test_fragmentinfo.R
@@ -1,8 +1,6 @@
 library(tinytest)
 library(tiledb)
 
-isOldWindows <- Sys.info()[["sysname"]] == "Windows" && grepl('Windows Server 2008', osVersion)
-if (isOldWindows) exit_file("skip this file on old Windows releases")
 isMacOS <- (Sys.info()['sysname'] == "Darwin")
 
 ctx <- tiledb_ctx(limitTileDBCores())

--- a/inst/tinytest/test_group.R
+++ b/inst/tinytest/test_group.R
@@ -1,8 +1,6 @@
 library(tinytest)
 library(tiledb)
 
-isOldWindows <- Sys.info()[["sysname"]] == "Windows" && grepl('Windows Server 2008', osVersion)
-if (isOldWindows) exit_file("skip this file on old Windows releases")
 isWindows <- Sys.info()[["sysname"]] == "Windows"
 isMacOS <- (Sys.info()['sysname'] == "Darwin")
 

--- a/inst/tinytest/test_libtiledb.R
+++ b/inst/tinytest/test_libtiledb.R
@@ -1,9 +1,6 @@
 library(tinytest)
 library(tiledb)
 
-isOldWindows <- Sys.info()[["sysname"]] == "Windows" && grepl('Windows Server 2008', osVersion)
-if (isOldWindows) exit_file("skip this file on old Windows releases")
-
 tiledb_ctx(limitTileDBCores())
 
 #test_that("version is valid", {

--- a/inst/tinytest/test_matrix.R
+++ b/inst/tinytest/test_matrix.R
@@ -2,9 +2,6 @@
 library(tinytest)
 library(tiledb)
 
-isOldWindows <- Sys.info()[["sysname"]] == "Windows" && grepl('Windows Server 2008', osVersion)
-if (isOldWindows) exit_file("skip this file on old Windows releases")
-
 ctx <- tiledb_ctx(limitTileDBCores())
 
 uri <- tempfile()

--- a/inst/tinytest/test_metadata.R
+++ b/inst/tinytest/test_metadata.R
@@ -1,9 +1,6 @@
 library(tinytest)
 library(tiledb)
 
-isOldWindows <- Sys.info()[["sysname"]] == "Windows" && grepl('Windows Server 2008', osVersion)
-if (isOldWindows) exit_file("skip this file on old Windows releases")
-
 ctx <- tiledb_ctx(limitTileDBCores())
 
 tmp <- tempfile()

--- a/inst/tinytest/test_misc.R
+++ b/inst/tinytest/test_misc.R
@@ -2,9 +2,6 @@
 library(tinytest)
 library(tiledb)
 
-isOldWindows <- Sys.info()[["sysname"]] == "Windows" && grepl('Windows Server 2008', osVersion)
-if (isOldWindows) exit_file("skip this file on old Windows releases")
-
 ctx <- tiledb_ctx(limitTileDBCores())
 
 if (is.null(get0("tiledb_error_message"))) exit_file("No 'tiledb_error_message'")

--- a/inst/tinytest/test_query.R
+++ b/inst/tinytest/test_query.R
@@ -1,9 +1,6 @@
 library(tinytest)
 library(tiledb)
 
-isOldWindows <- Sys.info()[["sysname"]] == "Windows" && grepl('Windows Server 2008', osVersion)
-if (isOldWindows) exit_file("skip this file on old Windows releases")
-
 tiledb_ctx(limitTileDBCores())
 
 .createArray <- function(tmp) {

--- a/inst/tinytest/test_querycondition.R
+++ b/inst/tinytest/test_querycondition.R
@@ -1,9 +1,7 @@
 library(tinytest)
 library(tiledb)
 
-isOldWindows <- Sys.info()[["sysname"]] == "Windows" && grepl('Windows Server 2008', osVersion)
 isWindows <- Sys.info()[["sysname"]] == "Windows"
-if (isOldWindows) exit_file("skip this file on old Windows releases")
 
 #if (Sys.getenv("_RUNNING_UNDER_VALGRIND_", "FALSE") == "TRUE" && Sys.Date() < as.Date("2022-08-06")) exit_file("Skipping under valgrind until Aug 6")
 

--- a/inst/tinytest/test_sparsematrix.R
+++ b/inst/tinytest/test_sparsematrix.R
@@ -1,9 +1,6 @@
 library(tinytest)
 library(tiledb)
 
-isOldWindows <- Sys.info()[["sysname"]] == "Windows" && grepl('Windows Server 2008', osVersion)
-if (isOldWindows) exit_file("skip this file on old Windows releases")
-
 ctx <- tiledb_ctx(limitTileDBCores())
 
 if (!requireNamespace("Matrix", quietly=TRUE)) exit_file("Need the 'Matrix' package")

--- a/inst/tinytest/test_tiledbarray.R
+++ b/inst/tinytest/test_tiledbarray.R
@@ -1,8 +1,6 @@
 library(tinytest)
 library(tiledb)
 
-isOldWindows <- Sys.info()[["sysname"]] == "Windows" && grepl('Windows Server 2008', osVersion)
-if (isOldWindows) exit_file("skip this file on old Windows releases")
 isMacOS <- (Sys.info()['sysname'] == "Darwin")
 
 ctx <- tiledb_ctx(limitTileDBCores())

--- a/inst/tinytest/test_tiledbarray_extra.R
+++ b/inst/tinytest/test_tiledbarray_extra.R
@@ -1,8 +1,7 @@
 library(tinytest)
 library(tiledb)
 exit_file("Skip for now")
-isOldWindows <- Sys.info()[["sysname"]] == "Windows" && grepl('Windows Server 2008', osVersion)
-if (isOldWindows) exit_file("skip this file on old Windows releases")
+
 isMacOS <- (Sys.info()['sysname'] == "Darwin")
 if (tiledb_version(TRUE) < "2.7.0") exit_file("Needs TileDB 2.7.* or later")
 

--- a/inst/tinytest/test_timetravel.R
+++ b/inst/tinytest/test_timetravel.R
@@ -1,8 +1,6 @@
 library(tinytest)
 library(tiledb)
 
-isOldWindows <- Sys.info()[["sysname"]] == "Windows" && grepl('Windows Server 2008', osVersion)
-if (isOldWindows) exit_file("skip this file on old Windows releases")
 isMacOS <- (Sys.info()['sysname'] == "Darwin")
 
 ctx <- tiledb_ctx(limitTileDBCores())

--- a/inst/tinytest/test_timetravel_extra.R
+++ b/inst/tinytest/test_timetravel_extra.R
@@ -2,8 +2,6 @@
 library(tinytest)
 library(tiledb)
 
-isOldWindows <- Sys.info()[["sysname"]] == "Windows" && grepl('Windows Server 2008', osVersion)
-if (isOldWindows) exit_file("skip this file on old Windows releases")
 isMacOS <- (Sys.info()['sysname'] == "Darwin")
 
 ctx <- tiledb_ctx(limitTileDBCores())

--- a/inst/tinytest/test_vfs.R
+++ b/inst/tinytest/test_vfs.R
@@ -1,9 +1,6 @@
 library(tinytest)
 library(tiledb)
 
-isOldWindows <- Sys.info()[["sysname"]] == "Windows" && grepl('Windows Server 2008', osVersion)
-if (isOldWindows) exit_file("skip this file on old Windows releases")
-
 tiledb_ctx(limitTileDBCores())
 
 #test_that("tiledb_vfs default constructor", {


### PR DESCRIPTION
The unit test files contained a number of long-redundant checks for the ancient Windows Server instance CRAN at Dortmund had been runnnig and which was at one point giving us fits.  This has long been taken care of so the (commented-out) conditioning can be removed.