### PR TITLE
No longer rely on now-deprecated dump() for fragment info

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tiledb
 Type: Package
-Version: 0.29.0.7
+Version: 0.29.0.8
 Title: Modern Database Engine for Complex Data Based on Multi-Dimensional Arrays
 Authors@R: c(person("TileDB, Inc.", role = c("aut", "cph")),
   person("Dirk", "Eddelbuettel", email = "dirk@tiledb.com", role = "cre"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,8 @@
 
 * `NDRectangle` objects can now return their number of dimensions and dimension data types (#743)
 
+* `FragmentInfo` objects are dump via the `<<` stringstream operator instead of a now-deprecated `dump()` method (#753)
+
 ## Documentation
 
 * The documentation website now uses favicon symbols for all pages rendered (#739)

--- a/src/libtiledb.cpp
+++ b/src/libtiledb.cpp
@@ -4942,7 +4942,13 @@ std::string libtiledb_fragment_info_to_vacuum_uri(XPtr<tiledb::FragmentInfo> fi,
 // [[Rcpp::export]]
 void libtiledb_fragment_info_dump(XPtr<tiledb::FragmentInfo> fi) {
     check_xptr_tag<tiledb::FragmentInfo>(fi);
-    return fi->dump();
+#if TILEDB_VERSION >= TileDB_Version(2,27,0)
+    std::stringstream ss;
+    ss << *fi;
+    Rcpp::Rcout << ss.str();
+#else
+    fi->dump();
+#endif
 }
 
 // [[Rcpp::export]]


### PR DESCRIPTION
Core just deprecated `dump()` for fragment info so we now rely on the stringstream method instead (as we had already done for a few other `dump()` replacements).

No new code, no new tests.