### PR TITLE
Encrypted read / write no longer uses deprecated / removed function

### DIFF
--- a/R/TileDBArray.R
+++ b/R/TileDBArray.R
@@ -1163,6 +1163,15 @@ setMethod("[", "tiledb_array",
     if (ncol(res) < 3) {
       stop("Seeing as.matrix argument with insufficient result set")
     }
+    ## special case of integer64
+    if (inherits(res[,1], "integer64")) {
+        res[,1] <- as.integer(res[,1])
+        if (min(res[,1]) == 0) res[,1] <- res[,1] + 1
+    }
+    if (ncol(res) >= 3 && inherits(res[,2], "integer64")) {
+        res[,2] <- as.integer(res[,2])
+        if (min(res[,2]) == 0) res[,2] <- res[,2] + 1
+    }
     if (!identical(unique(res[,1]), seq(1, length(unique(res[,1]))))) {
         cur <- unique(res[,1])
         for (l in seq_len(length(cur))) res[ which(res[,1] == cur[l]), 1 ] <- l

--- a/src/deprecation.cpp
+++ b/src/deprecation.cpp
@@ -31,12 +31,16 @@
 
 using namespace Rcpp;
 
-// Deprecated in Core April 2024
+// Deprecated in Core April 2024, removed July 2024
 // [[Rcpp::export]]
 XPtr<tiledb::Query> libtiledb_query_submit_async(XPtr<tiledb::Query> query) {
+#if TILEDB_VERSION < TileDB_Version(2,26,0)
     check_xptr_tag<tiledb::Query>(query);
     spdl::trace("[libtiledb_query_submit_async]");
     query->submit_async();
+#else
+    Rcpp::stop("This function was deprecated first, and is removed as of TileDB 2.26.0");
+#endif
     return query;
 }
 
@@ -49,13 +53,17 @@ tiledb_encryption_type_t _string_to_tiledb_encryption_type_t(std::string encstr)
     Rcpp::stop("Unknow TileDB encryption type '%s'", encstr.c_str());
 }
 
-// Deprecated in Core April 2024
+// Deprecated in Core April 2024, removed July 2024
 // [[Rcpp::export]]
 std::string libtiledb_array_create_with_key(std::string uri, XPtr<tiledb::ArraySchema> schema,
                                             std::string encryption_key) {
+#if TILEDB_VERSION < TileDB_Version(2,26,0)
     check_xptr_tag<tiledb::ArraySchema>(schema);
     tiledb::Array::create(uri, *schema.get(),
                           _string_to_tiledb_encryption_type_t("AES_256_GCM"),
                           encryption_key);
+#else
+    Rcpp::stop("This function was deprecated first, and is removed as of TileDB 2.26.0");
+#endif
     return uri;
 }


### PR DESCRIPTION
This PR catches up to the removal of two functions (notably 'array create with key') that had been deprecated for several month.  We retain the existing tests, and a new one using the simpler / newer method of setting key and encryption method via config settings.