### PR TITLE
Include 2.22 in nightly valgrind

### DIFF
--- a/.github/workflows/valgrind.yaml
+++ b/.github/workflows/valgrind.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tag: [ release-2.19, release-2.20, release-2.21, dev ]
+        tag: [ release-2.19, release-2.20, release-2.21, release-2.22, dev ]
 
     steps:
     - name: Checkout


### PR DESCRIPTION
No code change but expansion of the nightly valgrind run matrix to include release-2.22