### PR TITLE
More informative error in case of XPtr misuse

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tiledb
 Type: Package
-Version: 0.29.0
+Version: 0.29.0.1
 Title: Modern Database Engine for Complex Data Based on Multi-Dimensional Arrays
 Authors@R: c(person("TileDB, Inc.", role = c("aut", "cph")),
   person("Dirk", "Eddelbuettel", email = "dirk@tiledb.com", role = "cre"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,14 @@
+# Ongoing Development
+
+## Improvements
+
+* Error messages displayed when a mismatched external pointer is detected now show both expected and encountered types (#740)
+
+## Documentation
+
+* The documentation website now uses favicon symbols for all pages rendered (#739)
+
+
 # tiledb 0.29.0
 
 * This release of the R package builds against [TileDB 2.25.0](https://github.com/TileDB-Inc/TileDB/releases/tag/2.25.0), and has also been tested against earlier releases as well as the development version (#728, #736)


### PR DESCRIPTION
This PR defines a helper class to allow error messages in case of mismatched external pointer tags to be more informative.  In the example below, before this PR the message would have been "expected '130' but received '70'" showing the (integer) value of the tag.  With the PR this mapped to a char* that can be used in the error message.

```r
> dim <- tiledb_dim("dim", c(1L, 100L), 100L, "INT32") # create an object, here a Dimension
> dim                                                  # which has an R-level pretty-print  method
tiledb_dim(name="dim", domain=c(1L,100L), tile=100L, type="INT32") 
> tiledb:::libtiledb_query_submit(dim@ptr)             # pass pointer to low-leve method expecting a pointer
Error: Wrong tag type: expected 'Query' but received 'Dimension'
> 
```

The tagging of external pointers (in place for quite some time) avoids hard-to-debug and likely catastrophic run-time errors given that the use of `SEXP` forces type detection to the run-time.