### PR TITLE
Use TileDB 2.22.0-rc0

### DIFF
--- a/tools/tiledbVersion.txt
+++ b/tools/tiledbVersion.txt
@@ -1,2 +1,2 @@
-version: 2.21.1
-sha: acd5c50
+version: 2.22.0-rc0
+sha: ce9c7e7


### PR DESCRIPTION
This PR rolls the fallback pin to release 2.20.0-rc0 of TIleDB Embedded.