### PR TITLE
Roll nightly valgrind matrix to 2.25.0

### DIFF
--- a/.github/workflows/valgrind.yaml
+++ b/.github/workflows/valgrind.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tag: [ release-2.23, release-2.24, dev ]
+        tag: [ release-2.24, release-2.25, dev ]
 
     steps:
     - name: Checkout


### PR DESCRIPTION
Procedural change to ensure nightly valgrind checks cover the soon-to-be-formally-released 2.25.0 branch.