### PR TITLE
Refactor time travel test using absolute timestamps

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tiledb
 Type: Package
-Version: 0.27.0.4
+Version: 0.27.0.5
 Title: Modern Database Engine for Complex Data Based on Multi-Dimensional Arrays
 Authors@R: c(person("TileDB, Inc.", role = c("aut", "cph")),
   person("Dirk", "Eddelbuettel", email = "dirk@tiledb.com", role = "cre"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,8 @@
 
 * Building TileDB Embedded from source now uses `tiledb install-tiledb` as targets in a single CMake step. (#711, #713)
 
+* The time-travel tests now uses absolute (given) timestamps for writes as well as reads. (#716)
+
 
 # tiledb 0.27.0
 

--- a/R/Array.R
+++ b/R/Array.R
@@ -39,8 +39,8 @@
 #'
 #' @export
 tiledb_array_create <- function(uri, schema, encryption_key) {
-    stopifnot(`The 'uri' argument must be a string scalar` = !missing(uri) && is.scalar(uri, "character"),
-              `The 'schema' argument must be a tiledb_array_schema object` = !missing(schema) && is(schema, "tiledb_array_schema"))
+    stopifnot("The 'uri' argument must be a string scalar" = !missing(uri) && is.scalar(uri, "character"),
+              "The 'schema' argument must be a tiledb_array_schema object" = !missing(schema) && is(schema, "tiledb_array_schema"))
     if (missing(encryption_key)) {
         invisible(libtiledb_array_create(uri, schema@ptr))
     } else {

--- a/inst/tinytest/test_timetravel.R
+++ b/inst/tinytest/test_timetravel.R
@@ -172,26 +172,25 @@ invisible( tiledb_array_create(tmp, schema) )
 I <- c(1, 2, 2)
 J <- c(1, 4, 3)
 data <- c(1L, 2L, 3L)
-now1 <- Sys.time()
-A <- tiledb_array(uri = tmp, timestamp_start=now1)
+now1 <- as.POSIXct(60, tz="UTC") 		# the epoch plus one minute
+A <- tiledb_array(uri = tmp, timestamp_start=now1, timestamp_end=now1)
 A[I, J] <- data
 
-deltat <- 0.1
+deltat <- 1 							# delta of 1 second
 epst <- deltat/2
-Sys.sleep(deltat)
 
 I <- c(8, 6, 9)
 J <- c(5, 7, 8)
 data <- c(11L, 22L, 33L)
 now2 <- Sys.time()
-A <- tiledb_array(uri = tmp, timestamp_start=now2)
+A <- tiledb_array(uri = tmp, timestamp_start=now2, timestamp_end=now2)
 A[I, J] <- data
 
 A <- tiledb_array(uri = tmp, return_as="data.frame", timestamp_end=now1 - epst)
-expect_equal(nrow(A[]), 0)
+expect_equal(nrow(A[]), 0) 			# no rows before start
 A <- tiledb_array(uri = tmp, return_as="data.frame", timestamp_start=now1 + epst)
-expect_equal(nrow(A[]), 3)
+expect_equal(nrow(A[]), 3) 			# three rows in first write at now1
 A <- tiledb_array(uri = tmp, return_as="data.frame", timestamp_start=now1 - epst, timestamp_end=now2 - epst)
-expect_equal(nrow(A[]), 3)
+expect_equal(nrow(A[]), 3)			# three rows if end before now2
 A <- tiledb_array(uri = tmp, return_as="data.frame", timestamp_start=now1 - epst, timestamp_end=now2 + epst)
-expect_true(nrow(A[]) >= 3)
+expect_true(nrow(A[]) >= 3)			# all data from before now1 to after now2

--- a/src/Makevars.in
+++ b/src/Makevars.in
@@ -24,6 +24,7 @@ all: $(OBJECTS) $(LIB_CON) $(SHLIB)
 $(LIB_CON): connection/connection.o
 	@mkdir -p $(LIB_CON_DIR)
 	@$(SHLIB_LINK) $(SHLIB_LIBADD) $(LIBR) -o $@ $^
+	@rm $^
 
 clean:
 	rm -f $(SHLIB) $(OBJECTS) $(LIB_CON) connection/connection.o


### PR DESCRIPTION
This small review (belatedly) updates one unit tests: the time travel test would occassionally lapse on loaded or otherwise unusual machines are we relied on `sleep()` to pause between writes.  This has now been recast to write at absolute given timestamps which has been supported for some time.