### PR TITLE
Roll nightly valgrind to 2.26.0, retire 2.24.0

### DIFF
--- a/.github/workflows/valgrind.yaml
+++ b/.github/workflows/valgrind.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tag: [ release-2.24, release-2.25, dev ]
+        tag: [ release-2.25, release-2.26, dev ]
 
     steps:
     - name: Checkout


### PR DESCRIPTION
Procedural pull request to include the new release branch 2.26.0 in nightly valgrind tests, and retire 2.24.0.  

No actual code changes.