### PR TITLE
Use TileDB Embedded 2.24.0-rc1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tiledb
 Type: Package
-Version: 0.27.0.3
+Version: 0.27.0.4
 Title: Modern Database Engine for Complex Data Based on Multi-Dimensional Arrays
 Authors@R: c(person("TileDB, Inc.", role = c("aut", "cph")),
   person("Dirk", "Eddelbuettel", email = "dirk@tiledb.com", role = "cre"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # Ongoing development
 
-* This release of the R package builds against [TileDB 2.24.0-rc0](https://github.com/TileDB-Inc/TileDB/releases/tag/2.24.0-rc0), and has also been tested against earlier releases as well as the development version (#701, #704)
+* This release of the R package builds against [TileDB 2.24.0-rc1](https://github.com/TileDB-Inc/TileDB/releases/tag/2.24.0-rc1), and has also been tested against earlier releases as well as the development version (#714, #715)
 
 ## Improvements
 

--- a/tools/tiledbVersion.txt
+++ b/tools/tiledbVersion.txt
@@ -1,2 +1,3 @@
-version: 2.24.0-rc0
-sha: 52713e1
+version: 2.24.0-rc1
+sha: ff3879b
+


### PR DESCRIPTION
This PR rolls the fallback pin to release 2.24.0-rc1 of TIleDB Embedded.