### PR TITLE
Use TileDB Embedded 2.25.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # Ongoing Development
 
-* This release of the R package builds against [TileDB 2.25.0-rc0](https://github.com/TileDB-Inc/TileDB/releases/tag/2.25.0-rc0), and has also been tested against earlier releases as well as the development version (#728)
+* This release of the R package builds against [TileDB 2.25.0](https://github.com/TileDB-Inc/TileDB/releases/tag/2.25.0), and has also been tested against earlier releases as well as the development version (#728)
 
 ## Improvements
 

--- a/cleanup
+++ b/cleanup
@@ -1,5 +1,5 @@
 #!/bin/sh
 
-(cd src && make -f Makevars clean)
+(cd src && test -f Makevars && make -f Makevars clean)
 rm -f  src/Makevars src/*.o src/*.so config.log config.status inst/tiledb-*.tar.gz src/connection/*.o
 rm -rf tiledb.Rcheck autom4te.cache inst/tiledb/ inst/config.log inst/config.status tiledb/ inst/lib/

--- a/tools/tiledbVersion.txt
+++ b/tools/tiledbVersion.txt
@@ -1,2 +1,2 @@
-version: 2.25.0-rc0
-sha: ca07b03
+version: 2.25.0-rc1
+sha: 9ac1c76

--- a/tools/tiledbVersion.txt
+++ b/tools/tiledbVersion.txt
@@ -1,2 +1,2 @@
-version: 2.25.0-rc1
-sha: 9ac1c76
+version: 2.25.0
+sha: bbcbd3f


### PR DESCRIPTION
This rolls the pin (when artifacts are used) from 2.25.0-rc0 to 2.25.0. No changes in those artifacts, no changes here.