### PR TITLE
Support more NDRectangle domain types, extend tests

### DIFF
--- a/inst/tinytest/test_ndrectangle.R
+++ b/inst/tinytest/test_ndrectangle.R
@@ -6,26 +6,41 @@ ctx <- tiledb_ctx(limitTileDBCores())
 
 if (tiledb_version(TRUE) < "2.25.0") exit_file("These tests needs TileDB 2.25.0 or later")
 
-## INT32
-expect_silent(intdim <- tiledb_dim("dim", c(1L, 100L), type = "INT32"))
-expect_true(is(intdim, "tiledb_dim"))
-expect_silent(intdom <- tiledb_domain(dim = intdim))
-expect_true(is(intdom, "tiledb_domain"))
+for (tp in c("INT32", "UINT32", "INT16", "UINT16", "INT64", "UINT64", "INT8", "UINT8")) {
+    if (grepl("INT64", tp)) {
+        expect_silent(intdim <- tiledb_dim("dim", bit64::as.integer64(c(1L, 100L)),
+                                           bit64::as.integer64(50L), type = tp))
+    } else {
+        expect_silent(intdim <- tiledb_dim("dim", c(1L, 100L), 50L, type = tp))
+    }
+    expect_true(is(intdim, "tiledb_dim"))
+    expect_silent(intdom <- tiledb_domain(dim = intdim))
+    expect_true(is(intdom, "tiledb_domain"))
 
-expect_error(ndr <- tiledb_ndrectangle(intdim))
-expect_silent(ndr <- tiledb_ndrectangle(intdom))
-expect_true(is(ndr, "tiledb_ndrectangle"))
+    expect_error(ndr <- tiledb_ndrectangle(intdim))
+    expect_silent(ndr <- tiledb_ndrectangle(intdom))
+    expect_true(is(ndr, "tiledb_ndrectangle"))
 
-expect_error(tiledb_ndrectangle_set_range(intdim, "dim", 1, 2)) # wrong type
-expect_error(tiledb_ndrectangle_set_range(ndr, "notdim", 1, 2)) # wrong name
-expect_error(tiledb_ndrectangle_set_range(ndr, "dim", 1, 2L))   # wrong type
-expect_error(tiledb_ndrectangle_set_range(ndr, "dim", 1L, 2))   # wrong type
-expect_silent(ndr <- tiledb_ndrectangle_set_range(ndr, "dim", 1L, 20L))
+    expect_error(tiledb_ndrectangle_set_range(intdim, "dim", 1, 2)) # wrong type
+    expect_error(tiledb_ndrectangle_set_range(ndr, "notdim", 1, 2)) # wrong name
+    expect_error(tiledb_ndrectangle_set_range(ndr, "dim", 1, 2L))   # wrong type
+    expect_error(tiledb_ndrectangle_set_range(ndr, "dim", 1L, 2))   # wrong type
+    if (grepl("INT64", tp)) {
+        expect_silent(ndr <- tiledb_ndrectangle_set_range(ndr, "dim",
+                                                          bit64::as.integer64(1L),
+                                                          bit64::as.integer64(20L)))
+    } else {
+        expect_silent(ndr <- tiledb_ndrectangle_set_range(ndr, "dim", 1L, 20L))
+    }
 
-expect_error(tiledb_ndrectangle_get_range(intdim, "dim")) # wrong type
-expect_error(tiledb_ndrectangle_set_range(ndr, "notdim")) # wrong name
-expect_equal(tiledb_ndrectangle_get_range(ndr, "dim"), c(1L, 20L))
-
+    expect_error(tiledb_ndrectangle_get_range(intdim, "dim")) # wrong type
+    expect_error(tiledb_ndrectangle_set_range(ndr, "notdim")) # wrong name
+    if (grepl("INT64", tp)) {
+        expect_equal(tiledb_ndrectangle_get_range(ndr, "dim"), bit64::as.integer64(c(1L, 20L)))
+    } else {
+        expect_equal(tiledb_ndrectangle_get_range(ndr, "dim"), c(1L, 20L))
+    }
+}
 
 ## ASCII
 expect_silent(strdim <- tiledb_dim("strdim", c(NULL, NULL), NULL, type = "ASCII"))

--- a/src/libtiledb.cpp
+++ b/src/libtiledb.cpp
@@ -5449,7 +5449,27 @@ XPtr<tiledb::NDRectangle> libtiledb_ndrectangle_set_range(XPtr<tiledb::NDRectang
                                 static_cast<uint64_t>(Rcpp::fromInteger64(Rcpp::as<double>(start))),
                                 static_cast<uint64_t>(Rcpp::fromInteger64(Rcpp::as<double>(end))));
     } else if (dtype == TILEDB_INT32) {
-        ndr->set_range<int32_t>(dimname, as<int32_t>(start), as<int32_t>(end));
+        ndr->set_range<int32_t>(dimname, Rcpp::as<int32_t>(start), Rcpp::as<int32_t>(end));
+    } else if (dtype == TILEDB_UINT32) {
+        ndr->set_range<uint32_t>(dimname,
+                                 static_cast<uint32_t>(Rcpp::as<int32_t>(start)),
+                                 static_cast<uint32_t>(Rcpp::as<int32_t>(end)));
+    } else if (dtype == TILEDB_INT16) {
+        ndr->set_range<int16_t>(dimname,
+                                static_cast<int16_t>(Rcpp::as<int32_t>(start)),
+                                static_cast<int16_t>(Rcpp::as<int32_t>(end)));
+    } else if (dtype == TILEDB_UINT16) {
+        ndr->set_range<uint16_t>(dimname,
+                                 static_cast<uint16_t>(Rcpp::as<int32_t>(start)),
+                                 static_cast<uint16_t>(Rcpp::as<int32_t>(end)));
+    } else if (dtype == TILEDB_INT8) {
+        ndr->set_range<int8_t>(dimname,
+                               static_cast<int8_t>(Rcpp::as<int32_t>(start)),
+                               static_cast<int8_t>(Rcpp::as<int32_t>(end)));
+    } else if (dtype == TILEDB_UINT8) {
+        ndr->set_range<uint8_t>(dimname,
+                                 static_cast<uint8_t>(Rcpp::as<int32_t>(start)),
+                                 static_cast<uint8_t>(Rcpp::as<int32_t>(end)));
     } else {
         Rcpp::stop("Domain datatype '%s' of dimname '%s' is not currently supported",
                    _tiledb_datatype_to_string(dtype), dimname);
@@ -5466,17 +5486,37 @@ SEXP libtiledb_ndrectangle_get_range(XPtr<tiledb::NDRectangle> ndr,
 #if TILEDB_VERSION >= TileDB_Version(2,25,0)
     if (dtype == "CHAR" || dtype == "ASCII" || dtype == "UTF8") {
         auto range = ndr->range<std::string>(dimname);
-        return Rcpp::CharacterVector::create(std::get<0>(range), std::get<1>(range));
+        return Rcpp::CharacterVector::create(range[0], range[1]);
     } else if (dtype == "INT64") {
         auto range = ndr->range<int64_t>(dimname);
-        return Rcpp::toInteger64( std::vector<int64_t>{ std::get<0>(range), std::get<1>(range) } );
+        return Rcpp::toInteger64( std::vector<int64_t>{range[0], range[1] } );
     } else if (dtype == "UINT64") {
         auto range = ndr->range<uint64_t>(dimname);
-        return Rcpp::toInteger64( std::vector<int64_t>{ static_cast<int64_t>(std::get<0>(range)),
-                                                        static_cast<int64_t>(std::get<1>(range)) } );
+        return Rcpp::toInteger64( std::vector<int64_t>{ static_cast<int64_t>(range[0]),
+                                                        static_cast<int64_t>(range[1]) } );
     } else if (dtype == "INT32") {
         auto range = ndr->range<int32_t>(dimname);
-        return Rcpp::IntegerVector::create( std::get<0>(range), std::get<1>(range) );
+        return Rcpp::IntegerVector::create(range[0], range[1]);
+    } else if (dtype == "UINT32") {
+        auto range = ndr->range<uint32_t>(dimname);
+        return Rcpp::IntegerVector::create( static_cast<int32_t>(range[0]),
+                                            static_cast<int32_t>(range[1]) );
+    } else if (dtype == "INT16") {
+        auto range = ndr->range<int16_t>(dimname);
+        return Rcpp::IntegerVector::create( static_cast<int32_t>(range[0]),
+                                            static_cast<int32_t>(range[1]) );
+    } else if (dtype == "UINT16") {
+        auto range = ndr->range<uint16_t>(dimname);
+        return Rcpp::IntegerVector::create( static_cast<int32_t>(range[0]),
+                                            static_cast<int32_t>(range[1]) );
+    } else if (dtype == "INT8") {
+        auto range = ndr->range<int8_t>(dimname);
+        return Rcpp::IntegerVector::create( static_cast<int8_t>(range[0]),
+                                            static_cast<int8_t>(range[1]) );
+    } else if (dtype == "UINT8") {
+        auto range = ndr->range<uint8_t>(dimname);
+        return Rcpp::IntegerVector::create( static_cast<uint8_t>(range[0]),
+                                            static_cast<uint8_t>(range[1]) );
     } else {
         Rcpp::stop("Domain datatype '%s' of dimname '%s' is not currently supported", dtype, dimname);
     }


### PR DESCRIPTION
The initial implementation of NDRectangle range creation, setting and getting supported only a few domain types.  This PR expands it and lets the unit tests loop over all type {U}INT{8,16,32,64}.  