### PR TITLE
Deprecate tiledb_query_submit_async()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tiledb
 Type: Package
-Version: 0.25.0.8
+Version: 0.25.0.9
 Title: Modern Database Engine for Complex Data Based on Multi-Dimensional Arrays
 Authors@R: c(person("TileDB, Inc.", role = c("aut", "cph")),
   person("Dirk", "Eddelbuettel", email = "dirk@tiledb.com", role = "cre"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -30,6 +30,7 @@
 
 * Functions `tiledb_arrow_array_ptr()`, `tiledb_arrow_schmea_ptr()`, `tiledb_arrow_array_del()` and `tiledb_arrow_schema_del()` are deprecated (in favor of using the corresponding `nanoarrow` functions) and will be removed in a future release (#685)
 
+* The function `tiledb_query_submit_async()` is marked as deprecated (as is the underlying C++ function) and slated for removal in a future release (#694)
 
 # tiledb 0.25.0
 

--- a/R/Query.R
+++ b/R/Query.R
@@ -297,7 +297,9 @@ tiledb_query_submit <- function(query) {
 #' @return The modified query object, invisibly
 #' @export
 tiledb_query_submit_async <- function(query) {
-  stopifnot(`Argument 'query' must be a tiledb_query object` = is(query, "tiledb_query"))
+  stopifnot("Argument 'query' must be a tiledb_query object" = is(query, "tiledb_query"))
+  ## Deprecated April 2024, to be removed April 2025 or later
+  .Deprecated(msg="tiledb_query_submit_async() is deprecated, use tiledb_query_submit() instead.")
   libtiledb_query_submit_async(query@ptr)
   invisible(query)
 }

--- a/src/deprecation.cpp
+++ b/src/deprecation.cpp
@@ -1,6 +1,6 @@
 //  MIT License
 //
-//  Copyright (c) 2017-2023 TileDB Inc.
+//  Copyright (c) 2017-2024 TileDB Inc.
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal
@@ -225,5 +225,14 @@ XPtr<tiledb::Query> libtiledb_query_add_range(XPtr<tiledb::Query> query, int iid
     } else {
         Rcpp::stop("Invalid data type for query range: '%s'", Rcpp::type2name(starts));
     }
+    return query;
+}
+
+// Deprecated in Core April 2024
+// [[Rcpp::export]]
+XPtr<tiledb::Query> libtiledb_query_submit_async(XPtr<tiledb::Query> query) {
+    check_xptr_tag<tiledb::Query>(query);
+    spdl::trace("[libtiledb_query_submit_async]");
+    query->submit_async();
     return query;
 }

--- a/src/libtiledb.cpp
+++ b/src/libtiledb.cpp
@@ -3561,14 +3561,6 @@ XPtr<tiledb::Query> libtiledb_query_submit(XPtr<tiledb::Query> query) {
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::Query> libtiledb_query_submit_async(XPtr<tiledb::Query> query) {
-  check_xptr_tag<tiledb::Query>(query);
-  spdl::trace("[libtiledb_query_submit_async]");
-  query->submit_async();
-  return query;
-}
-
-// [[Rcpp::export]]
 XPtr<tiledb::Query> libtiledb_query_finalize(XPtr<tiledb::Query> query) {
   check_xptr_tag<tiledb::Query>(query);
   spdl::trace("[libtiledb_query_finalize]");


### PR DESCRIPTION
This shadows an on-going deprecation in Core and moves the accessor to file `src/deprecated.cpp` which is compiled with an added `#define` to keep the noise level down.

The R accessor is marked as deprecated and slated for removal no earlier than 12 months out.