### PR TITLE
Use 2.24.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tiledb
 Type: Package
-Version: 0.27.0.4
+Version: 0.27.0.5
 Title: Modern Database Engine for Complex Data Based on Multi-Dimensional Arrays
 Authors@R: c(person("TileDB, Inc.", role = c("aut", "cph")),
   person("Dirk", "Eddelbuettel", email = "dirk@tiledb.com", role = "cre"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # Ongoing development
 
-* This release of the R package builds against [TileDB 2.24.0-rc1](https://github.com/TileDB-Inc/TileDB/releases/tag/2.24.0-rc1), and has also been tested against earlier releases as well as the development version (#714, #715)
+* This release of the R package builds against [TileDB 2.24.0](https://github.com/TileDB-Inc/TileDB/releases/tag/2.24.0), and has also been tested against earlier releases as well as the development version (#714, #715, #717)
 
 ## Improvements
 

--- a/tools/tiledbVersion.txt
+++ b/tools/tiledbVersion.txt
@@ -1,3 +1,2 @@
-version: 2.24.0-rc1
+version: 2.24.0
 sha: ff3879b
-


### PR DESCRIPTION
This rolls the pin (when artifacts are used) from 2.24.0-rc1 to 2.24.0.  No changes in those artifacts, no changes here.