### PR TITLE
Add unit test for non-existing enum in QCs (for 2.21.0 or later)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tiledb
 Type: Package
-Version: 0.24.0.9
+Version: 0.24.0.10
 Title: Modern Database Engine for Multi-Modal Data via Sparse and Dense Multidimensional Arrays
 Authors@R: c(person("TileDB, Inc.", role = c("aut", "cph")),
  person("Dirk", "Eddelbuettel", email = "dirk@tiledb.com", role = "cre"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,8 @@
 
 * The vendored [nanoarrow](https://github.com/apache/arrow-nanoarrow) sources have been update to release 0.4.0, and use of its facilities has been extended (#663)
 
+* Query conditions can be expressed against non-existing enumeration (_i.e._, `factor`) values when TileDB Core 2.21.0 or later is used (#674)
+
 ## Bug Fixes
 
 * The `tiledb_get_query_range_var()` accessor now correctly calls the range getter for variable-sized dimensions (#662)
@@ -22,7 +24,9 @@
 
 * The nighly valgrind run was updated to include release 2.21 (#669)
 
-* Unit tests have been added for the TileDB 'object' functions (#671)
+* Unit tests have been added for the TileDB 'object' functions (#671, #672)
+
+* Obsolete checks for an ancient Windows version have been removed from the unit tests (#673)
 
 
 # tiledb 0.24.0

--- a/R/TileDBArray.R
+++ b/R/TileDBArray.R
@@ -1038,7 +1038,7 @@ setMethod("[", "tiledb_array",
                               col <- as.integer(col)
 
                           ## special case from schema evolution could have added twice so correct
-                          if (min(col, na.rm=TRUE) == 2 && max(col, na.rm=TRUE) == length(dct) + 1)
+                          if (length(col) > 0 && min(col, na.rm=TRUE) == 2 && max(col, na.rm=TRUE) == length(dct) + 1)
                               col <- col - 1L
 
                           if (inherits(dct, "character")) {

--- a/inst/tinytest/test_querycondition.R
+++ b/inst/tinytest/test_querycondition.R
@@ -523,6 +523,17 @@ res <- tiledb_array(uri, return_as="data.frame", query_condition=qc)[]
 expect_true(all(res$year != "2008"))
 expect_true(all(res$island == "Torgersen"))
 
+## For TileDB 2.21.* and later, do not fail on non-existing values
+if (tiledb_version(TRUE) >= "2.21.0") {
+    ## Non-existing values no longer throw
+    expect_silent(res <- tiledb_array(uri, return_as="data.frame",
+                                      query_condition=parse_query_condition(island == "Frobnidang"))[])
+    expect_equal(nrow(res), 0)
+    ## And empty results, even when not from enums, work fine too
+    expect_silent(res <- tiledb_array(uri, return_as="data.frame",
+                                      query_condition=parse_query_condition(year == 2024))[])
+    expect_equal(nrow(res), 0)
+}
 
 ## int64
 df <- data.frame(ind=1:10, val=as.integer64(1:10))


### PR DESCRIPTION
This also adds one additional conditioning needed for non-empty results sets, whether from enum or not.