### PR TITLE
Add initial minimal support for GEOM types

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tiledb
 Type: Package
-Version: 0.25.0.7
+Version: 0.25.0.8
 Title: Modern Database Engine for Complex Data Based on Multi-Dimensional Arrays
 Authors@R: c(person("TileDB, Inc.", role = c("aut", "cph")),
   person("Dirk", "Eddelbuettel", email = "dirk@tiledb.com", role = "cre"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,7 +8,7 @@
 
 * The Arrow integration has been simplified using [nanoarrow](https://github.com/apache/arrow-nanoarrow) returning a single `nanoarrow` object; an unexported helper function `nanoarrow2list()` is provided to matching the previous interface (#682, #685)
 
-* An new accessor for recursive listings of (currently S3-only) URI is now available (with TileDB Core >= 2.21.0) (#691)
+* An new accessor for recursive listings of (currently S3-only) URI is now available (with TileDB Core >= 2.22.0) (#691)
 
 ## Bug Fixes
 
@@ -18,7 +18,7 @@
 
 * The `configure` and `Makevars.in` received a minor update correcting small issues (#680)
 
-* The nightly valgrind run was updated to include release 2.22 (#687)
+* The nightly valgrind run was updated to include release 2.22.0 (#687)
 
 ## Documentation
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,8 @@
 
 * An new accessor for recursive listings of (currently S3-only) URI is now available (with TileDB Core >= 2.22.0) (#691)
 
+* Initial support for TILEDB_GEOM_WKB and TILEB_GEOM_WKT has been added (with TileDB Core >= 2.21.0) (#692)
+
 ## Bug Fixes
 
 * The column headers now correspond to the column content in the two-column `data.frame` returns by `tiledb_object_walk` (#684 closing #683)

--- a/R/VFS.R
+++ b/R/VFS.R
@@ -466,6 +466,6 @@ tiledb_vfs_ls_recursive <- function(uri, vfs = tiledb_get_vfs(), ctx = tiledb_ge
     stopifnot("Argument 'vfs' must be a tiledb_vfs object" = is(vfs, "tiledb_vfs"),
               "Argument 'ctx' must be a tiledb_ctx object" = is(ctx, "tiledb_ctx"),
               "Argument 'uri' must be character variable" = is.character(uri),
-              "This function needs TileDB 2.21.0 or later" = tiledb_version(TRUE) >= "2.17.0")
+              "This function needs TileDB 2.22.0 or later" = tiledb_version(TRUE) >= "2.22.0")
     libtiledb_vfs_ls_recursive(ctx@ptr, vfs@ptr, uri)
 }

--- a/inst/tinytest/test_vfs.R
+++ b/inst/tinytest/test_vfs.R
@@ -65,7 +65,7 @@ if (requireNamespace("palmerpenguins", quietly=TRUE)) {
     expect_equal(pp, tiledb_vfs_unserialize(uriser))
 }
 
-if (tiledb_version(TRUE) >= '2.21.0' && nzchar(Sys.getenv("AWS_ACCESS_KEY_ID"))) {
+if (tiledb_version(TRUE) >= '2.22.0' && nzchar(Sys.getenv("AWS_ACCESS_KEY_ID"))) {
     expect_silent(dat <- tiledb::tiledb_vfs_ls_recursive("s3://tiledb-test-arrays/1.4/customer"))
     expect_true(inherits(dat, "data.frame"))
     expect_true(nrow(dat) > 400)

--- a/src/libtiledb.cpp
+++ b/src/libtiledb.cpp
@@ -98,6 +98,12 @@ const char* _tiledb_datatype_to_string(tiledb_datatype_t dtype) {
     case TILEDB_BOOL:
       return "BOOL";
 #endif
+#if TILEDB_VERSION >= TileDB_Version(2,21,0)
+    case TILEDB_GEOM_WKB:
+      return "GEOM_WKB";
+    case TILEDB_GEOM_WKT:
+      return "GEOM_WKT";
+#endif
     default:
       Rcpp::stop("unknown tiledb_datatype_t (%d)", dtype);
   }
@@ -161,6 +167,12 @@ tiledb_datatype_t _string_to_tiledb_datatype(std::string typestr) {
 #if TILEDB_VERSION >= TileDB_Version(2,10,0)
   } else if (typestr == "BOOL") {
     return TILEDB_BOOL;
+#endif
+#if TILEDB_VERSION >= TileDB_Version(2,21,0)
+  } else if (typestr == "GEOM_WKB") {
+    return TILEDB_GEOM_WKB;
+  } else if (typestr == "GEOM_WKT") {
+    return TILEDB_GEOM_WKT;
 #endif
   } else {
     Rcpp::stop("Unknown TileDB type '%s'", typestr.c_str());
@@ -3185,7 +3197,12 @@ XPtr<query_buf_t> libtiledb_query_buffer_alloc_ptr(std::string domaintype,
      buf->size = sizeof(int16_t);
   } else if (domaintype == "INT8" || domaintype == "UINT8") {
      buf->size = sizeof(int8_t);
-  } else if (domaintype == "BLOB") {
+  } else if (domaintype == "BLOB"
+#if TILEDB_VERSION >= TileDB_Version(2,21,0)
+             || domaintype == "GEOM_WKB"
+             || domaintype == "GEOM_WKT"
+#endif
+             ) {
      buf->size = sizeof(int8_t);
 #if TILEDB_VERSION >= TileDB_Version(2,10,0)
   } else if (domaintype == "BOOL") {
@@ -4535,7 +4552,7 @@ Rcpp::DataFrame libtiledb_vfs_ls_recursive(XPtr<tiledb::Context> ctx,
     check_xptr_tag<tiledb::Context>(ctx);
     check_xptr_tag<tiledb::VFS>(vfs);
 
-#if TILEDB_VERSION >= TileDB_Version(2,21,0)
+#if TILEDB_VERSION >= TileDB_Version(2,22,0)
     // standard / default list object (a vector of a pair<string, uint64_t?>) and callback
     tiledb::VFSExperimental::LsObjects ls_objects;
     tiledb::VFSExperimental::LsCallback cb = [&](const std::string_view& path, uint64_t size) {


### PR DESCRIPTION
This PR adds very initial support for the two TILEDB_GEOM_WK{B,T} types.

It also correct conditioning for ls_recursive to 2.22.0 or later as we use the C++ API, not the C API added in 2.21.0