### PR TITLE
Use TileDB Embedded 2.23.0-rc0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tiledb
 Type: Package
-Version: 0.26.0.2
+Version: 0.26.0.3
 Title: Modern Database Engine for Complex Data Based on Multi-Dimensional Arrays
 Authors@R: c(person("TileDB, Inc.", role = c("aut", "cph")),
   person("Dirk", "Eddelbuettel", email = "dirk@tiledb.com", role = "cre"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # Ongoing development
 
+* This release of the R package builds against [TileDB 2.23.0-rc0](https://github.com/TileDB-Inc/TileDB/releases/tag/2.23.0-rc0), and has also been tested against earlier releases as well as the development version (#701)
+
 ## Build and Test Systems
 
 * The test files receives a minor refactoring absorbing two files (#698)

--- a/tools/tiledbVersion.txt
+++ b/tools/tiledbVersion.txt
@@ -1,2 +1,2 @@
-version: 2.22.0
-sha: 52e981e
+version: 2.23.0-rc0
+sha: 152093b


### PR DESCRIPTION
This PR rolls the fallback pin to release 2.23.0-rc~1~0 of TIleDB Embedded.