### PR TITLE
Support explicit timestamps in fromDataFrame convenience helper

### DIFF
--- a/inst/tinytest/test_dataframe.R
+++ b/inst/tinytest/test_dataframe.R
@@ -340,3 +340,27 @@ fromDataFrame(D, uri, col_index=1)
 arr <- tiledb_array(uri, return_as="data.frame")
 res <- arr[]
 expect_equivalent(res, D)
+
+
+## fromDataFrame with timestamps
+D <- data.frame(key=(1:10)*10, value=letters[1:10])
+uri <- tempfile()
+now <- Sys.time()
+fromDataFrame(D, uri)         # no timestamps
+expect_equal(nrow(tiledb_array(uri, return_as="data.frame")[]), 10)
+expect_equal(nrow(tiledb_array(uri, return_as="data.frame", timestamp_end=as.POSIXct(100, origin="1970-01-01"))[]),  0)
+expect_equal(nrow(tiledb_array(uri, return_as="data.frame", timestamp_start=now + 1)[]), 0)
+unlink(uri, recursive=TRUE)
+
+fromDataFrame(D, uri, timestamps=as.POSIXct(100, origin="1970-01-01"))         # end timestamps
+expect_equal(nrow(tiledb_array(uri, return_as="data.frame")[]), 10)
+expect_equal(nrow(tiledb_array(uri, return_as="data.frame", timestamp_end=as.POSIXct(50, origin="1970-01-01"))[]), 0)
+expect_equal(nrow(tiledb_array(uri, return_as="data.frame", timestamp_start=as.POSIXct(50, origin="1970-01-01"))[]), 10)
+expect_equal(nrow(tiledb_array(uri, return_as="data.frame", timestamp_start=as.POSIXct(150, origin="1970-01-01"))[]), 0)
+unlink(uri, recursive=TRUE)
+
+fromDataFrame(D, uri, timestamps=c(as.POSIXct(100, origin="1970-01-01"), as.POSIXct(100, origin="1970-01-01"))) # start and end
+expect_equal(nrow(tiledb_array(uri, return_as="data.frame")[]), 10)
+expect_equal(nrow(tiledb_array(uri, return_as="data.frame", timestamp_end=as.POSIXct(50, origin="1970-01-01"))[]), 0)
+expect_equal(nrow(tiledb_array(uri, return_as="data.frame", timestamp_start=as.POSIXct(50, origin="1970-01-01"))[]), 10)
+expect_equal(nrow(tiledb_array(uri, return_as="data.frame", timestamp_start=as.POSIXct(150, origin="1970-01-01"))[]), 0)

--- a/inst/tinytest/test_dataframe.R
+++ b/inst/tinytest/test_dataframe.R
@@ -343,6 +343,7 @@ expect_equivalent(res, D)
 
 
 ## fromDataFrame with timestamps
+if (tiledb_version(TRUE) < "2.15.0") exit_file("Remaining tests require TileDB 2.15.0 or later")
 D <- data.frame(key=(1:10)*10, value=letters[1:10])
 uri <- tempfile()
 now <- Sys.time()

--- a/inst/tinytest/test_timetravel.R
+++ b/inst/tinytest/test_timetravel.R
@@ -172,7 +172,7 @@ invisible( tiledb_array_create(tmp, schema) )
 I <- c(1, 2, 2)
 J <- c(1, 4, 3)
 data <- c(1L, 2L, 3L)
-now1 <- as.POSIXct(60, tz="UTC") 		# the epoch plus one minute
+now1 <- as.POSIXct(60, tz="UTC", origin="1970-01-01") 	# the epoch plus one minute
 A <- tiledb_array(uri = tmp, timestamp_start=now1, timestamp_end=now1)
 A[I, J] <- data
 

--- a/man/fromDataFrame.Rd
+++ b/man/fromDataFrame.Rd
@@ -21,7 +21,8 @@ fromDataFrame(
   coords_filters = "ZSTD",
   offsets_filters = "ZSTD",
   validity_filters = "RLE",
-  debug = FALSE
+  debug = FALSE,
+  timestamps = as.POSIXct(double(), origin = "1970-01-01")
 )
 }
 \arguments{
@@ -74,6 +75,11 @@ or attributes. The \code{filter} argument still applies for all unnamed argument
 \item{validity_filters}{A character vector with filters for coordinates, default is \code{RLE}.}
 
 \item{debug}{Logical flag to select additional output.}
+
+\item{timestamps}{Vector with up to two \code{POSIXct} variables denoting open intervals; default
+is length zero where start and end are set (implicitly) to current time; in case of one value it
+is used as the interval end, and in case of two values they are taken as start and end. This
+applies to write and append modes only and not to schema creation.}
 }
 \value{
 Null, invisibly.


### PR DESCRIPTION
This PR fills a minor convenience hole in that the helper function `fromDataFrame()` that is fairly widely used did not permit setting of explicit write timestamps which this PR corrects.

New tests have been added, one expression that upset R 4.2.0 has been expanded to accomodate the earlier version still used in some places.