### PR TITLE
Release 0.28.2 with TileDB Embedded 2.24.2 as fallback

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# tiledb 0.28.2
+
+* This release of the R package builds against [TileDB 2.24.2](https://github.com/TileDB-Inc/TileDB/releases/tag/2.24.2), and has also been tested against earlier releases as well as the development version (#725)
+
+
 # tiledb 0.28.1
 
 * This release of the R package builds against [TileDB 2.24.1](https://github.com/TileDB-Inc/TileDB/releases/tag/2.24.1), and has also been tested against earlier releases as well as the development version (#714, #715, #717, #724)

--- a/cleanup
+++ b/cleanup
@@ -1,4 +1,5 @@
 #!/bin/sh
 
+cd src && make -f Makevars clean
 rm -f  src/Makevars src/*.o src/*.so config.log config.status inst/tiledb-*.tar.gz src/connection/*.o
 rm -rf tiledb.Rcheck autom4te.cache inst/tiledb/ inst/config.log inst/config.status tiledb/ inst/lib/

--- a/src/Makevars.in
+++ b/src/Makevars.in
@@ -27,6 +27,6 @@ $(LIB_CON): connection/connection.o
 	@rm $^
 
 clean:
-	rm -f $(SHLIB) $(OBJECTS) $(LIB_CON) connection/connection.o
+	@rm -f $(SHLIB) $(OBJECTS) $(LIB_CON) connection/connection.o
 
 .PHONY: all clean

--- a/tools/tiledbVersion.txt
+++ b/tools/tiledbVersion.txt
@@ -1,2 +1,2 @@
-version: 2.24.1
-sha: db03540
+version: 2.24.2
+sha: 76cd03c


### PR DESCRIPTION
This PR formalises release 0.28.2 (not submitted to CRAN). From NEWS.md (with 'lowered' headline levels for display here):

##  tiledb 0.28.2                                                                                                                                                                   
                                                                                                                                                                                  
* This release of the R package builds against [TileDB 2.24.2](https://github.com/TileDB-Inc/TileDB/releases/tag/2.24.2), and has also been tested against earlier releases as we\
ll as the development version (#725)                                                                                                                                              
                                     