### PR TITLE
Remove long-deprecated args 'as.data.frame', 'as.matrix', 'as.array'

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tiledb
 Type: Package
-Version: 0.29.0.5
+Version: 0.29.0.6
 Title: Modern Database Engine for Complex Data Based on Multi-Dimensional Arrays
 Authors@R: c(person("TileDB, Inc.", role = c("aut", "cph")),
   person("Dirk", "Eddelbuettel", email = "dirk@tiledb.com", role = "cre"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # Ongoing Development
 
-* This release of the R package builds against [TileDB 2.26.0](https://github.com/TileDB-Inc/TileDB/releases/tag/2.26.0), and has also been tested against earlier releases as well as the development version (#745)
+* This release of the R package builds against [TileDB 2.26.0](https://github.com/TileDB-Inc/TileDB/releases/tag/2.26.0), and has also been tested against earlier releases as well as the development version (#745, #749, #750)
 
 ## Improvements
 
@@ -19,6 +19,11 @@
 * The nighly valgrind matrix now includes release 2.26.0 (#744)
 
 * The continuous integration script has been updated reflecting external changes (#746)
+
+## Removals
+
+* Boolean arguments `as.data.frame`, `as.matrix` and `as.array` to the `tiledb_array()` accessor, deprecated in release 0.20.0 in July 2023 in favor of the more general `return_as="..."` form, have been removed. (#751)
+
 
 
 # tiledb 0.29.0

--- a/man/tiledb_array-class.Rd
+++ b/man/tiledb_array-class.Rd
@@ -18,8 +18,6 @@ based on a refactored implementation utilising newer TileDB features.
 
 \item{\code{is.sparse}}{A logical value whether the array is sparse or not}
 
-\item{\code{as.data.frame}}{A logical value}
-
 \item{\code{attrs}}{A character vector to select particular column \sQuote{attributes};
 default is an empty character vector implying \sQuote{all} columns, the special
 value \code{NA_character_} has the opposite effect and selects \sQuote{none}.}
@@ -38,10 +36,6 @@ describes the selected points for dimension i}
 \item{\code{datetimes_as_int64}}{A logical value}
 
 \item{\code{encryption_key}}{A character value}
-
-\item{\code{as.matrix}}{A logical value}
-
-\item{\code{as.array}}{A logical value}
 
 \item{\code{query_condition}}{A Query Condition object}
 

--- a/man/tiledb_array.Rd
+++ b/man/tiledb_array.Rd
@@ -10,7 +10,6 @@ tiledb_array(
   uri,
   query_type = c("READ", "WRITE"),
   is.sparse = NA,
-  as.data.frame = FALSE,
   attrs = character(),
   extended = TRUE,
   selected_ranges = list(),
@@ -18,8 +17,6 @@ tiledb_array(
   query_layout = character(),
   datetimes_as_int64 = FALSE,
   encryption_key = character(),
-  as.matrix = FALSE,
-  as.array = FALSE,
   query_condition = new("tiledb_query_condition"),
   timestamp_start = as.POSIXct(double(), origin = "1970-01-01"),
   timestamp_end = as.POSIXct(double(), origin = "1970-01-01"),
@@ -44,8 +41,6 @@ tiledb_sparse(...)
 
 \item{is.sparse}{optional logical switch, defaults to "NA" letting array determine it}
 
-\item{as.data.frame}{optional logical switch, defaults to "FALSE"}
-
 \item{attrs}{optional character vector to select attributes, default is
 empty implying all are selected, the special value \code{NA_character_}
 has the opposite effect and implies no attributes are returned.}
@@ -68,12 +63,6 @@ representation as \sQuote{raw} \code{integer64} and not as \code{Date},
 
 \item{encryption_key}{optional A character value with an AES-256 encryption key
 in case the array was written with encryption.}
-
-\item{as.matrix}{optional logical switch, defaults to "FALSE"; currently limited to dense
-matrices; in the case of multiple attributes in query a list of matrices is returned}
-
-\item{as.array}{optional logical switch, defaults to "FALSE"; in the case of multiple
-attributes in query a list of arrays is returned}
 
 \item{query_condition}{optional \code{tiledb_query_condition} object, by default uninitialized
 without a condition; this functionality requires TileDB 2.3.0 or later}


### PR DESCRIPTION
The three arguments `as.data.frame`, `as.matrix` and `as.array` precede the more general (and preferred) replacement `return_as=` taking an argument.

We deprecated these three arguments in release 0.20.0 last summer well over a year ago, and can now remove them.

The PR removes them, and their documentation entries.  No new code, no changes to unit tests.

[SC 54632](https://app.shortcut.com/tiledb-inc/story/54632/remove-three-arguments-for-tiledb-array-deprecate-over-twelve-months-ago-in-0-20-0)