### PR TITLE
Temporarily re-admit `as.data.frame=TRUE` in tiledb_array()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tiledb
 Type: Package
-Version: 0.29.0.6
+Version: 0.29.0.7
 Title: Modern Database Engine for Complex Data Based on Multi-Dimensional Arrays
 Authors@R: c(person("TileDB, Inc.", role = c("aut", "cph")),
   person("Dirk", "Eddelbuettel", email = "dirk@tiledb.com", role = "cre"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -24,6 +24,9 @@
 
 * Boolean arguments `as.data.frame`, `as.matrix` and `as.array` to the `tiledb_array()` accessor, deprecated in release 0.20.0 in July 2023 in favor of the more general `return_as="..."` form, have been removed. (#751)
 
+## Deprecation
+
+* As BioConductor package \pkg{TileDBArray} still relies on `as.data.frame` it was temporarily re-admitted as an argument. It is expected to be removed following the upcoming 3.20 release of BioConducto.r (#752)
 
 
 # tiledb 0.29.0

--- a/R/TileDBArray.R
+++ b/R/TileDBArray.R
@@ -133,6 +133,9 @@ setClass("tiledb_array",
 #' \code{/dev/shm}) for writing out results buffers (for internal use / testing)
 #' @param buffers An optional list with full pathnames of shared memory buffers to read data from
 #' @param ctx optional tiledb_ctx
+#' @param as.data.frame An optional deprecated alternative to \code{return_as="data.frame"} which has
+#' been deprecated and removed, but is still used in one BioConductor package; this argument will be removed
+#' once the updated package has been released.
 #' @return tiledb_array object
 #' @importFrom spdl set_level
 #' @export
@@ -156,7 +159,8 @@ tiledb_array <- function(uri,
                          sil = list(),
                          dumpbuffers = character(),
                          buffers = list(),
-                         ctx = tiledb_get_context()) {
+                         ctx = tiledb_get_context(),
+                         as.data.frame = FALSE) {
   stopifnot("Argument 'ctx' must be a tiledb_ctx object" = is(ctx, "tiledb_ctx"),
             "Argument 'uri' must be a string scalar" = !missing(uri) && is.scalar(uri, "character"),
             "Argument 'matrix' (for 'return_as') cannot be selected for sparse arrays" =
@@ -168,6 +172,12 @@ tiledb_array <- function(uri,
     array_xptr <- libtiledb_array_open_with_key(ctx@ptr, uri, query_type, encryption_key)
   } else {
     array_xptr <- libtiledb_array_open(ctx@ptr, uri, query_type)
+  }
+
+  if (as.data.frame) {
+      ## accommodating TileDBArray prior to BioConductor 3.20
+      .Deprecated(old="as.data.frame", new=r"(return_as="data.frame")")
+      return_as <- "data.frame"
   }
 
   if (length(timestamp_start) > 0) {

--- a/man/tiledb_array.Rd
+++ b/man/tiledb_array.Rd
@@ -27,7 +27,8 @@ tiledb_array(
   sil = list(),
   dumpbuffers = character(),
   buffers = list(),
-  ctx = tiledb_get_context()
+  ctx = tiledb_get_context(),
+  as.data.frame = FALSE
 )
 
 tiledb_dense(...)
@@ -98,6 +99,10 @@ parsed.}
 \item{buffers}{An optional list with full pathnames of shared memory buffers to read data from}
 
 \item{ctx}{optional tiledb_ctx}
+
+\item{as.data.frame}{An optional deprecated alternative to \code{return_as="data.frame"} which has
+been deprecated and removed, but is still used in one BioConductor package; this argument will be removed
+once the updated package has been released.}
 
 \item{...}{Used as a pass-through for \code{tiledb_dense}
 and \code{tiledb_sparse} aliasing}


### PR DESCRIPTION
PR #751 yesterday removed three arguments to `tiledb_array()` that had been deprecated for fourteen months.  

Now, it turns out BioConductor package [TileDBArray](https://www.bioconductor.org/packages/release/bioc/html/TileDBArray.html) still uses it in release 3.19.  While this was fixed yesterday (thanks, @LTLA) in [this commit](https://github.com/LTLA/TileDBArray/commit/99cb3c5baa7e0396f1d0d1d9d46abd08fbd67858) we will need to wait for release 3.20 for this to propagate.

Tested in a container, accomodates current release of TileDBArray.

No new tests.

[SC 54634](https://app.shortcut.com/tiledb-inc/story/54634/readmit-as-data-frame-as-tiledbarray-still-uses-it-until-its-next-release)