### PR TITLE
Use TileDB Embedded 2.26.0 rc0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tiledb
 Type: Package
-Version: 0.29.0.4
+Version: 0.29.0.5
 Title: Modern Database Engine for Complex Data Based on Multi-Dimensional Arrays
 Authors@R: c(person("TileDB, Inc.", role = c("aut", "cph")),
   person("Dirk", "Eddelbuettel", email = "dirk@tiledb.com", role = "cre"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # Ongoing Development
 
+* This release of the R package builds against [TileDB 2.26.0](https://github.com/TileDB-Inc/TileDB/releases/tag/2.26.0), and has also been tested against earlier releases as well as the development version (#745)
+
 ## Improvements
 
 * Error messages displayed when a mismatched external pointer is detected now show both expected and encountered types (#740)
@@ -11,6 +13,10 @@
 ## Documentation
 
 * The documentation website now uses favicon symbols for all pages rendered (#739)
+
+## Build and Test Systems
+
+* The nighly valgrind matrix now includes release 2.26.0 (#744)
 
 
 # tiledb 0.29.0

--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,8 @@
 
 * The nighly valgrind matrix now includes release 2.26.0 (#744)
 
+* The continuous integration script has been updated reflecting external changes (#746)
+
 
 # tiledb 0.29.0
 

--- a/tools/tiledbVersion.txt
+++ b/tools/tiledbVersion.txt
@@ -1,2 +1,2 @@
-version: 2.25.0
-sha: bbcbd3f
+version: 2.26.0-rc0
+sha: 4487393


### PR DESCRIPTION
Switch to rc0 of the upcoming 2.26.0 release for the pin fallback. 

No code or test changes in the package.