### PR TITLE
Release 0.28.1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tiledb
 Type: Package
-Version: 0.28.0.2
+Version: 0.28.1
 Title: Modern Database Engine for Complex Data Based on Multi-Dimensional Arrays
 Authors@R: c(person("TileDB, Inc.", role = c("aut", "cph")),
   person("Dirk", "Eddelbuettel", email = "dirk@tiledb.com", role = "cre"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,6 @@
-# Ongoing development
+# tiledb 0.28.1
+
+* This release of the R package builds against [TileDB 2.24.1](https://github.com/TileDB-Inc/TileDB/releases/tag/2.24.1), and has also been tested against earlier releases as well as the development version (#714, #715, #717, #723)
 
 ## Improvements
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # tiledb 0.28.1
 
-* This release of the R package builds against [TileDB 2.24.1](https://github.com/TileDB-Inc/TileDB/releases/tag/2.24.1), and has also been tested against earlier releases as well as the development version (#714, #715, #717, #723)
+* This release of the R package builds against [TileDB 2.24.1](https://github.com/TileDB-Inc/TileDB/releases/tag/2.24.1), and has also been tested against earlier releases as well as the development version (#714, #715, #717, #724)
 
 ## Improvements
 

--- a/tools/tiledbVersion.txt
+++ b/tools/tiledbVersion.txt
@@ -1,2 +1,2 @@
-version: 2.24.0
-sha: ff3879b
+version: 2.24.1
+sha: db03540


### PR DESCRIPTION
This PR formalises release 0.28.1 (not submitted to CRAN). From NEWS.md (with 'lowered' headline levels for display here):

## tiledb 0.28.1

* This release of the R package builds against [TileDB 2.24.1](https://github.com/TileDB-Inc/TileDB/releases/tag/2.24.1), and has also been tested against earlier releases as well as the development version (#714, #715, #717, #724)

### Improvements

* When creating arrays with `fromDataFrame`, start and/or end timestamps can now be specified (#719)

### Build and Test Systems

* The nighly continuous integration matrix now included Core release 2.24.0 and 2.22.0 is dropped (#721)

* The Conda build is now accomodating the change from #710 (#722)

---

/cc @jdblischak 