### PR TITLE
De/sc 48601/use 2.24.0 rc0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tiledb
 Type: Package
-Version: 0.27.0.2
+Version: 0.27.0.3
 Title: Modern Database Engine for Complex Data Based on Multi-Dimensional Arrays
 Authors@R: c(person("TileDB, Inc.", role = c("aut", "cph")),
   person("Dirk", "Eddelbuettel", email = "dirk@tiledb.com", role = "cre"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # Ongoing development
 
-* This release of the R package builds against [TileDB 2.23.0](https://github.com/TileDB-Inc/TileDB/releases/tag/2.23.0), and has also been tested against earlier releases as well as the development version (#701, #704)
+* This release of the R package builds against [TileDB 2.24.0-rc0](https://github.com/TileDB-Inc/TileDB/releases/tag/2.24.0-rc0), and has also been tested against earlier releases as well as the development version (#701, #704)
 
 ## Improvements
 
@@ -10,7 +10,7 @@
 
 ## Build and Test Systems
 
-* Building TileDB Embedded from source now uses `install-tiledb` as a single CMake step. (#711)
+* Building TileDB Embedded from source now uses `tiledb install-tiledb` as targets in a single CMake step. (#711, #713)
 
 
 # tiledb 0.27.0
@@ -36,7 +36,6 @@
 ## Removals
 
 * Functions `libtiledb_query_add_range_with_type` and `libtiledb_query_add_range`, deprecated in release 0.17.1 in January 2023, have been now removed (#700).
-
 
 
 # tiledb 0.26.0

--- a/tools/tiledbVersion.txt
+++ b/tools/tiledbVersion.txt
@@ -1,2 +1,2 @@
-version: 2.23.0
-sha: 152093b
+version: 2.24.0-rc0
+sha: 52713e1


### PR DESCRIPTION
This PR rolls the fallback pin to release 2.24.0-rc0 of TIleDB Embedded.