### PR TITLE
Tweak two error messages to display text rather than enum counter

### DIFF
--- a/src/libtiledb.cpp
+++ b/src/libtiledb.cpp
@@ -2591,7 +2591,7 @@ bool libtiledb_array_put_metadata(XPtr<tiledb::Array> array,
       break;
     }
     default: {
-      Rcpp::stop("No support (yet) for type '%d'.", TYPEOF(obj));
+      Rcpp::stop("No support (yet) for type '%s'.", Rf_type2char(TYPEOF(obj)));
       break; // not reached
     }
   }
@@ -5016,7 +5016,7 @@ bool libtiledb_group_put_metadata(XPtr<tiledb::Group> grp, std::string key, SEXP
         break;// not reached
     }
     default: {
-        Rcpp::stop("No support (yet) for type '%d'.", TYPEOF(obj));
+        Rcpp::stop("No support (yet) for type '%s'.", Rf_type2char(TYPEOF(obj)));
         break; // not reached
     }
     }


### PR DESCRIPTION
This is a minor 'quality of life' fix: in two error messages stating that an R SEXP could not be matched, instead of just reporting the internal (ie enum counter) representation we now show the text value.