### PR TITLE
Roll to release 2.23 in valgrind nightly, retire out 2.21

### DIFF
--- a/.github/workflows/valgrind.yaml
+++ b/.github/workflows/valgrind.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tag: [ release-2.21, release-2.22, dev ]
+        tag: [ release-2.22, release-2.23, dev ]
 
     steps:
     - name: Checkout

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tiledb
 Type: Package
-Version: 0.26.0.4
+Version: 0.26.0.5
 Title: Modern Database Engine for Complex Data Based on Multi-Dimensional Arrays
 Authors@R: c(person("TileDB, Inc.", role = c("aut", "cph")),
   person("Dirk", "Eddelbuettel", email = "dirk@tiledb.com", role = "cre"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,8 @@
 
 * The test files receives a minor refactoring absorbing two files (#698)
 
+* The nightly valgrind run was updated to include release 2.23.0, release 2.21 has been removed (#703)
+
 ## Deprecations
 
 * Function `libtiledb_array_create_with_key`, accessing a deprecated Core function, is now in `src/deprecated.cpp` and will be removed at later point (#699)


### PR DESCRIPTION
No code change but expansion of the nightly valgrind run matrix to include release-2.23