### PR TITLE
Only open Issue for failed scheduled nightlies on main repo

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -34,7 +34,7 @@ jobs:
       issues: write
     runs-on: ubuntu-latest
     needs: dev
-    if: failure() || cancelled()
+    if: ( failure() || cancelled() ) && github.repository_owner == 'TileDB-Inc' && github.event_name == 'schedule'
     steps:
       - uses: actions/checkout@v4
       - name: Create Issue if Build Fails


### PR DESCRIPTION
This PR limits when the open-issue action is executed for a failed nightly build:

* Do not run on forks
* Only run on scheduled jobs. This prevents unnecessary noise when troubleshooting via manual `workflow_dispatch` calls against other branches