### PR TITLE
Use TileDB Embedded 2.22.0-rc1

### DIFF
--- a/tools/tiledbVersion.txt
+++ b/tools/tiledbVersion.txt
@@ -1,2 +1,2 @@
-version: 2.22.0-rc0
-sha: ce9c7e7
+version: 2.22.0-rc1
+sha: 52e981e


### PR DESCRIPTION
This PR rolls the fallback pin to release 2.20.0-rc1 of TIleDB Embedded.