### PR TITLE
Roll nighty valgrind to 2.24

### DIFF
--- a/.github/workflows/valgrind.yaml
+++ b/.github/workflows/valgrind.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tag: [ release-2.22, release-2.23, dev ]
+        tag: [ release-2.23, release-2.24, dev ]
 
     steps:
     - name: Checkout

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -11,8 +11,11 @@ jobs:
       fail-fast: false
       matrix:
         include: [
-          { windows: windows-latest, r: release    },
-          { windows: windows-latest, r: devel      }
+          #{ windows: windows-latest, r: release    },
+          #{ windows: windows-latest, r: devel      }
+          #
+          # for now just r-release
+          { windows: windows-latest, r: release    }
         ]
     steps:
       - run: git config --global core.autocrlf false


### PR DESCRIPTION
This PR rolls the nightly valgrind job to include release-2.24 (along with dev) and removes release-2.24.

No new code, no new tests.