### PR TITLE
Fix MacOS rpath

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tiledb
 Type: Package
-Version: 0.30.1.1
+Version: 0.30.1.2
 Title: Modern Database Engine for Complex Data Based on Multi-Dimensional Arrays
 Authors@R: c(person("TileDB, Inc.", role = c("aut", "cph")),
   person("Dirk", "Eddelbuettel", email = "dirk@tiledb.com", role = "cre"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,8 @@
 # Unreleased
 
-* Fix [#758](https://github.com/TileDB-Inc/TileDB-R/issues/758) "Can't read domain for dimensions of type UINT16"
+* [#760](https://github.com/TileDB-Inc/TileDB-R/issues/758) Fix MacOS `rpath`
 
+* [#758](https://github.com/TileDB-Inc/TileDB-R/issues/758) Fix "Can't read domain for dimensions of type UINT16"
 
 # tiledb 0.30.1
 

--- a/src/Makevars.in
+++ b/src/Makevars.in
@@ -11,14 +11,17 @@ LIB_CON_DIR = ../inst/lib$(R_ARCH)
 LIB_CON = $(LIB_CON_DIR)/libconnection@DYLIB_EXT@
 
 all: $(OBJECTS) $(LIB_CON) $(SHLIB)
-        # if we are
-        #  - on macOS aka Darwin which needs this
-        #  - the library is present (implying non-system library use)
-        # then let us call install_name_tool
-	@if [ `uname -s` = 'Darwin' ] && [ -f ../inst/tiledb/lib/libtiledb.dylib ] && [ -f tiledb.so ]; then \
-	    install_name_tool -change libz.1.dylib @rpath/libz.1.dylib ../inst/tiledb/lib/libtiledb.dylib; \
-	    install_name_tool -add_rpath @loader_path/../tiledb/lib tiledb.so; \
-	    install_name_tool -add_rpath @loader_path/../tiledb/lib $(LIB_CON); \
+        # On macOS aka Darwin we call install_name_tool
+        # Case one: If we had a downloaded TileDB Core artifact, adjust zlib path and add to @rpath
+        # Case two: If we see the system libraries (on macOS) ensure /usr/local/lib rpath is considered
+	@if [ `uname -s` = 'Darwin' ] && [ -f tiledb.so ]; then \
+	    if [ -f ../inst/tiledb/lib/libtiledb.dylib ] ; then \
+	        install_name_tool -change libz.1.dylib @rpath/libz.1.dylib ../inst/tiledb/lib/libtiledb.dylib; \
+	        install_name_tool -add_rpath @loader_path/../tiledb/lib tiledb.so; \
+	    fi; \
+	    if [ -f /usr/local/lib/libtiledb.dylib ] ; then \
+	        install_name_tool -add_rpath /usr/local/lib tiledb.so; \
+	    fi; \
 	fi
 
 $(LIB_CON): connection/connection.o


### PR DESCRIPTION
## Before

On MacOS for TileDB-R I've always noticed:

```
# build and install
rm -f *.tar.gz; R CMD build --no-build-vignettes --no-manual .
R CMD INSTALL --no-test-load --no-docs --no-html *tar.gz
```

```
$ R
> library(tiledb)
Error: package or namespace load failed for ‘tiledb’ in dyn.load(file, DLLpath = DLLpath, ...):
 unable to load shared object '/Users/johnkerl/R/tiledb/libs/tiledb.so':
  dlopen(/Users/johnkerl/R/tiledb/libs/tiledb.so, 0x0006): Library not loaded: @rpath/libtiledb.dylib
  Referenced from: <9D75719F-D075-3D56-BDDF-7429ACB097EE> /Users/johnkerl/R/tiledb/libs/tiledb.so
  Reason: tried: '/Library/Frameworks/R.framework/Resources/lib/libtiledb.dylib' (no such file), '/Library/Java/JavaVirtualMachines/jdk-11.0.18+10/Contents/Home/lib/server/libtiledb.dylib' (no such file)
```

I've always had this workaround:
```
$ alias rpatch
alias rpatch='install_name_tool -add_rpath /usr/local/lib ~/R/tiledb/libs/tiledb.so'
```

after which I can do `library(tiledb)`.

This is to say: the MacOS install is broken until/unless I manually fix the `rpath`.

## After

```
# build and install
rm -f *.tar.gz; R CMD build --no-build-vignettes --no-manual .
R CMD INSTALL --no-test-load --no-docs --no-html *tar.gz
```

```
$ R
> library(tiledb)
TileDB R 0.30.1 with TileDB Embedded 2.26.2 on macOS 15.0.
See https://tiledb.com for more information about TileDB.
```

## Note

We already did this for `tiledbsoma` here: https://github.com/single-cell-data/TileDB-SOMA/pull/1372

The current PR simply copy-pastes the same logic to TileDB-R.