### PR TITLE
Update NEWS and roll micro version [ci skip]

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tiledb
 Type: Package
-Version: 0.28.0
+Version: 0.28.0.1
 Title: Modern Database Engine for Complex Data Based on Multi-Dimensional Arrays
 Authors@R: c(person("TileDB, Inc.", role = c("aut", "cph")),
   person("Dirk", "Eddelbuettel", email = "dirk@tiledb.com", role = "cre"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# Ongoing development
+
+## Improvements
+
+* When creating arrays with `fromDataFrame`, start and/or end timestamps can now be specified (#719)
+
+
 # tiledb 0.28.0
 
 * This release of the R package builds against [TileDB 2.24.0](https://github.com/TileDB-Inc/TileDB/releases/tag/2.24.0), and has also been tested against earlier releases as well as the development version (#714, #715, #717)


### PR DESCRIPTION
This commit was supposed too go into #719 but given the four hours (!!) of queing foor macOS it was forgotten.  It would still good to go in just in order to mark an increased version away from the last release version.