### PR TITLE
Support ndrectangle setter and getter for float{32,64}

### DIFF
--- a/inst/tinytest/test_ndrectangle.R
+++ b/inst/tinytest/test_ndrectangle.R
@@ -6,22 +6,23 @@ ctx <- tiledb_ctx(limitTileDBCores())
 
 if (tiledb_version(TRUE) < "2.25.0") exit_file("These tests needs TileDB 2.25.0 or later")
 
-for (tp in c("INT32", "UINT32", "INT16", "UINT16", "INT64", "UINT64", "INT8", "UINT8")) {
+for (tp in c("INT32", "UINT32", "INT16", "UINT16", "INT64", "UINT64", "INT8", "UINT8", "FLOAT32", "FLOAT64")) {
     if (grepl("INT64", tp)) {
-        expect_silent(intdim <- tiledb_dim("dim", bit64::as.integer64(c(1L, 100L)),
-                                           bit64::as.integer64(50L), type = tp))
+        expect_silent(dim <- tiledb_dim("dim", bit64::as.integer64(c(1L, 100L)), bit64::as.integer64(50L), type = tp))
+    } else if (grepl("FLOAT", tp)) {
+        expect_silent(dim <- tiledb_dim("dim", c(1, 100), 50, type = tp))
     } else {
-        expect_silent(intdim <- tiledb_dim("dim", c(1L, 100L), 50L, type = tp))
+        expect_silent(dim <- tiledb_dim("dim", c(1L, 100L), 50L, type = tp))
     }
-    expect_true(is(intdim, "tiledb_dim"))
-    expect_silent(intdom <- tiledb_domain(dim = intdim))
-    expect_true(is(intdom, "tiledb_domain"))
+    expect_true(is(dim, "tiledb_dim"))
+    expect_silent(dom <- tiledb_domain(dim = dim))
+    expect_true(is(dom, "tiledb_domain"))
 
-    expect_error(ndr <- tiledb_ndrectangle(intdim))
-    expect_silent(ndr <- tiledb_ndrectangle(intdom))
+    expect_error(ndr <- tiledb_ndrectangle(dim))
+    expect_silent(ndr <- tiledb_ndrectangle(dom))
     expect_true(is(ndr, "tiledb_ndrectangle"))
 
-    expect_error(tiledb_ndrectangle_set_range(intdim, "dim", 1, 2)) # wrong type
+    expect_error(tiledb_ndrectangle_set_range(dim, "dim", 1, 2)) # wrong type
     expect_error(tiledb_ndrectangle_set_range(ndr, "notdim", 1, 2)) # wrong name
     expect_error(tiledb_ndrectangle_set_range(ndr, "dim", 1, 2L))   # wrong type
     expect_error(tiledb_ndrectangle_set_range(ndr, "dim", 1L, 2))   # wrong type
@@ -29,11 +30,13 @@ for (tp in c("INT32", "UINT32", "INT16", "UINT16", "INT64", "UINT64", "INT8", "U
         expect_silent(ndr <- tiledb_ndrectangle_set_range(ndr, "dim",
                                                           bit64::as.integer64(1L),
                                                           bit64::as.integer64(20L)))
+    } else if (grepl("FLOAT", tp)) {
+        expect_silent(ndr <- tiledb_ndrectangle_set_range(ndr, "dim", 1, 20))
     } else {
         expect_silent(ndr <- tiledb_ndrectangle_set_range(ndr, "dim", 1L, 20L))
     }
 
-    expect_error(tiledb_ndrectangle_get_range(intdim, "dim")) # wrong type
+    expect_error(tiledb_ndrectangle_get_range(dim, "dim")) # wrong type
     expect_error(tiledb_ndrectangle_set_range(ndr, "notdim")) # wrong name
     if (grepl("INT64", tp)) {
         expect_equal(tiledb_ndrectangle_get_range(ndr, "dim"), bit64::as.integer64(c(1L, 20L)))

--- a/src/libtiledb.cpp
+++ b/src/libtiledb.cpp
@@ -5468,8 +5468,14 @@ XPtr<tiledb::NDRectangle> libtiledb_ndrectangle_set_range(XPtr<tiledb::NDRectang
                                static_cast<int8_t>(Rcpp::as<int32_t>(end)));
     } else if (dtype == TILEDB_UINT8) {
         ndr->set_range<uint8_t>(dimname,
-                                 static_cast<uint8_t>(Rcpp::as<int32_t>(start)),
-                                 static_cast<uint8_t>(Rcpp::as<int32_t>(end)));
+                                static_cast<uint8_t>(Rcpp::as<int32_t>(start)),
+                                static_cast<uint8_t>(Rcpp::as<int32_t>(end)));
+    } else if (dtype == TILEDB_FLOAT64) {
+        ndr->set_range<double>(dimname, Rcpp::as<double>(start), Rcpp::as<double>(end));
+    } else if (dtype == TILEDB_FLOAT32) {
+        ndr->set_range<float>(dimname,
+                              static_cast<float>(Rcpp::as<double>(start)),
+                              static_cast<float>(Rcpp::as<double>(end)));
     } else {
         Rcpp::stop("Domain datatype '%s' of dimname '%s' is not currently supported",
                    _tiledb_datatype_to_string(dtype), dimname);
@@ -5517,6 +5523,13 @@ SEXP libtiledb_ndrectangle_get_range(XPtr<tiledb::NDRectangle> ndr,
         auto range = ndr->range<uint8_t>(dimname);
         return Rcpp::IntegerVector::create( static_cast<int32_t>(range[0]),
                                             static_cast<int32_t>(range[1]) );
+    } else if (dtype == "FLOAT64") {
+        auto range = ndr->range<double>(dimname);
+        return Rcpp::NumericVector::create(range[0], range[1]);
+    } else if (dtype == "FLOAT32") {
+        auto range = ndr->range<float>(dimname);
+        return Rcpp::NumericVector::create( static_cast<double>(range[0]),
+                                            static_cast<double>(range[1]));
     } else {
         Rcpp::stop("Domain datatype '%s' of dimname '%s' is not currently supported", dtype, dimname);
     }


### PR DESCRIPTION
This builds on #741 and adds support for float and double.

[SC 52170](https://app.shortcut.com/tiledb-inc/story/52170/extend-ndrectangle-domain-support-once-more)