### PR TITLE
Run `clang-format` on non-autogen C++ source code

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -43,11 +43,12 @@ tiledb_datatype_string_to_sizeof <- function(str) {
 
 #' Map from TileDB type to R datatype
 #'
-#' This function maps from the TileDB types to the (fewer) key datatypes in R. This
-#' can be lossy as TileDB integers range from (signed and unsigned) 8 to 64 bit whereas
-#' R only has (signed) 32 bit values. Similarly, R only has 64 bit doubles whereas TileDB
-#' has 32 and 64 bit floating point types. TileDB also has more character encodings, and the
-#' full range of (NumPy) date and time types.
+#' This function maps from the TileDB types to the (fewer) key datatypes in R.
+#' This can be lossy as TileDB integers range from (signed and unsigned) 8 to
+#' 64 bit whereas R only has (signed) 32 bit values. Similarly, R only has 64
+#' bit doubles whereas TileDB has 32 and 64 bit floating point types. TileDB
+#' also has more character encodings, and the full range of (NumPy) date and
+#' time types.
 #'
 #' @param datatype A string describing one TileDB datatype
 #' @return A string describing the closest match for an R datatype
@@ -1247,22 +1248,23 @@ vlcbuf_from_shmem <- function(datapath, dtype) {
 #' Create a custom file connection
 #'
 #' @details
-#' This \code{vfs_file()} connection works like the \code{file()} connection in R itself.
+#' This \code{vfs_file()} connection works like the \code{file()} connection
+#' in R itself.
 #'
 #' This connection works with both ASCII and binary data, e.g. using
 #' \code{readLines()} and \code{readBin()}.
 #'
-#' @param description path to a filename; contrary to \code{rconnection} a connection
-#' object is not supported.
-#' @param mode character string. A description of how to open the connection if
-#' it is to be opened upon creation e.g. "rb". Default "" (empty string) means
-#' to not open the connection on creation - user must still call \code{open()}.
-#' Note: If an "open" string is provided, the user must still call \code{close()}
-#' otherwise the contents of the file aren't completely flushed until the
-#' connection is garbage collected.
+#' @param description path to a filename; contrary to \code{rconnection} a
+#' connection object is not supported.
+#' @param mode character string. A description of how to open the connection
+#' if it is to be opened upon creation e.g. "rb". Default "" (empty string)
+#' means to not open the connection on creation - user must still call
+#' \code{open()}.  Note: If an "open" string is provided, the user must still
+#' call \code{close()} otherwise the contents of the file aren't completely
+#' flushed until the connection is garbage collected.
 #' @param verbosity integer value 0, 1, or 2. Default: 0.
-#' Set to \code{0} for no debugging messages, \code{1} for some high-level messages
-#' and \code{verbosity = 2} for all debugging messages.
+#' Set to \code{0} for no debugging messages, \code{1} for some high-level
+#' messages and \code{verbosity = 2} for all debugging messages.
 #'
 #' @export
 #'

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -43,12 +43,12 @@ tiledb_datatype_string_to_sizeof <- function(str) {
 
 #' Map from TileDB type to R datatype
 #'
-#' This function maps from the TileDB types to the (fewer) key datatypes in R.
-#' This can be lossy as TileDB integers range from (signed and unsigned) 8 to
-#' 64 bit whereas R only has (signed) 32 bit values. Similarly, R only has 64
-#' bit doubles whereas TileDB has 32 and 64 bit floating point types. TileDB
-#' also has more character encodings, and the full range of (NumPy) date and
-#' time types.
+#' This function maps from the TileDB types to the (fewer) key datatypes in
+#' R. This can be lossy as TileDB integers range from (signed and unsigned) 8
+#' to 64 bit whereas R only has (signed) 32 bit values. Similarly, R only has
+#' 64 bit doubles whereas TileDB has 32 and 64 bit floating point types.
+#' TileDB also has more character encodings, and the full range of (NumPy)
+#' date and time types.
 #'
 #' @param datatype A string describing one TileDB datatype
 #' @return A string describing the closest match for an R datatype

--- a/man/tiledb_datatype_R_type.Rd
+++ b/man/tiledb_datatype_R_type.Rd
@@ -13,9 +13,10 @@ tiledb_datatype_R_type(datatype)
 A string describing the closest match for an R datatype
 }
 \description{
-This function maps from the TileDB types to the (fewer) key datatypes in R. This
-can be lossy as TileDB integers range from (signed and unsigned) 8 to 64 bit whereas
-R only has (signed) 32 bit values. Similarly, R only has 64 bit doubles whereas TileDB
-has 32 and 64 bit floating point types. TileDB also has more character encodings, and the
-full range of (NumPy) date and time types.
+This function maps from the TileDB types to the (fewer) key datatypes in
+R. This can be lossy as TileDB integers range from (signed and unsigned) 8
+to 64 bit whereas R only has (signed) 32 bit values. Similarly, R only has
+64 bit doubles whereas TileDB has 32 and 64 bit floating point types.
+TileDB also has more character encodings, and the full range of (NumPy)
+date and time types.
 }

--- a/man/vfs_file.Rd
+++ b/man/vfs_file.Rd
@@ -7,25 +7,26 @@
 vfs_file(description, mode = "", verbosity = 0L)
 }
 \arguments{
-\item{description}{path to a filename; contrary to \code{rconnection} a connection
-object is not supported.}
+\item{description}{path to a filename; contrary to \code{rconnection} a
+connection object is not supported.}
 
-\item{mode}{character string. A description of how to open the connection if
-it is to be opened upon creation e.g. "rb". Default "" (empty string) means
-to not open the connection on creation - user must still call \code{open()}.
-Note: If an "open" string is provided, the user must still call \code{close()}
-otherwise the contents of the file aren't completely flushed until the
-connection is garbage collected.}
+\item{mode}{character string. A description of how to open the connection
+if it is to be opened upon creation e.g. "rb". Default "" (empty string)
+means to not open the connection on creation - user must still call
+\code{open()}.  Note: If an "open" string is provided, the user must still
+call \code{close()} otherwise the contents of the file aren't completely
+flushed until the connection is garbage collected.}
 
 \item{verbosity}{integer value 0, 1, or 2. Default: 0.
-Set to \code{0} for no debugging messages, \code{1} for some high-level messages
-and \code{verbosity = 2} for all debugging messages.}
+Set to \code{0} for no debugging messages, \code{1} for some high-level
+messages and \code{verbosity = 2} for all debugging messages.}
 }
 \description{
 Create a custom file connection
 }
 \details{
-This \code{vfs_file()} connection works like the \code{file()} connection in R itself.
+This \code{vfs_file()} connection works like the \code{file()} connection
+in R itself.
 
 This connection works with both ASCII and binary data, e.g. using
 \code{readLines()} and \code{readBin()}.

--- a/src/array_buffers.h
+++ b/src/array_buffers.h
@@ -33,7 +33,7 @@
 #ifndef ARRAY_BUFFERS_H
 #define ARRAY_BUFFERS_H
 
-#include <stdexcept>  // for windows: error C2039: 'runtime_error': is not a member of 'std'
+#include <stdexcept> // for windows: error C2039: 'runtime_error': is not a member of 'std'
 
 #include <span/span.hpp>
 #include <tiledb/tiledb>
@@ -45,77 +45,72 @@ namespace tiledb {
 using namespace tiledb;
 
 class ArrayBuffers {
-   public:
-    ArrayBuffers() = default;
-    ArrayBuffers(const ArrayBuffers&) = delete;
-    ArrayBuffers(ArrayBuffers&&) = default;
-    ~ArrayBuffers() = default;
+public:
+  ArrayBuffers() = default;
+  ArrayBuffers(const ArrayBuffers &) = delete;
+  ArrayBuffers(ArrayBuffers &&) = default;
+  ~ArrayBuffers() = default;
 
-    /**
-     * @brief Return the buffer with the given name.
-     *
-     * @param name Column name
-     * @return std::shared_ptr<ColumnBuffer> Column buffer
-     */
-    std::shared_ptr<ColumnBuffer> at(const std::string& name) {
-        if (!contains(name)) {
-            Rcpp::stop("[ArrayBuffers] column '%s' does not exist", name);
-        }
-        return buffers_[name];
+  /**
+   * @brief Return the buffer with the given name.
+   *
+   * @param name Column name
+   * @return std::shared_ptr<ColumnBuffer> Column buffer
+   */
+  std::shared_ptr<ColumnBuffer> at(const std::string &name) {
+    if (!contains(name)) {
+      Rcpp::stop("[ArrayBuffers] column '%s' does not exist", name);
     }
+    return buffers_[name];
+  }
 
-    /**
-     * @brief Return true if a buffer with the given name exists.
-     *
-     * @param name Column name
-     * @return True if a buffer with the given name exists
-     */
-    bool contains(const std::string& name) {
-        return buffers_.find(name) != buffers_.end();
+  /**
+   * @brief Return true if a buffer with the given name exists.
+   *
+   * @param name Column name
+   * @return True if a buffer with the given name exists
+   */
+  bool contains(const std::string &name) {
+    return buffers_.find(name) != buffers_.end();
+  }
+
+  /**
+   * @brief Add a column buffer with the given name to the ArrayBuffers,
+   * maintaining the insertion order.
+   *
+   * @param name Column name
+   * @param buffer Column buffer
+   */
+  void emplace(const std::string &name, std::shared_ptr<ColumnBuffer> buffer) {
+    if (contains(name)) {
+      Rcpp::stop("[ArrayBuffers] column '%s' already exists", name);
     }
+    names_.push_back(name);
+    buffers_.emplace(name, buffer);
+  }
 
-    /**
-     * @brief Add a column buffer with the given name to the ArrayBuffers,
-     * maintaining the insertion order.
-     *
-     * @param name Column name
-     * @param buffer Column buffer
-     */
-    void emplace(
-        const std::string& name, std::shared_ptr<ColumnBuffer> buffer) {
-        if (contains(name)) {
-            Rcpp::stop("[ArrayBuffers] column '%s' already exists", name);
-        }
-        names_.push_back(name);
-        buffers_.emplace(name, buffer);
-    }
+  /**
+   * @brief Returns the ordered vector of names.
+   *
+   * @return const std::vector<std::string>& Vector of names
+   */
+  const std::vector<std::string> &names() { return names_; }
 
-    /**
-     * @brief Returns the ordered vector of names.
-     *
-     * @return const std::vector<std::string>& Vector of names
-     */
-    const std::vector<std::string>& names() {
-        return names_;
-    }
+  /**
+   * @brief Returns the number of rows in the array buffer.
+   *
+   * @return uint64_t Number of rows
+   */
+  uint64_t num_rows() const { return buffers_.at(names_.front())->size(); }
 
-    /**
-     * @brief Returns the number of rows in the array buffer.
-     *
-     * @return uint64_t Number of rows
-     */
-    uint64_t num_rows() const {
-        return buffers_.at(names_.front())->size();
-    }
+private:
+  // A vector of column names that maintains the order the columns were added
+  std::vector<std::string> names_;
 
-   private:
-    // A vector of column names that maintains the order the columns were added
-    std::vector<std::string> names_;
-
-    // Map: column name -> ColumnBuffer
-    std::unordered_map<std::string, std::shared_ptr<ColumnBuffer>> buffers_;
+  // Map: column name -> ColumnBuffer
+  std::unordered_map<std::string, std::shared_ptr<ColumnBuffer>> buffers_;
 };
 
-}  // namespace tiledb
+} // namespace tiledb
 
 #endif

--- a/src/arrow_adapter.h
+++ b/src/arrow_adapter.h
@@ -20,255 +20,256 @@ namespace tiledb {
  *
  */
 struct ArrowBuffer {
-    ArrowBuffer(std::shared_ptr<ColumnBuffer> buffer)
-        : buffer_(buffer){};
+  ArrowBuffer(std::shared_ptr<ColumnBuffer> buffer) : buffer_(buffer){};
 
-    std::shared_ptr<ColumnBuffer> buffer_;
+  std::shared_ptr<ColumnBuffer> buffer_;
 };
 
 class ArrowAdapter {
-   public:
-    static void release_schema(struct ArrowSchema* schema) {
-        spdl::debug(tfm::format("[ArrowAdapter] release_schema %s", schema->name));
-        schema->release = nullptr;
+public:
+  static void release_schema(struct ArrowSchema *schema) {
+    spdl::debug(tfm::format("[ArrowAdapter] release_schema %s", schema->name));
+    schema->release = nullptr;
+  }
+
+  static void release_array(struct ArrowArray *array) {
+    auto arrow_buffer = static_cast<ArrowBuffer *>(array->private_data);
+
+    spdl::debug(tfm::format("[ArrowAdapter] release_array %s use_count=%d",
+                            arrow_buffer->buffer_->name(),
+                            arrow_buffer->buffer_.use_count()));
+
+    // Delete the ArrowBuffer, which was allocated with new.
+    // If the ArrowBuffer.buffer_ shared_ptr is the last reference to the
+    // underlying ColumnBuffer, the ColumnBuffer will be deleted.
+    delete arrow_buffer;
+
+    if (array->buffers != nullptr) {
+      free(array->buffers);
+    }
+    array->release = nullptr;
+  }
+
+  // /**
+  //  * @brief Convert ColumnBuffer Enumeration to an Arrow array.
+  //  *
+  //  * @return auto [Arrow array, Arrow schema]
+  //  */
+  // static auto enumeration_to_arrow(std::shared_ptr<std::vector<std::string>>
+  // enmr) {
+  //     spdl::warn("[enumeration_to_arrow] entered");
+  //     std::unique_ptr<ArrowSchema> schema = std::make_unique<ArrowSchema>();
+  //     std::unique_ptr<ArrowArray> array = std::make_unique<ArrowArray>();
+
+  //     schema->format = to_arrow_format(TILEDB_STRING_UTF8).data();  //
+  //     mandatory schema->name = nullptr; // optional schema->metadata =
+  //     nullptr;                               // optional schema->flags = 0;
+  //     // optional schema->n_children = 0; // mandatory schema->children =
+  //     nullptr;                               // optional schema->dictionary =
+  //     nullptr;                             // optional schema->release =
+  //     &release_schema;                        // mandatory
+  //     schema->private_data = nullptr;                           // optional
+
+  //     int n_buffers = 3;      // known constant
+
+  //     auto column = std::make_shared<ColumnBuffer>("", TILEDB_STRING_UTF8,
+  //                                                  enmr->size(),
+  //                                                  enmr->size(), // two
+  //                                                  placeholders true, false);
+  //     column->from_enumeration(enmr);
+
+  //     // Create an ArrowBuffer to manage the lifetime of `column`.
+  //     // - `arrow_buffer` holds a shared_ptr to `column`, which increments
+  //     //   the use count and keeps the ColumnBuffer data alive.
+  //     // - When the arrow array is released, `array->release()` is called
+  //     with
+  //     //   `arrow_buffer` in `private_data`. `arrow_buffer` is deleted, which
+  //     //   decrements the the `column` use count. When the `column` use count
+  //     //   reaches 0, the ColumnBuffer data will be deleted.
+  //     auto arrow_buffer = new ArrowBuffer(column);
+
+  //     array->length = enmr->size();               // mandatory: length is
+  //     number of 'levels' array->null_count = 0;                      //
+  //     mandatory array->offset = 0;                          // mandatory
+  //     array->n_buffers = n_buffers;               // mandatory
+  //     array->n_children = 0;                      // mandatory
+  //     array->buffers = nullptr;                   // mandatory
+  //     array->children = nullptr;                  // optional
+  //     array->dictionary = nullptr;                // optional
+  //     array->release = &release_array;            // mandatory
+  //     array->private_data = (void*)arrow_buffer;  // mandatory
+
+  //     spdl::debug(tfm::format("[ArrowAdapter::enumeration_array] create
+  //     dictionary length '%d'",
+  //                             array->length));
+
+  //     array->buffers = (const void**)malloc(sizeof(void*) * n_buffers);
+  //     assert(array->buffers != nullptr);
+  //     array->buffers[0] = nullptr;  // validity
+  //     array->buffers[2] = column->data<void*>().data();  // data
+  //     array->buffers[1] = column->offsets().data();  // offsets
+
+  //     return std::pair(std::move(array), std::move(schema));
+  // }
+
+  /**
+   * @brief Convert ColumnBuffer to an Arrow array.
+   *
+   * @return auto [Arrow array, Arrow schema]
+   */
+  static auto to_arrow(std::shared_ptr<ColumnBuffer> column) {
+    std::unique_ptr<ArrowSchema> schema = std::make_unique<ArrowSchema>();
+    std::unique_ptr<ArrowArray> array = std::make_unique<ArrowArray>();
+
+    schema->format = to_arrow_format(column->type()).data(); // mandatory
+    schema->name = column->name().data();                    // optional
+    schema->metadata = nullptr;                              // optional
+    schema->flags = 0;                                       // optional
+    schema->n_children = 0;                                  // mandatory
+    schema->children = nullptr;                              // optional
+    schema->dictionary = nullptr;                            // optional
+    schema->release = &release_schema;                       // mandatory
+    schema->private_data = nullptr;                          // optional
+
+    int n_buffers = column->is_var() ? 3 : 2;
+
+    // Create an ArrowBuffer to manage the lifetime of `column`.
+    // - `arrow_buffer` holds a shared_ptr to `column`, which increments
+    //   the use count and keeps the ColumnBuffer data alive.
+    // - When the arrow array is released, `array->release()` is called with
+    //   `arrow_buffer` in `private_data`. `arrow_buffer` is deleted, which
+    //   decrements the the `column` use count. When the `column` use count
+    //   reaches 0, the ColumnBuffer data will be deleted.
+    auto arrow_buffer = new ArrowBuffer(column);
+
+    array->length = column->size();             // mandatory
+    array->null_count = 0;                      // mandatory
+    array->offset = 0;                          // mandatory
+    array->n_buffers = n_buffers;               // mandatory
+    array->n_children = 0;                      // mandatory
+    array->buffers = nullptr;                   // mandatory
+    array->children = nullptr;                  // optional
+    array->dictionary = nullptr;                // optional
+    array->release = &release_array;            // mandatory
+    array->private_data = (void *)arrow_buffer; // mandatory
+
+    spdl::debug(tfm::format("[ArrowAdapter] create array name='%s' format='%s' "
+                            "use_count=%d addr=%p",
+                            column->name(), schema->format, column.use_count(),
+                            column->data<void *>().data()));
+
+    array->buffers = (const void **)malloc(sizeof(void *) * n_buffers);
+    assert(array->buffers != nullptr);
+    array->buffers[0] = nullptr;                                   // validity
+    array->buffers[n_buffers - 1] = column->data<void *>().data(); // data
+
+    if (n_buffers == 3) {
+      array->buffers[1] = column->offsets().data(); // offsets
     }
 
-    static void release_array(struct ArrowArray* array) {
-        auto arrow_buffer = static_cast<ArrowBuffer*>(array->private_data);
+    if (column->is_nullable()) {
+      schema->flags |= ARROW_FLAG_NULLABLE;
 
-        spdl::debug(tfm::format(
-            "[ArrowAdapter] release_array %s use_count=%d",
-            arrow_buffer->buffer_->name(),
-            arrow_buffer->buffer_.use_count()));
+      // Count nulls
+      for (auto v : column->validity()) {
+        array->null_count += v == 0;
+      }
 
-        // Delete the ArrowBuffer, which was allocated with new.
-        // If the ArrowBuffer.buffer_ shared_ptr is the last reference to the
-        // underlying ColumnBuffer, the ColumnBuffer will be deleted.
-        delete arrow_buffer;
-
-        if (array->buffers != nullptr) {
-            free(array->buffers);
-        }
-        array->release = nullptr;
+      // Convert validity bytemap to a bitmap in place
+      column->validity_to_bitmap();
+      array->buffers[0] = column->validity().data();
     }
 
-    // /**
-    //  * @brief Convert ColumnBuffer Enumeration to an Arrow array.
-    //  *
-    //  * @return auto [Arrow array, Arrow schema]
-    //  */
-    // static auto enumeration_to_arrow(std::shared_ptr<std::vector<std::string>> enmr) {
-    //     spdl::warn("[enumeration_to_arrow] entered");
-    //     std::unique_ptr<ArrowSchema> schema = std::make_unique<ArrowSchema>();
-    //     std::unique_ptr<ArrowArray> array = std::make_unique<ArrowArray>();
-
-    //     schema->format = to_arrow_format(TILEDB_STRING_UTF8).data();  // mandatory
-    //     schema->name = nullptr;					                      // optional
-    //     schema->metadata = nullptr;                               // optional
-    //     schema->flags = 0;                                        // optional
-    //     schema->n_children = 0;                                   // mandatory
-    //     schema->children = nullptr;                               // optional
-    //     schema->dictionary = nullptr;                             // optional
-    //     schema->release = &release_schema;                        // mandatory
-    //     schema->private_data = nullptr;                           // optional
-
-    //     int n_buffers = 3;      // known constant
-
-    //     auto column = std::make_shared<ColumnBuffer>("", TILEDB_STRING_UTF8,
-    //                                                  enmr->size(), enmr->size(), // two placeholders
-    //                                                  true, false);
-    //     column->from_enumeration(enmr);
-
-    //     // Create an ArrowBuffer to manage the lifetime of `column`.
-    //     // - `arrow_buffer` holds a shared_ptr to `column`, which increments
-    //     //   the use count and keeps the ColumnBuffer data alive.
-    //     // - When the arrow array is released, `array->release()` is called with
-    //     //   `arrow_buffer` in `private_data`. `arrow_buffer` is deleted, which
-    //     //   decrements the the `column` use count. When the `column` use count
-    //     //   reaches 0, the ColumnBuffer data will be deleted.
-    //     auto arrow_buffer = new ArrowBuffer(column);
-
-    //     array->length = enmr->size();               // mandatory: length is number of 'levels'
-    //     array->null_count = 0;                      // mandatory
-    //     array->offset = 0;                          // mandatory
-    //     array->n_buffers = n_buffers;               // mandatory
-    //     array->n_children = 0;                      // mandatory
-    //     array->buffers = nullptr;                   // mandatory
-    //     array->children = nullptr;                  // optional
-    //     array->dictionary = nullptr;                // optional
-    //     array->release = &release_array;            // mandatory
-    //     array->private_data = (void*)arrow_buffer;  // mandatory
-
-    //     spdl::debug(tfm::format("[ArrowAdapter::enumeration_array] create dictionary length '%d'",
-    //                             array->length));
-
-    //     array->buffers = (const void**)malloc(sizeof(void*) * n_buffers);
-    //     assert(array->buffers != nullptr);
-    //     array->buffers[0] = nullptr;  // validity
-    //     array->buffers[2] = column->data<void*>().data();  // data
-    //     array->buffers[1] = column->offsets().data();  // offsets
-
-    //     return std::pair(std::move(array), std::move(schema));
+    // if (column->has_enumeration()) {
+    //     std::shared_ptr<std::vector<std::string>> enmr =
+    //     column->get_enumeration(); auto pp = enumeration_to_arrow(enmr);
+    //     array->dictionary = pp.first.get();
+    //     schema->dictionary = pp.second.get();
+    //     spdl::warn(tfm::format("[ArrowAdapter::to_arrow] name='%s' enum=%d
+    //     string=%s",
+    //                            column->name(), column->has_enumeration(),
+    //                            (char*)array->dictionary->buffers[2]));
     // }
 
-    /**
-     * @brief Convert ColumnBuffer to an Arrow array.
-     *
-     * @return auto [Arrow array, Arrow schema]
-     */
-    static auto to_arrow(std::shared_ptr<ColumnBuffer> column) {
-        std::unique_ptr<ArrowSchema> schema = std::make_unique<ArrowSchema>();
-        std::unique_ptr<ArrowArray> array = std::make_unique<ArrowArray>();
-
-        schema->format = to_arrow_format(column->type()).data();  // mandatory
-        schema->name = column->name().data();                     // optional
-        schema->metadata = nullptr;                               // optional
-        schema->flags = 0;                                        // optional
-        schema->n_children = 0;                                   // mandatory
-        schema->children = nullptr;                               // optional
-        schema->dictionary = nullptr;                             // optional
-        schema->release = &release_schema;                        // mandatory
-        schema->private_data = nullptr;                           // optional
-
-        int n_buffers = column->is_var() ? 3 : 2;
-
-        // Create an ArrowBuffer to manage the lifetime of `column`.
-        // - `arrow_buffer` holds a shared_ptr to `column`, which increments
-        //   the use count and keeps the ColumnBuffer data alive.
-        // - When the arrow array is released, `array->release()` is called with
-        //   `arrow_buffer` in `private_data`. `arrow_buffer` is deleted, which
-        //   decrements the the `column` use count. When the `column` use count
-        //   reaches 0, the ColumnBuffer data will be deleted.
-        auto arrow_buffer = new ArrowBuffer(column);
-
-        array->length = column->size();             // mandatory
-        array->null_count = 0;                      // mandatory
-        array->offset = 0;                          // mandatory
-        array->n_buffers = n_buffers;               // mandatory
-        array->n_children = 0;                      // mandatory
-        array->buffers = nullptr;                   // mandatory
-        array->children = nullptr;                  // optional
-        array->dictionary = nullptr;                // optional
-        array->release = &release_array;            // mandatory
-        array->private_data = (void*)arrow_buffer;  // mandatory
-
-        spdl::debug(tfm::format(
-            "[ArrowAdapter] create array name='%s' format='%s' use_count=%d addr=%p",
-            column->name(), schema->format, column.use_count(), column->data<void*>().data()));
-
-        array->buffers = (const void**)malloc(sizeof(void*) * n_buffers);
-        assert(array->buffers != nullptr);
-        array->buffers[0] = nullptr;  // validity
-        array->buffers[n_buffers - 1] = column->data<void*>().data();  // data
-
-        if (n_buffers == 3) {
-            array->buffers[1] = column->offsets().data();  // offsets
-        }
-
-        if (column->is_nullable()) {
-            schema->flags |= ARROW_FLAG_NULLABLE;
-
-            // Count nulls
-            for (auto v : column->validity()) {
-                array->null_count += v == 0;
-            }
-
-            // Convert validity bytemap to a bitmap in place
-            column->validity_to_bitmap();
-            array->buffers[0] = column->validity().data();
-        }
-
-        // if (column->has_enumeration()) {
-        //     std::shared_ptr<std::vector<std::string>> enmr = column->get_enumeration();
-        //     auto pp = enumeration_to_arrow(enmr);
-        //     array->dictionary = pp.first.get();
-        //     schema->dictionary = pp.second.get();
-        //     spdl::warn(tfm::format("[ArrowAdapter::to_arrow] name='%s' enum=%d string=%s",
-        //                            column->name(), column->has_enumeration(),
-        //                            (char*)array->dictionary->buffers[2]));
-        // }
-
-
-#if TILEDB_VERSION >= TileDB_Version(2,10,0)
-        /* Workaround to cast TILEDB_BOOL from uint8 to 1-bit Arrow boolean. */
-        if (column->type() == TILEDB_BOOL) {
-            column->data_to_bitmap();
-        }
+#if TILEDB_VERSION >= TileDB_Version(2, 10, 0)
+    /* Workaround to cast TILEDB_BOOL from uint8 to 1-bit Arrow boolean. */
+    if (column->type() == TILEDB_BOOL) {
+      column->data_to_bitmap();
+    }
 #endif
 
-        /* Workaround for Date column with is 32-bit but treated as 64-bit */
-        if (column->type() == TILEDB_DATETIME_DAY) {
-            column->date_cast();
-        }
-
-        return std::pair(std::move(array), std::move(schema));
+    /* Workaround for Date column with is 32-bit but treated as 64-bit */
+    if (column->type() == TILEDB_DATETIME_DAY) {
+      column->date_cast();
     }
 
+    return std::pair(std::move(array), std::move(schema));
+  }
 
-    /**
-     * @brief Get Arrow format string from TileDB datatype.
-     *
-     * @param datatype TileDB datatype.
-     * @return std::string_view Arrow format string.
-     */
-    static std::string_view to_arrow_format(tiledb_datatype_t datatype) {
-        switch (datatype) {
-            case TILEDB_STRING_ASCII:
-            case TILEDB_STRING_UTF8:
-                return "U";  // large because TileDB uses 64bit offsets
-            case TILEDB_CHAR:
-            case TILEDB_BLOB:
-                return "Z";  // large because TileDB uses 64bit offsets
-#if TILEDB_VERSION >= TileDB_Version(2,10,0)
-            case TILEDB_BOOL:
-                return "b";
+  /**
+   * @brief Get Arrow format string from TileDB datatype.
+   *
+   * @param datatype TileDB datatype.
+   * @return std::string_view Arrow format string.
+   */
+  static std::string_view to_arrow_format(tiledb_datatype_t datatype) {
+    switch (datatype) {
+    case TILEDB_STRING_ASCII:
+    case TILEDB_STRING_UTF8:
+      return "U"; // large because TileDB uses 64bit offsets
+    case TILEDB_CHAR:
+    case TILEDB_BLOB:
+      return "Z"; // large because TileDB uses 64bit offsets
+#if TILEDB_VERSION >= TileDB_Version(2, 10, 0)
+    case TILEDB_BOOL:
+      return "b";
 #endif
-            case TILEDB_INT32:
-                return "i";
-            case TILEDB_INT64:
-                return "l";
-            case TILEDB_FLOAT32:
-                return "f";
-            case TILEDB_FLOAT64:
-                return "g";
-            case TILEDB_INT8:
-                return "c";
-            case TILEDB_UINT8:
-                return "C";
-            case TILEDB_INT16:
-                return "s";
-            case TILEDB_UINT16:
-                return "S";
-            case TILEDB_UINT32:
-                return "I";
-            case TILEDB_UINT64:
-                return "L";
-            case TILEDB_TIME_SEC:
-                return "tts";
-            case TILEDB_TIME_MS:
-                return "ttm";
-            case TILEDB_TIME_US:
-                return "ttu";
-            case TILEDB_TIME_NS:
-                return "ttn";
-            case TILEDB_DATETIME_SEC:
-                return "tss:";
-            case TILEDB_DATETIME_MS:
-                return "tsm:";
-            case TILEDB_DATETIME_US:
-                return "tsu:";
-            case TILEDB_DATETIME_NS:
-                return "tsn:";
-            case TILEDB_DATETIME_DAY:
-                return "tdD";
-            default:
-                break;
-        }
-        Rcpp::stop("ArrowAdapter: Unsupported TileDB datatype: %s ",
-            tiledb::impl::type_to_str(datatype));
+    case TILEDB_INT32:
+      return "i";
+    case TILEDB_INT64:
+      return "l";
+    case TILEDB_FLOAT32:
+      return "f";
+    case TILEDB_FLOAT64:
+      return "g";
+    case TILEDB_INT8:
+      return "c";
+    case TILEDB_UINT8:
+      return "C";
+    case TILEDB_INT16:
+      return "s";
+    case TILEDB_UINT16:
+      return "S";
+    case TILEDB_UINT32:
+      return "I";
+    case TILEDB_UINT64:
+      return "L";
+    case TILEDB_TIME_SEC:
+      return "tts";
+    case TILEDB_TIME_MS:
+      return "ttm";
+    case TILEDB_TIME_US:
+      return "ttu";
+    case TILEDB_TIME_NS:
+      return "ttn";
+    case TILEDB_DATETIME_SEC:
+      return "tss:";
+    case TILEDB_DATETIME_MS:
+      return "tsm:";
+    case TILEDB_DATETIME_US:
+      return "tsu:";
+    case TILEDB_DATETIME_NS:
+      return "tsn:";
+    case TILEDB_DATETIME_DAY:
+      return "tdD";
+    default:
+      break;
     }
+    Rcpp::stop("ArrowAdapter: Unsupported TileDB datatype: %s ",
+               tiledb::impl::type_to_str(datatype));
+  }
 };
 
-};  // namespace tiledb
+}; // namespace tiledb
 
 #endif

--- a/src/arrow_adapter.h
+++ b/src/arrow_adapter.h
@@ -50,68 +50,6 @@ public:
     array->release = nullptr;
   }
 
-  // /**
-  //  * @brief Convert ColumnBuffer Enumeration to an Arrow array.
-  //  *
-  //  * @return auto [Arrow array, Arrow schema]
-  //  */
-  // static auto enumeration_to_arrow(std::shared_ptr<std::vector<std::string>>
-  // enmr) {
-  //     spdl::warn("[enumeration_to_arrow] entered");
-  //     std::unique_ptr<ArrowSchema> schema = std::make_unique<ArrowSchema>();
-  //     std::unique_ptr<ArrowArray> array = std::make_unique<ArrowArray>();
-
-  //     schema->format = to_arrow_format(TILEDB_STRING_UTF8).data();  //
-  //     mandatory schema->name = nullptr; // optional schema->metadata =
-  //     nullptr;                               // optional schema->flags = 0;
-  //     // optional schema->n_children = 0; // mandatory schema->children =
-  //     nullptr;                               // optional schema->dictionary =
-  //     nullptr;                             // optional schema->release =
-  //     &release_schema;                        // mandatory
-  //     schema->private_data = nullptr;                           // optional
-
-  //     int n_buffers = 3;      // known constant
-
-  //     auto column = std::make_shared<ColumnBuffer>("", TILEDB_STRING_UTF8,
-  //                                                  enmr->size(),
-  //                                                  enmr->size(), // two
-  //                                                  placeholders true, false);
-  //     column->from_enumeration(enmr);
-
-  //     // Create an ArrowBuffer to manage the lifetime of `column`.
-  //     // - `arrow_buffer` holds a shared_ptr to `column`, which increments
-  //     //   the use count and keeps the ColumnBuffer data alive.
-  //     // - When the arrow array is released, `array->release()` is called
-  //     with
-  //     //   `arrow_buffer` in `private_data`. `arrow_buffer` is deleted, which
-  //     //   decrements the the `column` use count. When the `column` use count
-  //     //   reaches 0, the ColumnBuffer data will be deleted.
-  //     auto arrow_buffer = new ArrowBuffer(column);
-
-  //     array->length = enmr->size();               // mandatory: length is
-  //     number of 'levels' array->null_count = 0;                      //
-  //     mandatory array->offset = 0;                          // mandatory
-  //     array->n_buffers = n_buffers;               // mandatory
-  //     array->n_children = 0;                      // mandatory
-  //     array->buffers = nullptr;                   // mandatory
-  //     array->children = nullptr;                  // optional
-  //     array->dictionary = nullptr;                // optional
-  //     array->release = &release_array;            // mandatory
-  //     array->private_data = (void*)arrow_buffer;  // mandatory
-
-  //     spdl::debug(tfm::format("[ArrowAdapter::enumeration_array] create
-  //     dictionary length '%d'",
-  //                             array->length));
-
-  //     array->buffers = (const void**)malloc(sizeof(void*) * n_buffers);
-  //     assert(array->buffers != nullptr);
-  //     array->buffers[0] = nullptr;  // validity
-  //     array->buffers[2] = column->data<void*>().data();  // data
-  //     array->buffers[1] = column->offsets().data();  // offsets
-
-  //     return std::pair(std::move(array), std::move(schema));
-  // }
-
   /**
    * @brief Convert ColumnBuffer to an Arrow array.
    *
@@ -179,17 +117,6 @@ public:
       column->validity_to_bitmap();
       array->buffers[0] = column->validity().data();
     }
-
-    // if (column->has_enumeration()) {
-    //     std::shared_ptr<std::vector<std::string>> enmr =
-    //     column->get_enumeration(); auto pp = enumeration_to_arrow(enmr);
-    //     array->dictionary = pp.first.get();
-    //     schema->dictionary = pp.second.get();
-    //     spdl::warn(tfm::format("[ArrowAdapter::to_arrow] name='%s' enum=%d
-    //     string=%s",
-    //                            column->name(), column->has_enumeration(),
-    //                            (char*)array->dictionary->buffers[2]));
-    // }
 
 #if TILEDB_VERSION >= TileDB_Version(2, 10, 0)
     /* Workaround to cast TILEDB_BOOL from uint8 to 1-bit Arrow boolean. */

--- a/src/arrowio.cpp
+++ b/src/arrowio.cpp
@@ -3,131 +3,142 @@
 //  Copyright (c) 2020-2024 TileDB Inc.
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
-//  of this software and associated documentation files (the "Software"), to deal
-//  in the Software without restriction, including without limitation the rights
-//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-//  copies of the Software, and to permit persons to whom the Software is
+//  of this software and associated documentation files (the "Software"), to
+//  deal in the Software without restriction, including without limitation the
+//  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the Software is
 //  furnished to do so, subject to the following conditions:
 //
-//  The above copyright notice and this permission notice shall be included in all
-//  copies or substantial portions of the Software.
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
 //
 //  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 //  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 //  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 //  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-//  SOFTWARE.
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+//  IN THE SOFTWARE.
 
 #include "libtiledb.h"
-#include "tiledb_version.h"
 #include "nanoarrow/r.h"
+#include "tiledb_version.h"
 
 #include "tiledb_arrowio.h"
 
-#include "column_buffer.h"
 #include "arrow_adapter.h"
+#include "column_buffer.h"
 
-
-void _array_xptr_set_schema(SEXP array_xptr, SEXP schema_xptr); // forward declaration, see below
+void _array_xptr_set_schema(SEXP array_xptr,
+                            SEXP schema_xptr); // forward declaration, see below
 SEXP _array_xptr_get_schema(SEXP array_xptr);
-inline void exitIfError(const ArrowErrorCode ec, const std::string& msg);
-inline void* _getPtr(SEXP p) { return R_ExternalPtrAddr(p); }
+inline void exitIfError(const ArrowErrorCode ec, const std::string &msg);
+inline void *_getPtr(SEXP p) { return R_ExternalPtrAddr(p); }
 
 // [[Rcpp::export]]
 nanoarrowS3 libtiledb_query_export_buffer(XPtr<tiledb::Context> ctx,
                                           XPtr<tiledb::Query> query,
-                                          std::string& name) {
-    check_xptr_tag<tiledb::Context>(ctx);
-    check_xptr_tag<tiledb::Query>(query);
+                                          std::string &name) {
+  check_xptr_tag<tiledb::Context>(ctx);
+  check_xptr_tag<tiledb::Query>(query);
 
-    tiledb::arrow::ArrowAdapter adapter(ctx, query);
+  tiledb::arrow::ArrowAdapter adapter(ctx, query);
 
-    auto schemaxp = nanoarrow_schema_owning_xptr();
-    auto sch = nanoarrow_output_schema_from_xptr(schemaxp);
-    auto arrayxp = nanoarrow_array_owning_xptr();
-    auto arr = nanoarrow_output_array_from_xptr(arrayxp);
+  auto schemaxp = nanoarrow_schema_owning_xptr();
+  auto sch = nanoarrow_output_schema_from_xptr(schemaxp);
+  auto arrayxp = nanoarrow_array_owning_xptr();
+  auto arr = nanoarrow_output_array_from_xptr(arrayxp);
 
-    adapter.export_buffer(name.c_str(), arr, sch);
-    spdl::debug(tfm::format("[libtiledb_query_export_buffer] name '%s'", name.c_str()));
+  adapter.export_buffer(name.c_str(), arr, sch);
+  spdl::debug(
+      tfm::format("[libtiledb_query_export_buffer] name '%s'", name.c_str()));
 
-    // Nanoarrow special: stick schema into xptr tag to return single SEXP
-    _array_xptr_set_schema(arrayxp, schemaxp); 			// embed schema in array
-    return arrayxp;
+  // Nanoarrow special: stick schema into xptr tag to return single SEXP
+  _array_xptr_set_schema(arrayxp, schemaxp); // embed schema in array
+  return arrayxp;
 }
 
 // [[Rcpp::export]]
 XPtr<tiledb::Query> libtiledb_query_import_buffer(XPtr<tiledb::Context> ctx,
                                                   XPtr<tiledb::Query> query,
-                                                  std::string& name,
+                                                  std::string &name,
                                                   nanoarrowS3 naptr) {
-    check_xptr_tag<tiledb::Context>(ctx);
-    check_xptr_tag<tiledb::Query>(query);
-    tiledb::arrow::ArrowAdapter adapter(ctx, query);
+  check_xptr_tag<tiledb::Context>(ctx);
+  check_xptr_tag<tiledb::Query>(query);
+  tiledb::arrow::ArrowAdapter adapter(ctx, query);
 
-    // get schema xptr out of array xptr tag
-    auto schptr = _array_xptr_get_schema(naptr);
+  // get schema xptr out of array xptr tag
+  auto schptr = _array_xptr_get_schema(naptr);
 
-    adapter.import_buffer(name.c_str(),
-                          (struct ArrowArray*) _getPtr(naptr),
-                          (struct ArrowSchema*) _getPtr(schptr));
+  adapter.import_buffer(name.c_str(), (struct ArrowArray *)_getPtr(naptr),
+                        (struct ArrowSchema *)_getPtr(schptr));
 
-    return(query);
+  return (query);
 }
 
 // [[Rcpp::export]]
 nanoarrowS3 libtiledb_query_export_arrow_table(XPtr<tiledb::Context> ctx,
                                                XPtr<tiledb::Query> query,
                                                std::vector<std::string> names) {
-    check_xptr_tag<tiledb::Context>(ctx);
-    check_xptr_tag<tiledb::Query>(query);
-    size_t ncol = names.size();
-    tiledb::arrow::ArrowAdapter adapter(ctx, query);
+  check_xptr_tag<tiledb::Context>(ctx);
+  check_xptr_tag<tiledb::Query>(query);
+  size_t ncol = names.size();
+  tiledb::arrow::ArrowAdapter adapter(ctx, query);
 
-    auto schemaxp = nanoarrow_schema_owning_xptr();
-    auto sch = nanoarrow_output_schema_from_xptr(schemaxp);
-    exitIfError(ArrowSchemaInitFromType(sch, NANOARROW_TYPE_STRUCT), "Bad schema init");
-    exitIfError(ArrowSchemaSetName(sch, ""), "Bad schema name");
-    exitIfError(ArrowSchemaAllocateChildren(sch, ncol), "Bad schema children alloc");
+  auto schemaxp = nanoarrow_schema_owning_xptr();
+  auto sch = nanoarrow_output_schema_from_xptr(schemaxp);
+  exitIfError(ArrowSchemaInitFromType(sch, NANOARROW_TYPE_STRUCT),
+              "Bad schema init");
+  exitIfError(ArrowSchemaSetName(sch, ""), "Bad schema name");
+  exitIfError(ArrowSchemaAllocateChildren(sch, ncol),
+              "Bad schema children alloc");
 
-    auto arrayxp = nanoarrow_array_owning_xptr();
-    auto arr = nanoarrow_output_array_from_xptr(arrayxp);
-    exitIfError(ArrowArrayInitFromType(arr, NANOARROW_TYPE_STRUCT), "Bad array init");
-    exitIfError(ArrowArrayAllocateChildren(arr, ncol), "Bad array children alloc");
+  auto arrayxp = nanoarrow_array_owning_xptr();
+  auto arr = nanoarrow_output_array_from_xptr(arrayxp);
+  exitIfError(ArrowArrayInitFromType(arr, NANOARROW_TYPE_STRUCT),
+              "Bad array init");
+  exitIfError(ArrowArrayAllocateChildren(arr, ncol),
+              "Bad array children alloc");
 
-    arr->length = 0;
-    for (size_t i=0; i<ncol; i++) {
-        spdl::debug(tfm::format("[libtiledb_query_export_arrow_table] Accessing %s at %d", names[i], i));
+  arr->length = 0;
+  for (size_t i = 0; i < ncol; i++) {
+    spdl::debug(
+        tfm::format("[libtiledb_query_export_arrow_table] Accessing %s at %d",
+                    names[i], i));
 
-        adapter.export_buffer(names[i].c_str(), arr->children[i], sch->children[i]);
+    adapter.export_buffer(names[i].c_str(), arr->children[i], sch->children[i]);
 
-        if (arr->children[i]->length > arr->length) {
-            spdl::info(tfm::format("[libtiledb_query_export_arrow_table] Setting array length to %d", arr->children[i]->length));
-            arr->length = arr->children[i]->length;
-        }
-        spdl::info(tfm::format("[libtiledb_query_export_arrow_table] Seeing %s (%s) at length %d null_count %d buffers %d",
-                               names[i], sch->children[i]->format, arr->children[i]->length, arr->children[i]->null_count, arr->children[i]->n_buffers));
+    if (arr->children[i]->length > arr->length) {
+      spdl::info(tfm::format(
+          "[libtiledb_query_export_arrow_table] Setting array length to %d",
+          arr->children[i]->length));
+      arr->length = arr->children[i]->length;
     }
+    spdl::info(tfm::format(
+        "[libtiledb_query_export_arrow_table] Seeing %s (%s) at length %d "
+        "null_count %d buffers %d",
+        names[i], sch->children[i]->format, arr->children[i]->length,
+        arr->children[i]->null_count, arr->children[i]->n_buffers));
+  }
 
-    // Nanoarrow special: stick schema into xptr tag to return single SEXP
-    _array_xptr_set_schema(arrayxp, schemaxp); 			// embed schema in array
-    return arrayxp;
+  // Nanoarrow special: stick schema into xptr tag to return single SEXP
+  _array_xptr_set_schema(arrayxp, schemaxp); // embed schema in array
+  return arrayxp;
 }
 
-
-inline void exitIfError(const ArrowErrorCode ec, const std::string& msg) {
-    if (ec != NANOARROW_OK) Rcpp::stop(msg);
+inline void exitIfError(const ArrowErrorCode ec, const std::string &msg) {
+  if (ec != NANOARROW_OK)
+    Rcpp::stop(msg);
 }
 
 // Attaches a schema to an array external pointer. The nanoarrow R package
 // attempts to do this whenever possible to avoid misinterpreting arrays.
 void _array_xptr_set_schema(SEXP array_xptr, SEXP schema_xptr) {
-    R_SetExternalPtrTag(array_xptr, schema_xptr);
+  R_SetExternalPtrTag(array_xptr, schema_xptr);
 }
 // Reverse: peel the schema out of the array via the XPtr tag
 SEXP _array_xptr_get_schema(SEXP array_xptr) {
-    return R_ExternalPtrTag(array_xptr);
+  return R_ExternalPtrTag(array_xptr);
 }
 
 //  was: Rcpp::List
@@ -135,121 +146,139 @@ SEXP _array_xptr_get_schema(SEXP array_xptr) {
 nanoarrowS3 libtiledb_to_arrow(Rcpp::XPtr<tiledb::ArrayBuffers> ab,
                                Rcpp::XPtr<tiledb::Query> qry,
                                Rcpp::List dicts) {
-    check_xptr_tag<tiledb::ArrayBuffers>(ab);
-    check_xptr_tag<tiledb::Query>(qry);
-    std::vector<std::string> names = ab->names();
-    auto ncol = names.size();
-    std::vector<std::string> dictnames = dicts.names();
+  check_xptr_tag<tiledb::ArrayBuffers>(ab);
+  check_xptr_tag<tiledb::Query>(qry);
+  std::vector<std::string> names = ab->names();
+  auto ncol = names.size();
+  std::vector<std::string> dictnames = dicts.names();
 
-    // Schema first
-    auto schemaxp = nanoarrow_schema_owning_xptr();
-    auto sch = nanoarrow_output_schema_from_xptr(schemaxp);
-    exitIfError(ArrowSchemaInitFromType(sch, NANOARROW_TYPE_STRUCT), "Bad schema init");
-    exitIfError(ArrowSchemaSetName(sch, ""), "Bad schema name");
-    exitIfError(ArrowSchemaAllocateChildren(sch, ncol), "Bad schema children alloc");
+  // Schema first
+  auto schemaxp = nanoarrow_schema_owning_xptr();
+  auto sch = nanoarrow_output_schema_from_xptr(schemaxp);
+  exitIfError(ArrowSchemaInitFromType(sch, NANOARROW_TYPE_STRUCT),
+              "Bad schema init");
+  exitIfError(ArrowSchemaSetName(sch, ""), "Bad schema name");
+  exitIfError(ArrowSchemaAllocateChildren(sch, ncol),
+              "Bad schema children alloc");
 
-    // Array second
-    auto arrayxp = nanoarrow_array_owning_xptr();
-    auto arr = nanoarrow_output_array_from_xptr(arrayxp);
-    exitIfError(ArrowArrayInitFromType(arr, NANOARROW_TYPE_STRUCT), "Bad array init");
-    exitIfError(ArrowArrayAllocateChildren(arr, ncol), "Bad array children alloc");
+  // Array second
+  auto arrayxp = nanoarrow_array_owning_xptr();
+  auto arr = nanoarrow_output_array_from_xptr(arrayxp);
+  exitIfError(ArrowArrayInitFromType(arr, NANOARROW_TYPE_STRUCT),
+              "Bad array init");
+  exitIfError(ArrowArrayAllocateChildren(arr, ncol),
+              "Bad array children alloc");
 
-    struct ArrowError ec;
+  struct ArrowError ec;
 
-    arr->length = 0;
-    for (size_t i=0; i<ncol; i++) {
-        bool is_factor = dicts[i] != R_NilValue;
-        bool is_ordered = false;
-        if (is_factor) {
-            Rcpp::CharacterVector cvec = dicts[i];
-            is_ordered = cvec.attr("ordered");
-        }
-        auto buf = ab->at(names[i]);        // buf is a shared_ptr to ColumnBuffer
-        buf->update_size(*qry);
-        spdl::info(tfm::format("[libtiledb_to_arrow] Accessing %s (%s:%s) at %d use_count=%d sz %d nm %s tp %d",
-                               names[i], dictnames[i], (is_factor ? (is_ordered ? "<ordered>" : "<factor>") : ""), i,
-                               buf.use_count(), buf->size(), buf->name(), buf->type()));
-
-        // this is pair of array and schema pointer
-        auto pp = tiledb::ArrowAdapter::to_arrow(buf);
-
-        spdl::info(tfm::format("[libtiledb_to_arrow] Incoming name %s length %d",
-                               std::string(pp.second->name), pp.first->length));
-        ArrowArrayMove(pp.first.get(),   arr->children[i]);
-        ArrowSchemaMove(pp.second.get(), sch->children[i]);
-
-        if (is_factor) {        // create an arrow array of type string with the labels
-            // this could be rewritten if we generalized ColumnBuffer to allow passing of strings
-            std::vector<std::string> svec = Rcpp::as<std::vector<std::string>>(dicts[i]);
-            auto darrxp = nanoarrow_array_owning_xptr();
-            auto darr = nanoarrow_output_array_from_xptr(darrxp);
-            exitIfError(ArrowArrayInitFromType(darr, NANOARROW_TYPE_STRING), "Bad string array init");
-            exitIfError(ArrowArrayStartAppending(darr), "Bad string array append init");
-            auto dschxp = nanoarrow_schema_owning_xptr();
-            auto dsch = nanoarrow_output_schema_from_xptr(dschxp);
-            exitIfError(ArrowSchemaInitFromType(dsch, NANOARROW_TYPE_STRING), "Bad string schema init");
-            exitIfError(ArrowSchemaSetName(dsch, ""), "Bad string schema name");
-            if (is_ordered) {
-                dsch->flags |= ARROW_FLAG_DICTIONARY_ORDERED; // this line appears ignore
-                sch->children[i]->flags |= ARROW_FLAG_DICTIONARY_ORDERED; // this one matters more
-            }
-            for (auto str: svec) {
-                ArrowStringView asv = {str.data(), static_cast<int64_t>(str.size())};
-                exitIfError(ArrowArrayAppendString(darr, asv), "Bad string append");
-            }
-            if (NANOARROW_OK != ArrowArrayFinishBuildingDefault(darr, &ec))
-                Rcpp::stop(ec.message);
-
-            spdl::debug(tfm::format("[libtiledb_to_arrow] dict %s fmt %s -- len %d nbuf %d",
-                                    names[i], dsch->format, darr->length, darr->n_buffers));
-            sch->children[i]->dictionary = dsch;
-            arr->children[i]->dictionary = darr;
-        }
-
-        if (pp.first->length > arr->length) {
-           spdl::debug(tfm::format("[libtiledb_to_arrow] Setting array length to %d", pp.first->length));
-           arr->length = pp.first->length;
-        }
+  arr->length = 0;
+  for (size_t i = 0; i < ncol; i++) {
+    bool is_factor = dicts[i] != R_NilValue;
+    bool is_ordered = false;
+    if (is_factor) {
+      Rcpp::CharacterVector cvec = dicts[i];
+      is_ordered = cvec.attr("ordered");
     }
-    spdl::info("[libtiledb_to_arrow] After children loop");
-    //if (NANOARROW_OK != ArrowArrayFinishBuildingDefault(arr, &ec))
-    //    Rcpp::stop(ec.message);
-    spdl::info("[libtiledb_to_arrow] ArrowArrayFinishBuildingDefault");
+    auto buf = ab->at(names[i]); // buf is a shared_ptr to ColumnBuffer
+    buf->update_size(*qry);
+    spdl::info(
+        tfm::format("[libtiledb_to_arrow] Accessing %s (%s:%s) at %d "
+                    "use_count=%d sz %d nm %s tp %d",
+                    names[i], dictnames[i],
+                    (is_factor ? (is_ordered ? "<ordered>" : "<factor>") : ""),
+                    i, buf.use_count(), buf->size(), buf->name(), buf->type()));
 
-    // Nanoarrow special: stick schema into xptr tag to return single SEXP
-    _array_xptr_set_schema(arrayxp, schemaxp); 			// embed schema in array
+    // this is pair of array and schema pointer
+    auto pp = tiledb::ArrowAdapter::to_arrow(buf);
 
-    spdl::trace("[libtiledb_to_arrow] returning from libtiledb_to_arrow");
-    return arrayxp;
+    spdl::info(tfm::format("[libtiledb_to_arrow] Incoming name %s length %d",
+                           std::string(pp.second->name), pp.first->length));
+    ArrowArrayMove(pp.first.get(), arr->children[i]);
+    ArrowSchemaMove(pp.second.get(), sch->children[i]);
+
+    if (is_factor) { // create an arrow array of type string with the labels
+      // this could be rewritten if we generalized ColumnBuffer to allow passing
+      // of strings
+      std::vector<std::string> svec =
+          Rcpp::as<std::vector<std::string>>(dicts[i]);
+      auto darrxp = nanoarrow_array_owning_xptr();
+      auto darr = nanoarrow_output_array_from_xptr(darrxp);
+      exitIfError(ArrowArrayInitFromType(darr, NANOARROW_TYPE_STRING),
+                  "Bad string array init");
+      exitIfError(ArrowArrayStartAppending(darr),
+                  "Bad string array append init");
+      auto dschxp = nanoarrow_schema_owning_xptr();
+      auto dsch = nanoarrow_output_schema_from_xptr(dschxp);
+      exitIfError(ArrowSchemaInitFromType(dsch, NANOARROW_TYPE_STRING),
+                  "Bad string schema init");
+      exitIfError(ArrowSchemaSetName(dsch, ""), "Bad string schema name");
+      if (is_ordered) {
+        dsch->flags |=
+            ARROW_FLAG_DICTIONARY_ORDERED; // this line appears ignore
+        sch->children[i]->flags |=
+            ARROW_FLAG_DICTIONARY_ORDERED; // this one matters more
+      }
+      for (auto str : svec) {
+        ArrowStringView asv = {str.data(), static_cast<int64_t>(str.size())};
+        exitIfError(ArrowArrayAppendString(darr, asv), "Bad string append");
+      }
+      if (NANOARROW_OK != ArrowArrayFinishBuildingDefault(darr, &ec))
+        Rcpp::stop(ec.message);
+
+      spdl::debug(
+          tfm::format("[libtiledb_to_arrow] dict %s fmt %s -- len %d nbuf %d",
+                      names[i], dsch->format, darr->length, darr->n_buffers));
+      sch->children[i]->dictionary = dsch;
+      arr->children[i]->dictionary = darr;
+    }
+
+    if (pp.first->length > arr->length) {
+      spdl::debug(tfm::format("[libtiledb_to_arrow] Setting array length to %d",
+                              pp.first->length));
+      arr->length = pp.first->length;
+    }
+  }
+  spdl::info("[libtiledb_to_arrow] After children loop");
+  // if (NANOARROW_OK != ArrowArrayFinishBuildingDefault(arr, &ec))
+  //     Rcpp::stop(ec.message);
+  spdl::info("[libtiledb_to_arrow] ArrowArrayFinishBuildingDefault");
+
+  // Nanoarrow special: stick schema into xptr tag to return single SEXP
+  _array_xptr_set_schema(arrayxp, schemaxp); // embed schema in array
+
+  spdl::trace("[libtiledb_to_arrow] returning from libtiledb_to_arrow");
+  return arrayxp;
 }
 
-
 // [[Rcpp::export]]
-Rcpp::XPtr<tiledb::ArrayBuffers> libtiledb_allocate_column_buffers(Rcpp::XPtr<tiledb::Context> ctx,
-                                                                   Rcpp::XPtr<tiledb::Query> qry,
-                                                                   std::string uri,
-                                                                   std::vector<std::string> names,
-                                                                   const size_t memory_budget) {
-    check_xptr_tag<tiledb::Context>(ctx);
-    check_xptr_tag<tiledb::Query>(qry);
-    // allocate the ArrayBuffers object we will fill with ColumnBuffer objects and return
-    auto abp = new tiledb::ArrayBuffers;
-    // get the array and its pointer
-    auto arrsp = std::make_shared<tiledb::Array>(*ctx.get(), uri, TILEDB_READ);
-    for (auto name: names) {
-        // returns a shared pointer to new column buffer for 'name'
-        spdl::debug(tfm::format("[libtiledb_alloocate_column_buffers] creating %s", name));
-        auto cbsp = tiledb::ColumnBuffer::create(arrsp, name, memory_budget, *ctx.get());
-        abp->emplace(name, cbsp);
-        cbsp->attach(*qry.get());
-        spdl::debug(tfm::format("[libtiledb_alloocate_column_buffers] emplaced %s cnt %d membudget %d",
-                                name, cbsp.use_count(), memory_budget));
-    }
-    return make_xptr<tiledb::ArrayBuffers>(abp);
+Rcpp::XPtr<tiledb::ArrayBuffers> libtiledb_allocate_column_buffers(
+    Rcpp::XPtr<tiledb::Context> ctx, Rcpp::XPtr<tiledb::Query> qry,
+    std::string uri, std::vector<std::string> names,
+    const size_t memory_budget) {
+  check_xptr_tag<tiledb::Context>(ctx);
+  check_xptr_tag<tiledb::Query>(qry);
+  // allocate the ArrayBuffers object we will fill with ColumnBuffer objects and
+  // return
+  auto abp = new tiledb::ArrayBuffers;
+  // get the array and its pointer
+  auto arrsp = std::make_shared<tiledb::Array>(*ctx.get(), uri, TILEDB_READ);
+  for (auto name : names) {
+    // returns a shared pointer to new column buffer for 'name'
+    spdl::debug(
+        tfm::format("[libtiledb_alloocate_column_buffers] creating %s", name));
+    auto cbsp =
+        tiledb::ColumnBuffer::create(arrsp, name, memory_budget, *ctx.get());
+    abp->emplace(name, cbsp);
+    cbsp->attach(*qry.get());
+    spdl::debug(tfm::format(
+        "[libtiledb_alloocate_column_buffers] emplaced %s cnt %d membudget %d",
+        name, cbsp.use_count(), memory_budget));
+  }
+  return make_xptr<tiledb::ArrayBuffers>(abp);
 }
 
 // [[Rcpp::export]]
 Rcpp::List nanoarrow2list(nanoarrowS3 naarrptr) {
-    auto schptr = _array_xptr_get_schema(naarrptr);
-    return Rcpp::List::create(naarrptr, schptr);
+  auto schptr = _array_xptr_get_schema(naarrptr);
+  return Rcpp::List::create(naarrptr, schptr);
 }

--- a/src/batched.cpp
+++ b/src/batched.cpp
@@ -4,17 +4,18 @@
 
 class QueryWrapper {
 public:
-    QueryWrapper(SEXP qp): qryptr(qp), init(true) {};
-    inline bool is_intialized(void) { return qryptr != R_NilValue && init; }
+  QueryWrapper(SEXP qp) : qryptr(qp), init(true){};
+  inline bool is_intialized(void) { return qryptr != R_NilValue && init; }
+
 private:
-    SEXP qryptr = R_NilValue;
-    bool init = false;
+  SEXP qryptr = R_NilValue;
+  bool init = false;
 };
 
 // [[Rcpp::export]]
 SEXP makeQueryWrapper(SEXP qp) {
-    //alternate form: Rcpp::XPtr<QueryWrapper> makeQueryWrapper(SEXP qp) {
-    QueryWrapper* qwp = new QueryWrapper(qp);
-    Rcpp::XPtr<QueryWrapper> ptr(qwp);
-    return ptr;
+  // alternate form: Rcpp::XPtr<QueryWrapper> makeQueryWrapper(SEXP qp) {
+  QueryWrapper *qwp = new QueryWrapper(qp);
+  Rcpp::XPtr<QueryWrapper> ptr(qwp);
+  return ptr;
 }

--- a/src/column_buffer.cpp
+++ b/src/column_buffer.cpp
@@ -37,9 +37,10 @@
 // surface of code covered by this definition
 #define TILEDB_DEPRECATED
 
+#include "tinyspdl.h"
+
 #include "column_buffer.h"
 #include "tiledb_version.h"
-#include "tinyspdl.h"
 #if TILEDB_VERSION >= TileDB_Version(2, 17, 0)
 #include <tiledb/array_experimental.h>
 #include <tiledb/attribute_experimental.h>

--- a/src/column_buffer.cpp
+++ b/src/column_buffer.cpp
@@ -30,16 +30,17 @@
  * This file defines the a ColumBuffer class.
  */
 
-// compilation is noisy with the deprecation, we cannot use -Wno-deprecated-declarations
-// as CRAN flags it as a non-portable compiler option, and we cannot (easily) remove the
-// code (yet) so silencing it is for now, and regrouping the affected routines here which
-// also minimizes the surface of code covered by this definition
+// compilation is noisy with the deprecation, we cannot use
+// -Wno-deprecated-declarations as CRAN flags it as a non-portable compiler
+// option, and we cannot (easily) remove the code (yet) so silencing it is for
+// now, and regrouping the affected routines here which also minimizes the
+// surface of code covered by this definition
 #define TILEDB_DEPRECATED
 
-#include "tinyspdl.h"
 #include "column_buffer.h"
 #include "tiledb_version.h"
-#if TILEDB_VERSION >= TileDB_Version(2,17,0)
+#include "tinyspdl.h"
+#if TILEDB_VERSION >= TileDB_Version(2, 17, 0)
 #include <tiledb/array_experimental.h>
 #include <tiledb/attribute_experimental.h>
 #include <tiledb/enumeration_experimental.h>
@@ -57,208 +58,194 @@ std::shared_ptr<ColumnBuffer> ColumnBuffer::create(std::shared_ptr<Array> array,
                                                    size_t memory_budget,
                                                    tiledb::Context ctx) {
 
-    auto name_str = std::string(name);  // string for TileDB API
-    auto schema = array->schema();
+  auto name_str = std::string(name); // string for TileDB API
+  auto schema = array->schema();
 
-    if (schema.has_attribute(name_str)) {
-        auto attr = schema.attribute(name_str);
-        bool is_var = attr.cell_val_num() == TILEDB_VAR_NUM;
-        bool is_nullable = attr.nullable();
+  if (schema.has_attribute(name_str)) {
+    auto attr = schema.attribute(name_str);
+    bool is_var = attr.cell_val_num() == TILEDB_VAR_NUM;
+    bool is_nullable = attr.nullable();
 
-        if (!is_var && attr.cell_val_num() != 1) {
-            Rcpp::stop(std::string("[ColumnBuffer] Values per cell > 1 is not supported: ") +
-                       name_str);
-        }
-
-#if TILEDB_VERSION >= TileDB_Version(2,17,0)
-        auto enum_name = tiledb::AttributeExperimental::get_enumeration_name(ctx, attr);
-        if (enum_name != std::nullopt) {
-            spdl::trace(tfm::format("[ColumnBuffer::create] Seeing enumeration %s via %s",
-                                    enum_name.value(), name));
-            auto enmr = tiledb::ArrayExperimental::get_enumeration(ctx, *array, enum_name.value());
-            std::vector<std::string> enmr_vec = enmr.as_vector<std::string>();
-            return ColumnBuffer::alloc(array, attr.name(), attr.type(), is_var, is_nullable,
-                                       memory_budget, enmr_vec);
-        } else {
-            return ColumnBuffer::alloc(array, attr.name(), attr.type(), is_var, is_nullable,
-                                       memory_budget, std::nullopt);
-        }
-#else
-            return ColumnBuffer::alloc(array, attr.name(), attr.type(), is_var, is_nullable,
-                                       memory_budget, std::nullopt);
-#endif
-
-    } else if (schema.domain().has_dimension(name_str)) {
-        auto dim = schema.domain().dimension(name_str);
-        bool is_var = dim.cell_val_num() == TILEDB_VAR_NUM ||
-                      dim.type() == TILEDB_STRING_ASCII ||
-                      dim.type() == TILEDB_STRING_UTF8;
-
-        if (!is_var && dim.cell_val_num() != 1) {
-            Rcpp::stop(std::string("[ColumnBuffer] Values per cell > 1 is not supported: ") +
-                       name_str);
-        }
-
-        return ColumnBuffer::alloc(array, dim.name(), dim.type(), is_var, false,
-                                   memory_budget, std::nullopt);
-
+    if (!is_var && attr.cell_val_num() != 1) {
+      Rcpp::stop(
+          std::string("[ColumnBuffer] Values per cell > 1 is not supported: ") +
+          name_str);
     }
 
-    Rcpp::stop(std::string("[ColumnBuffer] Column name not found: ") + name_str);
+#if TILEDB_VERSION >= TileDB_Version(2, 17, 0)
+    auto enum_name =
+        tiledb::AttributeExperimental::get_enumeration_name(ctx, attr);
+    if (enum_name != std::nullopt) {
+      spdl::trace(
+          tfm::format("[ColumnBuffer::create] Seeing enumeration %s via %s",
+                      enum_name.value(), name));
+      auto enmr = tiledb::ArrayExperimental::get_enumeration(ctx, *array,
+                                                             enum_name.value());
+      std::vector<std::string> enmr_vec = enmr.as_vector<std::string>();
+      return ColumnBuffer::alloc(array, attr.name(), attr.type(), is_var,
+                                 is_nullable, memory_budget, enmr_vec);
+    } else {
+      return ColumnBuffer::alloc(array, attr.name(), attr.type(), is_var,
+                                 is_nullable, memory_budget, std::nullopt);
+    }
+#else
+    return ColumnBuffer::alloc(array, attr.name(), attr.type(), is_var,
+                               is_nullable, memory_budget, std::nullopt);
+#endif
+
+  } else if (schema.domain().has_dimension(name_str)) {
+    auto dim = schema.domain().dimension(name_str);
+    bool is_var = dim.cell_val_num() == TILEDB_VAR_NUM ||
+                  dim.type() == TILEDB_STRING_ASCII ||
+                  dim.type() == TILEDB_STRING_UTF8;
+
+    if (!is_var && dim.cell_val_num() != 1) {
+      Rcpp::stop(
+          std::string("[ColumnBuffer] Values per cell > 1 is not supported: ") +
+          name_str);
+    }
+
+    return ColumnBuffer::alloc(array, dim.name(), dim.type(), is_var, false,
+                               memory_budget, std::nullopt);
+  }
+
+  Rcpp::stop(std::string("[ColumnBuffer] Column name not found: ") + name_str);
 }
 
 void ColumnBuffer::to_bitmap(tcb::span<uint8_t> bytemap) {
-    int i_dst = 0;
-    for (unsigned int i_src = 0; i_src < bytemap.size(); i_src++) {
-        // Overwrite every 8 bytes with a one-byte bitmap
-        if (i_src % 8 == 0) {
-            // Each bit in the bitmap corresponds to one byte in the bytemap
-            // Note: the bitmap must be byte-aligned (8 bits)
-            int bitmap = 0;
-            for (unsigned int i = i_src; i < i_src + 8 && i < bytemap.size();
-                 i++) {
-                bitmap |= bytemap[i] << (i % 8);
-            }
-            bytemap[i_dst++] = bitmap;
-        }
+  int i_dst = 0;
+  for (unsigned int i_src = 0; i_src < bytemap.size(); i_src++) {
+    // Overwrite every 8 bytes with a one-byte bitmap
+    if (i_src % 8 == 0) {
+      // Each bit in the bitmap corresponds to one byte in the bytemap
+      // Note: the bitmap must be byte-aligned (8 bits)
+      int bitmap = 0;
+      for (unsigned int i = i_src; i < i_src + 8 && i < bytemap.size(); i++) {
+        bitmap |= bytemap[i] << (i % 8);
+      }
+      bytemap[i_dst++] = bitmap;
     }
+  }
 }
 
 void ColumnBuffer::date_cast_to_32bit(tcb::span<int64_t> data) {
-    size_t n = data.size();
-    std::vector<int32_t> vec(n);
-    for (size_t i=0; i<n; i++) {
-        vec[i] = static_cast<int32_t>(data[i]);
-    }
-    std::memcpy(data.data(), vec.data(), sizeof(int32_t) * n);
+  size_t n = data.size();
+  std::vector<int32_t> vec(n);
+  for (size_t i = 0; i < n; i++) {
+    vec[i] = static_cast<int32_t>(data[i]);
+  }
+  std::memcpy(data.data(), vec.data(), sizeof(int32_t) * n);
 }
-
 
 //===================================================================
 //= public non-static
 //===================================================================
 
-ColumnBuffer::ColumnBuffer(
-    std::string_view name,
-    tiledb_datatype_t type,
-    size_t num_cells,
-    size_t num_bytes,
-    bool is_var,
-    bool is_nullable)
-    //std::optional<std::vector<std::string>> enumeration)
-    : name_(name)
-    , type_(type)
-    , type_size_(tiledb::impl::type_size(type))
-    , num_cells_(0)
-    , is_var_(is_var)
-    , is_nullable_(is_nullable)
-    //, has_enumeration_(false)
+ColumnBuffer::ColumnBuffer(std::string_view name, tiledb_datatype_t type,
+                           size_t num_cells, size_t num_bytes, bool is_var,
+                           bool is_nullable)
+    // std::optional<std::vector<std::string>> enumeration)
+    : name_(name), type_(type), type_size_(tiledb::impl::type_size(type)),
+      num_cells_(0), is_var_(is_var), is_nullable_(is_nullable)
+//, has_enumeration_(false)
 {
-    spdl::debug(tfm::format(
-        "[ColumnBuffer] '%s' %d cells %d bytes is_var=%s is_nullable=%s",
-        name,
-        num_cells,
-        num_bytes,
-        (is_var_ ? "true" : "false"),
-        (is_nullable_ ? "true" : "false")));
-    // Call reserve() to allocate memory without initializing the contents.
-    // This reduce the time to allocate the buffer and reduces the
-    // resident memory footprint of the buffer.
-    data_.resize(num_bytes);
-    if (is_var_) {
-        offsets_.resize(num_cells + 1);  // extra offset for arrow
-    }
-    if (is_nullable_) {
-        validity_.resize(num_cells);
-    }
+  spdl::debug(tfm::format(
+      "[ColumnBuffer] '%s' %d cells %d bytes is_var=%s is_nullable=%s", name,
+      num_cells, num_bytes, (is_var_ ? "true" : "false"),
+      (is_nullable_ ? "true" : "false")));
+  // Call reserve() to allocate memory without initializing the contents.
+  // This reduce the time to allocate the buffer and reduces the
+  // resident memory footprint of the buffer.
+  data_.resize(num_bytes);
+  if (is_var_) {
+    offsets_.resize(num_cells + 1); // extra offset for arrow
+  }
+  if (is_nullable_) {
+    validity_.resize(num_cells);
+  }
 
-    // Store the enumeration (and we need a setter as this function is static)
-    // if (enumeration != std::nullopt) {
-    //     has_enumeration_ = true;
-    //     enmr_ = std::move(enumeration.value());
-    // }
+  // Store the enumeration (and we need a setter as this function is static)
+  // if (enumeration != std::nullopt) {
+  //     has_enumeration_ = true;
+  //     enmr_ = std::move(enumeration.value());
+  // }
 }
 
-void ColumnBuffer::attach(Query& query) {
-    // We cannot use:
-    // `set_data_buffer(const std::string& name, std::vector<T>& buf)`
-    // because data_ is allocated with reserve() and data_.size()
-    // does not represent the actual size of the buffer.
-    query.set_data_buffer(
-        name_, (void*)data_.data(), data_.capacity() / type_size_);
-    if (is_var_) {
-        // Remove one offset for TileDB, which checks that the
-        // offsets and validity buffers are the same size
-        query.set_offsets_buffer(
-            name_, offsets_.data(), offsets_.capacity() - 1);
-    }
-    if (is_nullable_) {
-        query.set_validity_buffer(
-            name_, validity_.data(), validity_.capacity());
-    }
+void ColumnBuffer::attach(Query &query) {
+  // We cannot use:
+  // `set_data_buffer(const std::string& name, std::vector<T>& buf)`
+  // because data_ is allocated with reserve() and data_.size()
+  // does not represent the actual size of the buffer.
+  query.set_data_buffer(name_, (void *)data_.data(),
+                        data_.capacity() / type_size_);
+  if (is_var_) {
+    // Remove one offset for TileDB, which checks that the
+    // offsets and validity buffers are the same size
+    query.set_offsets_buffer(name_, offsets_.data(), offsets_.capacity() - 1);
+  }
+  if (is_nullable_) {
+    query.set_validity_buffer(name_, validity_.data(), validity_.capacity());
+  }
 }
 
-size_t ColumnBuffer::update_size(const Query& query) {
-    auto [num_offsets, num_elements] = query.result_buffer_elements()[name_];
+size_t ColumnBuffer::update_size(const Query &query) {
+  auto [num_offsets, num_elements] = query.result_buffer_elements()[name_];
 
-    if (is_var()) {
-        num_cells_ = num_offsets;
-        // Set the extra offset value for arrow.
-        offsets_[num_offsets] = num_elements;
-    } else {
-        num_cells_ = num_elements;
-    }
+  if (is_var()) {
+    num_cells_ = num_offsets;
+    // Set the extra offset value for arrow.
+    offsets_[num_offsets] = num_elements;
+  } else {
+    num_cells_ = num_elements;
+  }
 
-    return num_cells_;
+  return num_cells_;
 }
 
 std::vector<std::string> ColumnBuffer::strings() {
-    std::vector<std::string> result;
+  std::vector<std::string> result;
 
-    for (size_t i = 0; i < num_cells_; i++) {
-        result.emplace_back(std::string(string_view(i)));
-    }
+  for (size_t i = 0; i < num_cells_; i++) {
+    result.emplace_back(std::string(string_view(i)));
+  }
 
-    return result;
+  return result;
 }
 
 std::string_view ColumnBuffer::string_view(uint64_t index) {
-    auto start = offsets_[index];
-    auto len = offsets_[index + 1] - start;
-    return std::string_view((char*)(data_.data() + start), len);
+  auto start = offsets_[index];
+  auto len = offsets_[index + 1] - start;
+  return std::string_view((char *)(data_.data() + start), len);
 }
 
 //===================================================================
 //= private static
 //===================================================================
 
-std::shared_ptr<ColumnBuffer> ColumnBuffer::alloc(
-    std::shared_ptr<Array> array,
-    std::string_view name,
-    tiledb_datatype_t type,
-    bool is_var,
-    bool is_nullable,
-    size_t memory_budget,
-    std::optional<std::vector<std::string>> enumeration) {
+std::shared_ptr<ColumnBuffer>
+ColumnBuffer::alloc(std::shared_ptr<Array> array, std::string_view name,
+                    tiledb_datatype_t type, bool is_var, bool is_nullable,
+                    size_t memory_budget,
+                    std::optional<std::vector<std::string>> enumeration) {
 
-    auto num_bytes = memory_budget;
-    spdl::debug(tfm::format("[ColumnBuffer::alloc] num_bytes = %d", num_bytes));
+  auto num_bytes = memory_budget;
+  spdl::debug(tfm::format("[ColumnBuffer::alloc] num_bytes = %d", num_bytes));
 
-    bool is_dense = array->schema().array_type() == TILEDB_DENSE;
-    if (is_dense) {
-        // TODO: Handle dense arrays similar to tiledb python module
-    }
+  bool is_dense = array->schema().array_type() == TILEDB_DENSE;
+  if (is_dense) {
+    // TODO: Handle dense arrays similar to tiledb python module
+  }
 
-    // For variable length column types, allocate an extra num_bytes to hold
-    //   offset values. The number of cells is the set by the size of the
-    //   offset type.
-    // For non-variable length column types, the number of cells is computed
-    //   from the type size.
-    size_t num_cells = is_var ? num_bytes / sizeof(uint64_t) :
-                                num_bytes / tiledb::impl::type_size(type);
+  // For variable length column types, allocate an extra num_bytes to hold
+  //   offset values. The number of cells is the set by the size of the
+  //   offset type.
+  // For non-variable length column types, the number of cells is computed
+  //   from the type size.
+  size_t num_cells = is_var ? num_bytes / sizeof(uint64_t)
+                            : num_bytes / tiledb::impl::type_size(type);
 
-    return std::make_shared<ColumnBuffer>(
-         name, type, num_cells, num_bytes, is_var, is_nullable); //, enumeration);
+  return std::make_shared<ColumnBuffer>(name, type, num_cells, num_bytes,
+                                        is_var, is_nullable); //, enumeration);
 }
 
-}  // namespace tiledb
+} // namespace tiledb

--- a/src/deprecation.cpp
+++ b/src/deprecation.cpp
@@ -3,27 +3,28 @@
 //  Copyright (c) 2017-2024 TileDB Inc.
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
-//  of this software and associated documentation files (the "Software"), to deal
-//  in the Software without restriction, including without limitation the rights
-//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-//  copies of the Software, and to permit persons to whom the Software is
+//  of this software and associated documentation files (the "Software"), to
+//  deal in the Software without restriction, including without limitation the
+//  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the Software is
 //  furnished to do so, subject to the following conditions:
 //
-//  The above copyright notice and this permission notice shall be included in all
-//  copies or substantial portions of the Software.
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
 //
 //  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 //  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 //  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 //  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-//  SOFTWARE.
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+//  IN THE SOFTWARE.
 
-// compilation is noisy with the deprecation, we cannot use -Wno-deprecated-declarations
-// as CRAN flags it as a non-portable compiler option, and we cannot (easily) remove the
-// code (yet) so silencing it is for now, and regrouping the affected routines here which
-// also minimizes the surface of code covered by this definition
+// compilation is noisy with the deprecation, we cannot use
+// -Wno-deprecated-declarations as CRAN flags it as a non-portable compiler
+// option, and we cannot (easily) remove the code (yet) so silencing it is for
+// now, and regrouping the affected routines here which also minimizes the
+// surface of code covered by this definition
 #define TILEDB_DEPRECATED
 
 #include "libtiledb.h"
@@ -34,36 +35,40 @@ using namespace Rcpp;
 // Deprecated in Core April 2024, removed July 2024
 // [[Rcpp::export]]
 XPtr<tiledb::Query> libtiledb_query_submit_async(XPtr<tiledb::Query> query) {
-#if TILEDB_VERSION < TileDB_Version(2,26,0)
-    check_xptr_tag<tiledb::Query>(query);
-    spdl::trace("[libtiledb_query_submit_async]");
-    query->submit_async();
+#if TILEDB_VERSION < TileDB_Version(2, 26, 0)
+  check_xptr_tag<tiledb::Query>(query);
+  spdl::trace("[libtiledb_query_submit_async]");
+  query->submit_async();
 #else
-    Rcpp::stop("This function was deprecated first, and is removed as of TileDB 2.26.0");
+  Rcpp::stop(
+      "This function was deprecated first, and is removed as of TileDB 2.26.0");
 #endif
-    return query;
+  return query;
 }
 
 // Helper for next function
-tiledb_encryption_type_t _string_to_tiledb_encryption_type_t(std::string encstr) {
-    tiledb_encryption_type_t enc;
-    int rc = tiledb_encryption_type_from_str(encstr.c_str(), &enc);
-    if (rc == TILEDB_OK)
-        return enc;
-    Rcpp::stop("Unknow TileDB encryption type '%s'", encstr.c_str());
+tiledb_encryption_type_t
+_string_to_tiledb_encryption_type_t(std::string encstr) {
+  tiledb_encryption_type_t enc;
+  int rc = tiledb_encryption_type_from_str(encstr.c_str(), &enc);
+  if (rc == TILEDB_OK)
+    return enc;
+  Rcpp::stop("Unknow TileDB encryption type '%s'", encstr.c_str());
 }
 
 // Deprecated in Core April 2024, removed July 2024
 // [[Rcpp::export]]
-std::string libtiledb_array_create_with_key(std::string uri, XPtr<tiledb::ArraySchema> schema,
+std::string libtiledb_array_create_with_key(std::string uri,
+                                            XPtr<tiledb::ArraySchema> schema,
                                             std::string encryption_key) {
-#if TILEDB_VERSION < TileDB_Version(2,26,0)
-    check_xptr_tag<tiledb::ArraySchema>(schema);
-    tiledb::Array::create(uri, *schema.get(),
-                          _string_to_tiledb_encryption_type_t("AES_256_GCM"),
-                          encryption_key);
+#if TILEDB_VERSION < TileDB_Version(2, 26, 0)
+  check_xptr_tag<tiledb::ArraySchema>(schema);
+  tiledb::Array::create(uri, *schema.get(),
+                        _string_to_tiledb_encryption_type_t("AES_256_GCM"),
+                        encryption_key);
 #else
-    Rcpp::stop("This function was deprecated first, and is removed as of TileDB 2.26.0");
+  Rcpp::stop(
+      "This function was deprecated first, and is removed as of TileDB 2.26.0");
 #endif
-    return uri;
+  return uri;
 }

--- a/src/durations.cpp
+++ b/src/durations.cpp
@@ -1,17 +1,19 @@
+#include <RcppInt64> // for toNanotime
 #include <tiledb.h>
-#include <RcppInt64>            // for toNanotime
 
-std::vector<int64_t> dates_to_int64(Rcpp::DateVector dv, tiledb_datatype_t dtype) {
+std::vector<int64_t> dates_to_int64(Rcpp::DateVector dv,
+                                    tiledb_datatype_t dtype) {
   size_t n = dv.size();
   std::vector<int64_t> iv(n);
-  for (size_t i=0; i<n; i++) {
+  for (size_t i = 0; i < n; i++) {
     Rcpp::Date dt(dv[i]);
     switch (dtype) {
     case TILEDB_DATETIME_YEAR:
       iv[i] = static_cast<int64_t>(dt.getYear() - 1970);
       break;
     case TILEDB_DATETIME_MONTH:
-      iv[i] = static_cast<int64_t>(12*(dt.getYear() - 1970) + dt.getMonth() - 1);
+      iv[i] =
+          static_cast<int64_t>(12 * (dt.getYear() - 1970) + dt.getMonth() - 1);
       break;
     case TILEDB_DATETIME_WEEK:
       // Hinnant's Date library can do weeks but it appears to just equal days/7
@@ -21,16 +23,19 @@ std::vector<int64_t> dates_to_int64(Rcpp::DateVector dv, tiledb_datatype_t dtype
       iv[i] = static_cast<int64_t>(dt.getDate());
       break;
     default:
-      Rcpp::stop("Inapplicable conversion tiledb_datatype_t (%d) for Date to int64 conversion", dtype);
+      Rcpp::stop("Inapplicable conversion tiledb_datatype_t (%d) for Date to "
+                 "int64 conversion",
+                 dtype);
     }
   }
   return iv;
 }
 
-Rcpp::DateVector int64_to_dates(std::vector<int64_t> iv, tiledb_datatype_t dtype) {
+Rcpp::DateVector int64_to_dates(std::vector<int64_t> iv,
+                                tiledb_datatype_t dtype) {
   int n = iv.size();
   Rcpp::DateVector dv(n);
-  for (int i=0; i<n; i++) {
+  for (int i = 0; i < n; i++) {
     switch (dtype) {
     case TILEDB_DATETIME_YEAR:
       dv[i] = Date(iv[i] + 1970, 1, 1);
@@ -46,23 +51,26 @@ Rcpp::DateVector int64_to_dates(std::vector<int64_t> iv, tiledb_datatype_t dtype
       dv[i] = Date(static_cast<int>(iv[i]));
       break;
     default:
-      Rcpp::stop("Inapplicable conversion tiledb_datatype_t (%d) for int64 to Date conversion", dtype);
+      Rcpp::stop("Inapplicable conversion tiledb_datatype_t (%d) for int64 to "
+                 "Date conversion",
+                 dtype);
     }
   }
   return dv;
 }
 
-std::vector<int64_t> datetimes_to_int64(Rcpp::DatetimeVector dv, tiledb_datatype_t dtype) {
+std::vector<int64_t> datetimes_to_int64(Rcpp::DatetimeVector dv,
+                                        tiledb_datatype_t dtype) {
   size_t n = dv.size();
   std::vector<int64_t> iv(n);
-  for (size_t i=0; i<n; i++) {
+  for (size_t i = 0; i < n; i++) {
     Rcpp::Datetime dt(dv[i]);
     switch (dtype) {
     case TILEDB_DATETIME_HR:
-      iv[i] = static_cast<int64_t>(double(dt)/3600);
+      iv[i] = static_cast<int64_t>(double(dt) / 3600);
       break;
     case TILEDB_DATETIME_MIN:
-      iv[i] = static_cast<int64_t>(double(dt)/60);
+      iv[i] = static_cast<int64_t>(double(dt) / 60);
       break;
     case TILEDB_DATETIME_SEC:
       // Hinnant's Date library can do weeks but it appears to just equal days/7
@@ -75,16 +83,19 @@ std::vector<int64_t> datetimes_to_int64(Rcpp::DatetimeVector dv, tiledb_datatype
       iv[i] = static_cast<int64_t>(double(dt) * 1e6);
       break;
     default:
-      Rcpp::stop("Inapplicable conversion tiledb_datatype_t (%d) for Datetime to int64 conversion", dtype);
+      Rcpp::stop("Inapplicable conversion tiledb_datatype_t (%d) for Datetime "
+                 "to int64 conversion",
+                 dtype);
     }
   }
   return iv;
 }
 
-Rcpp::DatetimeVector int64_to_datetimes(std::vector<int64_t> iv, tiledb_datatype_t dtype) {
+Rcpp::DatetimeVector int64_to_datetimes(std::vector<int64_t> iv,
+                                        tiledb_datatype_t dtype) {
   int n = iv.size();
   Rcpp::DatetimeVector dv(n);
-  for (int i=0; i<n; i++) {
+  for (int i = 0; i < n; i++) {
     switch (dtype) {
     case TILEDB_DATETIME_HR:
       dv[i] = iv[i] * 3600;
@@ -102,17 +113,20 @@ Rcpp::DatetimeVector int64_to_datetimes(std::vector<int64_t> iv, tiledb_datatype
       dv[i] = iv[i] * 1e-6;
       break;
     default:
-      Rcpp::stop("Inapplicable conversion tiledb_datatype_t (%d) for int64 to Datetime conversion", dtype);
+      Rcpp::stop("Inapplicable conversion tiledb_datatype_t (%d) for int64 to "
+                 "Datetime conversion",
+                 dtype);
     }
   }
   return dv;
 }
 
-std::vector<int64_t> subnano_to_int64(NumericVector nv, tiledb_datatype_t dtype) {
+std::vector<int64_t> subnano_to_int64(NumericVector nv,
+                                      tiledb_datatype_t dtype) {
   size_t n = nv.size();
   std::vector<int64_t> iv(n);
-  memcpy(iv.data(), &(nv[0]), n*sizeof(double));
-  for (size_t i=0; i<n; i++) {
+  memcpy(iv.data(), &(nv[0]), n * sizeof(double));
+  for (size_t i = 0; i < n; i++) {
     switch (dtype) {
     case TILEDB_DATETIME_NS:
       // nothing to do for int64 as nanotime is already the basecase
@@ -127,15 +141,18 @@ std::vector<int64_t> subnano_to_int64(NumericVector nv, tiledb_datatype_t dtype)
       iv[i] = iv[i] * 1e9;
       break;
     default:
-      Rcpp::stop("Inapplicable conversion tiledb_datatype_t (%d) for subnano to int64 conversion", dtype);
+      Rcpp::stop("Inapplicable conversion tiledb_datatype_t (%d) for subnano "
+                 "to int64 conversion",
+                 dtype);
     }
   }
   return iv;
 }
 
-Rcpp::NumericVector int64_to_subnano(std::vector<int64_t> iv, tiledb_datatype_t dtype) {
+Rcpp::NumericVector int64_to_subnano(std::vector<int64_t> iv,
+                                     tiledb_datatype_t dtype) {
   int n = iv.size();
-  for (int i=0; i<n; i++) {
+  for (int i = 0; i < n; i++) {
     switch (dtype) {
     case TILEDB_DATETIME_NS:
       // nothing to do for int64 as nanotime is already the basecase
@@ -150,7 +167,9 @@ Rcpp::NumericVector int64_to_subnano(std::vector<int64_t> iv, tiledb_datatype_t 
       iv[i] = iv[i] / 1e9;
       break;
     default:
-      Rcpp::stop("Inapplicable conversion tiledb_datatype_t (%d) for int64 to subnano conversion", dtype);
+      Rcpp::stop("Inapplicable conversion tiledb_datatype_t (%d) for int64 to "
+                 "subnano conversion",
+                 dtype);
     }
   }
   return toNanotime(iv);
@@ -159,18 +178,11 @@ Rcpp::NumericVector int64_to_subnano(std::vector<int64_t> iv, tiledb_datatype_t 
 // Check whether a column datatype is date or datetime
 //
 bool is_datetime_column(const tiledb_datatype_t dtype) {
-  return (dtype == TILEDB_DATETIME_YEAR)
-    || (dtype == TILEDB_DATETIME_MONTH)
-    || (dtype == TILEDB_DATETIME_WEEK)
-    || (dtype == TILEDB_DATETIME_DAY)
-    || (dtype == TILEDB_DATETIME_HR)
-    || (dtype == TILEDB_DATETIME_MIN)
-    || (dtype == TILEDB_DATETIME_SEC)
-    || (dtype == TILEDB_DATETIME_MS)
-    || (dtype == TILEDB_DATETIME_US)
-    || (dtype == TILEDB_DATETIME_NS)
-    || (dtype == TILEDB_DATETIME_PS)
-    || (dtype == TILEDB_DATETIME_FS)
-    || (dtype == TILEDB_DATETIME_AS)
-    ;
+  return (dtype == TILEDB_DATETIME_YEAR) || (dtype == TILEDB_DATETIME_MONTH) ||
+         (dtype == TILEDB_DATETIME_WEEK) || (dtype == TILEDB_DATETIME_DAY) ||
+         (dtype == TILEDB_DATETIME_HR) || (dtype == TILEDB_DATETIME_MIN) ||
+         (dtype == TILEDB_DATETIME_SEC) || (dtype == TILEDB_DATETIME_MS) ||
+         (dtype == TILEDB_DATETIME_US) || (dtype == TILEDB_DATETIME_NS) ||
+         (dtype == TILEDB_DATETIME_PS) || (dtype == TILEDB_DATETIME_FS) ||
+         (dtype == TILEDB_DATETIME_AS);
 }

--- a/src/libtiledb.cpp
+++ b/src/libtiledb.cpp
@@ -3,22 +3,22 @@
 //  Copyright (c) 2017-2024 TileDB Inc.
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
-//  of this software and associated documentation files (the "Software"), to deal
-//  in the Software without restriction, including without limitation the rights
-//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-//  copies of the Software, and to permit persons to whom the Software is
+//  of this software and associated documentation files (the "Software"), to
+//  deal in the Software without restriction, including without limitation the
+//  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the Software is
 //  furnished to do so, subject to the following conditions:
 //
-//  The above copyright notice and this permission notice shall be included in all
-//  copies or substantial portions of the Software.
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
 //
 //  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 //  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 //  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 //  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-//  SOFTWARE.
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+//  IN THE SOFTWARE.
 
 #include "libtiledb.h"
 #include "tiledb_version.h"
@@ -28,89 +28,89 @@
 
 using namespace Rcpp;
 
-const char* _tiledb_datatype_to_string(tiledb_datatype_t dtype) {
+const char *_tiledb_datatype_to_string(tiledb_datatype_t dtype) {
   switch (dtype) {
-    case TILEDB_INT8:
-      return "INT8";
-    case TILEDB_UINT8:
-      return "UINT8";
-    case TILEDB_INT16:
-      return "INT16";
-    case TILEDB_UINT16:
-      return "UINT16";
-    case TILEDB_INT32:
-      return "INT32";
-    case TILEDB_UINT32:
-      return "UINT32";
-    case TILEDB_INT64:
-      return "INT64";
-    case TILEDB_UINT64:
-      return "UINT64";
-    case TILEDB_FLOAT32:
-      return "FLOAT32";
-    case TILEDB_FLOAT64:
-      return "FLOAT64";
-    case TILEDB_CHAR:
-      return "CHAR";
-    case TILEDB_STRING_ASCII:
-      return "ASCII";
-    case TILEDB_STRING_UTF8:
-      return "UTF8";
-    case TILEDB_STRING_UTF16:
-      return "UTF16";
-    case TILEDB_STRING_UTF32:
-      return "UTF32";
-    case TILEDB_STRING_UCS2:
-      return "UCS2";
-    case TILEDB_STRING_UCS4:
-      return "UCS4";
-    case TILEDB_ANY:
-      return "ANY";
-    case TILEDB_DATETIME_YEAR:
-      return "DATETIME_YEAR";
-    case TILEDB_DATETIME_MONTH:
-      return "DATETIME_MONTH";
-    case TILEDB_DATETIME_WEEK:
-      return "DATETIME_WEEK";
-    case TILEDB_DATETIME_DAY:
-      return "DATETIME_DAY";
-    case TILEDB_DATETIME_HR:
-      return "DATETIME_HR";
-    case TILEDB_DATETIME_MIN:
-      return "DATETIME_MIN";
-    case TILEDB_DATETIME_SEC:
-      return "DATETIME_SEC";
-    case TILEDB_DATETIME_MS:
-      return "DATETIME_MS";
-    case TILEDB_DATETIME_US:
-      return "DATETIME_US";
-    case TILEDB_DATETIME_NS:
-      return "DATETIME_NS";
-    case TILEDB_DATETIME_PS:
-      return "DATETIME_PS";
-    case TILEDB_DATETIME_FS:
-      return "DATETIME_FS";
-    case TILEDB_DATETIME_AS:
-      return "DATETIME_AS";
-    case TILEDB_BLOB:
-      return "BLOB";
-#if TILEDB_VERSION >= TileDB_Version(2,10,0)
-    case TILEDB_BOOL:
-      return "BOOL";
+  case TILEDB_INT8:
+    return "INT8";
+  case TILEDB_UINT8:
+    return "UINT8";
+  case TILEDB_INT16:
+    return "INT16";
+  case TILEDB_UINT16:
+    return "UINT16";
+  case TILEDB_INT32:
+    return "INT32";
+  case TILEDB_UINT32:
+    return "UINT32";
+  case TILEDB_INT64:
+    return "INT64";
+  case TILEDB_UINT64:
+    return "UINT64";
+  case TILEDB_FLOAT32:
+    return "FLOAT32";
+  case TILEDB_FLOAT64:
+    return "FLOAT64";
+  case TILEDB_CHAR:
+    return "CHAR";
+  case TILEDB_STRING_ASCII:
+    return "ASCII";
+  case TILEDB_STRING_UTF8:
+    return "UTF8";
+  case TILEDB_STRING_UTF16:
+    return "UTF16";
+  case TILEDB_STRING_UTF32:
+    return "UTF32";
+  case TILEDB_STRING_UCS2:
+    return "UCS2";
+  case TILEDB_STRING_UCS4:
+    return "UCS4";
+  case TILEDB_ANY:
+    return "ANY";
+  case TILEDB_DATETIME_YEAR:
+    return "DATETIME_YEAR";
+  case TILEDB_DATETIME_MONTH:
+    return "DATETIME_MONTH";
+  case TILEDB_DATETIME_WEEK:
+    return "DATETIME_WEEK";
+  case TILEDB_DATETIME_DAY:
+    return "DATETIME_DAY";
+  case TILEDB_DATETIME_HR:
+    return "DATETIME_HR";
+  case TILEDB_DATETIME_MIN:
+    return "DATETIME_MIN";
+  case TILEDB_DATETIME_SEC:
+    return "DATETIME_SEC";
+  case TILEDB_DATETIME_MS:
+    return "DATETIME_MS";
+  case TILEDB_DATETIME_US:
+    return "DATETIME_US";
+  case TILEDB_DATETIME_NS:
+    return "DATETIME_NS";
+  case TILEDB_DATETIME_PS:
+    return "DATETIME_PS";
+  case TILEDB_DATETIME_FS:
+    return "DATETIME_FS";
+  case TILEDB_DATETIME_AS:
+    return "DATETIME_AS";
+  case TILEDB_BLOB:
+    return "BLOB";
+#if TILEDB_VERSION >= TileDB_Version(2, 10, 0)
+  case TILEDB_BOOL:
+    return "BOOL";
 #endif
-#if TILEDB_VERSION >= TileDB_Version(2,21,0)
-    case TILEDB_GEOM_WKB:
-      return "GEOM_WKB";
-    case TILEDB_GEOM_WKT:
-      return "GEOM_WKT";
+#if TILEDB_VERSION >= TileDB_Version(2, 21, 0)
+  case TILEDB_GEOM_WKB:
+    return "GEOM_WKB";
+  case TILEDB_GEOM_WKT:
+    return "GEOM_WKT";
 #endif
-    default:
-      Rcpp::stop("unknown tiledb_datatype_t (%d)", dtype);
+  default:
+    Rcpp::stop("unknown tiledb_datatype_t (%d)", dtype);
   }
 }
 
 tiledb_datatype_t _string_to_tiledb_datatype(std::string typestr) {
-  if (typestr == "FLOAT32")  {
+  if (typestr == "FLOAT32") {
     return TILEDB_FLOAT32;
   } else if (typestr == "FLOAT64") {
     return TILEDB_FLOAT64;
@@ -123,7 +123,7 @@ tiledb_datatype_t _string_to_tiledb_datatype(std::string typestr) {
   } else if (typestr == "UINT8") {
     return TILEDB_UINT8;
   } else if (typestr == "INT16") {
-    return  TILEDB_INT16;
+    return TILEDB_INT16;
   } else if (typestr == "UINT16") {
     return TILEDB_UINT16;
   } else if (typestr == "INT32") {
@@ -164,11 +164,11 @@ tiledb_datatype_t _string_to_tiledb_datatype(std::string typestr) {
     return TILEDB_STRING_UTF8;
   } else if (typestr == "BLOB") {
     return TILEDB_BLOB;
-#if TILEDB_VERSION >= TileDB_Version(2,10,0)
+#if TILEDB_VERSION >= TileDB_Version(2, 10, 0)
   } else if (typestr == "BOOL") {
     return TILEDB_BOOL;
 #endif
-#if TILEDB_VERSION >= TileDB_Version(2,21,0)
+#if TILEDB_VERSION >= TileDB_Version(2, 21, 0)
   } else if (typestr == "GEOM_WKB") {
     return TILEDB_GEOM_WKB;
   } else if (typestr == "GEOM_WKT") {
@@ -181,16 +181,18 @@ tiledb_datatype_t _string_to_tiledb_datatype(std::string typestr) {
 
 // [[Rcpp::export]]
 int32_t tiledb_datatype_string_to_sizeof(const std::string str) {
-    return static_cast<int32_t>(tiledb_datatype_size(_string_to_tiledb_datatype(str)));
+  return static_cast<int32_t>(
+      tiledb_datatype_size(_string_to_tiledb_datatype(str)));
 }
 
 //' Map from TileDB type to R datatype
 //'
-//' This function maps from the TileDB types to the (fewer) key datatypes in R. This
-//' can be lossy as TileDB integers range from (signed and unsigned) 8 to 64 bit whereas
-//' R only has (signed) 32 bit values. Similarly, R only has 64 bit doubles whereas TileDB
-//' has 32 and 64 bit floating point types. TileDB also has more character encodings, and the
-//' full range of (NumPy) date and time types.
+//' This function maps from the TileDB types to the (fewer) key datatypes in
+//' R. This can be lossy as TileDB integers range from (signed and unsigned) 8
+//' to 64 bit whereas R only has (signed) 32 bit values. Similarly, R only has
+//' 64 bit doubles whereas TileDB has 32 and 64 bit floating point types.
+//' TileDB also has more character encodings, and the full range of (NumPy)
+//' date and time types.
 //'
 //' @param datatype A string describing one TileDB datatype
 //' @return A string describing the closest match for an R datatype
@@ -199,67 +201,67 @@ int32_t tiledb_datatype_string_to_sizeof(const std::string str) {
 std::string tiledb_datatype_R_type(std::string datatype) {
   tiledb_datatype_t dtype = _string_to_tiledb_datatype(datatype);
   switch (dtype) {
-    case TILEDB_INT8:
-    case TILEDB_UINT8:
-    case TILEDB_INT16:
-    case TILEDB_UINT16:
-    case TILEDB_INT32:
-    case TILEDB_UINT32:
-    case TILEDB_INT64:
-    case TILEDB_UINT64:
-      return "integer";
-    case TILEDB_FLOAT32:
-    case TILEDB_FLOAT64:
-      return "double";
-    case TILEDB_CHAR:
-      return "raw";
-    case TILEDB_STRING_ASCII:
-    case TILEDB_STRING_UTF8:
-    case TILEDB_STRING_UTF16:
-    case TILEDB_STRING_UTF32:
-    case TILEDB_STRING_UCS2:
-    case TILEDB_STRING_UCS4:
-      return "character";
-    case TILEDB_ANY:
-      return "any";
-    case TILEDB_DATETIME_DAY:
-      return "DATETIME_DAY";
-    case TILEDB_DATETIME_SEC:
-      return "DATETIME_SEC";
-    case TILEDB_DATETIME_MS:
-      return "DATETIME_MS";
-    case TILEDB_DATETIME_US:
-      return "DATETIME_US";
-    case TILEDB_DATETIME_NS:
-      return "DATETIME_NS";
-#if TILEDB_VERSION >= TileDB_Version(2,10,0)
-    case TILEDB_BOOL:
-      return "BOOL";
+  case TILEDB_INT8:
+  case TILEDB_UINT8:
+  case TILEDB_INT16:
+  case TILEDB_UINT16:
+  case TILEDB_INT32:
+  case TILEDB_UINT32:
+  case TILEDB_INT64:
+  case TILEDB_UINT64:
+    return "integer";
+  case TILEDB_FLOAT32:
+  case TILEDB_FLOAT64:
+    return "double";
+  case TILEDB_CHAR:
+    return "raw";
+  case TILEDB_STRING_ASCII:
+  case TILEDB_STRING_UTF8:
+  case TILEDB_STRING_UTF16:
+  case TILEDB_STRING_UTF32:
+  case TILEDB_STRING_UCS2:
+  case TILEDB_STRING_UCS4:
+    return "character";
+  case TILEDB_ANY:
+    return "any";
+  case TILEDB_DATETIME_DAY:
+    return "DATETIME_DAY";
+  case TILEDB_DATETIME_SEC:
+    return "DATETIME_SEC";
+  case TILEDB_DATETIME_MS:
+    return "DATETIME_MS";
+  case TILEDB_DATETIME_US:
+    return "DATETIME_US";
+  case TILEDB_DATETIME_NS:
+    return "DATETIME_NS";
+#if TILEDB_VERSION >= TileDB_Version(2, 10, 0)
+  case TILEDB_BOOL:
+    return "BOOL";
 #endif
-    default:
-      Rcpp::stop("unknown tiledb_datatype_t (%d)", dtype);
+  default:
+    Rcpp::stop("unknown tiledb_datatype_t (%d)", dtype);
   }
 }
 
-const char* _tiledb_layout_to_string(tiledb_layout_t layout) {
-  switch(layout) {
-    case TILEDB_ROW_MAJOR:
-      return "ROW_MAJOR";
-    case TILEDB_COL_MAJOR:
-      return "COL_MAJOR";
-    case TILEDB_GLOBAL_ORDER:
-      return "GLOBAL_ORDER";
-    case TILEDB_UNORDERED:
-      return "UNORDERED";
-    case TILEDB_HILBERT:
-      return "HILBERT";
-    default:
-      Rcpp::stop("unknown tiledb_layout_t (%d)", layout);
+const char *_tiledb_layout_to_string(tiledb_layout_t layout) {
+  switch (layout) {
+  case TILEDB_ROW_MAJOR:
+    return "ROW_MAJOR";
+  case TILEDB_COL_MAJOR:
+    return "COL_MAJOR";
+  case TILEDB_GLOBAL_ORDER:
+    return "GLOBAL_ORDER";
+  case TILEDB_UNORDERED:
+    return "UNORDERED";
+  case TILEDB_HILBERT:
+    return "HILBERT";
+  default:
+    Rcpp::stop("unknown tiledb_layout_t (%d)", layout);
   }
 }
 
 tiledb_layout_t _string_to_tiledb_layout(std::string lstr) {
-  if (lstr == "ROW_MAJOR")  {
+  if (lstr == "ROW_MAJOR") {
     return TILEDB_ROW_MAJOR;
   } else if (lstr == "COL_MAJOR") {
     return TILEDB_COL_MAJOR;
@@ -301,15 +303,15 @@ tiledb_filter_type_t _string_to_tiledb_filter(std::string filter) {
     return TILEDB_FILTER_CHECKSUM_MD5;
   } else if (filter == "CHECKSUM_SHA256") {
     return TILEDB_FILTER_CHECKSUM_SHA256;
-#if TILEDB_VERSION >= TileDB_Version(2,9,0)
+#if TILEDB_VERSION >= TileDB_Version(2, 9, 0)
   } else if (filter == "DICTIONARY_ENCODING") {
     return TILEDB_FILTER_DICTIONARY;
 #endif
-#if TILEDB_VERSION >= TileDB_Version(2,11,0)
+#if TILEDB_VERSION >= TileDB_Version(2, 11, 0)
   } else if (filter == "SCALE_FLOAT") {
     return TILEDB_FILTER_SCALE_FLOAT;
 #endif
-#if TILEDB_VERSION >= TileDB_Version(2,12,0)
+#if TILEDB_VERSION >= TileDB_Version(2, 12, 0)
   } else if (filter == "FILTER_XOR") {
     return TILEDB_FILTER_XOR;
 #endif
@@ -318,60 +320,61 @@ tiledb_filter_type_t _string_to_tiledb_filter(std::string filter) {
   }
 }
 
-const char* _tiledb_filter_to_string(tiledb_filter_type_t filter) {
-  switch(filter) {
-    case TILEDB_FILTER_NONE:
-     return "NONE";
-    case TILEDB_FILTER_GZIP:
-      return "GZIP";
-    case TILEDB_FILTER_ZSTD:
-      return "ZSTD";
-    case TILEDB_FILTER_LZ4:
-      return "LZ4";
-    case TILEDB_FILTER_RLE:
-      return "RLE";
-    case TILEDB_FILTER_BZIP2:
-      return "BZIP2";
-    case TILEDB_FILTER_DOUBLE_DELTA:
-      return "DOUBLE_DELTA";
-    case TILEDB_FILTER_BIT_WIDTH_REDUCTION:
-      return "BIT_WIDTH_REDUCTION";
-    case TILEDB_FILTER_BITSHUFFLE:
-      return "BITSHUFFLE";
-    case TILEDB_FILTER_BYTESHUFFLE:
-      return "BYTESHUFFLE";
-    case TILEDB_FILTER_POSITIVE_DELTA:
-      return "POSITIVE_DELTA";
-    case TILEDB_FILTER_CHECKSUM_MD5:
-      return "CHECKSUM_MD5";
-    case TILEDB_FILTER_CHECKSUM_SHA256:
-      return "CHECKSUM_SHA256";
-#if TILEDB_VERSION >= TileDB_Version(2,9,0)
-    case TILEDB_FILTER_DICTIONARY:
-      return "DICTIONARY_ENCODING";
+const char *_tiledb_filter_to_string(tiledb_filter_type_t filter) {
+  switch (filter) {
+  case TILEDB_FILTER_NONE:
+    return "NONE";
+  case TILEDB_FILTER_GZIP:
+    return "GZIP";
+  case TILEDB_FILTER_ZSTD:
+    return "ZSTD";
+  case TILEDB_FILTER_LZ4:
+    return "LZ4";
+  case TILEDB_FILTER_RLE:
+    return "RLE";
+  case TILEDB_FILTER_BZIP2:
+    return "BZIP2";
+  case TILEDB_FILTER_DOUBLE_DELTA:
+    return "DOUBLE_DELTA";
+  case TILEDB_FILTER_BIT_WIDTH_REDUCTION:
+    return "BIT_WIDTH_REDUCTION";
+  case TILEDB_FILTER_BITSHUFFLE:
+    return "BITSHUFFLE";
+  case TILEDB_FILTER_BYTESHUFFLE:
+    return "BYTESHUFFLE";
+  case TILEDB_FILTER_POSITIVE_DELTA:
+    return "POSITIVE_DELTA";
+  case TILEDB_FILTER_CHECKSUM_MD5:
+    return "CHECKSUM_MD5";
+  case TILEDB_FILTER_CHECKSUM_SHA256:
+    return "CHECKSUM_SHA256";
+#if TILEDB_VERSION >= TileDB_Version(2, 9, 0)
+  case TILEDB_FILTER_DICTIONARY:
+    return "DICTIONARY_ENCODING";
 #endif
-#if TILEDB_VERSION >= TileDB_Version(2,11,0)
-    case TILEDB_FILTER_SCALE_FLOAT:
-      return "SCALE_FLOAT";
+#if TILEDB_VERSION >= TileDB_Version(2, 11, 0)
+  case TILEDB_FILTER_SCALE_FLOAT:
+    return "SCALE_FLOAT";
 #endif
-#if TILEDB_VERSION >= TileDB_Version(2,12,0)
+#if TILEDB_VERSION >= TileDB_Version(2, 12, 0)
   case TILEDB_FILTER_XOR:
     return "FILTER_XOR";
 #endif
   default: {
-      Rcpp::stop("unknown tiledb_filter_t (%d)", filter);
-    }
+    Rcpp::stop("unknown tiledb_filter_t (%d)", filter);
+  }
   }
 }
 
-tiledb_filter_option_t _string_to_tiledb_filter_option(std::string filter_option) {
+tiledb_filter_option_t
+_string_to_tiledb_filter_option(std::string filter_option) {
   if (filter_option == "COMPRESSION_LEVEL") {
     return TILEDB_COMPRESSION_LEVEL;
   } else if (filter_option == "BIT_WIDTH_MAX_WINDOW") {
     return TILEDB_BIT_WIDTH_MAX_WINDOW;
   } else if (filter_option == "POSITIVE_DELTA_MAX_WINDOW") {
     return TILEDB_POSITIVE_DELTA_MAX_WINDOW;
-#if TILEDB_VERSION >= TileDB_Version(2,11,0)
+#if TILEDB_VERSION >= TileDB_Version(2, 11, 0)
   } else if (filter_option == "SCALE_FLOAT_BYTEWIDTH") {
     return TILEDB_SCALE_FLOAT_BYTEWIDTH;
   } else if (filter_option == "SCALE_FLOAT_FACTOR") {
@@ -384,15 +387,16 @@ tiledb_filter_option_t _string_to_tiledb_filter_option(std::string filter_option
   }
 }
 
-const char* _tiledb_filter_option_to_string(tiledb_filter_option_t filter_option) {
-  switch(filter_option) {
+const char *
+_tiledb_filter_option_to_string(tiledb_filter_option_t filter_option) {
+  switch (filter_option) {
   case TILEDB_COMPRESSION_LEVEL:
     return "COMPRESSION_LEVEL";
   case TILEDB_BIT_WIDTH_MAX_WINDOW:
     return "BIT_WIDTH_MAX_WINDOW";
   case TILEDB_POSITIVE_DELTA_MAX_WINDOW:
     return "POSITIVE_DELTA_MAX_WINDOW";
-#if TILEDB_VERSION >= TileDB_Version(2,11,0)
+#if TILEDB_VERSION >= TileDB_Version(2, 11, 0)
   case TILEDB_SCALE_FLOAT_BYTEWIDTH:
     return "SCALE_FLOAT_BYTEWIDTH";
   case TILEDB_SCALE_FLOAT_FACTOR:
@@ -410,7 +414,7 @@ tiledb_query_type_t _string_to_tiledb_query_type(std::string qtstr) {
     return TILEDB_READ;
   } else if (qtstr == "WRITE") {
     return TILEDB_WRITE;
-#if TILEDB_VERSION >= TileDB_Version(2,12,0)
+#if TILEDB_VERSION >= TileDB_Version(2, 12, 0)
   } else if (qtstr == "MODIFY_EXCLUSIVE") {
     return TILEDB_MODIFY_EXCLUSIVE;
   } else if (qtstr == "DELETE") {
@@ -423,29 +427,29 @@ tiledb_query_type_t _string_to_tiledb_query_type(std::string qtstr) {
 
 std::string _tiledb_query_type_to_string(tiledb_query_type_t qtype) {
   switch (qtype) {
-    case TILEDB_READ:
-      return "READ";
-    case TILEDB_WRITE:
-      return "WRITE";
-#if TILEDB_VERSION >= TileDB_Version(2,12,0)
-    case TILEDB_DELETE:
-      return "DELETE";
-    case TILEDB_MODIFY_EXCLUSIVE:
-      return "MODIFY_EXCLUSIVE";
+  case TILEDB_READ:
+    return "READ";
+  case TILEDB_WRITE:
+    return "WRITE";
+#if TILEDB_VERSION >= TileDB_Version(2, 12, 0)
+  case TILEDB_DELETE:
+    return "DELETE";
+  case TILEDB_MODIFY_EXCLUSIVE:
+    return "MODIFY_EXCLUSIVE";
 #endif
-    default:
-      Rcpp::stop("unknown tiledb_query_type_t (%d)", qtype);
+  default:
+    Rcpp::stop("unknown tiledb_query_type_t (%d)", qtype);
   }
 }
 
-const char* _tiledb_array_type_to_string(tiledb_array_type_t atype) {
+const char *_tiledb_array_type_to_string(tiledb_array_type_t atype) {
   switch (atype) {
-    case TILEDB_DENSE:
-      return "dense";
-    case TILEDB_SPARSE:
-      return "sparse";
-    default:
-      Rcpp::stop("Unknown tiledb_array_type_t");
+  case TILEDB_DENSE:
+    return "dense";
+  case TILEDB_SPARSE:
+    return "sparse";
+  default:
+    Rcpp::stop("Unknown tiledb_array_type_t");
   }
 }
 
@@ -471,39 +475,43 @@ tiledb_vfs_mode_t _string_to_tiledb_vfs_mode_t(std::string modestr) {
   }
 }
 
-#if TILEDB_VERSION >= TileDB_Version(2,25,0)
-std::string _tiledb_current_domain_type_to_string(tiledb_current_domain_type_t type) {
-    if (type == TILEDB_NDRECTANGLE) {
-        return std::string{"NDRECTANGLE"};
-    } else {
-        Rcpp::stop("Unknown TileDB CurrentDomain type (%d)", (int32_t) type);
-    }
-    return std::string();
+#if TILEDB_VERSION >= TileDB_Version(2, 25, 0)
+std::string
+_tiledb_current_domain_type_to_string(tiledb_current_domain_type_t type) {
+  if (type == TILEDB_NDRECTANGLE) {
+    return std::string{"NDRECTANGLE"};
+  } else {
+    Rcpp::stop("Unknown TileDB CurrentDomain type (%d)", (int32_t)type);
+  }
+  return std::string();
 }
 #endif
 
-#if TILEDB_VERSION >= TileDB_Version(2,25,0)
-tiledb_current_domain_type_t _string_to_tiledb_current_domain_type(std::string typestr) {
-    if (typestr == "NDRECTANGLE") {
-        return TILEDB_NDRECTANGLE;
-    } else {
-        Rcpp::stop("Unknown TileDB CurrentDomain type '%s'", typestr.c_str());
-    }
+#if TILEDB_VERSION >= TileDB_Version(2, 25, 0)
+tiledb_current_domain_type_t
+_string_to_tiledb_current_domain_type(std::string typestr) {
+  if (typestr == "NDRECTANGLE") {
+    return TILEDB_NDRECTANGLE;
+  } else {
+    Rcpp::stop("Unknown TileDB CurrentDomain type '%s'", typestr.c_str());
+  }
 }
 #endif
 
-// NB Limited type coverage here as aimed to sizing R allocations of either int, double or char
-// Also note that there is 'inline size_t type_size(tiledb_datatype_t type)' in core_interface.h
+// NB Limited type coverage here as aimed to sizing R allocations of either int,
+// double or char Also note that there is 'inline size_t
+// type_size(tiledb_datatype_t type)' in core_interface.h
 const size_t _tiledb_datatype_sizeof(const tiledb_datatype_t dtype) {
-  switch(dtype) {
-    case TILEDB_FLOAT64:
-      return sizeof(double);
-    case TILEDB_INT32:
-      return sizeof(int32_t);
-    case TILEDB_CHAR:
-      return sizeof(char);
-    default:
-      Rcpp::stop("Unsupported tiledb_datatype_t '%s'", _tiledb_datatype_to_string(dtype));
+  switch (dtype) {
+  case TILEDB_FLOAT64:
+    return sizeof(double);
+  case TILEDB_INT32:
+    return sizeof(int32_t);
+  case TILEDB_CHAR:
+    return sizeof(char);
+  default:
+    Rcpp::stop("Unsupported tiledb_datatype_t '%s'",
+               _tiledb_datatype_to_string(dtype));
   }
 }
 
@@ -516,19 +524,28 @@ NumericVector libtiledb_version() {
 }
 
 // [[Rcpp::export]]
-size_t tiledb_datatype_max_value(const std::string& datatype) {
-    tiledb_datatype_t dtype = _string_to_tiledb_datatype(datatype);
-    switch (dtype) {
-    case TILEDB_INT8:    return std::numeric_limits<int8_t>::max();
-    case TILEDB_UINT8:   return std::numeric_limits<uint8_t>::max();
-    case TILEDB_INT16:   return std::numeric_limits<int16_t>::max();
-    case TILEDB_UINT16:  return std::numeric_limits<uint16_t>::max();
-    case TILEDB_INT32:   return std::numeric_limits<int32_t>::max();
-    case TILEDB_UINT32:  return std::numeric_limits<uint32_t>::max();
-    case TILEDB_INT64:   return std::numeric_limits<int64_t>::max();
-    case TILEDB_UINT64:  return std::numeric_limits<uint64_t>::max();
-    default: Rcpp::stop("currently unsupported datatype (%s)", datatype);
-    }
+size_t tiledb_datatype_max_value(const std::string &datatype) {
+  tiledb_datatype_t dtype = _string_to_tiledb_datatype(datatype);
+  switch (dtype) {
+  case TILEDB_INT8:
+    return std::numeric_limits<int8_t>::max();
+  case TILEDB_UINT8:
+    return std::numeric_limits<uint8_t>::max();
+  case TILEDB_INT16:
+    return std::numeric_limits<int16_t>::max();
+  case TILEDB_UINT16:
+    return std::numeric_limits<uint16_t>::max();
+  case TILEDB_INT32:
+    return std::numeric_limits<int32_t>::max();
+  case TILEDB_UINT32:
+    return std::numeric_limits<uint32_t>::max();
+  case TILEDB_INT64:
+    return std::numeric_limits<int64_t>::max();
+  case TILEDB_UINT64:
+    return std::numeric_limits<uint64_t>::max();
+  default:
+    Rcpp::stop("currently unsupported datatype (%s)", datatype);
+  }
 }
 
 /**
@@ -536,27 +553,29 @@ size_t tiledb_datatype_max_value(const std::string& datatype) {
  */
 
 // [[Rcpp::export]]
-XPtr<tiledb::Context> libtiledb_ctx(Nullable<XPtr<tiledb::Config>> config = R_NilValue) {
-    if (config.isNull()) {
-        return make_xptr<tiledb::Context>(new tiledb::Context());
-    } else {
-        XPtr<tiledb::Config> config_xptr(config);
-        return make_xptr<tiledb::Context>(new tiledb::Context(*config_xptr.get()));
-    }
+XPtr<tiledb::Context>
+libtiledb_ctx(Nullable<XPtr<tiledb::Config>> config = R_NilValue) {
+  if (config.isNull()) {
+    return make_xptr<tiledb::Context>(new tiledb::Context());
+  } else {
+    XPtr<tiledb::Config> config_xptr(config);
+    return make_xptr<tiledb::Context>(new tiledb::Context(*config_xptr.get()));
+  }
 }
 
 // [[Rcpp::export]]
 XPtr<tiledb::Config> libtiledb_ctx_config(XPtr<tiledb::Context> ctx) {
-    check_xptr_tag<tiledb::Context>(ctx);
-    return make_xptr<tiledb::Config>(new tiledb::Config(ctx.get()->config()));
+  check_xptr_tag<tiledb::Context>(ctx);
+  return make_xptr<tiledb::Config>(new tiledb::Config(ctx.get()->config()));
 }
 
 // [[Rcpp::export]]
-bool libtiledb_ctx_is_supported_fs(XPtr<tiledb::Context> ctx, std::string scheme) {
+bool libtiledb_ctx_is_supported_fs(XPtr<tiledb::Context> ctx,
+                                   std::string scheme) {
   check_xptr_tag<tiledb::Context>(ctx);
   if (scheme == "file") {
     return true;
-  } else if  (scheme == "s3") {
+  } else if (scheme == "s3") {
     return ctx->is_supported_fs(TILEDB_S3);
   } else if (scheme == "hdfs") {
     return ctx->is_supported_fs(TILEDB_HDFS);
@@ -572,15 +591,16 @@ bool libtiledb_ctx_is_supported_fs(XPtr<tiledb::Context> ctx, std::string scheme
 }
 
 // [[Rcpp::export]]
-void libtiledb_ctx_set_tag(XPtr<tiledb::Context> ctx, std::string key, std::string value) {
+void libtiledb_ctx_set_tag(XPtr<tiledb::Context> ctx, std::string key,
+                           std::string value) {
   check_xptr_tag<tiledb::Context>(ctx);
   ctx->set_tag(key, value);
 }
 
 // [[Rcpp::export]]
 std::string libtiledb_ctx_stats(XPtr<tiledb::Context> ctx) {
-    check_xptr_tag<tiledb::Context>(ctx);
-    return ctx->stats();
+  check_xptr_tag<tiledb::Context>(ctx);
+  return ctx->stats();
 }
 
 /**
@@ -588,7 +608,8 @@ std::string libtiledb_ctx_stats(XPtr<tiledb::Context> ctx) {
  */
 
 // [[Rcpp::export]]
-XPtr<tiledb::Config> libtiledb_config(Nullable<CharacterVector> config = R_NilValue) {
+XPtr<tiledb::Config>
+libtiledb_config(Nullable<CharacterVector> config = R_NilValue) {
   XPtr<tiledb::Config> ptr = make_xptr<tiledb::Config>(new tiledb::Config());
   if (config.isNotNull()) {
     auto config_vec = config.as();
@@ -603,7 +624,8 @@ XPtr<tiledb::Config> libtiledb_config(Nullable<CharacterVector> config = R_NilVa
 }
 
 // [[Rcpp::export]]
-std::string libtiledb_config_save_to_file(XPtr<tiledb::Config> config, std::string filename) {
+std::string libtiledb_config_save_to_file(XPtr<tiledb::Config> config,
+                                          std::string filename) {
   check_xptr_tag<tiledb::Config>(config);
   config->save_to_file(filename);
   return filename;
@@ -611,7 +633,8 @@ std::string libtiledb_config_save_to_file(XPtr<tiledb::Config> config, std::stri
 
 // [[Rcpp::export]]
 XPtr<tiledb::Config> libtiledb_config_load_from_file(std::string filename) {
-  XPtr<tiledb::Config> ptr = make_xptr<tiledb::Config>(new tiledb::Config(filename));
+  XPtr<tiledb::Config> ptr =
+      make_xptr<tiledb::Config>(new tiledb::Config(filename));
   return ptr;
 }
 
@@ -619,29 +642,31 @@ XPtr<tiledb::Config> libtiledb_config_load_from_file(std::string filename) {
 CharacterVector libtiledb_config_vector(XPtr<tiledb::Config> config) {
   check_xptr_tag<tiledb::Config>(config);
   CharacterVector config_vec;
-  for (auto& p : *config) {
-    config_vec[p.first]  = p.second;
+  for (auto &p : *config) {
+    config_vec[p.first] = p.second;
   }
   return config_vec;
 }
 
 // [[Rcpp::export]]
 XPtr<tiledb::Config> libtiledb_config_set(XPtr<tiledb::Config> config,
-                                          std::string param, std::string value) {
+                                          std::string param,
+                                          std::string value) {
   check_xptr_tag<tiledb::Config>(config);
   (*config)[param] = value;
   return config;
 }
 
 // [[Rcpp::export]]
-CharacterVector libtiledb_config_get(XPtr<tiledb::Config> config, CharacterVector params) {
+CharacterVector libtiledb_config_get(XPtr<tiledb::Config> config,
+                                     CharacterVector params) {
   check_xptr_tag<tiledb::Config>(config);
   CharacterVector result;
-  for (auto const& p : params) {
+  for (auto const &p : params) {
     auto param = as<std::string>(p);
     try {
       result.push_back(config->get(param), param);
-    } catch (std::exception& err) {
+    } catch (std::exception &err) {
       result.push_back(NA_STRING, as<std::string>(NA_STRING));
     }
   }
@@ -649,7 +674,8 @@ CharacterVector libtiledb_config_get(XPtr<tiledb::Config> config, CharacterVecto
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::Config> libtiledb_config_unset(XPtr<tiledb::Config> config, std::string param) {
+XPtr<tiledb::Config> libtiledb_config_unset(XPtr<tiledb::Config> config,
+                                            std::string param) {
   check_xptr_tag<tiledb::Config>(config);
   config->unset(param);
   return config;
@@ -659,19 +685,20 @@ XPtr<tiledb::Config> libtiledb_config_unset(XPtr<tiledb::Config> config, std::st
 void libtiledb_config_dump(XPtr<tiledb::Config> config) {
   check_xptr_tag<tiledb::Config>(config);
   Rcout << "Config settings:\n";
-  for (auto& p : *config) {
+  for (auto &p : *config) {
     Rcout << "\"" << p.first << "\" : \"" << p.second << "\"\n";
   }
 }
 
-// Placed here as it relates to config. (New as of 2.17, uses experimental header)
+// Placed here as it relates to config. (New as of 2.17, uses experimental
+// header)
 // [[Rcpp::export]]
 std::string libtiledb_as_built_dump() {
-    std::string str = "";
-#if TILEDB_VERSION >= TileDB_Version(2,17,0)
-    str = tiledb::AsBuilt::dump();
+  std::string str = "";
+#if TILEDB_VERSION >= TileDB_Version(2, 17, 0)
+  str = tiledb::AsBuilt::dump();
 #endif
-    return str;
+  return str;
 }
 
 /**
@@ -679,209 +706,215 @@ std::string libtiledb_as_built_dump() {
  */
 // [[Rcpp::export]]
 XPtr<tiledb::Dimension> libtiledb_dim(XPtr<tiledb::Context> ctx,
-                                      std::string name,
-                                      std::string type,
-                                      SEXP domain,
-                                      SEXP tile_extent) {
-    check_xptr_tag<tiledb::Context>(ctx);
-    // check that the dimension type is supported
-    const tiledb_datatype_t dtype = _string_to_tiledb_datatype(type);
-    if (dtype != TILEDB_INT8 &&
-        dtype != TILEDB_INT16 &&
-        dtype != TILEDB_INT32 &&
-        dtype != TILEDB_INT64 &&
-        dtype != TILEDB_UINT8 &&
-        dtype != TILEDB_UINT16 &&
-        dtype != TILEDB_UINT32 &&
-        dtype != TILEDB_UINT64 &&
-        dtype != TILEDB_FLOAT32 &&
-        dtype != TILEDB_FLOAT64 &&
-        dtype != TILEDB_DATETIME_YEAR &&
-        dtype != TILEDB_DATETIME_MONTH &&
-        dtype != TILEDB_DATETIME_WEEK &&
-        dtype != TILEDB_DATETIME_DAY &&
-        dtype != TILEDB_DATETIME_HR &&
-        dtype != TILEDB_DATETIME_MIN &&
-        dtype != TILEDB_DATETIME_SEC &&
-        dtype != TILEDB_DATETIME_MS &&
-        dtype != TILEDB_DATETIME_US &&
-        dtype != TILEDB_DATETIME_NS &&
-        dtype != TILEDB_DATETIME_PS &&
-        dtype != TILEDB_DATETIME_FS &&
-        dtype != TILEDB_DATETIME_AS &&
-        dtype != TILEDB_STRING_ASCII) {
-        Rcpp::stop("only integer ((U)INT{8,16,32,64}), real (FLOAT{32,64}), DATETIME_{YEAR,MONTH,WEEK,DAY,HR,MIN,SEC,MS,US,NS,PS,FS,AS}, STRING_ASCII domains supported");
+                                      std::string name, std::string type,
+                                      SEXP domain, SEXP tile_extent) {
+  check_xptr_tag<tiledb::Context>(ctx);
+  // check that the dimension type is supported
+  const tiledb_datatype_t dtype = _string_to_tiledb_datatype(type);
+  if (dtype != TILEDB_INT8 && dtype != TILEDB_INT16 && dtype != TILEDB_INT32 &&
+      dtype != TILEDB_INT64 && dtype != TILEDB_UINT8 &&
+      dtype != TILEDB_UINT16 && dtype != TILEDB_UINT32 &&
+      dtype != TILEDB_UINT64 && dtype != TILEDB_FLOAT32 &&
+      dtype != TILEDB_FLOAT64 && dtype != TILEDB_DATETIME_YEAR &&
+      dtype != TILEDB_DATETIME_MONTH && dtype != TILEDB_DATETIME_WEEK &&
+      dtype != TILEDB_DATETIME_DAY && dtype != TILEDB_DATETIME_HR &&
+      dtype != TILEDB_DATETIME_MIN && dtype != TILEDB_DATETIME_SEC &&
+      dtype != TILEDB_DATETIME_MS && dtype != TILEDB_DATETIME_US &&
+      dtype != TILEDB_DATETIME_NS && dtype != TILEDB_DATETIME_PS &&
+      dtype != TILEDB_DATETIME_FS && dtype != TILEDB_DATETIME_AS &&
+      dtype != TILEDB_STRING_ASCII) {
+    Rcpp::stop("only integer ((U)INT{8,16,32,64}), real (FLOAT{32,64}), "
+               "DATETIME_{YEAR,MONTH,WEEK,DAY,HR,MIN,SEC,MS,US,NS,PS,FS,AS}, "
+               "STRING_ASCII domains supported");
+  }
+  // check that the dimension type aligns with the domain and tiledb_extent type
+  if (dtype == TILEDB_INT32 &&
+      (TYPEOF(domain) != INTSXP || TYPEOF(tile_extent) != INTSXP)) {
+    Rcpp::stop("domain or tile_extent does not match dimension type");
+  } else if (dtype == TILEDB_FLOAT64 &&
+             (TYPEOF(domain) != REALSXP || TYPEOF(tile_extent) != REALSXP)) {
+    Rcpp::stop("domain or tile_extent does not match dimension type");
+  }
+  if (dtype == TILEDB_INT32) {
+    Rcpp::IntegerVector domain_vec = Rcpp::IntegerVector(domain);
+    if (domain_vec.length() != 2) {
+      Rcpp::stop("dimension domain must be a c(lower bound, upper bound) pair");
     }
-    // check that the dimension type aligns with the domain and tiledb_extent type
-    if (dtype == TILEDB_INT32 && (TYPEOF(domain) != INTSXP || TYPEOF(tile_extent) != INTSXP)) {
-        Rcpp::stop("domain or tile_extent does not match dimension type");
-    } else if (dtype == TILEDB_FLOAT64 && (TYPEOF(domain) != REALSXP || TYPEOF(tile_extent) != REALSXP)) {
-        Rcpp::stop("domain or tile_extent does not match dimension type");
+    std::array<int32_t, 2> _domain = {domain_vec[0], domain_vec[1]};
+    int32_t _tile_extent = Rcpp::as<int32_t>(tile_extent);
+    auto dim = new tiledb::Dimension(tiledb::Dimension::create<int32_t>(
+        *ctx.get(), name, _domain, _tile_extent));
+    auto ptr = make_xptr<tiledb::Dimension>(dim);
+    return ptr;
+
+  } else if (dtype == TILEDB_UINT32) {
+    Rcpp::IntegerVector domain_vec = Rcpp::IntegerVector(domain);
+    if (domain_vec.length() != 2) {
+      Rcpp::stop("dimension domain must be a c(lower bound, upper bound) pair");
     }
-    if (dtype == TILEDB_INT32) {
-        Rcpp::IntegerVector domain_vec = Rcpp::IntegerVector(domain);
-        if (domain_vec.length() != 2) {
-            Rcpp::stop("dimension domain must be a c(lower bound, upper bound) pair");
-        }
-        std::array<int32_t, 2> _domain = {domain_vec[0], domain_vec[1]};
-        int32_t _tile_extent = Rcpp::as<int32_t>(tile_extent);
-        auto dim = new tiledb::Dimension(tiledb::Dimension::create<int32_t>(*ctx.get(), name, _domain, _tile_extent));
-        auto ptr = make_xptr<tiledb::Dimension>(dim);
-        return ptr;
+    std::array<uint32_t, 2> _domain = {static_cast<uint32_t>(domain_vec[0]),
+                                       static_cast<uint32_t>(domain_vec[1])};
+    uint32_t _tile_extent = Rcpp::as<uint32_t>(tile_extent);
+    auto dim = new tiledb::Dimension(tiledb::Dimension::create<uint32_t>(
+        *ctx.get(), name, _domain, _tile_extent));
+    auto ptr = make_xptr<tiledb::Dimension>(dim);
+    return ptr;
 
-    } else if (dtype == TILEDB_UINT32) {
-        Rcpp::IntegerVector domain_vec = Rcpp::IntegerVector(domain);
-        if (domain_vec.length() != 2) {
-            Rcpp::stop("dimension domain must be a c(lower bound, upper bound) pair");
-        }
-        std::array<uint32_t, 2> _domain = {static_cast<uint32_t>(domain_vec[0]), static_cast<uint32_t>(domain_vec[1])};
-        uint32_t _tile_extent = Rcpp::as<uint32_t>(tile_extent);
-        auto dim = new tiledb::Dimension(tiledb::Dimension::create<uint32_t>(*ctx.get(), name, _domain, _tile_extent));
-        auto ptr = make_xptr<tiledb::Dimension>(dim);
-        return ptr;
+  } else if (dtype == TILEDB_INT16) {
+    Rcpp::IntegerVector domain_vec = Rcpp::IntegerVector(domain);
+    if (domain_vec.length() != 2) {
+      Rcpp::stop("dimension domain must be a c(lower bound, upper bound) pair");
+    }
+    std::array<int16_t, 2> _domain = {static_cast<int16_t>(domain_vec[0]),
+                                      static_cast<int16_t>(domain_vec[1])};
+    int16_t _tile_extent = Rcpp::as<int16_t>(tile_extent);
+    auto dim = new tiledb::Dimension(tiledb::Dimension::create<int16_t>(
+        *ctx.get(), name, _domain, _tile_extent));
+    auto ptr = make_xptr<tiledb::Dimension>(dim);
+    return ptr;
 
-    } else if (dtype == TILEDB_INT16) {
-        Rcpp::IntegerVector domain_vec = Rcpp::IntegerVector(domain);
-        if (domain_vec.length() != 2) {
-            Rcpp::stop("dimension domain must be a c(lower bound, upper bound) pair");
-        }
-        std::array<int16_t, 2> _domain = {static_cast<int16_t>(domain_vec[0]), static_cast<int16_t>(domain_vec[1])};
-        int16_t _tile_extent = Rcpp::as<int16_t>(tile_extent);
-        auto dim = new tiledb::Dimension(tiledb::Dimension::create<int16_t>(*ctx.get(), name, _domain, _tile_extent));
-        auto ptr = make_xptr<tiledb::Dimension>(dim);
-        return ptr;
+  } else if (dtype == TILEDB_UINT16) {
+    Rcpp::IntegerVector domain_vec = Rcpp::IntegerVector(domain);
+    if (domain_vec.length() != 2) {
+      Rcpp::stop("dimension domain must be a c(lower bound, upper bound) pair");
+    }
+    std::array<uint16_t, 2> _domain = {static_cast<uint16_t>(domain_vec[0]),
+                                       static_cast<uint16_t>(domain_vec[1])};
+    uint16_t _tile_extent = Rcpp::as<uint16_t>(tile_extent);
+    auto dim = new tiledb::Dimension(tiledb::Dimension::create<uint16_t>(
+        *ctx.get(), name, _domain, _tile_extent));
+    auto ptr = make_xptr<tiledb::Dimension>(dim);
+    return ptr;
 
-    } else if (dtype == TILEDB_UINT16) {
-        Rcpp::IntegerVector domain_vec = Rcpp::IntegerVector(domain);
-        if (domain_vec.length() != 2) {
-            Rcpp::stop("dimension domain must be a c(lower bound, upper bound) pair");
-        }
-        std::array<uint16_t, 2> _domain = {static_cast<uint16_t>(domain_vec[0]), static_cast<uint16_t>(domain_vec[1])};
-        uint16_t _tile_extent = Rcpp::as<uint16_t>(tile_extent);
-        auto dim = new tiledb::Dimension(tiledb::Dimension::create<uint16_t>(*ctx.get(), name, _domain, _tile_extent));
-        auto ptr = make_xptr<tiledb::Dimension>(dim);
-        return ptr;
-
-    } else if (dtype == TILEDB_INT8) {
-        Rcpp::IntegerVector domain_vec = Rcpp::IntegerVector(domain);
-        if (domain_vec.length() != 2) {
-            Rcpp::stop("dimension domain must be a c(lower bound, upper bound) pair");
-        }
-        std::array<int8_t, 2> _domain = {static_cast<int8_t>(domain_vec[0]), static_cast<int8_t>(domain_vec[1])};
-        int8_t _tile_extent = static_cast<int8_t>(Rcpp::as<int16_t>(tile_extent));
-        auto dim = new tiledb::Dimension(tiledb::Dimension::create<int8_t>(*ctx.get(), name, _domain, _tile_extent));
-        auto ptr = make_xptr<tiledb::Dimension>(dim);
-        return ptr;
+  } else if (dtype == TILEDB_INT8) {
+    Rcpp::IntegerVector domain_vec = Rcpp::IntegerVector(domain);
+    if (domain_vec.length() != 2) {
+      Rcpp::stop("dimension domain must be a c(lower bound, upper bound) pair");
+    }
+    std::array<int8_t, 2> _domain = {static_cast<int8_t>(domain_vec[0]),
+                                     static_cast<int8_t>(domain_vec[1])};
+    int8_t _tile_extent = static_cast<int8_t>(Rcpp::as<int16_t>(tile_extent));
+    auto dim = new tiledb::Dimension(tiledb::Dimension::create<int8_t>(
+        *ctx.get(), name, _domain, _tile_extent));
+    auto ptr = make_xptr<tiledb::Dimension>(dim);
+    return ptr;
 
   } else if (dtype == TILEDB_UINT8) {
-        Rcpp::IntegerVector domain_vec = Rcpp::IntegerVector(domain);
-        if (domain_vec.length() != 2) {
-            Rcpp::stop("dimension domain must be a c(lower bound, upper bound) pair");
-        }
-        std::array<uint8_t, 2> _domain = {static_cast<uint8_t>(domain_vec[0]), static_cast<uint8_t>(domain_vec[1])};
-        uint8_t _tile_extent = Rcpp::as<uint8_t>(tile_extent);
-        auto dim = new tiledb::Dimension(tiledb::Dimension::create<uint8_t>(*ctx.get(), name, _domain, _tile_extent));
-        auto ptr = make_xptr<tiledb::Dimension>(dim);
-        return ptr;
+    Rcpp::IntegerVector domain_vec = Rcpp::IntegerVector(domain);
+    if (domain_vec.length() != 2) {
+      Rcpp::stop("dimension domain must be a c(lower bound, upper bound) pair");
+    }
+    std::array<uint8_t, 2> _domain = {static_cast<uint8_t>(domain_vec[0]),
+                                      static_cast<uint8_t>(domain_vec[1])};
+    uint8_t _tile_extent = Rcpp::as<uint8_t>(tile_extent);
+    auto dim = new tiledb::Dimension(tiledb::Dimension::create<uint8_t>(
+        *ctx.get(), name, _domain, _tile_extent));
+    auto ptr = make_xptr<tiledb::Dimension>(dim);
+    return ptr;
 
   } else if (dtype == TILEDB_INT64) {
-        // for int64 domains and extents we require integer64 types which are internally memmap'ed from double
-        Rcpp::NumericVector dv(domain);
-        if (!isInteger64(dv)) {
-            Rcpp::stop("dimension domain for INT64 must be an integer64 type in R");
-        }
-        if (dv.size() != 2) {
-            Rcpp::stop("dimension domain must be a c(lower bound, upper bound) pair");
-        }
-        std::vector<int64_t> domain_vec = fromInteger64(Rcpp::NumericVector(dv));
-        std::array<int64_t, 2> _domain = {domain_vec[0], domain_vec[1]};
-        Rcpp::NumericVector ext(tile_extent);
-        if (!isInteger64(ext)) {
-            Rcpp::stop("tile exent for INT64 domain must be an integer64 type in R");
-        }
-        int64_t _tile_extent = fromInteger64(ext[0]);
-        auto dim = new tiledb::Dimension(tiledb::Dimension::create<int64_t>(*ctx.get(), name, _domain, _tile_extent));
-        auto ptr = make_xptr<tiledb::Dimension>(dim);
-        return ptr;
-
-    } else if (dtype == TILEDB_UINT64) {
-        // for uint64 domains and extents we require integer64 types which are internally memmap'ed from double
-        Rcpp::NumericVector dv(domain);
-        if (!isInteger64(dv)) {
-            Rcpp::stop("dimension domain for UINT64 must be an integer64 type in R");
-        }
-        if (dv.size() != 2) {
-            Rcpp::stop("dimension domain must be a c(lower bound, upper bound) pair");
-        }
-        std::vector<int64_t> domain_vec = fromInteger64(Rcpp::NumericVector(dv));
-        std::array<uint64_t, 2> _domain = { static_cast<uint64_t>(domain_vec[0]), static_cast<uint64_t>(domain_vec[1])};
-        Rcpp::NumericVector ext(tile_extent);
-        if (!isInteger64(ext)) {
-            Rcpp::stop("tile exent for UINT64 domain must be an integer64 type in R");
-        }
-        uint64_t _tile_extent = static_cast<uint64_t>(fromInteger64(ext[0]));
-        auto dim = new tiledb::Dimension(tiledb::Dimension::create<uint64_t>(*ctx.get(), name, _domain, _tile_extent));
-        auto ptr = make_xptr<tiledb::Dimension>(dim);
-        return ptr;
-
-    } else if (dtype == TILEDB_FLOAT32) {
-        Rcpp::NumericVector domain_vec = Rcpp::NumericVector(domain);
-        if (domain_vec.length() != 2) {
-            Rcpp::stop("dimension domain must be a c(lower bound, upper bound) pair");
-        }
-        std::array<float, 2> _domain = {static_cast<float>(domain_vec[0]), static_cast<float>(domain_vec[1])};
-        float_t _tile_extent = Rcpp::as<float>(tile_extent);
-        auto d = new tiledb::Dimension(tiledb::Dimension::create<float>(*ctx.get(), name, _domain, _tile_extent));
-        auto ptr = make_xptr<tiledb::Dimension>(d);
-        return ptr;
-
-    } else if (dtype == TILEDB_FLOAT64) {
-        Rcpp::NumericVector domain_vec = Rcpp::NumericVector(domain);
-        if (domain_vec.length() != 2) {
-            Rcpp::stop("dimension domain must be a c(lower bound, upper bound) pair");
-        }
-        std::array<double, 2> _domain = {static_cast<double>(domain_vec[0]), static_cast<double>(domain_vec[1])};
-        double_t _tile_extent = Rcpp::as<double>(tile_extent);
-        auto d = new tiledb::Dimension(tiledb::Dimension::create<double>(*ctx.get(), name, _domain, _tile_extent));
-        auto ptr = make_xptr<tiledb::Dimension>(d);
-        return ptr;
-
-    } else if (dtype == TILEDB_DATETIME_YEAR ||
-               dtype == TILEDB_DATETIME_MONTH ||
-               dtype == TILEDB_DATETIME_WEEK ||
-               dtype == TILEDB_DATETIME_DAY ||
-               dtype == TILEDB_DATETIME_HR  ||
-               dtype == TILEDB_DATETIME_MIN ||
-               dtype == TILEDB_DATETIME_SEC ||
-               dtype == TILEDB_DATETIME_MS  ||
-               dtype == TILEDB_DATETIME_US  ||
-               dtype == TILEDB_DATETIME_NS  ||
-               dtype == TILEDB_DATETIME_PS  ||
-               dtype == TILEDB_DATETIME_FS  ||
-               dtype == TILEDB_DATETIME_AS    ) {
-        auto domain_vec = as<std::vector<int64_t>>(domain);
-        if (domain_vec.size() != 2) {
-            Rcpp::stop("dimension domain must be a c(lower bound, upper bound) pair");
-        }
-        int64_t domain[] = {domain_vec[0], domain_vec[1]};
-        int64_t extent = Rcpp::as<int64_t>(tile_extent);
-        auto dim = new tiledb::Dimension(tiledb::Dimension::create(*ctx.get(), name, dtype, domain, &extent));
-        auto ptr = make_xptr<tiledb::Dimension>(dim);
-        return ptr;
-
-    } else if (dtype == TILEDB_STRING_ASCII) {
-        if (Rf_isNull(domain) && Rf_isNull(tile_extent)) {
-            auto d = tiledb::Dimension::create(*ctx.get(), name, dtype, nullptr, nullptr);
-            auto dim = new tiledb::Dimension(d);
-            auto ptr = make_xptr<tiledb::Dimension>(dim);
-            return ptr;
-
-        } else {
-            Rcpp::stop("Non-null domain or extent to be added.");
-        }
-    } else {
-        Rcpp::stop("Unsupported tiledb type (%d) this should not happen!", dtype);
+    // for int64 domains and extents we require integer64 types which are
+    // internally memmap'ed from double
+    Rcpp::NumericVector dv(domain);
+    if (!isInteger64(dv)) {
+      Rcpp::stop("dimension domain for INT64 must be an integer64 type in R");
     }
+    if (dv.size() != 2) {
+      Rcpp::stop("dimension domain must be a c(lower bound, upper bound) pair");
+    }
+    std::vector<int64_t> domain_vec = fromInteger64(Rcpp::NumericVector(dv));
+    std::array<int64_t, 2> _domain = {domain_vec[0], domain_vec[1]};
+    Rcpp::NumericVector ext(tile_extent);
+    if (!isInteger64(ext)) {
+      Rcpp::stop("tile exent for INT64 domain must be an integer64 type in R");
+    }
+    int64_t _tile_extent = fromInteger64(ext[0]);
+    auto dim = new tiledb::Dimension(tiledb::Dimension::create<int64_t>(
+        *ctx.get(), name, _domain, _tile_extent));
+    auto ptr = make_xptr<tiledb::Dimension>(dim);
+    return ptr;
+
+  } else if (dtype == TILEDB_UINT64) {
+    // for uint64 domains and extents we require integer64 types which are
+    // internally memmap'ed from double
+    Rcpp::NumericVector dv(domain);
+    if (!isInteger64(dv)) {
+      Rcpp::stop("dimension domain for UINT64 must be an integer64 type in R");
+    }
+    if (dv.size() != 2) {
+      Rcpp::stop("dimension domain must be a c(lower bound, upper bound) pair");
+    }
+    std::vector<int64_t> domain_vec = fromInteger64(Rcpp::NumericVector(dv));
+    std::array<uint64_t, 2> _domain = {static_cast<uint64_t>(domain_vec[0]),
+                                       static_cast<uint64_t>(domain_vec[1])};
+    Rcpp::NumericVector ext(tile_extent);
+    if (!isInteger64(ext)) {
+      Rcpp::stop("tile exent for UINT64 domain must be an integer64 type in R");
+    }
+    uint64_t _tile_extent = static_cast<uint64_t>(fromInteger64(ext[0]));
+    auto dim = new tiledb::Dimension(tiledb::Dimension::create<uint64_t>(
+        *ctx.get(), name, _domain, _tile_extent));
+    auto ptr = make_xptr<tiledb::Dimension>(dim);
+    return ptr;
+
+  } else if (dtype == TILEDB_FLOAT32) {
+    Rcpp::NumericVector domain_vec = Rcpp::NumericVector(domain);
+    if (domain_vec.length() != 2) {
+      Rcpp::stop("dimension domain must be a c(lower bound, upper bound) pair");
+    }
+    std::array<float, 2> _domain = {static_cast<float>(domain_vec[0]),
+                                    static_cast<float>(domain_vec[1])};
+    float_t _tile_extent = Rcpp::as<float>(tile_extent);
+    auto d = new tiledb::Dimension(tiledb::Dimension::create<float>(
+        *ctx.get(), name, _domain, _tile_extent));
+    auto ptr = make_xptr<tiledb::Dimension>(d);
+    return ptr;
+
+  } else if (dtype == TILEDB_FLOAT64) {
+    Rcpp::NumericVector domain_vec = Rcpp::NumericVector(domain);
+    if (domain_vec.length() != 2) {
+      Rcpp::stop("dimension domain must be a c(lower bound, upper bound) pair");
+    }
+    std::array<double, 2> _domain = {static_cast<double>(domain_vec[0]),
+                                     static_cast<double>(domain_vec[1])};
+    double_t _tile_extent = Rcpp::as<double>(tile_extent);
+    auto d = new tiledb::Dimension(tiledb::Dimension::create<double>(
+        *ctx.get(), name, _domain, _tile_extent));
+    auto ptr = make_xptr<tiledb::Dimension>(d);
+    return ptr;
+
+  } else if (dtype == TILEDB_DATETIME_YEAR || dtype == TILEDB_DATETIME_MONTH ||
+             dtype == TILEDB_DATETIME_WEEK || dtype == TILEDB_DATETIME_DAY ||
+             dtype == TILEDB_DATETIME_HR || dtype == TILEDB_DATETIME_MIN ||
+             dtype == TILEDB_DATETIME_SEC || dtype == TILEDB_DATETIME_MS ||
+             dtype == TILEDB_DATETIME_US || dtype == TILEDB_DATETIME_NS ||
+             dtype == TILEDB_DATETIME_PS || dtype == TILEDB_DATETIME_FS ||
+             dtype == TILEDB_DATETIME_AS) {
+    auto domain_vec = as<std::vector<int64_t>>(domain);
+    if (domain_vec.size() != 2) {
+      Rcpp::stop("dimension domain must be a c(lower bound, upper bound) pair");
+    }
+    int64_t domain[] = {domain_vec[0], domain_vec[1]};
+    int64_t extent = Rcpp::as<int64_t>(tile_extent);
+    auto dim = new tiledb::Dimension(
+        tiledb::Dimension::create(*ctx.get(), name, dtype, domain, &extent));
+    auto ptr = make_xptr<tiledb::Dimension>(dim);
+    return ptr;
+
+  } else if (dtype == TILEDB_STRING_ASCII) {
+    if (Rf_isNull(domain) && Rf_isNull(tile_extent)) {
+      auto d =
+          tiledb::Dimension::create(*ctx.get(), name, dtype, nullptr, nullptr);
+      auto dim = new tiledb::Dimension(d);
+      auto ptr = make_xptr<tiledb::Dimension>(dim);
+      return ptr;
+
+    } else {
+      Rcpp::stop("Non-null domain or extent to be added.");
+    }
+  } else {
+    Rcpp::stop("Unsupported tiledb type (%d) this should not happen!", dtype);
+  }
 }
 
 // [[Rcpp::export]]
@@ -895,105 +928,113 @@ SEXP libtiledb_dim_get_domain(XPtr<tiledb::Dimension> dim) {
   check_xptr_tag<tiledb::Dimension>(dim);
   auto dim_type = dim->type();
   switch (dim_type) {
-    case TILEDB_FLOAT32: {
-      using DataType = tiledb::impl::tiledb_to_type<TILEDB_FLOAT32>::type;
-      return NumericVector({dim->domain<DataType>().first,
-                            dim->domain<DataType>().second});
+  case TILEDB_FLOAT32: {
+    using DataType = tiledb::impl::tiledb_to_type<TILEDB_FLOAT32>::type;
+    return NumericVector(
+        {dim->domain<DataType>().first, dim->domain<DataType>().second});
+  }
+  case TILEDB_FLOAT64: {
+    using DataType = tiledb::impl::tiledb_to_type<TILEDB_FLOAT64>::type;
+    auto d1 = dim->domain<DataType>().first;
+    auto d2 = dim->domain<DataType>().second;
+    if (d1 == R_NaReal || d2 == R_NaReal) {
+      Rcpp::stop(
+          "tiledb_dim domain FLOAT64 value not representable as an R double");
     }
-    case TILEDB_FLOAT64: {
-      using DataType = tiledb::impl::tiledb_to_type<TILEDB_FLOAT64>::type;
-      auto d1 = dim->domain<DataType>().first;
-      auto d2 = dim->domain<DataType>().second;
-      if (d1 == R_NaReal || d2 == R_NaReal) {
-        Rcpp::stop("tiledb_dim domain FLOAT64 value not representable as an R double");
-      }
-      return NumericVector({d1, d2});
+    return NumericVector({d1, d2});
+  }
+  case TILEDB_INT8: {
+    using DataType = tiledb::impl::tiledb_to_type<TILEDB_INT8>::type;
+    return IntegerVector(
+        {dim->domain<DataType>().first, dim->domain<DataType>().second});
+  }
+  case TILEDB_UINT8: {
+    using DataType = tiledb::impl::tiledb_to_type<TILEDB_UINT8>::type;
+    return IntegerVector(
+        {dim->domain<DataType>().first, dim->domain<DataType>().second});
+  }
+  case TILEDB_INT16: {
+    using DataType = tiledb::impl::tiledb_to_type<TILEDB_INT16>::type;
+    return IntegerVector(
+        {dim->domain<DataType>().first, dim->domain<DataType>().second});
+  }
+  case TILEDB_UINT16: {
+    using DataType = tiledb::impl::tiledb_to_type<TILEDB_UINT16>::type;
+    return IntegerVector(
+        {dim->domain<DataType>().first, dim->domain<DataType>().second});
+  }
+  case TILEDB_INT32: {
+    using DataType = tiledb::impl::tiledb_to_type<TILEDB_INT32>::type;
+    auto d1 = dim->domain<DataType>().first;
+    auto d2 = dim->domain<DataType>().second;
+    if (d1 == R_NaInt || d2 == R_NaInt) {
+      Rcpp::stop(
+          "tiledb_dim domain INT32 value not representable as an R integer");
     }
-    case TILEDB_INT8: {
-      using DataType = tiledb::impl::tiledb_to_type<TILEDB_INT8>::type;
-      return IntegerVector({dim->domain<DataType>().first,
-                            dim->domain<DataType>().second});
+    return IntegerVector({d1, d2});
+  }
+  case TILEDB_UINT32: {
+    using DataType = tiledb::impl::tiledb_to_type<TILEDB_UINT32>::type;
+    auto d1 = dim->domain<DataType>().first;
+    auto d2 = dim->domain<DataType>().second;
+    if (d1 > std::numeric_limits<uint32_t>::max() ||
+        d2 > std::numeric_limits<uint32_t>::max()) {
+      Rcpp::stop("tiledb_dim domain UINT32 value not representable as an R "
+                 "integer64 type");
     }
-    case TILEDB_UINT8: {
-      using DataType = tiledb::impl::tiledb_to_type<TILEDB_UINT8>::type;
-      return IntegerVector({dim->domain<DataType>().first,
-                            dim->domain<DataType>().second});
+    std::vector<int64_t> v = {static_cast<int64_t>(d1),
+                              static_cast<int64_t>(d2)};
+    return toInteger64(v);
+  }
+  case TILEDB_INT64: {
+    using DataType = tiledb::impl::tiledb_to_type<TILEDB_INT64>::type;
+    auto d1 = dim->domain<DataType>().first;
+    auto d2 = dim->domain<DataType>().second;
+    if (d1 > std::numeric_limits<int64_t>::max() ||
+        d2 > std::numeric_limits<int64_t>::max()) {
+      return NumericVector({static_cast<double>(d1), static_cast<double>(d2)});
     }
-    case TILEDB_INT16: {
-      using DataType = tiledb::impl::tiledb_to_type<TILEDB_INT16>::type;
-      return IntegerVector({dim->domain<DataType>().first,
-                            dim->domain<DataType>().second});
+    std::vector<int64_t> v = {d1, d2};
+    return toInteger64(v);
+  }
+  case TILEDB_UINT64: {
+    using DataType = tiledb::impl::tiledb_to_type<TILEDB_UINT64>::type;
+    auto d1 = dim->domain<DataType>().first;
+    auto d2 = dim->domain<DataType>().second;
+    if (d1 > std::numeric_limits<int64_t>::max() ||
+        d2 > std::numeric_limits<int64_t>::max()) {
+      return NumericVector({static_cast<double>(d1), static_cast<double>(d2)});
     }
-    case TILEDB_UINT16: {
-      using DataType = tiledb::impl::tiledb_to_type<TILEDB_UINT16>::type;
-      return IntegerVector({dim->domain<DataType>().first,
-                            dim->domain<DataType>().second});
+    std::vector<int64_t> v = {static_cast<int64_t>(d1),
+                              static_cast<int64_t>(d2)};
+    return toInteger64(v);
+  }
+  case TILEDB_DATETIME_YEAR:
+  case TILEDB_DATETIME_MONTH:
+  case TILEDB_DATETIME_WEEK:
+  case TILEDB_DATETIME_DAY:
+  case TILEDB_DATETIME_HR:
+  case TILEDB_DATETIME_MIN:
+  case TILEDB_DATETIME_SEC:
+  case TILEDB_DATETIME_MS:
+  case TILEDB_DATETIME_US:
+  case TILEDB_DATETIME_NS:
+  case TILEDB_DATETIME_PS:
+  case TILEDB_DATETIME_FS:
+  case TILEDB_DATETIME_AS: {
+    using DataType = tiledb::impl::tiledb_to_type<TILEDB_INT64>::type;
+    auto d1 = dim->domain<DataType>().first;
+    auto d2 = dim->domain<DataType>().second;
+    if (d1 <= R_NaInt || d1 > std::numeric_limits<int32_t>::max() ||
+        d2 <= R_NaInt || d2 > std::numeric_limits<int32_t>::max()) {
+      std::vector<int64_t> v{d1, d2}; // return as int64
+      return toInteger64(v);          // which 'travels' as a double
     }
-    case TILEDB_INT32: {
-      using DataType = tiledb::impl::tiledb_to_type<TILEDB_INT32>::type;
-      auto d1 = dim->domain<DataType>().first;
-      auto d2 = dim->domain<DataType>().second;
-      if (d1 == R_NaInt || d2 == R_NaInt) {
-        Rcpp::stop("tiledb_dim domain INT32 value not representable as an R integer");
-      }
-      return IntegerVector({d1, d2});
-    }
-    case TILEDB_UINT32: {
-      using DataType = tiledb::impl::tiledb_to_type<TILEDB_UINT32>::type;
-      auto d1 = dim->domain<DataType>().first;
-      auto d2 = dim->domain<DataType>().second;
-      if (d1 > std::numeric_limits<uint32_t>::max() ||
-          d2 > std::numeric_limits<uint32_t>::max()) {
-        Rcpp::stop("tiledb_dim domain UINT32 value not representable as an R integer64 type");
-      }
-      std::vector<int64_t> v = { static_cast<int64_t>(d1), static_cast<int64_t>(d2) };
-      return toInteger64(v);
-    }
-    case TILEDB_INT64: {
-      using DataType = tiledb::impl::tiledb_to_type<TILEDB_INT64>::type;
-      auto d1 = dim->domain<DataType>().first;
-      auto d2 = dim->domain<DataType>().second;
-      if (d1 > std::numeric_limits<int64_t>::max() || d2 > std::numeric_limits<int64_t>::max()) {
-          return NumericVector({static_cast<double>(d1), static_cast<double>(d2)});
-      }
-      std::vector<int64_t> v = { d1, d2 };
-      return toInteger64(v);
-    }
-    case TILEDB_UINT64: {
-      using DataType = tiledb::impl::tiledb_to_type<TILEDB_UINT64>::type;
-      auto d1 = dim->domain<DataType>().first;
-      auto d2 = dim->domain<DataType>().second;
-      if (d1 > std::numeric_limits<int64_t>::max() || d2 > std::numeric_limits<int64_t>::max()) {
-          return NumericVector({static_cast<double>(d1), static_cast<double>(d2)});
-      }
-      std::vector<int64_t> v = { static_cast<int64_t>(d1), static_cast<int64_t>(d2) };
-      return toInteger64(v);
-    }
-    case TILEDB_DATETIME_YEAR:
-    case TILEDB_DATETIME_MONTH:
-    case TILEDB_DATETIME_WEEK:
-    case TILEDB_DATETIME_DAY:
-    case TILEDB_DATETIME_HR:
-    case TILEDB_DATETIME_MIN:
-    case TILEDB_DATETIME_SEC:
-    case TILEDB_DATETIME_MS:
-    case TILEDB_DATETIME_US:
-    case TILEDB_DATETIME_NS:
-    case TILEDB_DATETIME_PS:
-    case TILEDB_DATETIME_FS:
-    case TILEDB_DATETIME_AS: {
-      using DataType = tiledb::impl::tiledb_to_type<TILEDB_INT64>::type;
-      auto d1 = dim->domain<DataType>().first;
-      auto d2 = dim->domain<DataType>().second;
-      if (d1 <= R_NaInt || d1 > std::numeric_limits<int32_t>::max() ||
-          d2 <= R_NaInt || d2 > std::numeric_limits<int32_t>::max()) {
-          std::vector<int64_t> v{d1, d2};     // return as int64
-          return toInteger64(v);              // which 'travels' as a double
-      }
-      return IntegerVector({static_cast<int32_t>(d1), static_cast<int32_t>(d2)});
-    }
-    default:
-      Rcpp::stop("invalid tiledb_dim domain type (%s)", _tiledb_datatype_to_string(dim_type));
+    return IntegerVector({static_cast<int32_t>(d1), static_cast<int32_t>(d2)});
+  }
+  default:
+    Rcpp::stop("invalid tiledb_dim domain type (%s)",
+               _tiledb_datatype_to_string(dim_type));
   }
 }
 
@@ -1002,91 +1043,96 @@ SEXP libtiledb_dim_get_tile_extent(XPtr<tiledb::Dimension> dim) {
   check_xptr_tag<tiledb::Dimension>(dim);
   auto dim_type = dim->type();
   switch (dim_type) {
-    case TILEDB_FLOAT32: {
-      using DataType = tiledb::impl::tiledb_to_type<TILEDB_FLOAT32>::type;
-      return Rcpp::wrap(static_cast<double>(dim->tile_extent<DataType>()));
+  case TILEDB_FLOAT32: {
+    using DataType = tiledb::impl::tiledb_to_type<TILEDB_FLOAT32>::type;
+    return Rcpp::wrap(static_cast<double>(dim->tile_extent<DataType>()));
+  }
+  case TILEDB_FLOAT64: {
+    using DataType = tiledb::impl::tiledb_to_type<TILEDB_FLOAT64>::type;
+    auto t = dim->tile_extent<DataType>();
+    if (t == R_NaReal) {
+      Rcpp::stop(
+          "tiledb_dim tile FLOAT64 value not representable as an R double");
     }
-    case TILEDB_FLOAT64: {
-      using DataType = tiledb::impl::tiledb_to_type<TILEDB_FLOAT64>::type;
-      auto t = dim->tile_extent<DataType>();
-      if (t == R_NaReal) {
-        Rcpp::stop("tiledb_dim tile FLOAT64 value not representable as an R double");
-      }
-      return Rcpp::wrap(static_cast<double>(dim->tile_extent<DataType>()));
+    return Rcpp::wrap(static_cast<double>(dim->tile_extent<DataType>()));
+  }
+  case TILEDB_INT8: {
+    using DataType = tiledb::impl::tiledb_to_type<TILEDB_INT8>::type;
+    return Rcpp::wrap(static_cast<int32_t>(dim->tile_extent<DataType>()));
+  }
+  case TILEDB_UINT8: {
+    using DataType = tiledb::impl::tiledb_to_type<TILEDB_UINT8>::type;
+    return Rcpp::wrap(static_cast<int32_t>(dim->tile_extent<DataType>()));
+  }
+  case TILEDB_INT16: {
+    using DataType = tiledb::impl::tiledb_to_type<TILEDB_INT16>::type;
+    return Rcpp::wrap(static_cast<int32_t>(dim->tile_extent<DataType>()));
+  }
+  case TILEDB_UINT16: {
+    using DataType = tiledb::impl::tiledb_to_type<TILEDB_UINT16>::type;
+    return Rcpp::wrap(static_cast<int32_t>(dim->tile_extent<DataType>()));
+  }
+  case TILEDB_INT32: {
+    using DataType = tiledb::impl::tiledb_to_type<TILEDB_INT32>::type;
+    auto t = dim->tile_extent<DataType>();
+    if (t == R_NaInt) {
+      Rcpp::stop(
+          "tiledb_dim tile INT32 value not representable as an R integer");
     }
-    case TILEDB_INT8: {
-      using DataType = tiledb::impl::tiledb_to_type<TILEDB_INT8>::type;
-      return Rcpp::wrap(static_cast<int32_t>(dim->tile_extent<DataType>()));
-    }
-    case TILEDB_UINT8: {
-      using DataType = tiledb::impl::tiledb_to_type<TILEDB_UINT8>::type;
-      return Rcpp::wrap(static_cast<int32_t>(dim->tile_extent<DataType>()));
-    }
-    case TILEDB_INT16: {
-      using DataType = tiledb::impl::tiledb_to_type<TILEDB_INT16>::type;
-      return Rcpp::wrap(static_cast<int32_t>(dim->tile_extent<DataType>()));
-    }
-    case TILEDB_UINT16: {
-      using DataType = tiledb::impl::tiledb_to_type<TILEDB_UINT16>::type;
-      return Rcpp::wrap(static_cast<int32_t>(dim->tile_extent<DataType>()));
-    }
-    case TILEDB_INT32: {
-      using DataType = tiledb::impl::tiledb_to_type<TILEDB_INT32>::type;
-      auto t = dim->tile_extent<DataType>();
-      if (t == R_NaInt) {
-        Rcpp::stop("tiledb_dim tile INT32 value not representable as an R integer");
-      }
+    return Rcpp::wrap(static_cast<int32_t>(t));
+  }
+  case TILEDB_UINT32: {
+    using DataType = tiledb::impl::tiledb_to_type<TILEDB_UINT32>::type;
+    auto t = dim->tile_extent<DataType>();
+    if (t > std::numeric_limits<int32_t>::max()) {
+      Rcpp::warning("tiledb_dim tile UINT32 value not representable as an R "
+                    "integer, returning double");
+      return Rcpp::wrap(static_cast<double>(t));
+    } else {
       return Rcpp::wrap(static_cast<int32_t>(t));
     }
-    case TILEDB_UINT32: {
-      using DataType = tiledb::impl::tiledb_to_type<TILEDB_UINT32>::type;
-      auto t = dim->tile_extent<DataType>();
-      if (t > std::numeric_limits<int32_t>::max()) {
-        Rcpp::warning("tiledb_dim tile UINT32 value not representable as an R integer, returning double");
-        return Rcpp::wrap(static_cast<double>(t));
-      } else {
-        return Rcpp::wrap(static_cast<int32_t>(t));
-      }
+  }
+  case TILEDB_DATETIME_YEAR:
+  case TILEDB_DATETIME_MONTH:
+  case TILEDB_DATETIME_WEEK:
+  case TILEDB_DATETIME_DAY:
+  case TILEDB_DATETIME_HR:
+  case TILEDB_DATETIME_MIN:
+  case TILEDB_DATETIME_SEC:
+  case TILEDB_DATETIME_MS:
+  case TILEDB_DATETIME_US:
+  case TILEDB_DATETIME_NS:
+  case TILEDB_DATETIME_PS:
+  case TILEDB_DATETIME_FS:
+  case TILEDB_DATETIME_AS:
+  case TILEDB_INT64: {
+    using DataType = tiledb::impl::tiledb_to_type<TILEDB_INT64>::type;
+    auto t = dim->tile_extent<DataType>();
+    if (t <= R_NaInt || t > std::numeric_limits<int32_t>::max()) {
+      std::vector<int64_t> v{t}; // return as int64
+      return toInteger64(v);     // which 'travels' as a double
     }
-    case TILEDB_DATETIME_YEAR:
-    case TILEDB_DATETIME_MONTH:
-    case TILEDB_DATETIME_WEEK:
-    case TILEDB_DATETIME_DAY:
-    case TILEDB_DATETIME_HR:
-    case TILEDB_DATETIME_MIN:
-    case TILEDB_DATETIME_SEC:
-    case TILEDB_DATETIME_MS:
-    case TILEDB_DATETIME_US:
-    case TILEDB_DATETIME_NS:
-    case TILEDB_DATETIME_PS:
-    case TILEDB_DATETIME_FS:
-    case TILEDB_DATETIME_AS:
-    case TILEDB_INT64: {
-      using DataType = tiledb::impl::tiledb_to_type<TILEDB_INT64>::type;
-      auto t = dim->tile_extent<DataType>();
-      if (t <= R_NaInt || t > std::numeric_limits<int32_t>::max()) {
-          std::vector<int64_t> v{t};         // return as int64
-          return toInteger64(v);             // which 'travels' as a double
-      }
-      // 'else' i.e. default cast to int32
-      return Rcpp::wrap(static_cast<int32_t>(t));
+    // 'else' i.e. default cast to int32
+    return Rcpp::wrap(static_cast<int32_t>(t));
+  }
+  case TILEDB_UINT64: {
+    using DataType = tiledb::impl::tiledb_to_type<TILEDB_UINT64>::type;
+    auto t = dim->tile_extent<DataType>();
+    if (t > std::numeric_limits<int64_t>::max()) {
+      Rcpp::warning("tiledb_dim tile UINT32 value not representable as an "
+                    "INT64, returning double");
+      return Rcpp::wrap(static_cast<double>(t));
     }
-    case TILEDB_UINT64: {
-      using DataType = tiledb::impl::tiledb_to_type<TILEDB_UINT64>::type;
-      auto t = dim->tile_extent<DataType>();
-      if (t > std::numeric_limits<int64_t>::max()) {
-          Rcpp::warning("tiledb_dim tile UINT32 value not representable as an INT64, returning double");
-          return Rcpp::wrap(static_cast<double>(t));
-      }
-      if (t > std::numeric_limits<int32_t>::max()) {
-          auto tt = static_cast<int64_t>(t); // avoids a 'narrowing' watnings
-          std::vector<int64_t> v{ tt };      // return as int64
-          return toInteger64(v);             // which 'travels' as a double
-      }
-      return Rcpp::wrap(static_cast<int32_t>(t));
+    if (t > std::numeric_limits<int32_t>::max()) {
+      auto tt = static_cast<int64_t>(t); // avoids a 'narrowing' watnings
+      std::vector<int64_t> v{tt};        // return as int64
+      return toInteger64(v);             // which 'travels' as a double
     }
-    default:
-      Rcpp::stop("invalid tiledb_dim domain type (%s)", _tiledb_datatype_to_string(dim_type));
+    return Rcpp::wrap(static_cast<int32_t>(t));
+  }
+  default:
+    Rcpp::stop("invalid tiledb_dim domain type (%s)",
+               _tiledb_datatype_to_string(dim_type));
   }
 }
 
@@ -1098,7 +1144,8 @@ std::string libtiledb_dim_get_datatype(XPtr<tiledb::Dimension> dim) {
 
 // Computes the TileDB subarray for a given dimension domain
 // [[Rcpp::export]]
-NumericVector dim_domain_subarray(NumericVector domain, NumericVector subscript) {
+NumericVector dim_domain_subarray(NumericVector domain,
+                                  NumericVector subscript) {
   if (domain.length() != 2) {
     Rcpp::stop("invalid tiledb_dim domain");
   }
@@ -1125,8 +1172,8 @@ NumericVector dim_domain_subarray(NumericVector domain, NumericVector subscript)
       Rcpp::stop("NA subscripting not supported");
     }
     if (high < domain_lb || high > domain_ub) {
-      Rcpp::stop("subscript out of domain bounds: (at index: [%d] %f < %f",
-                 i, high, domain_lb);
+      Rcpp::stop("subscript out of domain bounds: (at index: [%d] %f < %f", i,
+                 high, domain_lb);
     }
     double diff = high - low;
     if (diff > 1.0 || diff < 1.0) {
@@ -1147,7 +1194,7 @@ int libtiledb_dim_get_cell_val_num(XPtr<tiledb::Dimension> dim) {
   check_xptr_tag<tiledb::Dimension>(dim);
   unsigned int ncells = dim->cell_val_num();
   if (ncells == TILEDB_VAR_NUM) {
-    return R_NaInt;          // set to R's NA for integer
+    return R_NaInt; // set to R's NA for integer
   } else if (ncells > std::numeric_limits<int32_t>::max()) {
     Rcpp::stop("tiledb_attr ncells value not representable as an R integer");
   }
@@ -1155,20 +1202,22 @@ int libtiledb_dim_get_cell_val_num(XPtr<tiledb::Dimension> dim) {
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::FilterList> libtiledb_dimension_get_filter_list(XPtr<tiledb::Dimension> dim) {
+XPtr<tiledb::FilterList>
+libtiledb_dimension_get_filter_list(XPtr<tiledb::Dimension> dim) {
   check_xptr_tag<tiledb::Dimension>(dim);
-  return make_xptr<tiledb::FilterList>(new tiledb::FilterList(dim->filter_list()));
+  return make_xptr<tiledb::FilterList>(
+      new tiledb::FilterList(dim->filter_list()));
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::Dimension> libtiledb_dimension_set_filter_list(XPtr<tiledb::Dimension> dim,
-                                                            XPtr<tiledb::FilterList> fltrlst) {
+XPtr<tiledb::Dimension>
+libtiledb_dimension_set_filter_list(XPtr<tiledb::Dimension> dim,
+                                    XPtr<tiledb::FilterList> fltrlst) {
   check_xptr_tag<tiledb::Dimension>(dim);
   check_xptr_tag<tiledb::FilterList>(fltrlst);
   dim->set_filter_list(*fltrlst);
   return dim;
 }
-
 
 /**
  * TileDB Domain
@@ -1180,15 +1229,18 @@ XPtr<tiledb::Domain> libtiledb_domain(XPtr<tiledb::Context> ctx, List dims) {
   if (ndims == 0) {
     Rcpp::stop("domain must have one or more dimensions");
   }
-  for (R_xlen_t i=0; i < ndims; i++) {
+  for (R_xlen_t i = 0; i < ndims; i++) {
     SEXP d = dims[i];
     if (TYPEOF(d) != EXTPTRSXP) {
-      Rcpp::stop("Invalid tiledb_dim object at index %d (type %s)", i, Rcpp::type2name(d));
+      Rcpp::stop("Invalid tiledb_dim object at index %d (type %s)", i,
+                 Rcpp::type2name(d));
     }
   }
-  XPtr<tiledb::Domain> domain = make_xptr<tiledb::Domain>(new tiledb::Domain(*ctx.get()));
-  for (auto& val : dims) {
-    // TODO: we can't do much type checking for the cast here until we wrap EXTPTRSXP in S4 classes
+  XPtr<tiledb::Domain> domain =
+      make_xptr<tiledb::Domain>(new tiledb::Domain(*ctx.get()));
+  for (auto &val : dims) {
+    // TODO: we can't do much type checking for the cast here until we wrap
+    // EXTPTRSXP in S4 classes
     auto dim = as<XPtr<tiledb::Dimension>>(val);
     check_xptr_tag<tiledb::Dimension>(dim);
     domain->add_dimension(*dim.get());
@@ -1214,7 +1266,8 @@ int libtiledb_domain_get_ndim(XPtr<tiledb::Domain> domain) {
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::Dimension> libtiledb_domain_get_dimension_from_index(XPtr<tiledb::Domain> dom, int idx) {
+XPtr<tiledb::Dimension>
+libtiledb_domain_get_dimension_from_index(XPtr<tiledb::Domain> dom, int idx) {
   check_xptr_tag<tiledb::Domain>(dom);
   auto dim = dom->dimension(idx);
   auto ptr = make_xptr<tiledb::Dimension>(new tiledb::Dimension(dim));
@@ -1222,8 +1275,9 @@ XPtr<tiledb::Dimension> libtiledb_domain_get_dimension_from_index(XPtr<tiledb::D
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::Dimension> libtiledb_domain_get_dimension_from_name(XPtr<tiledb::Domain> dom,
-                                                                 std::string name) {
+XPtr<tiledb::Dimension>
+libtiledb_domain_get_dimension_from_name(XPtr<tiledb::Domain> dom,
+                                         std::string name) {
   check_xptr_tag<tiledb::Domain>(dom);
   auto dim = dom->dimension(name.c_str());
   auto ptr = make_xptr<tiledb::Dimension>(new tiledb::Dimension(dim));
@@ -1234,14 +1288,16 @@ XPtr<tiledb::Dimension> libtiledb_domain_get_dimension_from_name(XPtr<tiledb::Do
 List libtiledb_domain_get_dimensions(XPtr<tiledb::Domain> domain) {
   check_xptr_tag<tiledb::Domain>(domain);
   List dimensions;
-  for (auto& dim : domain->dimensions()) {
-    dimensions.push_back(make_xptr<tiledb::Dimension>(new tiledb::Dimension(dim)));
+  for (auto &dim : domain->dimensions()) {
+    dimensions.push_back(
+        make_xptr<tiledb::Dimension>(new tiledb::Dimension(dim)));
   }
   return dimensions;
 }
 
 // [[Rcpp::export]]
-bool libtiledb_domain_has_dimension(XPtr<tiledb::Domain> domain, std::string name) {
+bool libtiledb_domain_has_dimension(XPtr<tiledb::Domain> domain,
+                                    std::string name) {
   check_xptr_tag<tiledb::Domain>(domain);
   return domain->has_dimension(name.c_str());
 }
@@ -1249,7 +1305,7 @@ bool libtiledb_domain_has_dimension(XPtr<tiledb::Domain> domain, std::string nam
 // [[Rcpp::export]]
 void libtiledb_domain_dump(XPtr<tiledb::Domain> domain) {
   check_xptr_tag<tiledb::Domain>(domain);
-#if TILEDB_VERSION >= TileDB_Version(2,25,0)
+#if TILEDB_VERSION >= TileDB_Version(2, 25, 0)
   std::stringstream ss;
   ss << *domain;
   Rcpp::Rcout << ss.str();
@@ -1259,7 +1315,8 @@ void libtiledb_domain_dump(XPtr<tiledb::Domain> domain) {
 }
 
 double _domain_datatype_time_scale_factor(tiledb_datatype_t dtype) {
-  //Rcpp::Rcout << "In _domain_datatype_time_scale_factor " << dtype << std::endl;
+  // Rcpp::Rcout << "In _domain_datatype_time_scale_factor " << dtype <<
+  // std::endl;
   switch (dtype) {
   case TILEDB_INT8:
   case TILEDB_UINT8:
@@ -1279,11 +1336,11 @@ double _domain_datatype_time_scale_factor(tiledb_datatype_t dtype) {
   case TILEDB_STRING_UCS2:
   case TILEDB_STRING_UCS4:
   case TILEDB_ANY:
-    return 1.0;               // fallback, could also error here
+    return 1.0; // fallback, could also error here
   case TILEDB_DATETIME_YEAR:
   case TILEDB_DATETIME_MONTH:
   case TILEDB_DATETIME_WEEK:
-    return 1.0;                 // also fallback
+    return 1.0; // also fallback
   case TILEDB_DATETIME_DAY:
     return 24 * 60 * 60 * 1e9;
   case TILEDB_DATETIME_HR:
@@ -1310,12 +1367,12 @@ double _domain_datatype_time_scale_factor(tiledb_datatype_t dtype) {
   return R_NaReal; // not reached
 }
 
-
 /**
  * TileDB Filter
  */
 //[[Rcpp::export]]
-XPtr<tiledb::Filter> libtiledb_filter(XPtr<tiledb::Context> ctx, std::string filter) {
+XPtr<tiledb::Filter> libtiledb_filter(XPtr<tiledb::Context> ctx,
+                                      std::string filter) {
   check_xptr_tag<tiledb::Context>(ctx);
   tiledb_filter_type_t fltr = _string_to_tiledb_filter(filter);
   return make_xptr<tiledb::Filter>(new tiledb::Filter(*ctx.get(), fltr));
@@ -1328,10 +1385,13 @@ std::string libtiledb_filter_get_type(XPtr<tiledb::Filter> filter) {
 }
 
 //[[Rcpp::export]]
-R_xlen_t libtiledb_filter_get_option(XPtr<tiledb::Filter> filter, std::string filter_option_str) {
+R_xlen_t libtiledb_filter_get_option(XPtr<tiledb::Filter> filter,
+                                     std::string filter_option_str) {
   check_xptr_tag<tiledb::Filter>(filter);
-  tiledb_filter_option_t filter_option = _string_to_tiledb_filter_option(filter_option_str);
-  if (filter_option == TILEDB_BIT_WIDTH_MAX_WINDOW || filter_option == TILEDB_POSITIVE_DELTA_MAX_WINDOW) {
+  tiledb_filter_option_t filter_option =
+      _string_to_tiledb_filter_option(filter_option_str);
+  if (filter_option == TILEDB_BIT_WIDTH_MAX_WINDOW ||
+      filter_option == TILEDB_POSITIVE_DELTA_MAX_WINDOW) {
     uint32_t value;
     filter->get_option(filter_option, &value);
     return static_cast<R_xlen_t>(value);
@@ -1342,39 +1402,46 @@ R_xlen_t libtiledb_filter_get_option(XPtr<tiledb::Filter> filter, std::string fi
 }
 
 //[[Rcpp::export]]
-XPtr<tiledb::Filter> libtiledb_filter_set_option(XPtr<tiledb::Filter> filter, std::string filter_option_str, SEXP valuesxp) {
-    check_xptr_tag<tiledb::Filter>(filter);
-    tiledb_filter_option_t filter_option = _string_to_tiledb_filter_option(filter_option_str);
-#if TILEDB_VERSION >= TileDB_Version(2,11,0)
-    // For scale_float filters we need either a double, or an
-    if (filter_option == TILEDB_SCALE_FLOAT_FACTOR || filter_option == TILEDB_SCALE_FLOAT_OFFSET) {
-        double value = Rcpp::as<double>(valuesxp);
-        spdl::debug(tfm::format("[libtiledb_filter_set_option] setting %s to %f", filter_option_str, value));
-        filter->set_option(filter_option, &value);
-        return filter;
-    } else if (filter_option == TILEDB_SCALE_FLOAT_BYTEWIDTH) {
-        double dblval = Rcpp::as<double>(valuesxp);
-        int64_t int64val = fromInteger64(dblval);
-        uint64_t value = static_cast<uint64_t>(int64val);
-        spdl::debug(tfm::format("[libtiledb_filter_set_option] setting %s to %ld", filter_option_str, value));
-        filter->set_option(filter_option, &value);
-        return filter;
-    }
-#endif
-    // all others set an int value
-    int32_t value = Rcpp::as<int32_t>(valuesxp);
+XPtr<tiledb::Filter> libtiledb_filter_set_option(XPtr<tiledb::Filter> filter,
+                                                 std::string filter_option_str,
+                                                 SEXP valuesxp) {
+  check_xptr_tag<tiledb::Filter>(filter);
+  tiledb_filter_option_t filter_option =
+      _string_to_tiledb_filter_option(filter_option_str);
+#if TILEDB_VERSION >= TileDB_Version(2, 11, 0)
+  // For scale_float filters we need either a double, or an
+  if (filter_option == TILEDB_SCALE_FLOAT_FACTOR ||
+      filter_option == TILEDB_SCALE_FLOAT_OFFSET) {
+    double value = Rcpp::as<double>(valuesxp);
+    spdl::debug(tfm::format("[libtiledb_filter_set_option] setting %s to %f",
+                            filter_option_str, value));
     filter->set_option(filter_option, &value);
     return filter;
+  } else if (filter_option == TILEDB_SCALE_FLOAT_BYTEWIDTH) {
+    double dblval = Rcpp::as<double>(valuesxp);
+    int64_t int64val = fromInteger64(dblval);
+    uint64_t value = static_cast<uint64_t>(int64val);
+    spdl::debug(tfm::format("[libtiledb_filter_set_option] setting %s to %ld",
+                            filter_option_str, value));
+    filter->set_option(filter_option, &value);
+    return filter;
+  }
+#endif
+  // all others set an int value
+  int32_t value = Rcpp::as<int32_t>(valuesxp);
+  filter->set_option(filter_option, &value);
+  return filter;
 }
-
 
 /**
  * TileDB Filter List
  */
 //[[Rcpp::export]]
-XPtr<tiledb::FilterList> libtiledb_filter_list(XPtr<tiledb::Context> ctx, List filters) {
+XPtr<tiledb::FilterList> libtiledb_filter_list(XPtr<tiledb::Context> ctx,
+                                               List filters) {
   check_xptr_tag<tiledb::Context>(ctx);
-  XPtr<tiledb::FilterList> fltrlst = make_xptr<tiledb::FilterList>(new tiledb::FilterList(*ctx.get()));
+  XPtr<tiledb::FilterList> fltrlst =
+      make_xptr<tiledb::FilterList>(new tiledb::FilterList(*ctx.get()));
   // check that external pointers are supported
   R_xlen_t nfilters = filters.length();
   if (nfilters > 0) {
@@ -1388,13 +1455,15 @@ XPtr<tiledb::FilterList> libtiledb_filter_list(XPtr<tiledb::Context> ctx, List f
 }
 
 //[[Rcpp::export]]
-void libtiledb_filter_list_set_max_chunk_size(XPtr<tiledb::FilterList> filterList, uint32_t max_chunk_size) {
+void libtiledb_filter_list_set_max_chunk_size(
+    XPtr<tiledb::FilterList> filterList, uint32_t max_chunk_size) {
   check_xptr_tag<tiledb::FilterList>(filterList);
   filterList->set_max_chunk_size(max_chunk_size);
 }
 
 //[[Rcpp::export]]
-int libtiledb_filter_list_get_max_chunk_size(XPtr<tiledb::FilterList> filterList) {
+int libtiledb_filter_list_get_max_chunk_size(
+    XPtr<tiledb::FilterList> filterList) {
   check_xptr_tag<tiledb::FilterList>(filterList);
   return filterList->max_chunk_size();
 }
@@ -1406,82 +1475,78 @@ int libtiledb_filter_list_get_nfilters(XPtr<tiledb::FilterList> filterList) {
 }
 
 //[[Rcpp::export]]
-XPtr<tiledb::Filter> libtiledb_filter_list_get_filter_from_index(XPtr<tiledb::FilterList> filterList, uint32_t filter_index) {
+XPtr<tiledb::Filter>
+libtiledb_filter_list_get_filter_from_index(XPtr<tiledb::FilterList> filterList,
+                                            uint32_t filter_index) {
   check_xptr_tag<tiledb::FilterList>(filterList);
-  return make_xptr<tiledb::Filter>(new tiledb::Filter(filterList->filter(filter_index)));
+  return make_xptr<tiledb::Filter>(
+      new tiledb::Filter(filterList->filter(filter_index)));
 }
-
-
 
 /**
  * TileDB Attribute
  */
 //[[Rcpp::export]]
 XPtr<tiledb::Attribute> libtiledb_attribute(XPtr<tiledb::Context> ctx,
-                                            std::string name,
-                                            std::string type,
+                                            std::string name, std::string type,
                                             XPtr<tiledb::FilterList> fltrlst,
-                                            int ncells,
-                                            bool nullable) {
-    check_xptr_tag<tiledb::Context>(ctx);
-    spdl::debug(tfm::format("[libtiledb_attribute] Attr name %s type %s ncells %d nullable %s",
-                            name, type, ncells, nullable ? "true" : "false"));
-    tiledb_datatype_t attr_dtype = _string_to_tiledb_datatype(type);
-    if (ncells < 1 && ncells != R_NaInt) {
-        Rcpp::stop("ncells must be >= 1 (or NA for variable cells)");
-    }
-    // placeholder, overwritten in all branches below
-    XPtr<tiledb::Attribute> attr = XPtr<tiledb::Attribute>(static_cast<tiledb::Attribute*>(nullptr));
+                                            int ncells, bool nullable) {
+  check_xptr_tag<tiledb::Context>(ctx);
+  spdl::debug(tfm::format(
+      "[libtiledb_attribute] Attr name %s type %s ncells %d nullable %s", name,
+      type, ncells, nullable ? "true" : "false"));
+  tiledb_datatype_t attr_dtype = _string_to_tiledb_datatype(type);
+  if (ncells < 1 && ncells != R_NaInt) {
+    Rcpp::stop("ncells must be >= 1 (or NA for variable cells)");
+  }
+  // placeholder, overwritten in all branches below
+  XPtr<tiledb::Attribute> attr =
+      XPtr<tiledb::Attribute>(static_cast<tiledb::Attribute *>(nullptr));
 
-    if (attr_dtype == TILEDB_INT32 ||
-        attr_dtype == TILEDB_UINT32 ||
-        attr_dtype == TILEDB_FLOAT64 ||
-        attr_dtype == TILEDB_FLOAT32 ||
-        attr_dtype == TILEDB_INT64  ||
-        attr_dtype == TILEDB_UINT64 ||
-        attr_dtype == TILEDB_UINT32 ||
-        attr_dtype == TILEDB_INT16  ||
-        attr_dtype == TILEDB_UINT16 ||
-        attr_dtype == TILEDB_INT8   ||
-        attr_dtype == TILEDB_UINT8  ||
-        attr_dtype == TILEDB_DATETIME_YEAR ||
-        attr_dtype == TILEDB_DATETIME_MONTH ||
-        attr_dtype == TILEDB_DATETIME_WEEK ||
-        attr_dtype == TILEDB_DATETIME_DAY ||
-        attr_dtype == TILEDB_DATETIME_HR ||
-        attr_dtype == TILEDB_DATETIME_MIN ||
-        attr_dtype == TILEDB_DATETIME_SEC ||
-        attr_dtype == TILEDB_DATETIME_MS  ||
-        attr_dtype == TILEDB_DATETIME_US  ||
-        attr_dtype == TILEDB_DATETIME_NS  ||
-        attr_dtype == TILEDB_DATETIME_PS  ||
-        attr_dtype == TILEDB_DATETIME_FS  ||
-        attr_dtype == TILEDB_DATETIME_AS) {
-        attr = make_xptr<tiledb::Attribute>(new tiledb::Attribute(*ctx.get(), name, attr_dtype));
-        attr->set_cell_val_num(static_cast<uint64_t>(ncells));
-    } else if (attr_dtype == TILEDB_CHAR ||
-               attr_dtype == TILEDB_STRING_ASCII ||
-               attr_dtype == TILEDB_STRING_UTF8) {
-        attr = make_xptr<tiledb::Attribute>(new tiledb::Attribute(*ctx.get(), name, attr_dtype));
-#if TILEDB_VERSION >= TileDB_Version(2,10,0)
-    } else if (attr_dtype == TILEDB_BOOL) {
-        attr = make_xptr<tiledb::Attribute>(new tiledb::Attribute(*ctx.get(), name, attr_dtype));
+  if (attr_dtype == TILEDB_INT32 || attr_dtype == TILEDB_UINT32 ||
+      attr_dtype == TILEDB_FLOAT64 || attr_dtype == TILEDB_FLOAT32 ||
+      attr_dtype == TILEDB_INT64 || attr_dtype == TILEDB_UINT64 ||
+      attr_dtype == TILEDB_UINT32 || attr_dtype == TILEDB_INT16 ||
+      attr_dtype == TILEDB_UINT16 || attr_dtype == TILEDB_INT8 ||
+      attr_dtype == TILEDB_UINT8 || attr_dtype == TILEDB_DATETIME_YEAR ||
+      attr_dtype == TILEDB_DATETIME_MONTH ||
+      attr_dtype == TILEDB_DATETIME_WEEK || attr_dtype == TILEDB_DATETIME_DAY ||
+      attr_dtype == TILEDB_DATETIME_HR || attr_dtype == TILEDB_DATETIME_MIN ||
+      attr_dtype == TILEDB_DATETIME_SEC || attr_dtype == TILEDB_DATETIME_MS ||
+      attr_dtype == TILEDB_DATETIME_US || attr_dtype == TILEDB_DATETIME_NS ||
+      attr_dtype == TILEDB_DATETIME_PS || attr_dtype == TILEDB_DATETIME_FS ||
+      attr_dtype == TILEDB_DATETIME_AS) {
+    attr = make_xptr<tiledb::Attribute>(
+        new tiledb::Attribute(*ctx.get(), name, attr_dtype));
+    attr->set_cell_val_num(static_cast<uint64_t>(ncells));
+  } else if (attr_dtype == TILEDB_CHAR || attr_dtype == TILEDB_STRING_ASCII ||
+             attr_dtype == TILEDB_STRING_UTF8) {
+    attr = make_xptr<tiledb::Attribute>(
+        new tiledb::Attribute(*ctx.get(), name, attr_dtype));
+#if TILEDB_VERSION >= TileDB_Version(2, 10, 0)
+  } else if (attr_dtype == TILEDB_BOOL) {
+    attr = make_xptr<tiledb::Attribute>(
+        new tiledb::Attribute(*ctx.get(), name, attr_dtype));
 #endif
-    } else {
-        Rcpp::stop("Only integer ((U)INT{8,16,32,64}), logical (INT32), real (FLOAT{32,64}), "
-                   "Date (DATEIME_DAY), Datetime (DATETIME_{SEC,MS,US}), nanotime (DATETIME_NS), "
-#if TILEDB_VERSION >= TileDB_Version(2,10,0)
-                   "logical (BOOL), "
+  } else {
+    Rcpp::stop("Only integer ((U)INT{8,16,32,64}), logical (INT32), real "
+               "(FLOAT{32,64}), "
+               "Date (DATEIME_DAY), Datetime (DATETIME_{SEC,MS,US}), nanotime "
+               "(DATETIME_NS), "
+#if TILEDB_VERSION >= TileDB_Version(2, 10, 0)
+               "logical (BOOL), "
 #endif
-                   "and character (CHAR,ASCII,UTF8) attributes are supported "
-                   "-- seeing %s which is not", type.c_str());
-    }
-    // R's NA is different from TileDB's NA so test for NA_integer_, else cast
-    uint64_t num = (ncells == R_NaInt) ? TILEDB_VAR_NUM : static_cast<uint64_t>(ncells);
-    attr->set_cell_val_num(num);
-    attr->set_filter_list(*fltrlst);
-    attr->set_nullable(nullable);
-    return attr;
+               "and character (CHAR,ASCII,UTF8) attributes are supported "
+               "-- seeing %s which is not",
+               type.c_str());
+  }
+  // R's NA is different from TileDB's NA so test for NA_integer_, else cast
+  uint64_t num =
+      (ncells == R_NaInt) ? TILEDB_VAR_NUM : static_cast<uint64_t>(ncells);
+  attr->set_cell_val_num(num);
+  attr->set_filter_list(*fltrlst);
+  attr->set_nullable(nullable);
+  return attr;
 }
 
 // [[Rcpp::export]]
@@ -1504,13 +1569,17 @@ double libtiledb_attribute_get_cell_size(XPtr<tiledb::Attribute> attr) {
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::FilterList> libtiledb_attribute_get_filter_list(XPtr<tiledb::Attribute> attr) {
+XPtr<tiledb::FilterList>
+libtiledb_attribute_get_filter_list(XPtr<tiledb::Attribute> attr) {
   check_xptr_tag<tiledb::Attribute>(attr);
-  return make_xptr<tiledb::FilterList>(new tiledb::FilterList(attr->filter_list()));
+  return make_xptr<tiledb::FilterList>(
+      new tiledb::FilterList(attr->filter_list()));
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::Attribute> libtiledb_attribute_set_filter_list(XPtr<tiledb::Attribute> attr, XPtr<tiledb::FilterList> fltrlst) {
+XPtr<tiledb::Attribute>
+libtiledb_attribute_set_filter_list(XPtr<tiledb::Attribute> attr,
+                                    XPtr<tiledb::FilterList> fltrlst) {
   check_xptr_tag<tiledb::Attribute>(attr);
   check_xptr_tag<tiledb::FilterList>(fltrlst);
   attr->set_filter_list(*fltrlst);
@@ -1522,7 +1591,7 @@ int libtiledb_attribute_get_cell_val_num(XPtr<tiledb::Attribute> attr) {
   check_xptr_tag<tiledb::Attribute>(attr);
   unsigned int ncells = attr->cell_val_num();
   if (ncells == TILEDB_VAR_NUM) {
-    return R_NaInt;          // set to R's NA for integer
+    return R_NaInt; // set to R's NA for integer
   } else if (ncells > std::numeric_limits<int32_t>::max()) {
     Rcpp::stop("tiledb_attr ncells value not representable as an R integer");
   }
@@ -1530,15 +1599,17 @@ int libtiledb_attribute_get_cell_val_num(XPtr<tiledb::Attribute> attr) {
 }
 
 // [[Rcpp::export]]
-void libtiledb_attribute_set_cell_val_num(XPtr<tiledb::Attribute> attr, int num) {
+void libtiledb_attribute_set_cell_val_num(XPtr<tiledb::Attribute> attr,
+                                          int num) {
   check_xptr_tag<tiledb::Attribute>(attr);
   uint64_t ncells = static_cast<uint64_t>(num);
   if (num == R_NaInt) {
-    ncells = TILEDB_VAR_NUM;             // R's NA is different from TileDB's NA
+    ncells = TILEDB_VAR_NUM; // R's NA is different from TileDB's NA
   } else if (num <= 0) {
     Rcpp::stop("Variable cell number of '%d' not sensible", num);
   }
-  attr->set_cell_val_num(ncells);        // returns reference to self so nothing for us to return
+  attr->set_cell_val_num(
+      ncells); // returns reference to self so nothing for us to return
 }
 
 // [[Rcpp::export]]
@@ -1550,7 +1621,7 @@ bool libtiledb_attribute_is_variable_sized(XPtr<tiledb::Attribute> attr) {
 // [[Rcpp::export]]
 void libtiledb_attribute_dump(XPtr<tiledb::Attribute> attr) {
   check_xptr_tag<tiledb::Attribute>(attr);
-#if TILEDB_VERSION >= TileDB_Version(2,25,0)
+#if TILEDB_VERSION >= TileDB_Version(2, 25, 0)
   std::stringstream ss;
   ss << *attr;
   Rcpp::Rcout << ss.str();
@@ -1560,26 +1631,34 @@ void libtiledb_attribute_dump(XPtr<tiledb::Attribute> attr) {
 }
 
 // [[Rcpp::export]]
-void libtiledb_attribute_set_fill_value(XPtr<tiledb::Attribute> attr, SEXP val) {
+void libtiledb_attribute_set_fill_value(XPtr<tiledb::Attribute> attr,
+                                        SEXP val) {
   tiledb_datatype_t dtype = attr->type();
   check_xptr_tag<tiledb::Attribute>(attr);
   if (dtype == TILEDB_INT32) {
     IntegerVector v(val);
-    if (v.size() > 1) Rcpp::stop("Setting fill values only supports scalar values for now.");
-    attr->set_fill_value((void*) &(v[0]), static_cast<uint64_t>(sizeof(int32_t)));
+    if (v.size() > 1)
+      Rcpp::stop("Setting fill values only supports scalar values for now.");
+    attr->set_fill_value((void *)&(v[0]),
+                         static_cast<uint64_t>(sizeof(int32_t)));
   } else if (dtype == TILEDB_UINT32) {
     IntegerVector v(val);
-    if (v.size() > 1) Rcpp::stop("Setting fill values only supports scalar values for now.");
-    attr->set_fill_value((void*) &(v[0]), static_cast<uint64_t>(sizeof(uint32_t)));
+    if (v.size() > 1)
+      Rcpp::stop("Setting fill values only supports scalar values for now.");
+    attr->set_fill_value((void *)&(v[0]),
+                         static_cast<uint64_t>(sizeof(uint32_t)));
   } else if (dtype == TILEDB_FLOAT64) {
     NumericVector v(val);
-    if (v.size() > 1) Rcpp::stop("Setting fill values only supports scalar values for now.");
-    attr->set_fill_value((void*) &(v[0]), static_cast<uint64_t>(sizeof(double)));
+    if (v.size() > 1)
+      Rcpp::stop("Setting fill values only supports scalar values for now.");
+    attr->set_fill_value((void *)&(v[0]),
+                         static_cast<uint64_t>(sizeof(double)));
   } else if (dtype == TILEDB_STRING_ASCII || dtype == TILEDB_CHAR) {
     CharacterVector v(val);
-    if (v.size() > 1) Rcpp::stop("Setting fill values only supports scalar values for now.");
+    if (v.size() > 1)
+      Rcpp::stop("Setting fill values only supports scalar values for now.");
     std::string s(v[0]);
-    attr->set_fill_value((void*) s.c_str(), static_cast<uint64_t>(s.size()));
+    attr->set_fill_value((void *)s.c_str(), static_cast<uint64_t>(s.size()));
   } else {
     std::string typestr = _tiledb_datatype_to_string(dtype);
     Rcpp::stop("Type '%s' is not currently supported.", typestr.c_str());
@@ -1590,20 +1669,20 @@ void libtiledb_attribute_set_fill_value(XPtr<tiledb::Attribute> attr, SEXP val) 
 SEXP libtiledb_attribute_get_fill_value(XPtr<tiledb::Attribute> attr) {
   check_xptr_tag<tiledb::Attribute>(attr);
   tiledb_datatype_t dtype = attr->type();
-  const void* valptr;
+  const void *valptr;
   uint64_t size = sizeof(dtype);
   attr->get_fill_value(&valptr, &size);
   if (dtype == TILEDB_INT32) {
-    int32_t v = *(const int32_t*)valptr;
+    int32_t v = *(const int32_t *)valptr;
     return wrap(v);
   } else if (dtype == TILEDB_UINT32) {
-    uint32_t v = *(const uint32_t*)valptr;
+    uint32_t v = *(const uint32_t *)valptr;
     return wrap(v);
   } else if (dtype == TILEDB_FLOAT64) {
-    double v = *(const double*)valptr;
+    double v = *(const double *)valptr;
     return wrap(v);
   } else if (dtype == TILEDB_STRING_ASCII || dtype == TILEDB_CHAR) {
-    std::string s(static_cast<const char*>(valptr), static_cast<size_t>(size));
+    std::string s(static_cast<const char *>(valptr), static_cast<size_t>(size));
     return wrap(s);
   } else {
     std::string typestr = _tiledb_datatype_to_string(dtype);
@@ -1612,243 +1691,257 @@ SEXP libtiledb_attribute_get_fill_value(XPtr<tiledb::Attribute> attr) {
 }
 
 // [[Rcpp::export]]
-void libtiledb_attribute_set_nullable(XPtr<tiledb::Attribute> attr, const bool flag) {
-    check_xptr_tag<tiledb::Attribute>(attr);
-    attr->set_nullable(flag);
+void libtiledb_attribute_set_nullable(XPtr<tiledb::Attribute> attr,
+                                      const bool flag) {
+  check_xptr_tag<tiledb::Attribute>(attr);
+  attr->set_nullable(flag);
 }
 
 // [[Rcpp::export]]
 bool libtiledb_attribute_get_nullable(XPtr<tiledb::Attribute> attr) {
-    check_xptr_tag<tiledb::Attribute>(attr);
-    return attr->nullable();
+  check_xptr_tag<tiledb::Attribute>(attr);
+  return attr->nullable();
 }
 
 // [[Rcpp::export]]
 bool libtiledb_attribute_has_enumeration(XPtr<tiledb::Context> ctx,
                                          XPtr<tiledb::Attribute> attr) {
-    check_xptr_tag<tiledb::Context>(ctx);
-    check_xptr_tag<tiledb::Attribute>(attr);
-    bool res = false;
-#if TILEDB_VERSION >= TileDB_Version(2,17,0)
-    auto enmr = tiledb::AttributeExperimental::get_enumeration_name(*ctx.get(), *attr.get());
-    if (enmr != std::nullopt) {
-        res = true;
-    }
+  check_xptr_tag<tiledb::Context>(ctx);
+  check_xptr_tag<tiledb::Attribute>(attr);
+  bool res = false;
+#if TILEDB_VERSION >= TileDB_Version(2, 17, 0)
+  auto enmr = tiledb::AttributeExperimental::get_enumeration_name(*ctx.get(),
+                                                                  *attr.get());
+  if (enmr != std::nullopt) {
+    res = true;
+  }
 #endif
-    return res;
+  return res;
 }
 
 // [[Rcpp::export]]
-Rcpp::String libtiledb_attribute_get_enumeration_type(XPtr<tiledb::Context> ctx,
-                                                      XPtr<tiledb::Attribute> attr,
-                                                      XPtr<tiledb::Array> arr) {
+Rcpp::String
+libtiledb_attribute_get_enumeration_type(XPtr<tiledb::Context> ctx,
+                                         XPtr<tiledb::Attribute> attr,
+                                         XPtr<tiledb::Array> arr) {
 
-    check_xptr_tag<tiledb::Context>(ctx);
-    check_xptr_tag<tiledb::Attribute>(attr);
-    check_xptr_tag<tiledb::Array>(arr);
-#if TILEDB_VERSION >= TileDB_Version(2,17,0)
-    auto enmrname = tiledb::AttributeExperimental::get_enumeration_name(*ctx.get(), *attr.get());
-    if (enmrname == std::nullopt) {
-        Rcpp::stop("No enumeration name for attribute");
-    }
-    auto enmr = tiledb::ArrayExperimental::get_enumeration(*ctx.get(), *arr.get(), enmrname.value());
-    if (enmr.ptr() == nullptr) {
-        Rcpp::stop("No enumeration for given attribute.");
-    }
-    Rcpp::String res = Rcpp::as<Rcpp::String>(Rcpp::wrap(_tiledb_datatype_to_string(enmr.type())));
+  check_xptr_tag<tiledb::Context>(ctx);
+  check_xptr_tag<tiledb::Attribute>(attr);
+  check_xptr_tag<tiledb::Array>(arr);
+#if TILEDB_VERSION >= TileDB_Version(2, 17, 0)
+  auto enmrname = tiledb::AttributeExperimental::get_enumeration_name(
+      *ctx.get(), *attr.get());
+  if (enmrname == std::nullopt) {
+    Rcpp::stop("No enumeration name for attribute");
+  }
+  auto enmr = tiledb::ArrayExperimental::get_enumeration(*ctx.get(), *arr.get(),
+                                                         enmrname.value());
+  if (enmr.ptr() == nullptr) {
+    Rcpp::stop("No enumeration for given attribute.");
+  }
+  Rcpp::String res = Rcpp::as<Rcpp::String>(
+      Rcpp::wrap(_tiledb_datatype_to_string(enmr.type())));
 #else
-    Rcpp::String res = Rcpp::as<Rcpp::String>(NA_STRING);
+  Rcpp::String res = Rcpp::as<Rcpp::String>(NA_STRING);
 #endif
-    return res;
+  return res;
 }
 
 // [[Rcpp::export]]
 SEXP libtiledb_attribute_get_enumeration_vector(XPtr<tiledb::Context> ctx,
                                                 XPtr<tiledb::Attribute> attr,
                                                 XPtr<tiledb::Array> arr) {
-    check_xptr_tag<tiledb::Context>(ctx);
-    check_xptr_tag<tiledb::Attribute>(attr);
-    check_xptr_tag<tiledb::Array>(arr);
-    SEXP res = R_NilValue;
-#if TILEDB_VERSION >= TileDB_Version(2,17,0)
-    auto enmrname = tiledb::AttributeExperimental::get_enumeration_name(*ctx.get(), *attr.get());
-    if (enmrname == std::nullopt) {
-        Rcpp::stop("No enumeration name for attribute");
-    }
-    auto enmr = tiledb::ArrayExperimental::get_enumeration(*ctx.get(), *arr.get(), enmrname.value());
-    if (enmr.ptr() == nullptr) {
-        Rcpp::stop("No enumeration for given attribute.");
-    }
-    auto dtype = enmr.type();
-    if (dtype == TILEDB_FLOAT32 || dtype == TILEDB_FLOAT64) {
-        auto v = enmr.as_vector<double>();
-        res = Rcpp::wrap(v);
-    } else if (dtype == TILEDB_INT8 || dtype == TILEDB_INT16 || dtype == TILEDB_INT32 ||
-               dtype == TILEDB_UINT8 || dtype == TILEDB_UINT16 || dtype == TILEDB_UINT32) {
-        auto v = enmr.as_vector<int32_t>();
-        res = Rcpp::wrap(v);
-    } else if (dtype == TILEDB_INT64 || dtype == TILEDB_UINT64) {
-        auto v = enmr.as_vector<int64_t>();
-        res = Rcpp::toInteger64(v);
-    } else if (dtype == TILEDB_BOOL) {
-        auto v = enmr.as_vector<bool>();
-        res = Rcpp::wrap(v);
-    } else {
-        Rcpp::stop("Unsupported non-string type '%s'", _tiledb_datatype_to_string(dtype));
-    }
+  check_xptr_tag<tiledb::Context>(ctx);
+  check_xptr_tag<tiledb::Attribute>(attr);
+  check_xptr_tag<tiledb::Array>(arr);
+  SEXP res = R_NilValue;
+#if TILEDB_VERSION >= TileDB_Version(2, 17, 0)
+  auto enmrname = tiledb::AttributeExperimental::get_enumeration_name(
+      *ctx.get(), *attr.get());
+  if (enmrname == std::nullopt) {
+    Rcpp::stop("No enumeration name for attribute");
+  }
+  auto enmr = tiledb::ArrayExperimental::get_enumeration(*ctx.get(), *arr.get(),
+                                                         enmrname.value());
+  if (enmr.ptr() == nullptr) {
+    Rcpp::stop("No enumeration for given attribute.");
+  }
+  auto dtype = enmr.type();
+  if (dtype == TILEDB_FLOAT32 || dtype == TILEDB_FLOAT64) {
+    auto v = enmr.as_vector<double>();
+    res = Rcpp::wrap(v);
+  } else if (dtype == TILEDB_INT8 || dtype == TILEDB_INT16 ||
+             dtype == TILEDB_INT32 || dtype == TILEDB_UINT8 ||
+             dtype == TILEDB_UINT16 || dtype == TILEDB_UINT32) {
+    auto v = enmr.as_vector<int32_t>();
+    res = Rcpp::wrap(v);
+  } else if (dtype == TILEDB_INT64 || dtype == TILEDB_UINT64) {
+    auto v = enmr.as_vector<int64_t>();
+    res = Rcpp::toInteger64(v);
+  } else if (dtype == TILEDB_BOOL) {
+    auto v = enmr.as_vector<bool>();
+    res = Rcpp::wrap(v);
+  } else {
+    Rcpp::stop("Unsupported non-string type '%s'",
+               _tiledb_datatype_to_string(dtype));
+  }
 #endif
-    return res;
+  return res;
 }
 
 // [[Rcpp::export]]
-std::vector<std::string> libtiledb_attribute_get_enumeration(XPtr<tiledb::Context> ctx,
-                                                             XPtr<tiledb::Attribute> attr,
-                                                             XPtr<tiledb::Array> arr) {
-    check_xptr_tag<tiledb::Context>(ctx);
-    check_xptr_tag<tiledb::Attribute>(attr);
-    check_xptr_tag<tiledb::Array>(arr);
-    std::vector<std::string> res;
-#if TILEDB_VERSION >= TileDB_Version(2,17,0)
-    auto enmrname = tiledb::AttributeExperimental::get_enumeration_name(*ctx.get(), *attr.get());
-    if (enmrname == std::nullopt) {
-        Rcpp::stop("No enumeration name for attribute");
-    }
-    auto enmr = tiledb::ArrayExperimental::get_enumeration(*ctx.get(), *arr.get(), enmrname.value());
-    if (enmr.ptr() == nullptr) {
-        Rcpp::stop("No enumeration for given attribute.");
-    }
-    res = enmr.as_vector<std::string>();
+std::vector<std::string>
+libtiledb_attribute_get_enumeration(XPtr<tiledb::Context> ctx,
+                                    XPtr<tiledb::Attribute> attr,
+                                    XPtr<tiledb::Array> arr) {
+  check_xptr_tag<tiledb::Context>(ctx);
+  check_xptr_tag<tiledb::Attribute>(attr);
+  check_xptr_tag<tiledb::Array>(arr);
+  std::vector<std::string> res;
+#if TILEDB_VERSION >= TileDB_Version(2, 17, 0)
+  auto enmrname = tiledb::AttributeExperimental::get_enumeration_name(
+      *ctx.get(), *attr.get());
+  if (enmrname == std::nullopt) {
+    Rcpp::stop("No enumeration name for attribute");
+  }
+  auto enmr = tiledb::ArrayExperimental::get_enumeration(*ctx.get(), *arr.get(),
+                                                         enmrname.value());
+  if (enmr.ptr() == nullptr) {
+    Rcpp::stop("No enumeration for given attribute.");
+  }
+  res = enmr.as_vector<std::string>();
 #endif
-    return res;
+  return res;
 }
 
-
 // [[Rcpp::export]]
-XPtr<tiledb::Attribute> libtiledb_attribute_set_enumeration(XPtr<tiledb::Context> ctx,
-                                                            XPtr<tiledb::Attribute> attr,
-                                                            const std::string &enum_name) {
-    check_xptr_tag<tiledb::Context>(ctx);
-    check_xptr_tag<tiledb::Attribute>(attr);
-#if TILEDB_VERSION >= TileDB_Version(2,17,0)
-    tiledb::AttributeExperimental::set_enumeration_name(*ctx.get(), *attr.get(), enum_name);
+XPtr<tiledb::Attribute>
+libtiledb_attribute_set_enumeration(XPtr<tiledb::Context> ctx,
+                                    XPtr<tiledb::Attribute> attr,
+                                    const std::string &enum_name) {
+  check_xptr_tag<tiledb::Context>(ctx);
+  check_xptr_tag<tiledb::Attribute>(attr);
+#if TILEDB_VERSION >= TileDB_Version(2, 17, 0)
+  tiledb::AttributeExperimental::set_enumeration_name(*ctx.get(), *attr.get(),
+                                                      enum_name);
 #endif
-    return attr;
+  return attr;
 }
 
 // [[Rcpp::export]]
 bool libtiledb_attribute_is_ordered_enumeration(XPtr<tiledb::Context> ctx,
                                                 XPtr<tiledb::Attribute> attr,
                                                 XPtr<tiledb::Array> arr) {
-    check_xptr_tag<tiledb::Context>(ctx);
-    check_xptr_tag<tiledb::Attribute>(attr);
-    check_xptr_tag<tiledb::Array>(arr);
-    bool res = false;
-#if TILEDB_VERSION >= TileDB_Version(2,17,0)
-    auto enmrname = tiledb::AttributeExperimental::get_enumeration_name(*ctx.get(), *attr.get());
-    if (enmrname == std::nullopt) {
-        Rcpp::stop("No enumeration name for attribute");
-    }
-    auto enmr = tiledb::ArrayExperimental::get_enumeration(*ctx.get(), *arr.get(), enmrname.value());
-    if (enmr.ptr() != nullptr) {
-        res = enmr.ordered();
-    }
+  check_xptr_tag<tiledb::Context>(ctx);
+  check_xptr_tag<tiledb::Attribute>(attr);
+  check_xptr_tag<tiledb::Array>(arr);
+  bool res = false;
+#if TILEDB_VERSION >= TileDB_Version(2, 17, 0)
+  auto enmrname = tiledb::AttributeExperimental::get_enumeration_name(
+      *ctx.get(), *attr.get());
+  if (enmrname == std::nullopt) {
+    Rcpp::stop("No enumeration name for attribute");
+  }
+  auto enmr = tiledb::ArrayExperimental::get_enumeration(*ctx.get(), *arr.get(),
+                                                         enmrname.value());
+  if (enmr.ptr() != nullptr) {
+    res = enmr.ordered();
+  }
 #endif
-    return res;
+  return res;
 }
-
 
 /**
  * TileDB Array Schema
  */
 
 // forward declaration
-XPtr<tiledb::ArraySchema> libtiledb_array_schema_set_enumeration(XPtr<tiledb::Context> ctx,
-                                                                 XPtr<tiledb::ArraySchema> schema,
-                                                                 XPtr<tiledb::Attribute> attr,
-                                                                 const std::string enum_name,
-                                                                 std::vector<std::string> values,
-                                                                 bool nullable,
-                                                                 bool ordered);
+XPtr<tiledb::ArraySchema> libtiledb_array_schema_set_enumeration(
+    XPtr<tiledb::Context> ctx, XPtr<tiledb::ArraySchema> schema,
+    XPtr<tiledb::Attribute> attr, const std::string enum_name,
+    std::vector<std::string> values, bool nullable, bool ordered);
 
 //[[Rcpp::export]]
-XPtr<tiledb::ArraySchema>
-libtiledb_array_schema(XPtr<tiledb::Context> ctx,
-                       XPtr<tiledb::Domain> domain,
-                       List attributes,
-                       std::string cell_order,
-                       std::string tile_order,
-                       Nullable<XPtr<tiledb::FilterList>> coords_filter_list = R_NilValue,
-                       Nullable<XPtr<tiledb::FilterList>> offsets_filter_list = R_NilValue,
-                       Nullable<XPtr<tiledb::FilterList>> validity_filter_list = R_NilValue,
-                       bool sparse = false,
-                       Nullable<List> enumerations_list = R_NilValue) {
-    // check that external pointers are supported
-    check_xptr_tag<tiledb::Context>(ctx);
-    check_xptr_tag<tiledb::Domain>(domain);
-    R_xlen_t nattr = attributes.length();
-    if (nattr > 0) {
-        for (R_xlen_t i=0; i < nattr; i++)  {
-            XPtr<tiledb::Attribute> attr = as<XPtr<tiledb::Attribute>>(attributes[i]);
-            check_xptr_tag<tiledb::Attribute>(attr);
-        }
+XPtr<tiledb::ArraySchema> libtiledb_array_schema(
+    XPtr<tiledb::Context> ctx, XPtr<tiledb::Domain> domain, List attributes,
+    std::string cell_order, std::string tile_order,
+    Nullable<XPtr<tiledb::FilterList>> coords_filter_list = R_NilValue,
+    Nullable<XPtr<tiledb::FilterList>> offsets_filter_list = R_NilValue,
+    Nullable<XPtr<tiledb::FilterList>> validity_filter_list = R_NilValue,
+    bool sparse = false, Nullable<List> enumerations_list = R_NilValue) {
+  // check that external pointers are supported
+  check_xptr_tag<tiledb::Context>(ctx);
+  check_xptr_tag<tiledb::Domain>(domain);
+  R_xlen_t nattr = attributes.length();
+  if (nattr > 0) {
+    for (R_xlen_t i = 0; i < nattr; i++) {
+      XPtr<tiledb::Attribute> attr = as<XPtr<tiledb::Attribute>>(attributes[i]);
+      check_xptr_tag<tiledb::Attribute>(attr);
     }
-    auto _cell_order = _string_to_tiledb_layout(cell_order);
-    auto _tile_order = _string_to_tiledb_layout(tile_order);
-    auto schptr = new tiledb::ArraySchema(tiledb::ArraySchema(*ctx.get(), sparse ? TILEDB_SPARSE : TILEDB_DENSE));
-    auto schema = make_xptr<tiledb::ArraySchema>(schptr);
-    schema->set_domain(*domain.get());
+  }
+  auto _cell_order = _string_to_tiledb_layout(cell_order);
+  auto _tile_order = _string_to_tiledb_layout(tile_order);
+  auto schptr = new tiledb::ArraySchema(
+      tiledb::ArraySchema(*ctx.get(), sparse ? TILEDB_SPARSE : TILEDB_DENSE));
+  auto schema = make_xptr<tiledb::ArraySchema>(schptr);
+  schema->set_domain(*domain.get());
 
-    // Deal with enumerations before attributes (that use them) are added
-    if (enumerations_list.isNotNull()) {
-        List enumerations(enumerations_list); // instantiate from now known non-null Nullable<List> wrapper
-        CharacterVector enumnames = enumerations.names();
-        R_xlen_t nenum = enumerations.length();
-        for (R_xlen_t i=0; i < nenum; i++)  {
-            bool nn = enumerations[i] == R_NilValue;
-            if (nn == false) {
-                XPtr<tiledb::Attribute> attr = as<XPtr<tiledb::Attribute>>(attributes[i]);
-                std::vector<std::string> enums = as<std::vector<std::string>>(enumerations[i]);
-                std::string enum_name = std::string(enumnames[i]);
-                bool is_ordered = false; // default
-                // 'ordered' is an attribute off the CharacterVector
-                CharacterVector enumvect = enumerations[i];
-                if (enumvect.hasAttribute("ordered")) {
-                    is_ordered = (as<bool>(enumvect.attr("ordered")) == true);
-                }
-                libtiledb_array_schema_set_enumeration(ctx, schema, attr, enum_name, enums,
-                                                       false, is_ordered);
-            }
+  // Deal with enumerations before attributes (that use them) are added
+  if (enumerations_list.isNotNull()) {
+    List enumerations(enumerations_list); // instantiate from now known non-null
+                                          // Nullable<List> wrapper
+    CharacterVector enumnames = enumerations.names();
+    R_xlen_t nenum = enumerations.length();
+    for (R_xlen_t i = 0; i < nenum; i++) {
+      bool nn = enumerations[i] == R_NilValue;
+      if (nn == false) {
+        XPtr<tiledb::Attribute> attr =
+            as<XPtr<tiledb::Attribute>>(attributes[i]);
+        std::vector<std::string> enums =
+            as<std::vector<std::string>>(enumerations[i]);
+        std::string enum_name = std::string(enumnames[i]);
+        bool is_ordered = false; // default
+        // 'ordered' is an attribute off the CharacterVector
+        CharacterVector enumvect = enumerations[i];
+        if (enumvect.hasAttribute("ordered")) {
+          is_ordered = (as<bool>(enumvect.attr("ordered")) == true);
         }
+        libtiledb_array_schema_set_enumeration(ctx, schema, attr, enum_name,
+                                               enums, false, is_ordered);
+      }
     }
+  }
 
-    // Now add attributes
-    if (nattr > 0) {
-        for (SEXP a : attributes) {
-            auto attr = as<XPtr<tiledb::Attribute>>(a);
-            spdl::debug(tfm::format("[libtiledb_array_schema] About to attr %s", libtiledb_attribute_get_name(attr)));
-            schema->add_attribute(*attr.get());
-        }
+  // Now add attributes
+  if (nattr > 0) {
+    for (SEXP a : attributes) {
+      auto attr = as<XPtr<tiledb::Attribute>>(a);
+      spdl::debug(tfm::format("[libtiledb_array_schema] About to attr %s",
+                              libtiledb_attribute_get_name(attr)));
+      schema->add_attribute(*attr.get());
     }
-    schema->set_cell_order(_cell_order);
-    schema->set_tile_order(_tile_order);
-    if (coords_filter_list.isNotNull()) {
-        XPtr<tiledb::FilterList> xptr_coords(coords_filter_list);
-        schema->set_coords_filter_list(*xptr_coords);
-    }
-    if (offsets_filter_list.isNotNull()) {
-        XPtr<tiledb::FilterList> xptr_offsets(offsets_filter_list);
-        schema->set_offsets_filter_list(*xptr_offsets);
-    }
-    if (validity_filter_list.isNotNull()) {
-        XPtr<tiledb::FilterList> xptr_validity(validity_filter_list);
-        schema->set_validity_filter_list(*xptr_validity);
-    }
-    schema->check();
-    return schema;
+  }
+  schema->set_cell_order(_cell_order);
+  schema->set_tile_order(_tile_order);
+  if (coords_filter_list.isNotNull()) {
+    XPtr<tiledb::FilterList> xptr_coords(coords_filter_list);
+    schema->set_coords_filter_list(*xptr_coords);
+  }
+  if (offsets_filter_list.isNotNull()) {
+    XPtr<tiledb::FilterList> xptr_offsets(offsets_filter_list);
+    schema->set_offsets_filter_list(*xptr_offsets);
+  }
+  if (validity_filter_list.isNotNull()) {
+    XPtr<tiledb::FilterList> xptr_validity(validity_filter_list);
+    schema->set_validity_filter_list(*xptr_validity);
+  }
+  schema->check();
+  return schema;
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::ArraySchema> libtiledb_array_schema_create(XPtr<tiledb::Context> ctx, std::string atstr) {
+XPtr<tiledb::ArraySchema>
+libtiledb_array_schema_create(XPtr<tiledb::Context> ctx, std::string atstr) {
   check_xptr_tag<tiledb::Context>(ctx);
   auto at = _string_to_tiledb_array_type(atstr);
   auto ptr = new tiledb::ArraySchema(*ctx.get(), at);
@@ -1856,23 +1949,24 @@ XPtr<tiledb::ArraySchema> libtiledb_array_schema_create(XPtr<tiledb::Context> ct
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::ArraySchema> libtiledb_array_schema_load(XPtr<tiledb::Context> ctx, std::string uri) {
-    check_xptr_tag<tiledb::Context>(ctx);
-    auto ptr = new tiledb::ArraySchema(*ctx.get(), uri);
-    return make_xptr<tiledb::ArraySchema>(ptr);
+XPtr<tiledb::ArraySchema> libtiledb_array_schema_load(XPtr<tiledb::Context> ctx,
+                                                      std::string uri) {
+  check_xptr_tag<tiledb::Context>(ctx);
+  auto ptr = new tiledb::ArraySchema(*ctx.get(), uri);
+  return make_xptr<tiledb::ArraySchema>(ptr);
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::ArraySchema> libtiledb_array_schema_load_with_key(XPtr<tiledb::Context> ctx,
-                                                               std::string uri,
-                                                               std::string key) {
-    check_xptr_tag<tiledb::Context>(ctx);
-    spdl::debug("[libtiledb_array_schema_load_with_key] function is deprecated");
-    XPtr<tiledb::Config> cfg = libtiledb_ctx_config(ctx);
-    cfg = libtiledb_config_set(cfg, "sm.encryption_key", key);
-    cfg = libtiledb_config_set(cfg, "sm.encryption_type", "AES_256_GCM");
-    XPtr<tiledb::Context> newctx = libtiledb_ctx(cfg);
-    return libtiledb_array_schema_load(newctx, uri);
+XPtr<tiledb::ArraySchema>
+libtiledb_array_schema_load_with_key(XPtr<tiledb::Context> ctx, std::string uri,
+                                     std::string key) {
+  check_xptr_tag<tiledb::Context>(ctx);
+  spdl::debug("[libtiledb_array_schema_load_with_key] function is deprecated");
+  XPtr<tiledb::Config> cfg = libtiledb_ctx_config(ctx);
+  cfg = libtiledb_config_set(cfg, "sm.encryption_key", key);
+  cfg = libtiledb_config_set(cfg, "sm.encryption_type", "AES_256_GCM");
+  XPtr<tiledb::Context> newctx = libtiledb_ctx(cfg);
+  return libtiledb_array_schema_load(newctx, uri);
 }
 
 // [[Rcpp::export]]
@@ -1883,7 +1977,8 @@ void libtiledb_array_schema_set_domain(XPtr<tiledb::ArraySchema> schema,
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::Domain> libtiledb_array_schema_get_domain(XPtr<tiledb::ArraySchema> schema) {
+XPtr<tiledb::Domain>
+libtiledb_array_schema_get_domain(XPtr<tiledb::ArraySchema> schema) {
   check_xptr_tag<tiledb::ArraySchema>(schema);
   auto ptr = make_xptr<tiledb::Domain>(new tiledb::Domain(schema->domain()));
   return ptr;
@@ -1902,50 +1997,57 @@ List libtiledb_array_schema_attributes(XPtr<tiledb::ArraySchema> schema) {
   check_xptr_tag<tiledb::ArraySchema>(schema);
   List result;
   int nattr = schema->attribute_num();
-  for (auto i=0; i < nattr; i++) {
-    auto attr = make_xptr<tiledb::Attribute>(new tiledb::Attribute(schema->attribute(i)));
+  for (auto i = 0; i < nattr; i++) {
+    auto attr = make_xptr<tiledb::Attribute>(
+        new tiledb::Attribute(schema->attribute(i)));
     result[attr->name()] = attr;
   }
   return result;
 }
 
 // [[Rcpp::export]]
-std::string libtiledb_array_schema_get_array_type(XPtr<tiledb::ArraySchema> schema) {
+std::string
+libtiledb_array_schema_get_array_type(XPtr<tiledb::ArraySchema> schema) {
   check_xptr_tag<tiledb::ArraySchema>(schema);
   auto type = schema->array_type();
   return _tiledb_array_type_to_string(type);
 }
 
 // [[Rcpp::export]]
-void libtiledb_array_schema_set_cell_order(XPtr<tiledb::ArraySchema> schema, std::string ord) {
+void libtiledb_array_schema_set_cell_order(XPtr<tiledb::ArraySchema> schema,
+                                           std::string ord) {
   check_xptr_tag<tiledb::ArraySchema>(schema);
   tiledb_layout_t cellorder = _string_to_tiledb_layout(ord);
   schema->set_cell_order(cellorder);
 }
 
 // [[Rcpp::export]]
-std::string libtiledb_array_schema_get_cell_order(XPtr<tiledb::ArraySchema> schema) {
+std::string
+libtiledb_array_schema_get_cell_order(XPtr<tiledb::ArraySchema> schema) {
   check_xptr_tag<tiledb::ArraySchema>(schema);
   auto order = schema->cell_order();
   return _tiledb_layout_to_string(order);
 }
 
 // [[Rcpp::export]]
-void libtiledb_array_schema_set_tile_order(XPtr<tiledb::ArraySchema> schema, std::string ord) {
+void libtiledb_array_schema_set_tile_order(XPtr<tiledb::ArraySchema> schema,
+                                           std::string ord) {
   check_xptr_tag<tiledb::ArraySchema>(schema);
   tiledb_layout_t tileorder = _string_to_tiledb_layout(ord);
   schema->set_cell_order(tileorder);
 }
 
 // [[Rcpp::export]]
-std::string libtiledb_array_schema_get_tile_order(XPtr<tiledb::ArraySchema> schema) {
+std::string
+libtiledb_array_schema_get_tile_order(XPtr<tiledb::ArraySchema> schema) {
   check_xptr_tag<tiledb::ArraySchema>(schema);
   auto order = schema->tile_order();
   return _tiledb_layout_to_string(order);
 }
 
 // [[Rcpp::export]]
-void libtiledb_array_schema_set_capacity(XPtr<tiledb::ArraySchema> schema, int cap) {
+void libtiledb_array_schema_set_capacity(XPtr<tiledb::ArraySchema> schema,
+                                         int cap) {
   check_xptr_tag<tiledb::ArraySchema>(schema);
   if (cap <= 0) {
     Rcpp::stop("Tile capacity of '%d' not sensible", cap);
@@ -1972,23 +2074,24 @@ bool libtiledb_array_schema_get_allows_dups(XPtr<tiledb::ArraySchema> schema) {
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::ArraySchema> libtiledb_array_schema_set_allows_dups(XPtr<tiledb::ArraySchema> schema,
-                                                                 bool allows_dups) {
+XPtr<tiledb::ArraySchema>
+libtiledb_array_schema_set_allows_dups(XPtr<tiledb::ArraySchema> schema,
+                                       bool allows_dups) {
   check_xptr_tag<tiledb::ArraySchema>(schema);
   schema->set_allows_dups(allows_dups);
   return schema;
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::FilterList>
-libtiledb_array_schema_get_coords_filter_list(XPtr<tiledb::ArraySchema> schema) {
-  return make_xptr<tiledb::FilterList>(new tiledb::FilterList(schema->coords_filter_list()));
+XPtr<tiledb::FilterList> libtiledb_array_schema_get_coords_filter_list(
+    XPtr<tiledb::ArraySchema> schema) {
+  return make_xptr<tiledb::FilterList>(
+      new tiledb::FilterList(schema->coords_filter_list()));
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::ArraySchema>
-libtiledb_array_schema_set_coords_filter_list(XPtr<tiledb::ArraySchema> schema,
-                                              XPtr<tiledb::FilterList> fltrlst) {
+XPtr<tiledb::ArraySchema> libtiledb_array_schema_set_coords_filter_list(
+    XPtr<tiledb::ArraySchema> schema, XPtr<tiledb::FilterList> fltrlst) {
   check_xptr_tag<tiledb::ArraySchema>(schema);
   check_xptr_tag<tiledb::FilterList>(fltrlst);
   schema->set_coords_filter_list(*fltrlst);
@@ -1996,16 +2099,16 @@ libtiledb_array_schema_set_coords_filter_list(XPtr<tiledb::ArraySchema> schema,
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::FilterList>
-libtiledb_array_schema_get_offsets_filter_list(XPtr<tiledb::ArraySchema> schema) {
+XPtr<tiledb::FilterList> libtiledb_array_schema_get_offsets_filter_list(
+    XPtr<tiledb::ArraySchema> schema) {
   check_xptr_tag<tiledb::ArraySchema>(schema);
-  return make_xptr<tiledb::FilterList>(new tiledb::FilterList(schema->offsets_filter_list()));
+  return make_xptr<tiledb::FilterList>(
+      new tiledb::FilterList(schema->offsets_filter_list()));
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::ArraySchema>
-libtiledb_array_schema_set_offsets_filter_list(XPtr<tiledb::ArraySchema> schema,
-                                               XPtr<tiledb::FilterList> fltrlst) {
+XPtr<tiledb::ArraySchema> libtiledb_array_schema_set_offsets_filter_list(
+    XPtr<tiledb::ArraySchema> schema, XPtr<tiledb::FilterList> fltrlst) {
   check_xptr_tag<tiledb::ArraySchema>(schema);
   check_xptr_tag<tiledb::FilterList>(fltrlst);
   schema->set_offsets_filter_list(*fltrlst);
@@ -2013,22 +2116,21 @@ libtiledb_array_schema_set_offsets_filter_list(XPtr<tiledb::ArraySchema> schema,
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::FilterList>
-libtiledb_array_schema_get_validity_filter_list(XPtr<tiledb::ArraySchema> schema) {
-    check_xptr_tag<tiledb::ArraySchema>(schema);
-    return make_xptr<tiledb::FilterList>(new tiledb::FilterList(schema->validity_filter_list()));
+XPtr<tiledb::FilterList> libtiledb_array_schema_get_validity_filter_list(
+    XPtr<tiledb::ArraySchema> schema) {
+  check_xptr_tag<tiledb::ArraySchema>(schema);
+  return make_xptr<tiledb::FilterList>(
+      new tiledb::FilterList(schema->validity_filter_list()));
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::ArraySchema>
-libtiledb_array_schema_set_validity_filter_list(XPtr<tiledb::ArraySchema> schema,
-                                                XPtr<tiledb::FilterList> fltrlst) {
-    check_xptr_tag<tiledb::ArraySchema>(schema);
-    check_xptr_tag<tiledb::FilterList>(fltrlst);
-    schema->set_validity_filter_list(*fltrlst);
-    return schema;
+XPtr<tiledb::ArraySchema> libtiledb_array_schema_set_validity_filter_list(
+    XPtr<tiledb::ArraySchema> schema, XPtr<tiledb::FilterList> fltrlst) {
+  check_xptr_tag<tiledb::ArraySchema>(schema);
+  check_xptr_tag<tiledb::FilterList>(fltrlst);
+  schema->set_validity_filter_list(*fltrlst);
+  return schema;
 }
-
 
 // [[Rcpp::export]]
 int libtiledb_array_schema_get_attribute_num(XPtr<tiledb::ArraySchema> schema) {
@@ -2041,25 +2143,29 @@ int libtiledb_array_schema_get_attribute_num(XPtr<tiledb::ArraySchema> schema) {
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::Attribute> libtiledb_array_schema_get_attribute_from_index(XPtr<tiledb::ArraySchema> schema,
-                                                                        int ind) {
+XPtr<tiledb::Attribute> libtiledb_array_schema_get_attribute_from_index(
+    XPtr<tiledb::ArraySchema> schema, int ind) {
   check_xptr_tag<tiledb::ArraySchema>(schema);
   if (ind < 0) {
     Rcpp::stop("Index must be non-negative.");
   }
   uint32_t idx = static_cast<uint32_t>(ind);
-  return make_xptr<tiledb::Attribute>(new tiledb::Attribute(schema->attribute(idx)));
+  return make_xptr<tiledb::Attribute>(
+      new tiledb::Attribute(schema->attribute(idx)));
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::Attribute> libtiledb_array_schema_get_attribute_from_name(XPtr<tiledb::ArraySchema> schema,
-                                                                       std::string name) {
+XPtr<tiledb::Attribute>
+libtiledb_array_schema_get_attribute_from_name(XPtr<tiledb::ArraySchema> schema,
+                                               std::string name) {
   check_xptr_tag<tiledb::ArraySchema>(schema);
-  return make_xptr<tiledb::Attribute>(new tiledb::Attribute(schema->attribute(name)));
+  return make_xptr<tiledb::Attribute>(
+      new tiledb::Attribute(schema->attribute(name)));
 }
 
 // [[Rcpp::export]]
-bool libtiledb_array_schema_has_attribute(XPtr<tiledb::ArraySchema> schema, std::string name) {
+bool libtiledb_array_schema_has_attribute(XPtr<tiledb::ArraySchema> schema,
+                                          std::string name) {
   check_xptr_tag<tiledb::ArraySchema>(schema);
   return schema->has_attribute(name);
 }
@@ -2073,7 +2179,7 @@ bool libtiledb_array_schema_sparse(XPtr<tiledb::ArraySchema> schema) {
 // [[Rcpp::export]]
 void libtiledb_array_schema_dump(XPtr<tiledb::ArraySchema> schema) {
   check_xptr_tag<tiledb::ArraySchema>(schema);
-#if TILEDB_VERSION >= TileDB_Version(2,25,0)
+#if TILEDB_VERSION >= TileDB_Version(2, 25, 0)
   std::stringstream ss;
   ss << *schema;
   Rcpp::Rcout << ss.str();
@@ -2085,7 +2191,7 @@ void libtiledb_array_schema_dump(XPtr<tiledb::ArraySchema> schema) {
 // [[Rcpp::export]]
 bool libtiledb_array_schema_check(XPtr<tiledb::ArraySchema> schema) {
   check_xptr_tag<tiledb::ArraySchema>(schema);
-  schema->check();   // throws, rather than returning bool
+  schema->check(); // throws, rather than returning bool
   return true;
 }
 
@@ -2096,75 +2202,77 @@ int libtiledb_array_schema_version(XPtr<tiledb::ArraySchema> schema) {
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::ArraySchema> libtiledb_array_schema_set_enumeration(XPtr<tiledb::Context> ctx,
-                                                                 XPtr<tiledb::ArraySchema> schema,
-                                                                 XPtr<tiledb::Attribute> attr,
-                                                                 const std::string enum_name,
-                                                                 std::vector<std::string> values,
-                                                                 bool nullable = false,
-                                                                 bool ordered = false) {
-    check_xptr_tag<tiledb::Context>(ctx);
-    check_xptr_tag<tiledb::ArraySchema>(schema);
-    check_xptr_tag<tiledb::Attribute>(attr);
-#if TILEDB_VERSION >= TileDB_Version(2,17,0)
-    auto enumeration = tiledb::Enumeration::create(*ctx.get(), enum_name, values, ordered);
-    tiledb::ArraySchemaExperimental::add_enumeration(*ctx.get(), *schema.get(), enumeration);
-    tiledb::AttributeExperimental::set_enumeration_name(*ctx.get(), *attr.get(), enum_name);
+XPtr<tiledb::ArraySchema> libtiledb_array_schema_set_enumeration(
+    XPtr<tiledb::Context> ctx, XPtr<tiledb::ArraySchema> schema,
+    XPtr<tiledb::Attribute> attr, const std::string enum_name,
+    std::vector<std::string> values, bool nullable = false,
+    bool ordered = false) {
+  check_xptr_tag<tiledb::Context>(ctx);
+  check_xptr_tag<tiledb::ArraySchema>(schema);
+  check_xptr_tag<tiledb::Attribute>(attr);
+#if TILEDB_VERSION >= TileDB_Version(2, 17, 0)
+  auto enumeration =
+      tiledb::Enumeration::create(*ctx.get(), enum_name, values, ordered);
+  tiledb::ArraySchemaExperimental::add_enumeration(*ctx.get(), *schema.get(),
+                                                   enumeration);
+  tiledb::AttributeExperimental::set_enumeration_name(*ctx.get(), *attr.get(),
+                                                      enum_name);
 #endif
-    return schema;
+  return schema;
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::ArraySchema>
-libtiledb_array_schema_set_enumeration_empty(XPtr<tiledb::Context> ctx,
-                                             XPtr<tiledb::ArraySchema> schema,
-                                             XPtr<tiledb::Attribute> attr,
-                                             const std::string enum_name,
-                                             const std::string type_str,
-                                             int cell_val_num,
-                                             bool ordered) {
-    check_xptr_tag<tiledb::Context>(ctx);
-    check_xptr_tag<tiledb::ArraySchema>(schema);
-    check_xptr_tag<tiledb::Attribute>(attr);
-#if TILEDB_VERSION >= TileDB_Version(2,17,3)
-    tiledb_datatype_t type = _string_to_tiledb_datatype(type_str);
-    uint32_t num = static_cast<uint64_t>(cell_val_num);
-    if (cell_val_num == R_NaInt) {
-        num = TILEDB_VAR_NUM;           // R's NA is different from TileDB's NA
-    }
-    auto enumeration = tiledb::Enumeration::create_empty(*ctx.get(), enum_name, type, num, ordered);
-    tiledb::ArraySchemaExperimental::add_enumeration(*ctx.get(), *schema.get(), enumeration);
-    tiledb::AttributeExperimental::set_enumeration_name(*ctx.get(), *attr.get(), enum_name);
+XPtr<tiledb::ArraySchema> libtiledb_array_schema_set_enumeration_empty(
+    XPtr<tiledb::Context> ctx, XPtr<tiledb::ArraySchema> schema,
+    XPtr<tiledb::Attribute> attr, const std::string enum_name,
+    const std::string type_str, int cell_val_num, bool ordered) {
+  check_xptr_tag<tiledb::Context>(ctx);
+  check_xptr_tag<tiledb::ArraySchema>(schema);
+  check_xptr_tag<tiledb::Attribute>(attr);
+#if TILEDB_VERSION >= TileDB_Version(2, 17, 3)
+  tiledb_datatype_t type = _string_to_tiledb_datatype(type_str);
+  uint32_t num = static_cast<uint64_t>(cell_val_num);
+  if (cell_val_num == R_NaInt) {
+    num = TILEDB_VAR_NUM; // R's NA is different from TileDB's NA
+  }
+  auto enumeration = tiledb::Enumeration::create_empty(*ctx.get(), enum_name,
+                                                       type, num, ordered);
+  tiledb::ArraySchemaExperimental::add_enumeration(*ctx.get(), *schema.get(),
+                                                   enumeration);
+  tiledb::AttributeExperimental::set_enumeration_name(*ctx.get(), *attr.get(),
+                                                      enum_name);
 #endif
-    return schema;
+  return schema;
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::CurrentDomain> libtiledb_array_schema_get_current_domain(XPtr<tiledb::Context> ctx,
-                                                                      XPtr<tiledb::ArraySchema> sch) {
-    check_xptr_tag<tiledb::Context>(ctx);
-    check_xptr_tag<tiledb::ArraySchema>(sch);
-#if TILEDB_VERSION >= TileDB_Version(2,25,0)
-    auto cd = tiledb::ArraySchemaExperimental::current_domain(*ctx.get(), *sch.get());
+XPtr<tiledb::CurrentDomain>
+libtiledb_array_schema_get_current_domain(XPtr<tiledb::Context> ctx,
+                                          XPtr<tiledb::ArraySchema> sch) {
+  check_xptr_tag<tiledb::Context>(ctx);
+  check_xptr_tag<tiledb::ArraySchema>(sch);
+#if TILEDB_VERSION >= TileDB_Version(2, 25, 0)
+  auto cd =
+      tiledb::ArraySchemaExperimental::current_domain(*ctx.get(), *sch.get());
 #else
-    auto cd = tiledb::CurrentDomain();
+  auto cd = tiledb::CurrentDomain();
 #endif
-    auto ptr = make_xptr<tiledb::CurrentDomain>(new tiledb::CurrentDomain(cd));
-    return ptr;
+  auto ptr = make_xptr<tiledb::CurrentDomain>(new tiledb::CurrentDomain(cd));
+  return ptr;
 }
 
 // [[Rcpp::export]]
 void libtiledb_array_schema_set_current_domain(XPtr<tiledb::Context> ctx,
                                                XPtr<tiledb::ArraySchema> sch,
                                                XPtr<tiledb::CurrentDomain> cd) {
-    check_xptr_tag<tiledb::Context>(ctx);
-    check_xptr_tag<tiledb::ArraySchema>(sch);
-    check_xptr_tag<tiledb::CurrentDomain>(cd);
-#if TILEDB_VERSION >= TileDB_Version(2,25,0)
-    tiledb::ArraySchemaExperimental::set_current_domain(*ctx.get(), *sch.get(), *cd.get());
+  check_xptr_tag<tiledb::Context>(ctx);
+  check_xptr_tag<tiledb::ArraySchema>(sch);
+  check_xptr_tag<tiledb::CurrentDomain>(cd);
+#if TILEDB_VERSION >= TileDB_Version(2, 25, 0)
+  tiledb::ArraySchemaExperimental::set_current_domain(*ctx.get(), *sch.get(),
+                                                      *cd.get());
 #endif
 }
-
 
 /**
  * TileDB Array Schema Evolution
@@ -2172,196 +2280,204 @@ void libtiledb_array_schema_set_current_domain(XPtr<tiledb::Context> ctx,
 //[[Rcpp::export]]
 XPtr<tiledb::ArraySchemaEvolution>
 libtiledb_array_schema_evolution(XPtr<tiledb::Context> ctx) {
-    check_xptr_tag<tiledb::Context>(ctx);
-    auto p = new tiledb::ArraySchemaEvolution(*ctx.get());
-    auto ptr = make_xptr<tiledb::ArraySchemaEvolution>(p);
-    return ptr;
+  check_xptr_tag<tiledb::Context>(ctx);
+  auto p = new tiledb::ArraySchemaEvolution(*ctx.get());
+  auto ptr = make_xptr<tiledb::ArraySchemaEvolution>(p);
+  return ptr;
 }
 
 //[[Rcpp::export]]
 XPtr<tiledb::ArraySchemaEvolution>
-libtiledb_array_schema_evolution_add_attribute(XPtr<tiledb::ArraySchemaEvolution> ase,
-                                               XPtr<tiledb::Attribute> attr) {
-    check_xptr_tag<tiledb::ArraySchemaEvolution>(ase);
-    check_xptr_tag<tiledb::Attribute>(attr);
-    tiledb::ArraySchemaEvolution res = ase->add_attribute(*attr.get());
-    auto ptr = new tiledb::ArraySchemaEvolution(res);
-    return make_xptr<tiledb::ArraySchemaEvolution>(ptr);
+libtiledb_array_schema_evolution_add_attribute(
+    XPtr<tiledb::ArraySchemaEvolution> ase, XPtr<tiledb::Attribute> attr) {
+  check_xptr_tag<tiledb::ArraySchemaEvolution>(ase);
+  check_xptr_tag<tiledb::Attribute>(attr);
+  tiledb::ArraySchemaEvolution res = ase->add_attribute(*attr.get());
+  auto ptr = new tiledb::ArraySchemaEvolution(res);
+  return make_xptr<tiledb::ArraySchemaEvolution>(ptr);
 }
 
 //[[Rcpp::export]]
 XPtr<tiledb::ArraySchemaEvolution>
-libtiledb_array_schema_evolution_drop_attribute(XPtr<tiledb::ArraySchemaEvolution> ase,
-                                                const std::string & attrname) {
-    check_xptr_tag<tiledb::ArraySchemaEvolution>(ase);
-    tiledb::ArraySchemaEvolution res = ase->drop_attribute(attrname);
-    auto ptr = new tiledb::ArraySchemaEvolution(res);
-    return make_xptr<tiledb::ArraySchemaEvolution>(ptr);
+libtiledb_array_schema_evolution_drop_attribute(
+    XPtr<tiledb::ArraySchemaEvolution> ase, const std::string &attrname) {
+  check_xptr_tag<tiledb::ArraySchemaEvolution>(ase);
+  tiledb::ArraySchemaEvolution res = ase->drop_attribute(attrname);
+  auto ptr = new tiledb::ArraySchemaEvolution(res);
+  return make_xptr<tiledb::ArraySchemaEvolution>(ptr);
 }
 
 //[[Rcpp::export]]
 XPtr<tiledb::ArraySchemaEvolution>
-libtiledb_array_schema_evolution_array_evolve(XPtr<tiledb::ArraySchemaEvolution> ase,
-                                              const std::string & uri) {
-    check_xptr_tag<tiledb::ArraySchemaEvolution>(ase);
-    tiledb::ArraySchemaEvolution res = ase->array_evolve(uri);
-    auto ptr = new tiledb::ArraySchemaEvolution(res);
-    return make_xptr<tiledb::ArraySchemaEvolution>(ptr);
+libtiledb_array_schema_evolution_array_evolve(
+    XPtr<tiledb::ArraySchemaEvolution> ase, const std::string &uri) {
+  check_xptr_tag<tiledb::ArraySchemaEvolution>(ase);
+  tiledb::ArraySchemaEvolution res = ase->array_evolve(uri);
+  auto ptr = new tiledb::ArraySchemaEvolution(res);
+  return make_xptr<tiledb::ArraySchemaEvolution>(ptr);
 }
 
 //[[Rcpp::export]]
 XPtr<tiledb::ArraySchemaEvolution>
-libtiledb_array_schema_evolution_add_enumeration(XPtr<tiledb::Context> ctx,
-                                                 XPtr<tiledb::ArraySchemaEvolution> ase,
-                                                 const std::string & enum_name,
-                                                 std::vector<std::string> values,
-                                                 bool nullable = false,
-                                                 bool ordered = false) {
-    check_xptr_tag<tiledb::Context>(ctx);
-    check_xptr_tag<tiledb::ArraySchemaEvolution>(ase);
-#if TILEDB_VERSION >= TileDB_Version(2,17,0)
-    auto enumeration = tiledb::Enumeration::create(*ctx.get(), enum_name, values, ordered);
-    tiledb::ArraySchemaEvolution res = ase->add_enumeration(enumeration);
-    auto ptr = new tiledb::ArraySchemaEvolution(res);
-    return make_xptr<tiledb::ArraySchemaEvolution>(ptr);
+libtiledb_array_schema_evolution_add_enumeration(
+    XPtr<tiledb::Context> ctx, XPtr<tiledb::ArraySchemaEvolution> ase,
+    const std::string &enum_name, std::vector<std::string> values,
+    bool nullable = false, bool ordered = false) {
+  check_xptr_tag<tiledb::Context>(ctx);
+  check_xptr_tag<tiledb::ArraySchemaEvolution>(ase);
+#if TILEDB_VERSION >= TileDB_Version(2, 17, 0)
+  auto enumeration =
+      tiledb::Enumeration::create(*ctx.get(), enum_name, values, ordered);
+  tiledb::ArraySchemaEvolution res = ase->add_enumeration(enumeration);
+  auto ptr = new tiledb::ArraySchemaEvolution(res);
+  return make_xptr<tiledb::ArraySchemaEvolution>(ptr);
 #endif
-    return ase;
+  return ase;
 }
 
 //[[Rcpp::export]]
 XPtr<tiledb::ArraySchemaEvolution>
-libtiledb_array_schema_evolution_add_enumeration_empty(XPtr<tiledb::Context> ctx,
-                                                       XPtr<tiledb::ArraySchemaEvolution> ase,
-                                                       const std::string & enum_name,
-                                                       const std::string type_str,
-                                                       int cell_val_num,
-                                                       bool ordered = false) {
-    check_xptr_tag<tiledb::Context>(ctx);
-    check_xptr_tag<tiledb::ArraySchemaEvolution>(ase);
-#if TILEDB_VERSION >= TileDB_Version(2,17,3)
-    tiledb_datatype_t type = _string_to_tiledb_datatype(type_str);
-    uint32_t num = static_cast<uint32_t>(cell_val_num);
-    auto enumeration = tiledb::Enumeration::create_empty(*ctx.get(), enum_name, type, num, ordered);
-    tiledb::ArraySchemaEvolution res = ase->add_enumeration(enumeration);
-    auto ptr = new tiledb::ArraySchemaEvolution(res);
-    return make_xptr<tiledb::ArraySchemaEvolution>(ptr);
+libtiledb_array_schema_evolution_add_enumeration_empty(
+    XPtr<tiledb::Context> ctx, XPtr<tiledb::ArraySchemaEvolution> ase,
+    const std::string &enum_name, const std::string type_str, int cell_val_num,
+    bool ordered = false) {
+  check_xptr_tag<tiledb::Context>(ctx);
+  check_xptr_tag<tiledb::ArraySchemaEvolution>(ase);
+#if TILEDB_VERSION >= TileDB_Version(2, 17, 3)
+  tiledb_datatype_t type = _string_to_tiledb_datatype(type_str);
+  uint32_t num = static_cast<uint32_t>(cell_val_num);
+  auto enumeration = tiledb::Enumeration::create_empty(*ctx.get(), enum_name,
+                                                       type, num, ordered);
+  tiledb::ArraySchemaEvolution res = ase->add_enumeration(enumeration);
+  auto ptr = new tiledb::ArraySchemaEvolution(res);
+  return make_xptr<tiledb::ArraySchemaEvolution>(ptr);
 #endif
-    return ase;
-}
-
-
-//[[Rcpp::export]]
-XPtr<tiledb::ArraySchemaEvolution>
-libtiledb_array_schema_evolution_drop_enumeration(XPtr<tiledb::ArraySchemaEvolution> ase,
-                                                  const std::string & attrname) {
-    check_xptr_tag<tiledb::ArraySchemaEvolution>(ase);
-#if TILEDB_VERSION >= TileDB_Version(2,17,0)
-    tiledb::ArraySchemaEvolution res = ase->drop_attribute(attrname);
-    auto ptr = new tiledb::ArraySchemaEvolution(res);
-    return make_xptr<tiledb::ArraySchemaEvolution>(ptr);
-#endif
-    return ase;
+  return ase;
 }
 
 //[[Rcpp::export]]
 XPtr<tiledb::ArraySchemaEvolution>
-libtiledb_array_schema_evolution_extend_enumeration(XPtr<tiledb::Context> ctx,
-                                                    XPtr<tiledb::ArraySchemaEvolution> ase,
-                                                    XPtr<tiledb::Array> array,
-                                                    const std::string & enum_name,
-                                                    std::vector<std::string> new_values,
-                                                    bool nullable = false,
-                                                    bool ordered = false) {
-    check_xptr_tag<tiledb::Context>(ctx);
-    check_xptr_tag<tiledb::ArraySchemaEvolution>(ase);
-    check_xptr_tag<tiledb::Array>(array);
-#if TILEDB_VERSION >= TileDB_Version(2,17,3)
-    auto old_enumeration = tiledb::ArrayExperimental::get_enumeration(*ctx.get(), *array.get(), enum_name);
-    auto new_enumeration = old_enumeration.extend(new_values);
-    tiledb::ArraySchemaEvolution res = ase->extend_enumeration(new_enumeration);
-    auto ptr = new tiledb::ArraySchemaEvolution(res);
-    return make_xptr<tiledb::ArraySchemaEvolution>(ptr);
+libtiledb_array_schema_evolution_drop_enumeration(
+    XPtr<tiledb::ArraySchemaEvolution> ase, const std::string &attrname) {
+  check_xptr_tag<tiledb::ArraySchemaEvolution>(ase);
+#if TILEDB_VERSION >= TileDB_Version(2, 17, 0)
+  tiledb::ArraySchemaEvolution res = ase->drop_attribute(attrname);
+  auto ptr = new tiledb::ArraySchemaEvolution(res);
+  return make_xptr<tiledb::ArraySchemaEvolution>(ptr);
 #endif
-    return ase;
+  return ase;
 }
 
 //[[Rcpp::export]]
 XPtr<tiledb::ArraySchemaEvolution>
-libtiledb_array_schema_evolution_expand_current_domain(XPtr<tiledb::ArraySchemaEvolution> ase,
-                                                       XPtr<tiledb::CurrentDomain> cd) {
-    check_xptr_tag<tiledb::ArraySchemaEvolution>(ase);
-    check_xptr_tag<tiledb::CurrentDomain>(cd);
-#if TILEDB_VERSION >= TileDB_Version(2,25,0)
-    ase->expand_current_domain(*cd.get());
+libtiledb_array_schema_evolution_extend_enumeration(
+    XPtr<tiledb::Context> ctx, XPtr<tiledb::ArraySchemaEvolution> ase,
+    XPtr<tiledb::Array> array, const std::string &enum_name,
+    std::vector<std::string> new_values, bool nullable = false,
+    bool ordered = false) {
+  check_xptr_tag<tiledb::Context>(ctx);
+  check_xptr_tag<tiledb::ArraySchemaEvolution>(ase);
+  check_xptr_tag<tiledb::Array>(array);
+#if TILEDB_VERSION >= TileDB_Version(2, 17, 3)
+  auto old_enumeration = tiledb::ArrayExperimental::get_enumeration(
+      *ctx.get(), *array.get(), enum_name);
+  auto new_enumeration = old_enumeration.extend(new_values);
+  tiledb::ArraySchemaEvolution res = ase->extend_enumeration(new_enumeration);
+  auto ptr = new tiledb::ArraySchemaEvolution(res);
+  return make_xptr<tiledb::ArraySchemaEvolution>(ptr);
 #endif
-    return ase;
+  return ase;
 }
 
+//[[Rcpp::export]]
+XPtr<tiledb::ArraySchemaEvolution>
+libtiledb_array_schema_evolution_expand_current_domain(
+    XPtr<tiledb::ArraySchemaEvolution> ase, XPtr<tiledb::CurrentDomain> cd) {
+  check_xptr_tag<tiledb::ArraySchemaEvolution>(ase);
+  check_xptr_tag<tiledb::CurrentDomain>(cd);
+#if TILEDB_VERSION >= TileDB_Version(2, 25, 0)
+  ase->expand_current_domain(*cd.get());
+#endif
+  return ase;
+}
 
 /**
  * TileDB Array
  */
 // [[Rcpp::export]]
-std::string libtiledb_array_create(std::string uri, XPtr<tiledb::ArraySchema> schema) {
+std::string libtiledb_array_create(std::string uri,
+                                   XPtr<tiledb::ArraySchema> schema) {
   check_xptr_tag<tiledb::ArraySchema>(schema);
   tiledb::Array::create(uri, *schema.get());
   return uri;
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::Array> libtiledb_array_open(XPtr<tiledb::Context> ctx, std::string uri,
-                                         std::string type) {
+XPtr<tiledb::Array> libtiledb_array_open(XPtr<tiledb::Context> ctx,
+                                         std::string uri, std::string type) {
   check_xptr_tag<tiledb::Context>(ctx);
   auto query_type = _string_to_tiledb_query_type(type);
-  return make_xptr<tiledb::Array>(new tiledb::Array(*ctx.get(), uri, query_type));
+  return make_xptr<tiledb::Array>(
+      new tiledb::Array(*ctx.get(), uri, query_type));
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::Array> libtiledb_array_open_at(XPtr<tiledb::Context> ctx, std::string uri,
-                                            std::string type, Datetime tstamp) {
-    check_xptr_tag<tiledb::Context>(ctx);
-    auto query_type = _string_to_tiledb_query_type(type);
-    // get timestamp as seconds since epoch (plus fractional seconds, returns double), scale to millisec
-    uint64_t ts_ms = static_cast<uint64_t>(std::round(tstamp.getFractionalTimestamp() * 1000));
-#if TILEDB_VERSION >= TileDB_Version(2,15,0)
-    auto ptr = new tiledb::Array(*ctx.get(), uri, query_type, tiledb::TemporalPolicy(tiledb::TimeTravel, ts_ms));
-    ptr->set_open_timestamp_end(ts_ms);
+XPtr<tiledb::Array> libtiledb_array_open_at(XPtr<tiledb::Context> ctx,
+                                            std::string uri, std::string type,
+                                            Datetime tstamp) {
+  check_xptr_tag<tiledb::Context>(ctx);
+  auto query_type = _string_to_tiledb_query_type(type);
+  // get timestamp as seconds since epoch (plus fractional seconds, returns
+  // double), scale to millisec
+  uint64_t ts_ms =
+      static_cast<uint64_t>(std::round(tstamp.getFractionalTimestamp() * 1000));
+#if TILEDB_VERSION >= TileDB_Version(2, 15, 0)
+  auto ptr =
+      new tiledb::Array(*ctx.get(), uri, query_type,
+                        tiledb::TemporalPolicy(tiledb::TimeTravel, ts_ms));
+  ptr->set_open_timestamp_end(ts_ms);
 #else
-    auto ptr = new tiledb::Array(*ctx.get(), uri, query_type);
-    ptr->set_open_timestamp_end(ts_ms);
+  auto ptr = new tiledb::Array(*ctx.get(), uri, query_type);
+  ptr->set_open_timestamp_end(ts_ms);
 #endif
-    return make_xptr<tiledb::Array>(ptr);
+  return make_xptr<tiledb::Array>(ptr);
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::Array> libtiledb_array_open_with_key(XPtr<tiledb::Context> ctx, std::string uri,
+XPtr<tiledb::Array> libtiledb_array_open_with_key(XPtr<tiledb::Context> ctx,
+                                                  std::string uri,
                                                   std::string type,
                                                   std::string enc_key) {
-    check_xptr_tag<tiledb::Context>(ctx);
-    spdl::debug("[libtiledb_array_open_with_key] function is deprecated");
-    XPtr<tiledb::Config> cfg = libtiledb_ctx_config(ctx);
-    cfg = libtiledb_config_set(cfg, "sm.encryption_key", enc_key);
-    cfg = libtiledb_config_set(cfg, "sm.encryption_type", "AES_256_GCM");
-    XPtr<tiledb::Context> newctx = libtiledb_ctx(cfg);
-    return libtiledb_array_open(newctx, uri, type);
+  check_xptr_tag<tiledb::Context>(ctx);
+  spdl::debug("[libtiledb_array_open_with_key] function is deprecated");
+  XPtr<tiledb::Config> cfg = libtiledb_ctx_config(ctx);
+  cfg = libtiledb_config_set(cfg, "sm.encryption_key", enc_key);
+  cfg = libtiledb_config_set(cfg, "sm.encryption_type", "AES_256_GCM");
+  XPtr<tiledb::Context> newctx = libtiledb_ctx(cfg);
+  return libtiledb_array_open(newctx, uri, type);
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::Array> libtiledb_array_open_at_with_key(XPtr<tiledb::Context> ctx, std::string uri,
-                                                     std::string type, std::string enc_key,
+XPtr<tiledb::Array> libtiledb_array_open_at_with_key(XPtr<tiledb::Context> ctx,
+                                                     std::string uri,
+                                                     std::string type,
+                                                     std::string enc_key,
                                                      Datetime tstamp) {
-    check_xptr_tag<tiledb::Context>(ctx);
-    spdl::debug("[libtiledb_array_open_at_with_key] function is deprecated");
-    auto query_type = _string_to_tiledb_query_type(type);
-    uint64_t ts_ms = static_cast<uint64_t>(std::round(tstamp.getFractionalTimestamp() * 1000));
-    XPtr<tiledb::Array> ptr = libtiledb_array_open_with_key(ctx, uri, type, enc_key);
-    ptr->close();               // close to reopen at timestamp, this should be revisited
-    ptr->open(query_type, TILEDB_AES_256_GCM, enc_key, ts_ms);
-    return ptr;
+  check_xptr_tag<tiledb::Context>(ctx);
+  spdl::debug("[libtiledb_array_open_at_with_key] function is deprecated");
+  auto query_type = _string_to_tiledb_query_type(type);
+  uint64_t ts_ms =
+      static_cast<uint64_t>(std::round(tstamp.getFractionalTimestamp() * 1000));
+  XPtr<tiledb::Array> ptr =
+      libtiledb_array_open_with_key(ctx, uri, type, enc_key);
+  ptr->close(); // close to reopen at timestamp, this should be revisited
+  ptr->open(query_type, TILEDB_AES_256_GCM, enc_key, ts_ms);
+  return ptr;
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::Array> libtiledb_array_open_with_ptr(XPtr<tiledb::Array> array, std::string query_type) {
+XPtr<tiledb::Array> libtiledb_array_open_with_ptr(XPtr<tiledb::Array> array,
+                                                  std::string query_type) {
   check_xptr_tag<tiledb::Array>(array);
   tiledb_query_type_t qtype = _string_to_tiledb_query_type(query_type);
   array->open(qtype);
@@ -2391,9 +2507,11 @@ std::string libtiledb_array_get_uri(XPtr<tiledb::Array> array) {
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::ArraySchema> libtiledb_array_get_schema(XPtr<tiledb::Array> array) {
+XPtr<tiledb::ArraySchema>
+libtiledb_array_get_schema(XPtr<tiledb::Array> array) {
   check_xptr_tag<tiledb::Array>(array);
-  return make_xptr<tiledb::ArraySchema>(new tiledb::ArraySchema(array->schema()));
+  return make_xptr<tiledb::ArraySchema>(
+      new tiledb::ArraySchema(array->schema()));
 }
 
 // [[Rcpp::export]]
@@ -2425,39 +2543,40 @@ List libtiledb_array_get_non_empty_domain(XPtr<tiledb::Array> array) {
   if (domain.type() == TILEDB_INT32) {
     using DType = tiledb::impl::tiledb_to_type<TILEDB_INT32>::type;
     auto res = array->non_empty_domain<DType>();
-    for (auto& d: res) {
+    for (auto &d : res) {
       auto dim_name = d.first;
       auto dim_domain = d.second;
-      nonempty_domain[dim_name] = IntegerVector::create(dim_domain.first,
-                                                        dim_domain.second);
+      nonempty_domain[dim_name] =
+          IntegerVector::create(dim_domain.first, dim_domain.second);
     }
   } else if (domain.type() == TILEDB_FLOAT64) {
     using DType = tiledb::impl::tiledb_to_type<TILEDB_FLOAT64>::type;
     auto res = array->non_empty_domain<DType>();
-    for (auto& d: res) {
+    for (auto &d : res) {
       auto dim_name = d.first;
       auto dim_domain = d.second;
-      nonempty_domain[dim_name] = NumericVector::create(dim_domain.first,
-                                                        dim_domain.second);
+      nonempty_domain[dim_name] =
+          NumericVector::create(dim_domain.first, dim_domain.second);
     }
   } else {
-    Rcpp::stop("Invalid tiledb_schema domain type: '%s'", _tiledb_datatype_to_string(domain.type()));
+    Rcpp::stop("Invalid tiledb_schema domain type: '%s'",
+               _tiledb_datatype_to_string(domain.type()));
   }
   return nonempty_domain;
 }
 
 // [[Rcpp::export]]
-CharacterVector libtiledb_array_get_non_empty_domain_var_from_name(XPtr<tiledb::Array> array,
-                                                                   std::string name) {
+CharacterVector
+libtiledb_array_get_non_empty_domain_var_from_name(XPtr<tiledb::Array> array,
+                                                   std::string name) {
   check_xptr_tag<tiledb::Array>(array);
   auto res = array->non_empty_domain_var(name);
   return CharacterVector::create(res.first, res.second);
 }
 
 // [[Rcpp::export]]
-CharacterVector libtiledb_array_get_non_empty_domain_var_from_index(XPtr<tiledb::Array> array,
-                                                                    int32_t idx,
-                                                                    std::string typestr = "ASCII") {
+CharacterVector libtiledb_array_get_non_empty_domain_var_from_index(
+    XPtr<tiledb::Array> array, int32_t idx, std::string typestr = "ASCII") {
   check_xptr_tag<tiledb::Array>(array);
   if (typestr == "ASCII") {
     auto res = array->non_empty_domain_var(idx);
@@ -2470,9 +2589,8 @@ CharacterVector libtiledb_array_get_non_empty_domain_var_from_index(XPtr<tiledb:
 }
 
 // [[Rcpp::export]]
-NumericVector libtiledb_array_get_non_empty_domain_from_name(XPtr<tiledb::Array> array,
-                                                             std::string name,
-                                                             std::string typestr) {
+NumericVector libtiledb_array_get_non_empty_domain_from_name(
+    XPtr<tiledb::Array> array, std::string name, std::string typestr) {
   check_xptr_tag<tiledb::Array>(array);
   if (typestr == "INT64") {
     auto p = array->non_empty_domain<int64_t>(name);
@@ -2480,7 +2598,8 @@ NumericVector libtiledb_array_get_non_empty_domain_from_name(XPtr<tiledb::Array>
     return toInteger64(v);
   } else if (typestr == "UINT64") {
     auto p = array->non_empty_domain<uint64_t>(name);
-    std::vector<int64_t> v{ static_cast<int64_t>(p.first), static_cast<int64_t>(p.second) };
+    std::vector<int64_t> v{static_cast<int64_t>(p.first),
+                           static_cast<int64_t>(p.second)};
     return toInteger64(v);
   } else if (typestr == "INT32") {
     auto p = array->non_empty_domain<int32_t>(name);
@@ -2506,18 +2625,12 @@ NumericVector libtiledb_array_get_non_empty_domain_from_name(XPtr<tiledb::Array>
   } else if (typestr == "FLOAT32") {
     auto p = array->non_empty_domain<float>(name);
     return NumericVector::create(p.first, p.second);
-  } else if (typestr == "DATETIME_YEAR" ||
-             typestr == "DATETIME_MONTH" ||
-             typestr == "DATETIME_WEEK" ||
-             typestr == "DATETIME_DAY" ||
-             typestr == "DATETIME_HR"  ||
-             typestr == "DATETIME_MIN" ||
-             typestr == "DATETIME_SEC" ||
-             typestr == "DATETIME_MS"  ||
-             typestr == "DATETIME_US"  ||
-             typestr == "DATETIME_PS"  ||
-             typestr == "DATETIME_FS"  ||
-             typestr == "DATETIME_AS"    ) {
+  } else if (typestr == "DATETIME_YEAR" || typestr == "DATETIME_MONTH" ||
+             typestr == "DATETIME_WEEK" || typestr == "DATETIME_DAY" ||
+             typestr == "DATETIME_HR" || typestr == "DATETIME_MIN" ||
+             typestr == "DATETIME_SEC" || typestr == "DATETIME_MS" ||
+             typestr == "DATETIME_US" || typestr == "DATETIME_PS" ||
+             typestr == "DATETIME_FS" || typestr == "DATETIME_AS") {
     // type_check() from exception.h gets invoked and wants an int64_t
     auto p = array->non_empty_domain<int64_t>(name);
     std::vector<int64_t> v{p.first, p.second};
@@ -2527,16 +2640,15 @@ NumericVector libtiledb_array_get_non_empty_domain_from_name(XPtr<tiledb::Array>
     std::vector<int64_t> v{p.first, p.second};
     return toNanotime(v);
   } else {
-    Rcpp::stop("Currently unsupported tiledb domain type: '%s'", typestr.c_str());
+    Rcpp::stop("Currently unsupported tiledb domain type: '%s'",
+               typestr.c_str());
     return NumericVector::create(NA_REAL, NA_REAL); // not reached
   }
 }
 
-
 // [[Rcpp::export]]
-NumericVector libtiledb_array_get_non_empty_domain_from_index(XPtr<tiledb::Array> array,
-                                                              int32_t idx,
-                                                              std::string typestr) {
+NumericVector libtiledb_array_get_non_empty_domain_from_index(
+    XPtr<tiledb::Array> array, int32_t idx, std::string typestr) {
   check_xptr_tag<tiledb::Array>(array);
   if (typestr == "INT64") {
     auto p = array->non_empty_domain<int64_t>(idx);
@@ -2544,7 +2656,8 @@ NumericVector libtiledb_array_get_non_empty_domain_from_index(XPtr<tiledb::Array
     return toInteger64(v);
   } else if (typestr == "UINT64") {
     auto p = array->non_empty_domain<uint64_t>(idx);
-    std::vector<int64_t> v{ static_cast<int64_t>(p.first), static_cast<int64_t>(p.second) };
+    std::vector<int64_t> v{static_cast<int64_t>(p.first),
+                           static_cast<int64_t>(p.second)};
     return toInteger64(v);
   } else if (typestr == "INT32") {
     auto p = array->non_empty_domain<int32_t>(idx);
@@ -2570,18 +2683,12 @@ NumericVector libtiledb_array_get_non_empty_domain_from_index(XPtr<tiledb::Array
   } else if (typestr == "FLOAT32") {
     auto p = array->non_empty_domain<float>(idx);
     return NumericVector::create(p.first, p.second);
-  } else if (typestr == "DATETIME_YEAR" ||
-             typestr == "DATETIME_MONTH" ||
-             typestr == "DATETIME_WEEK" ||
-             typestr == "DATETIME_DAY" ||
-             typestr == "DATETIME_HR"  ||
-             typestr == "DATETIME_MIN" ||
-             typestr == "DATETIME_SEC" ||
-             typestr == "DATETIME_MS"  ||
-             typestr == "DATETIME_US"  ||
-             typestr == "DATETIME_PS"  ||
-             typestr == "DATETIME_FS"  ||
-             typestr == "DATETIME_AS"    ) {
+  } else if (typestr == "DATETIME_YEAR" || typestr == "DATETIME_MONTH" ||
+             typestr == "DATETIME_WEEK" || typestr == "DATETIME_DAY" ||
+             typestr == "DATETIME_HR" || typestr == "DATETIME_MIN" ||
+             typestr == "DATETIME_SEC" || typestr == "DATETIME_MS" ||
+             typestr == "DATETIME_US" || typestr == "DATETIME_PS" ||
+             typestr == "DATETIME_FS" || typestr == "DATETIME_AS") {
     // type_check() from exception.h gets invoked and wants an int64_t
     auto p = array->non_empty_domain<int64_t>(idx);
     std::vector<int64_t> v{p.first, p.second};
@@ -2591,16 +2698,16 @@ NumericVector libtiledb_array_get_non_empty_domain_from_index(XPtr<tiledb::Array
     std::vector<int64_t> v{p.first, p.second};
     return toNanotime(v);
   } else {
-    Rcpp::stop("Currently unsupported tiledb domain type: '%s'", typestr.c_str());
+    Rcpp::stop("Currently unsupported tiledb domain type: '%s'",
+               typestr.c_str());
     return NumericVector::create(NA_REAL, NA_REAL); // not reached
   }
 }
 
-
 // [[Rcpp::export]]
-void libtiledb_array_consolidate(XPtr<tiledb::Context> ctx,
-                                 std::string uri,
-                                 Nullable<XPtr<tiledb::Config>> cfgptr = R_NilValue) {
+void libtiledb_array_consolidate(
+    XPtr<tiledb::Context> ctx, std::string uri,
+    Nullable<XPtr<tiledb::Config>> cfgptr = R_NilValue) {
   check_xptr_tag<tiledb::Context>(ctx);
   if (cfgptr.isNotNull()) {
     XPtr<tiledb::Config> cfg(cfgptr);
@@ -2612,9 +2719,9 @@ void libtiledb_array_consolidate(XPtr<tiledb::Context> ctx,
 }
 
 // [[Rcpp::export]]
-void libtiledb_array_vacuum(XPtr<tiledb::Context> ctx,
-                            std::string uri,
-                            Nullable<XPtr<tiledb::Config>> cfgptr = R_NilValue) {
+void libtiledb_array_vacuum(
+    XPtr<tiledb::Context> ctx, std::string uri,
+    Nullable<XPtr<tiledb::Config>> cfgptr = R_NilValue) {
   check_xptr_tag<tiledb::Context>(ctx);
   if (cfgptr.isNotNull()) {
     XPtr<tiledb::Config> cfg(cfgptr);
@@ -2625,55 +2732,58 @@ void libtiledb_array_vacuum(XPtr<tiledb::Context> ctx,
   }
 }
 
-
 // [[Rcpp::export]]
-bool libtiledb_array_put_metadata(XPtr<tiledb::Array> array,
-                                  std::string key, SEXP obj) {
+bool libtiledb_array_put_metadata(XPtr<tiledb::Array> array, std::string key,
+                                  SEXP obj) {
   check_xptr_tag<tiledb::Array>(array);
   // we implement a simpler interface here as the 'type' is given from
   // the supplied SEXP, as is the extent
-  switch(TYPEOF(obj)) {
-    case VECSXP: {
-      Rcpp::stop("List objects are not supported.");
-      break;// not reached
+  switch (TYPEOF(obj)) {
+  case VECSXP: {
+    Rcpp::stop("List objects are not supported.");
+    break; // not reached
+  }
+  case REALSXP: {
+    Rcpp::NumericVector v(obj);
+    if (isInteger64(v)) {
+      std::vector<int64_t> iv = fromInteger64(v);
+      array->put_metadata(key.c_str(), TILEDB_INT64, iv.size(), (void *)&iv[0]);
+    } else {
+      array->put_metadata(key.c_str(), TILEDB_FLOAT64, v.size(), v.begin());
     }
-    case REALSXP: {
-      Rcpp::NumericVector v(obj);
-      if (isInteger64(v)) {
-          std::vector<int64_t> iv = fromInteger64(v);
-          array->put_metadata(key.c_str(), TILEDB_INT64, iv.size(), (void*) &iv[0]);
-      } else {
-          array->put_metadata(key.c_str(), TILEDB_FLOAT64, v.size(), v.begin());
-      }
-      break;
-    }
-    case INTSXP: {
-      Rcpp::IntegerVector v(obj);
-      array->put_metadata(key.c_str(), TILEDB_INT32, v.size(), v.begin());
-      break;
-    }
-    case STRSXP: {
-      Rcpp::CharacterVector v(obj);
-      std::string s(v[0]);
-      // We use TILEDB_CHAR interchangeably with TILEDB_STRING_ASCII is this best string type?
-      array->put_metadata(key.c_str(), TILEDB_STRING_ASCII, s.length(), s.c_str());
-      break;
-    }
-    case LGLSXP: {              // experimental: map R logical (ie TRUE, FALSE, NA) to int8
-      Rcpp::LogicalVector v(obj);
-      size_t n = static_cast<size_t>(v.size());
-      std::vector<int8_t> ints(n);
-      for (size_t i=0; i<n; i++) ints[i] = static_cast<int8_t>(v[i]);
-      array->put_metadata(key.c_str(), TILEDB_INT8, ints.size(), ints.data());
-      break;
-    }
-    default: {
-      Rcpp::stop("No support (yet) for type '%s'.", Rf_type2char(TYPEOF(obj)));
-      break; // not reached
-    }
+    break;
+  }
+  case INTSXP: {
+    Rcpp::IntegerVector v(obj);
+    array->put_metadata(key.c_str(), TILEDB_INT32, v.size(), v.begin());
+    break;
+  }
+  case STRSXP: {
+    Rcpp::CharacterVector v(obj);
+    std::string s(v[0]);
+    // We use TILEDB_CHAR interchangeably with TILEDB_STRING_ASCII is this best
+    // string type?
+    array->put_metadata(key.c_str(), TILEDB_STRING_ASCII, s.length(),
+                        s.c_str());
+    break;
+  }
+  case LGLSXP: { // experimental: map R logical (ie TRUE, FALSE, NA) to int8
+    Rcpp::LogicalVector v(obj);
+    size_t n = static_cast<size_t>(v.size());
+    std::vector<int8_t> ints(n);
+    for (size_t i = 0; i < n; i++)
+      ints[i] = static_cast<int8_t>(v[i]);
+    array->put_metadata(key.c_str(), TILEDB_INT8, ints.size(), ints.data());
+    break;
+  }
+  default: {
+    Rcpp::stop("No support (yet) for type '%s'.", Rf_type2char(TYPEOF(obj)));
+    break; // not reached
+  }
   }
   // Close array - Important so that the metadata get flushed
-  // not here, array opening and closing responsibility of caller:  array.close();
+  // not here, array opening and closing responsibility of caller:
+  // array.close();
   return true;
 }
 
@@ -2686,46 +2796,53 @@ R_xlen_t libtiledb_array_get_metadata_num(XPtr<tiledb::Array> array) {
 
 // helper function to copy int vector
 template <typename T>
-Rcpp::IntegerVector copy_int_vector(const uint32_t v_num, const void* v) {
-  // Strictly speaking a check for under/overflow would be needed here yet this for
-  // metadata annotation (and not data payload) so extreme ranges are less likely
+Rcpp::IntegerVector copy_int_vector(const uint32_t v_num, const void *v) {
+  // Strictly speaking a check for under/overflow would be needed here yet this
+  // for metadata annotation (and not data payload) so extreme ranges are less
+  // likely
   Rcpp::IntegerVector vec(v_num);
-  const T *ivec = static_cast<const T*>(v);
+  const T *ivec = static_cast<const T *>(v);
   size_t n = static_cast<size_t>(v_num);
-  for (size_t i=0; i<n; i++) vec[i] = static_cast<int32_t>(ivec[i]);
-  return(vec);
+  for (size_t i = 0; i < n; i++)
+    vec[i] = static_cast<int32_t>(ivec[i]);
+  return (vec);
 }
 
 // helper function to convert_metadata
-SEXP _metadata_to_sexp(const tiledb_datatype_t v_type, const uint32_t v_num, const void* v) {
+SEXP _metadata_to_sexp(const tiledb_datatype_t v_type, const uint32_t v_num,
+                       const void *v) {
   // This supports a limited set of basic types as the metadata
   // annotation is not meant to support complete serialization
   if (v_type == TILEDB_INT32) {
     Rcpp::IntegerVector vec(v_num);
-    std::memcpy(vec.begin(), v, v_num*sizeof(int32_t));
-    return(vec);
+    std::memcpy(vec.begin(), v, v_num * sizeof(int32_t));
+    return (vec);
   } else if (v_type == TILEDB_FLOAT64) {
     Rcpp::NumericVector vec(v_num);
-    std::memcpy(vec.begin(), v, v_num*sizeof(double));
-    return(vec);
+    std::memcpy(vec.begin(), v, v_num * sizeof(double));
+    return (vec);
   } else if (v_type == TILEDB_FLOAT32) {
     Rcpp::NumericVector vec(v_num);
-    const float *fvec = static_cast<const float*>(v);
+    const float *fvec = static_cast<const float *>(v);
     size_t n = static_cast<size_t>(v_num);
-    for (size_t i=0; i<n; i++) vec[i] = static_cast<double>(fvec[i]);
-    return(vec);
-  } else if (v_type == TILEDB_CHAR || v_type == TILEDB_STRING_ASCII || v_type == TILEDB_STRING_UTF8) {
-    std::string s(static_cast<const char*>(v), v_num);
-    return(Rcpp::wrap(s));
+    for (size_t i = 0; i < n; i++)
+      vec[i] = static_cast<double>(fvec[i]);
+    return (vec);
+  } else if (v_type == TILEDB_CHAR || v_type == TILEDB_STRING_ASCII ||
+             v_type == TILEDB_STRING_UTF8) {
+    std::string s(static_cast<const char *>(v), v_num);
+    return (Rcpp::wrap(s));
   } else if (v_type == TILEDB_INT8) {
     Rcpp::LogicalVector vec(v_num);
-    const int8_t *ivec = static_cast<const int8_t*>(v);
+    const int8_t *ivec = static_cast<const int8_t *>(v);
     size_t n = static_cast<size_t>(v_num);
-    for (size_t i=0; i<n; i++) vec[i] = static_cast<bool>(ivec[i]);
-    return(vec);
+    for (size_t i = 0; i < n; i++)
+      vec[i] = static_cast<bool>(ivec[i]);
+    return (vec);
   } else if (v_type == TILEDB_UINT8) {
-    // Strictly speaking a check for under/overflow would be needed here (and below) yet this
-    // is for metadata annotation (and not data payload) so extreme ranges are less likely
+    // Strictly speaking a check for under/overflow would be needed here (and
+    // below) yet this is for metadata annotation (and not data payload) so
+    // extreme ranges are less likely
     return copy_int_vector<uint8_t>(v_num, v);
   } else if (v_type == TILEDB_INT16) {
     return copy_int_vector<int16_t>(v_num, v);
@@ -2735,7 +2852,7 @@ SEXP _metadata_to_sexp(const tiledb_datatype_t v_type, const uint32_t v_num, con
     return copy_int_vector<uint32_t>(v_num, v);
   } else if (v_type == TILEDB_INT64) {
     std::vector<int64_t> iv(v_num);
-    std::memcpy(&(iv[0]), v, v_num*sizeof(int64_t));
+    std::memcpy(&(iv[0]), v, v_num * sizeof(int64_t));
     return toInteger64(iv);
   } else if (v_type == TILEDB_UINT64) {
     return copy_int_vector<uint64_t>(v_num, v);
@@ -2745,13 +2862,15 @@ SEXP _metadata_to_sexp(const tiledb_datatype_t v_type, const uint32_t v_num, con
 }
 
 // [[Rcpp::export]]
-SEXP libtiledb_array_get_metadata_from_index(XPtr<tiledb::Array> array, int idx) {
+SEXP libtiledb_array_get_metadata_from_index(XPtr<tiledb::Array> array,
+                                             int idx) {
   check_xptr_tag<tiledb::Array>(array);
   std::string key;
   tiledb_datatype_t v_type;
   uint32_t v_num;
-  const void* v;
-  array->get_metadata_from_index(static_cast<uint64_t>(idx), &key, &v_type, &v_num, &v);
+  const void *v;
+  array->get_metadata_from_index(static_cast<uint64_t>(idx), &key, &v_type,
+                                 &v_num, &v);
   if (v == NULL) {
     return R_NilValue;
   }
@@ -2768,9 +2887,10 @@ SEXP libtiledb_array_get_metadata_list(XPtr<tiledb::Array> array) {
   int n = static_cast<int>(num);
   Rcpp::List lst(n);
   Rcpp::CharacterVector names(n);
-  for (auto i=0; i<n; i++) {
-    // we trick this a little by having the returned object also carry an attribute
-    // cleaner way (in a C++ pure sense) would be to return a pair of string and SEXP
+  for (auto i = 0; i < n; i++) {
+    // we trick this a little by having the returned object also carry an
+    // attribute cleaner way (in a C++ pure sense) would be to return a pair of
+    // string and SEXP
     SEXP v = libtiledb_array_get_metadata_from_index(array, i);
     Rcpp::RObject obj(v);
     Rcpp::CharacterVector objnms = obj.attr("names");
@@ -2783,73 +2903,85 @@ SEXP libtiledb_array_get_metadata_list(XPtr<tiledb::Array> array) {
 }
 
 // [[Rcpp::export]]
-void libtiledb_array_delete_metadata(XPtr<tiledb::Array> array, std::string key) {
+void libtiledb_array_delete_metadata(XPtr<tiledb::Array> array,
+                                     std::string key) {
   check_xptr_tag<tiledb::Array>(array);
   array->delete_metadata(key.c_str());
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::Array> libtiledb_array_set_open_timestamp_start(XPtr<tiledb::Array> array, Rcpp::Datetime tstamp) {
-    check_xptr_tag<tiledb::Array>(array);
-    uint64_t ts_ms = static_cast<uint64_t>(std::round(tstamp.getFractionalTimestamp() * 1000));
-    array->set_open_timestamp_start(ts_ms);
-    return array;
+XPtr<tiledb::Array>
+libtiledb_array_set_open_timestamp_start(XPtr<tiledb::Array> array,
+                                         Rcpp::Datetime tstamp) {
+  check_xptr_tag<tiledb::Array>(array);
+  uint64_t ts_ms =
+      static_cast<uint64_t>(std::round(tstamp.getFractionalTimestamp() * 1000));
+  array->set_open_timestamp_start(ts_ms);
+  return array;
 }
 
 // [[Rcpp::export]]
 Rcpp::Datetime libtiledb_array_open_timestamp_start(XPtr<tiledb::Array> array) {
-    check_xptr_tag<tiledb::Array>(array);
-    uint64_t ts_ms = array->open_timestamp_start();
-    double ts = ts_ms / 1000.0;
-    return(Rcpp::Datetime(ts));
+  check_xptr_tag<tiledb::Array>(array);
+  uint64_t ts_ms = array->open_timestamp_start();
+  double ts = ts_ms / 1000.0;
+  return (Rcpp::Datetime(ts));
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::Array> libtiledb_array_set_open_timestamp_end(XPtr<tiledb::Array> array, Rcpp::Datetime tstamp) {
-    check_xptr_tag<tiledb::Array>(array);
-    uint64_t ts_ms = static_cast<uint64_t>(std::round(tstamp.getFractionalTimestamp() * 1000));
-    array->set_open_timestamp_end(ts_ms);
-    return array;
+XPtr<tiledb::Array>
+libtiledb_array_set_open_timestamp_end(XPtr<tiledb::Array> array,
+                                       Rcpp::Datetime tstamp) {
+  check_xptr_tag<tiledb::Array>(array);
+  uint64_t ts_ms =
+      static_cast<uint64_t>(std::round(tstamp.getFractionalTimestamp() * 1000));
+  array->set_open_timestamp_end(ts_ms);
+  return array;
 }
 
 // [[Rcpp::export]]
 Rcpp::Datetime libtiledb_array_open_timestamp_end(XPtr<tiledb::Array> array) {
-    check_xptr_tag<tiledb::Array>(array);
-    uint64_t ts_ms = array->open_timestamp_end();
-    double ts = ts_ms / 1000.0;
-    return(Rcpp::Datetime(ts));
+  check_xptr_tag<tiledb::Array>(array);
+  uint64_t ts_ms = array->open_timestamp_end();
+  double ts = ts_ms / 1000.0;
+  return (Rcpp::Datetime(ts));
 }
 
 // [[Rcpp::export]]
-void libtiledb_array_delete_fragments(XPtr<tiledb::Context> ctx, XPtr<tiledb::Array> array,
-                                      Rcpp::Datetime tstamp_start, Rcpp::Datetime tstamp_end) {
-#if TILEDB_VERSION >= TileDB_Version(2,12,0)
-    check_xptr_tag<tiledb::Context>(ctx);
-    check_xptr_tag<tiledb::Array>(array);
-    const std::string uri = array->uri();
-    uint64_t ts_ms_st = static_cast<uint64_t>(std::round(tstamp_start.getFractionalTimestamp() * 1000));
-    uint64_t ts_ms_en = static_cast<uint64_t>(std::round(tstamp_end.getFractionalTimestamp() * 1000));
-#if TILEDB_VERSION >= TileDB_Version(2,18,0)
-    tiledb::Array::delete_fragments(*ctx.get(), uri, ts_ms_st, ts_ms_en);
+void libtiledb_array_delete_fragments(XPtr<tiledb::Context> ctx,
+                                      XPtr<tiledb::Array> array,
+                                      Rcpp::Datetime tstamp_start,
+                                      Rcpp::Datetime tstamp_end) {
+#if TILEDB_VERSION >= TileDB_Version(2, 12, 0)
+  check_xptr_tag<tiledb::Context>(ctx);
+  check_xptr_tag<tiledb::Array>(array);
+  const std::string uri = array->uri();
+  uint64_t ts_ms_st = static_cast<uint64_t>(
+      std::round(tstamp_start.getFractionalTimestamp() * 1000));
+  uint64_t ts_ms_en = static_cast<uint64_t>(
+      std::round(tstamp_end.getFractionalTimestamp() * 1000));
+#if TILEDB_VERSION >= TileDB_Version(2, 18, 0)
+  tiledb::Array::delete_fragments(*ctx.get(), uri, ts_ms_st, ts_ms_en);
 #else
-    array->delete_fragments(uri, ts_ms_st, ts_ms_en);
+  array->delete_fragments(uri, ts_ms_st, ts_ms_en);
 #endif
 #endif
 }
 
 // [[Rcpp::export]]
-void libtiledb_array_delete_fragments_list(XPtr<tiledb::Context> ctx, XPtr<tiledb::Array> array,
+void libtiledb_array_delete_fragments_list(XPtr<tiledb::Context> ctx,
+                                           XPtr<tiledb::Array> array,
                                            std::vector<std::string> fragments) {
-    check_xptr_tag<tiledb::Context>(ctx);
-    check_xptr_tag<tiledb::Array>(array);
-    const std::string uri = array->uri();
-    size_t n = fragments.size();
-    std::vector<const char*> frags(n);
-    for (size_t i = 0; i < n; i++) {
-        frags[i] = fragments[i].c_str();
-    }
-#if TILEDB_VERSION >= TileDB_Version(2,18,0)
-    tiledb::Array::delete_fragments_list(*ctx.get(), uri, &frags[0], n);
+  check_xptr_tag<tiledb::Context>(ctx);
+  check_xptr_tag<tiledb::Array>(array);
+  const std::string uri = array->uri();
+  size_t n = fragments.size();
+  std::vector<const char *> frags(n);
+  for (size_t i = 0; i < n; i++) {
+    frags[i] = fragments[i].c_str();
+  }
+#if TILEDB_VERSION >= TileDB_Version(2, 18, 0)
+  tiledb::Array::delete_fragments_list(*ctx.get(), uri, &frags[0], n);
 #endif
 }
 
@@ -2857,68 +2989,71 @@ void libtiledb_array_delete_fragments_list(XPtr<tiledb::Context> ctx, XPtr<tiled
 bool libtiledb_array_has_enumeration(XPtr<tiledb::Context> ctx,
                                      XPtr<tiledb::Array> arr,
                                      const std::string name) {
-    check_xptr_tag<tiledb::Context>(ctx);
-    check_xptr_tag<tiledb::Array>(arr);
-    bool res = false;
-#if TILEDB_VERSION >= TileDB_Version(2,17,0)
-    auto enmr = tiledb::ArrayExperimental::get_enumeration(*ctx.get(), *arr.get(), name);
-    if (enmr.ptr() != nullptr) {
-        res = true;
-    }
+  check_xptr_tag<tiledb::Context>(ctx);
+  check_xptr_tag<tiledb::Array>(arr);
+  bool res = false;
+#if TILEDB_VERSION >= TileDB_Version(2, 17, 0)
+  auto enmr =
+      tiledb::ArrayExperimental::get_enumeration(*ctx.get(), *arr.get(), name);
+  if (enmr.ptr() != nullptr) {
+    res = true;
+  }
 #endif
-    return res;
+  return res;
 }
 
 // [[Rcpp::export]]
-std::vector<std::string> libtiledb_array_get_enumeration(XPtr<tiledb::Context> ctx,
-                                                         XPtr<tiledb::Array> arr,
-                                                         const std::string name) {
-    check_xptr_tag<tiledb::Context>(ctx);
-    check_xptr_tag<tiledb::Array>(arr);
-    std::vector<std::string> res;
-#if TILEDB_VERSION >= TileDB_Version(2,17,0)
-    auto enmr = tiledb::ArrayExperimental::get_enumeration(*ctx.get(), *arr.get(), name);
-    if (enmr.ptr() == nullptr) {
-        Rcpp::stop("No enumeration named '%s' in array.");
-    }
-    res = enmr.as_vector<std::string>();
+std::vector<std::string>
+libtiledb_array_get_enumeration(XPtr<tiledb::Context> ctx,
+                                XPtr<tiledb::Array> arr,
+                                const std::string name) {
+  check_xptr_tag<tiledb::Context>(ctx);
+  check_xptr_tag<tiledb::Array>(arr);
+  std::vector<std::string> res;
+#if TILEDB_VERSION >= TileDB_Version(2, 17, 0)
+  auto enmr =
+      tiledb::ArrayExperimental::get_enumeration(*ctx.get(), *arr.get(), name);
+  if (enmr.ptr() == nullptr) {
+    Rcpp::stop("No enumeration named '%s' in array.");
+  }
+  res = enmr.as_vector<std::string>();
 #endif
-    return res;
+  return res;
 }
 
 // quick and dirty checker for an entire array
 // [[Rcpp::export]]
-Rcpp::LogicalVector libtiledb_array_has_enumeration_vector(XPtr<tiledb::Context> ctx, XPtr<tiledb::Array> array) {
-    check_xptr_tag<tiledb::Context>(ctx);
-    check_xptr_tag<tiledb::Array>(array);
-    Rcpp::XPtr<tiledb::ArraySchema> arrsch = libtiledb_array_get_schema(array);
-    Rcpp::List attrs = libtiledb_array_schema_attributes(arrsch);
-    size_t n = attrs.size();
-    Rcpp::LogicalVector has_enum = Rcpp::LogicalVector(n);
-    Rcpp::CharacterVector attr_names(n);
-    for (size_t i = 0; i < n; i++) {
-        has_enum[i] = libtiledb_attribute_has_enumeration(ctx, attrs[i]);
-        attr_names[i] = libtiledb_attribute_get_name(attrs[i]);
-    }
-    has_enum.attr("names") = attr_names;
-    return has_enum;
+Rcpp::LogicalVector
+libtiledb_array_has_enumeration_vector(XPtr<tiledb::Context> ctx,
+                                       XPtr<tiledb::Array> array) {
+  check_xptr_tag<tiledb::Context>(ctx);
+  check_xptr_tag<tiledb::Array>(array);
+  Rcpp::XPtr<tiledb::ArraySchema> arrsch = libtiledb_array_get_schema(array);
+  Rcpp::List attrs = libtiledb_array_schema_attributes(arrsch);
+  size_t n = attrs.size();
+  Rcpp::LogicalVector has_enum = Rcpp::LogicalVector(n);
+  Rcpp::CharacterVector attr_names(n);
+  for (size_t i = 0; i < n; i++) {
+    has_enum[i] = libtiledb_attribute_has_enumeration(ctx, attrs[i]);
+    attr_names[i] = libtiledb_attribute_get_name(attrs[i]);
+  }
+  has_enum.attr("names") = attr_names;
+  return has_enum;
 }
 
 // [[Rcpp::export]]
-void libtiledb_array_upgrade_version(XPtr<tiledb::Context> ctx,
-                                     XPtr<tiledb::Array> array,
-                                     std::string& uri,
-                                     Rcpp::Nullable<XPtr<tiledb::Config>> cfg = R_NilValue) {
-    check_xptr_tag<tiledb::Context>(ctx);
-    check_xptr_tag<tiledb::Array>(array);
-    if (cfg.isNull()) {
-        array->upgrade_version(*ctx.get(), uri);
-    } else {
-        XPtr<tiledb::Config> config(cfg);
-        array->upgrade_version(*ctx.get(), uri, config.get());
-    }
+void libtiledb_array_upgrade_version(
+    XPtr<tiledb::Context> ctx, XPtr<tiledb::Array> array, std::string &uri,
+    Rcpp::Nullable<XPtr<tiledb::Config>> cfg = R_NilValue) {
+  check_xptr_tag<tiledb::Context>(ctx);
+  check_xptr_tag<tiledb::Array>(array);
+  if (cfg.isNull()) {
+    array->upgrade_version(*ctx.get(), uri);
+  } else {
+    XPtr<tiledb::Config> config(cfg);
+    array->upgrade_version(*ctx.get(), uri, config.get());
+  }
 }
-
 
 /**
  * Query
@@ -2956,83 +3091,85 @@ std::string libtiledb_query_layout(XPtr<tiledb::Query> query) {
   return _tiledb_layout_to_string(layout);
 }
 
-// NB Function XPtr<tiledb::Array> libtiledb_query_get_array(XPtr<tiledb::Query> query,
-//                                                           XPtr<tiledb::Context> ctx) {
+// NB Function XPtr<tiledb::Array> libtiledb_query_get_array(XPtr<tiledb::Query>
+// query,
+//                                                           XPtr<tiledb::Context>
+//                                                           ctx) {
 // is below along with schema getter
-
 
 // generalized version which switches
 // [[Rcpp::export]]
-XPtr<tiledb::Query> libtiledb_query_set_subarray_with_type(XPtr<tiledb::Query> query,
-                                                           SEXP subarray, std::string typestr) {
-    check_xptr_tag<tiledb::Query>(query);
-    spdl::debug(tfm::format("libtiledb_query_set_subarray_with_type] setting subarray for type %s", typestr));
-    tiledb::Subarray subarr(query->ctx(), query->array());
-    if (typestr == "INT32") {
-        IntegerVector vec(subarray);
-        subarr.set_subarray(vec.begin(), vec.length());
-    } else if (typestr == "FLOAT64") {
-        NumericVector sub(subarray);
-        subarr.set_subarray(sub.begin(), sub.length());
-    } else if (typestr == "INT64" ||
-               typestr == "UINT32" ||
-               typestr == "DATETIME_NS") {
-        NumericVector sub(subarray);
-        std::vector<int64_t> v(sub.length());
-        for (int i=0; i<sub.length(); i++)
-            v[i] = static_cast<int64_t>(sub[i]);
-        subarr.set_subarray(v);
-    } else if (typestr == "DATETIME_YEAR"  ||
-               typestr == "DATETIME_MONTH" ||
-               typestr == "DATETIME_WEEK"  ||
-               typestr == "DATETIME_DAY") {
-        DateVector sub(subarray);
-        std::vector<int64_t> v = dates_to_int64(sub, _string_to_tiledb_datatype(typestr));
-        subarr.set_subarray(v);
-    } else if (typestr == "DATETIME_HR"  ||
-               typestr == "DATETIME_MIN" ||
-               typestr == "DATETIME_SEC" ||
-               typestr == "DATETIME_MS"  ||
-               typestr == "DATETIME_US") {
-        DatetimeVector sub(subarray);
-        std::vector<int64_t> v = datetimes_to_int64(sub, _string_to_tiledb_datatype(typestr));
-        subarr.set_subarray(v);
-    } else if (typestr == "UINT64") {
-        NumericVector sub(subarray);
-        std::vector<uint64_t> v(sub.length());
-        for (int i=0; i<sub.length(); i++)
-            v[i] = static_cast<uint64_t>(sub[i]);
-        subarr.set_subarray(v);
-    } else {
-        Rcpp::stop("currently unsupported subarray datatype '%s'", typestr.c_str());
-    }
-    query->set_subarray(subarr);
-    return query;
+XPtr<tiledb::Query>
+libtiledb_query_set_subarray_with_type(XPtr<tiledb::Query> query, SEXP subarray,
+                                       std::string typestr) {
+  check_xptr_tag<tiledb::Query>(query);
+  spdl::debug(tfm::format(
+      "libtiledb_query_set_subarray_with_type] setting subarray for type %s",
+      typestr));
+  tiledb::Subarray subarr(query->ctx(), query->array());
+  if (typestr == "INT32") {
+    IntegerVector vec(subarray);
+    subarr.set_subarray(vec.begin(), vec.length());
+  } else if (typestr == "FLOAT64") {
+    NumericVector sub(subarray);
+    subarr.set_subarray(sub.begin(), sub.length());
+  } else if (typestr == "INT64" || typestr == "UINT32" ||
+             typestr == "DATETIME_NS") {
+    NumericVector sub(subarray);
+    std::vector<int64_t> v(sub.length());
+    for (int i = 0; i < sub.length(); i++)
+      v[i] = static_cast<int64_t>(sub[i]);
+    subarr.set_subarray(v);
+  } else if (typestr == "DATETIME_YEAR" || typestr == "DATETIME_MONTH" ||
+             typestr == "DATETIME_WEEK" || typestr == "DATETIME_DAY") {
+    DateVector sub(subarray);
+    std::vector<int64_t> v =
+        dates_to_int64(sub, _string_to_tiledb_datatype(typestr));
+    subarr.set_subarray(v);
+  } else if (typestr == "DATETIME_HR" || typestr == "DATETIME_MIN" ||
+             typestr == "DATETIME_SEC" || typestr == "DATETIME_MS" ||
+             typestr == "DATETIME_US") {
+    DatetimeVector sub(subarray);
+    std::vector<int64_t> v =
+        datetimes_to_int64(sub, _string_to_tiledb_datatype(typestr));
+    subarr.set_subarray(v);
+  } else if (typestr == "UINT64") {
+    NumericVector sub(subarray);
+    std::vector<uint64_t> v(sub.length());
+    for (int i = 0; i < sub.length(); i++)
+      v[i] = static_cast<uint64_t>(sub[i]);
+    subarr.set_subarray(v);
+  } else {
+    Rcpp::stop("currently unsupported subarray datatype '%s'", typestr.c_str());
+  }
+  query->set_subarray(subarr);
+  return query;
 }
 
 // [[Rcpp::export]]
 XPtr<tiledb::Query> libtiledb_query_set_subarray(XPtr<tiledb::Query> query,
                                                  SEXP subarray) {
-    check_xptr_tag<tiledb::Query>(query);
-    spdl::debug(tfm::format("libtiledb_query_set_subarray] setting subarray for type %s", Rf_type2char(TYPEOF(subarray))));
-    tiledb::Subarray subarr(query->ctx(), query->array());
-    if (TYPEOF(subarray) == INTSXP) {
-        IntegerVector vec(subarray);
-        subarr.set_subarray(vec.begin(), vec.length());
-    } else if (TYPEOF(subarray) == REALSXP) {
-        NumericVector vec(subarray);
-        subarr.set_subarray(vec.begin(), vec.length());
-    } else {
-        Rcpp::stop("currently unsupported subarray datatype");
-    }
-    query->set_subarray(subarr);
-    return query;
+  check_xptr_tag<tiledb::Query>(query);
+  spdl::debug(
+      tfm::format("libtiledb_query_set_subarray] setting subarray for type %s",
+                  Rf_type2char(TYPEOF(subarray))));
+  tiledb::Subarray subarr(query->ctx(), query->array());
+  if (TYPEOF(subarray) == INTSXP) {
+    IntegerVector vec(subarray);
+    subarr.set_subarray(vec.begin(), vec.length());
+  } else if (TYPEOF(subarray) == REALSXP) {
+    NumericVector vec(subarray);
+    subarr.set_subarray(vec.begin(), vec.length());
+  } else {
+    Rcpp::stop("currently unsupported subarray datatype");
+  }
+  query->set_subarray(subarr);
+  return query;
 }
 
 // [[Rcpp::export]]
 XPtr<tiledb::Query> libtiledb_query_set_buffer(XPtr<tiledb::Query> query,
-                                               std::string attr,
-                                               SEXP buffer) {
+                                               std::string attr, SEXP buffer) {
   check_xptr_tag<tiledb::Query>(query);
   if (TYPEOF(buffer) == INTSXP) {
     IntegerVector vec(buffer);
@@ -3043,7 +3180,8 @@ XPtr<tiledb::Query> libtiledb_query_set_buffer(XPtr<tiledb::Query> query,
     query->set_data_buffer(attr, vec.begin(), vec.length());
     return query;
   } else if (TYPEOF(buffer) == LGLSXP) {
-    LogicalVector vec(buffer);  // note that it is really an int at the element storage
+    LogicalVector vec(
+        buffer); // note that it is really an int at the element storage
     query->set_data_buffer(attr, vec.begin(), vec.length());
     return query;
   } else {
@@ -3055,137 +3193,151 @@ XPtr<tiledb::Query> libtiledb_query_set_buffer(XPtr<tiledb::Query> query,
 // -- vlc_buf_t functions below
 
 // [[Rcpp::export]]
-XPtr<vlc_buf_t> libtiledb_query_buffer_var_char_alloc_direct(double szoffsets, double szdata,
-                                                             bool nullable, int cols=1) {
-    XPtr<vlc_buf_t> buf = make_xptr<vlc_buf_t>(new vlc_buf_t);
-    buf->offsets.resize(static_cast<size_t>(szoffsets));
-    buf->str.resize(static_cast<size_t>(szdata));
-    buf->rows = std::round(szoffsets/cols);           // guess for number of elements
-    buf->cols = cols;
-    buf->nullable = nullable;
-    buf->validity_map.resize(static_cast<size_t>(szdata));
-    buf->legacy_validity = false; 		              // for legacy validity mode
-    return buf;
+XPtr<vlc_buf_t> libtiledb_query_buffer_var_char_alloc_direct(double szoffsets,
+                                                             double szdata,
+                                                             bool nullable,
+                                                             int cols = 1) {
+  XPtr<vlc_buf_t> buf = make_xptr<vlc_buf_t>(new vlc_buf_t);
+  buf->offsets.resize(static_cast<size_t>(szoffsets));
+  buf->str.resize(static_cast<size_t>(szdata));
+  buf->rows = std::round(szoffsets / cols); // guess for number of elements
+  buf->cols = cols;
+  buf->nullable = nullable;
+  buf->validity_map.resize(static_cast<size_t>(szdata));
+  buf->legacy_validity = false; // for legacy validity mode
+  return buf;
 }
 
 // [[Rcpp::export]]
-bool libtiledb_query_buffer_var_char_get_legacy_validity_value(XPtr<tiledb::Context> ctx,
-                                                               bool validity_override = false) {
-    check_xptr_tag<tiledb::Context>(ctx);
-    XPtr<tiledb::Config> cfg = libtiledb_ctx_config(ctx);
-    Rcpp::CharacterVector vec = libtiledb_config_get(cfg, "r.legacy_validity_mode");
-    bool legacy_validity = std::string("true") == std::string(vec[0]) || validity_override;
-    return legacy_validity;
+bool libtiledb_query_buffer_var_char_get_legacy_validity_value(
+    XPtr<tiledb::Context> ctx, bool validity_override = false) {
+  check_xptr_tag<tiledb::Context>(ctx);
+  XPtr<tiledb::Config> cfg = libtiledb_ctx_config(ctx);
+  Rcpp::CharacterVector vec =
+      libtiledb_config_get(cfg, "r.legacy_validity_mode");
+  bool legacy_validity =
+      std::string("true") == std::string(vec[0]) || validity_override;
+  return legacy_validity;
 }
 
 // [[Rcpp::export]]
-XPtr<vlc_buf_t> libtiledb_query_buffer_var_char_legacy_validity_mode(XPtr<tiledb::Context> ctx,
-                                                                     XPtr<vlc_buf_t> buf,
-                                                                     bool validity_override = false) {
-    buf->legacy_validity = libtiledb_query_buffer_var_char_get_legacy_validity_value(ctx,
-                                                                                     validity_override);
-    spdl::debug(tfm::format("[libtiledb_query_buffer_var_char_legacy_validity_mode] "
-                            "legacy_validity set to %s", buf->legacy_validity ? "true" : "false"));
-    return buf;
+XPtr<vlc_buf_t> libtiledb_query_buffer_var_char_legacy_validity_mode(
+    XPtr<tiledb::Context> ctx, XPtr<vlc_buf_t> buf,
+    bool validity_override = false) {
+  buf->legacy_validity =
+      libtiledb_query_buffer_var_char_get_legacy_validity_value(
+          ctx, validity_override);
+  spdl::debug(
+      tfm::format("[libtiledb_query_buffer_var_char_legacy_validity_mode] "
+                  "legacy_validity set to %s",
+                  buf->legacy_validity ? "true" : "false"));
+  return buf;
 }
 
 // assigning (for a write) allocates
 // [[Rcpp::export]]
-XPtr<vlc_buf_t> libtiledb_query_buffer_var_char_create(CharacterVector vec, bool nullable,
-                                                       bool legacy_validity = false) {
-    size_t n = vec.size();
-    XPtr<vlc_buf_t> bufptr = make_xptr<vlc_buf_t>(new vlc_buf_t);
-    bufptr->offsets.resize(n);
-    bufptr->validity_map.resize(n);
-    bufptr->nullable = nullable;
-    bufptr->legacy_validity = legacy_validity;
-    bufptr->str = "";
-    uint64_t cumlen = 0;
-    for (size_t i=0; i<n; i++) {
-        std::string s(vec[i]);
-        bufptr->offsets[i] = cumlen;
-        bufptr->str += s;
-        cumlen += s.length();
-        if (nullable) {
-            if (legacy_validity) {
-                bufptr->validity_map[i] = vec[i] == R_NaString;
-            } else {
-                bufptr->validity_map[i] = vec[i] != R_NaString;
-            }
-        }
+XPtr<vlc_buf_t>
+libtiledb_query_buffer_var_char_create(CharacterVector vec, bool nullable,
+                                       bool legacy_validity = false) {
+  size_t n = vec.size();
+  XPtr<vlc_buf_t> bufptr = make_xptr<vlc_buf_t>(new vlc_buf_t);
+  bufptr->offsets.resize(n);
+  bufptr->validity_map.resize(n);
+  bufptr->nullable = nullable;
+  bufptr->legacy_validity = legacy_validity;
+  bufptr->str = "";
+  uint64_t cumlen = 0;
+  for (size_t i = 0; i < n; i++) {
+    std::string s(vec[i]);
+    bufptr->offsets[i] = cumlen;
+    bufptr->str += s;
+    cumlen += s.length();
+    if (nullable) {
+      if (legacy_validity) {
+        bufptr->validity_map[i] = vec[i] == R_NaString;
+      } else {
+        bufptr->validity_map[i] = vec[i] != R_NaString;
+      }
     }
-    bufptr->rows = bufptr->cols = 0; // signal unassigned for the write case
-    return(bufptr);
+  }
+  bufptr->rows = bufptr->cols = 0; // signal unassigned for the write case
+  return (bufptr);
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::Query> libtiledb_query_set_buffer_var_char(XPtr<tiledb::Query> query,
-                                                        std::string attr,
-                                                        XPtr<vlc_buf_t> bufptr) {
-    check_xptr_tag<tiledb::Query>(query);
-    check_xptr_tag<vlc_buf_t>(bufptr);
-    if (bufptr->nullable) {
-        query->set_validity_buffer(attr, bufptr->validity_map);
-    }
-    query->set_data_buffer(attr, bufptr->str);
-    query->set_offsets_buffer(attr, bufptr->offsets);
-    return query;
+XPtr<tiledb::Query>
+libtiledb_query_set_buffer_var_char(XPtr<tiledb::Query> query, std::string attr,
+                                    XPtr<vlc_buf_t> bufptr) {
+  check_xptr_tag<tiledb::Query>(query);
+  check_xptr_tag<vlc_buf_t>(bufptr);
+  if (bufptr->nullable) {
+    query->set_validity_buffer(attr, bufptr->validity_map);
+  }
+  query->set_data_buffer(attr, bufptr->str);
+  query->set_offsets_buffer(attr, bufptr->offsets);
+  return query;
 }
 
-// 'len' is the length of the query result set, i.e. buffer elements for standard columns
-// 'nchar' is the length of the result set for the particular column, i.e. actual (ex-post)
+// 'len' is the length of the query result set, i.e. buffer elements for
+// standard columns 'nchar' is the length of the result set for the particular
+// column, i.e. actual (ex-post)
 //    string length in bufptr (as opposed to ex-ante guess)
 // [[Rcpp::export]]
 CharacterMatrix libtiledb_query_get_buffer_var_char(XPtr<vlc_buf_t> bufptr,
-                                                    int32_t len=0, int32_t nchar=0) {
+                                                    int32_t len = 0,
+                                                    int32_t nchar = 0) {
   check_xptr_tag<vlc_buf_t>(bufptr);
-  size_t n = (len==0 ? bufptr->offsets.size() : len);
-  //Rprintf("n=%d, strsize=%d, row %d col %d, nchar %d, nullable %d len=%d nchar=%d\n",
-  //        n, bufptr->str.size(), bufptr->rows, bufptr->cols, nchar, bufptr->nullable, len, nchar);
+  size_t n = (len == 0 ? bufptr->offsets.size() : len);
+  // Rprintf("n=%d, strsize=%d, row %d col %d, nchar %d, nullable %d len=%d
+  // nchar=%d\n",
+  //         n, bufptr->str.size(), bufptr->rows, bufptr->cols, nchar,
+  //         bufptr->nullable, len, nchar);
   std::vector<uint64_t> str_sizes(n);
-  for (size_t i = 0; i < n - 1; i++) {                          // all but last
-      //  Rprintf("%d %d %d\n", i, bufptr->offsets[i + 1] , bufptr->offsets[i]);
-      str_sizes[i] = bufptr->offsets[i + 1] - bufptr->offsets[i];
-  }                                                             // last is total size minus last start
-  str_sizes[n-1] = (nchar==0 ? bufptr->str.size() * sizeof(char) : nchar) - bufptr->offsets[n-1];
+  for (size_t i = 0; i < n - 1; i++) { // all but last
+    //  Rprintf("%d %d %d\n", i, bufptr->offsets[i + 1] , bufptr->offsets[i]);
+    str_sizes[i] = bufptr->offsets[i + 1] - bufptr->offsets[i];
+  } // last is total size minus last start
+  str_sizes[n - 1] = (nchar == 0 ? bufptr->str.size() * sizeof(char) : nchar) -
+                     bufptr->offsets[n - 1];
   // Get the strings
   CharacterMatrix mat(bufptr->rows, bufptr->cols);
   for (size_t i = 0; i < n; i++) {
-      if (bufptr->nullable) {
-          if (bufptr->legacy_validity) {
-              if (bufptr->validity_map[i] == 0)
-                  mat[i] = std::string(&bufptr->str[bufptr->offsets[i]], str_sizes[i]);
-              else
-                  mat[i] = R_NaString;
-          } else {
-              if (bufptr->validity_map[i] != 0)
-                  mat[i] = std::string(&bufptr->str[bufptr->offsets[i]], str_sizes[i]);
-              else
-                  mat[i] = R_NaString;
-          }
-      } else {
+    if (bufptr->nullable) {
+      if (bufptr->legacy_validity) {
+        if (bufptr->validity_map[i] == 0)
           mat[i] = std::string(&bufptr->str[bufptr->offsets[i]], str_sizes[i]);
+        else
+          mat[i] = R_NaString;
+      } else {
+        if (bufptr->validity_map[i] != 0)
+          mat[i] = std::string(&bufptr->str[bufptr->offsets[i]], str_sizes[i]);
+        else
+          mat[i] = R_NaString;
       }
+    } else {
+      mat[i] = std::string(&bufptr->str[bufptr->offsets[i]], str_sizes[i]);
+    }
   }
-  return(mat);
+  return (mat);
 }
 
 // more of a debugging helper
 // [[Rcpp::export]]
 std::string libtiledb_query_get_buffer_var_char_simple(XPtr<vlc_buf_t> bufptr) {
   check_xptr_tag<vlc_buf_t>(bufptr);
-  return(bufptr->str);
+  return (bufptr->str);
 }
 
 // -- vlv_buf_t functions below
 
 // assigning (for a write) allocates
 // [[Rcpp::export]]
-XPtr<vlv_buf_t> libtiledb_query_buffer_var_vec_create(IntegerVector intoffsets, SEXP data) {
+XPtr<vlv_buf_t> libtiledb_query_buffer_var_vec_create(IntegerVector intoffsets,
+                                                      SEXP data) {
   int n = intoffsets.size();
   XPtr<vlv_buf_t> bufptr = make_xptr<vlv_buf_t>(new vlv_buf_t);
   bufptr->offsets.resize(n);
-  for (int i=0; i<n; i++) {
+  for (int i = 0; i < n; i++) {
     bufptr->offsets[i] = static_cast<uint64_t>(intoffsets[i]);
   }
   if (TYPEOF(data) == INTSXP) {
@@ -3196,255 +3348,251 @@ XPtr<vlv_buf_t> libtiledb_query_buffer_var_vec_create(IntegerVector intoffsets, 
     bufptr->ddata = Rcpp::as<std::vector<double>>(data);
     bufptr->idata.clear();
     bufptr->dtype = TILEDB_FLOAT64;
-    return(bufptr);
+    return (bufptr);
   } else {
     Rcpp::stop("Invalid data type for buffer: '%s'", Rcpp::type2name(data));
   }
-  return(bufptr);
+  return (bufptr);
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::Query> libtiledb_query_set_buffer_var_vec(XPtr<tiledb::Query> query,
-                                                       std::string attr, XPtr<vlv_buf_t> buf) {
+XPtr<tiledb::Query>
+libtiledb_query_set_buffer_var_vec(XPtr<tiledb::Query> query, std::string attr,
+                                   XPtr<vlv_buf_t> buf) {
   check_xptr_tag<vlv_buf_t>(buf);
   if (buf->dtype == TILEDB_INT32) {
-      query->set_data_buffer(attr, buf->idata);
-      query->set_offsets_buffer(attr, buf->offsets);
+    query->set_data_buffer(attr, buf->idata);
+    query->set_offsets_buffer(attr, buf->offsets);
   } else if (buf->dtype == TILEDB_FLOAT64) {
-      query->set_data_buffer(attr, buf->ddata);
-      query->set_offsets_buffer(attr, buf->offsets);
+    query->set_data_buffer(attr, buf->ddata);
+    query->set_offsets_buffer(attr, buf->offsets);
   } else {
-      Rcpp::stop("Unsupported type '%s' for buffer", _tiledb_datatype_to_string(buf->dtype));
+    Rcpp::stop("Unsupported type '%s' for buffer",
+               _tiledb_datatype_to_string(buf->dtype));
   }
   return query;
 }
 
 // [[Rcpp::export]]
-List libtiledb_query_get_buffer_var_vec(XPtr<tiledb::Query> query, std::string attr,
-                                        XPtr<vlv_buf_t> buf) {
+List libtiledb_query_get_buffer_var_vec(XPtr<tiledb::Query> query,
+                                        std::string attr, XPtr<vlv_buf_t> buf) {
 
   check_xptr_tag<tiledb::Query>(query);
   check_xptr_tag<vlv_buf_t>(buf);
   int n = buf->offsets.size();
   IntegerVector ivec(n);
-  for (int i=0; i<n; i++) {
+  for (int i = 0; i < n; i++) {
     ivec[i] = static_cast<int32_t>(buf->offsets[i]);
   }
-  auto dims = query->result_buffer_elements()[attr]; // actual result dims post query
-  n = dims.second;            // actual size, not allocated size
+  auto dims =
+      query->result_buffer_elements()[attr]; // actual result dims post query
+  n = dims.second;                           // actual size, not allocated size
   if (buf->dtype == TILEDB_INT32) {
     IntegerVector dvec(n);
-    for (int i=0; i<n; i++) {
+    for (int i = 0; i < n; i++) {
       dvec[i] = static_cast<int32_t>(buf->idata[i]);
     }
-    List rl = List::create(Rcpp::Named("offsets") = ivec,
-                           Rcpp::Named("data")    = dvec);
-    return(rl);
+    List rl =
+        List::create(Rcpp::Named("offsets") = ivec, Rcpp::Named("data") = dvec);
+    return (rl);
   } else if (buf->dtype == TILEDB_FLOAT64) {
     NumericVector dvec(n);
-    for (int i=0; i<n; i++) {
+    for (int i = 0; i < n; i++) {
       dvec[i] = static_cast<double>(buf->ddata[i]);
     }
-    List rl = List::create(Rcpp::Named("offsets") = ivec,
-                           Rcpp::Named("data")    = dvec);
-    return(rl);
+    List rl =
+        List::create(Rcpp::Named("offsets") = ivec, Rcpp::Named("data") = dvec);
+    return (rl);
   } else {
-    Rcpp::stop("Unsupported type '%s' for buffer", _tiledb_datatype_to_string(buf->dtype));
+    Rcpp::stop("Unsupported type '%s' for buffer",
+               _tiledb_datatype_to_string(buf->dtype));
   }
   return Rcpp::as<Rcpp::List>(R_NilValue); // not reached
 }
 
 // -- query_buf_t aka sparse_coords_buf_t
 
-// In the following signature we cannot have a templated type as the return type so we have
-// to bring the switch between types 'inside' and make it run-time dependent on the subarray
-// type we already had
+// In the following signature we cannot have a templated type as the return type
+// so we have to bring the switch between types 'inside' and make it run-time
+// dependent on the subarray type we already had
 // [[Rcpp::export]]
 XPtr<query_buf_t> libtiledb_query_buffer_alloc_ptr(std::string domaintype,
                                                    R_xlen_t ncells,
                                                    bool nullable = false,
                                                    int32_t numvar = 1) {
   XPtr<query_buf_t> buf = make_xptr<query_buf_t>(new query_buf_t);
-  if (domaintype == "INT32"  || domaintype == "UINT32") {
-     buf->size = sizeof(int32_t);
+  if (domaintype == "INT32" || domaintype == "UINT32") {
+    buf->size = sizeof(int32_t);
   } else if (domaintype == "INT16" || domaintype == "UINT16") {
-     buf->size = sizeof(int16_t);
+    buf->size = sizeof(int16_t);
   } else if (domaintype == "INT8" || domaintype == "UINT8") {
-     buf->size = sizeof(int8_t);
+    buf->size = sizeof(int8_t);
   } else if (domaintype == "BLOB"
-#if TILEDB_VERSION >= TileDB_Version(2,21,0)
-             || domaintype == "GEOM_WKB"
-             || domaintype == "GEOM_WKT"
+#if TILEDB_VERSION >= TileDB_Version(2, 21, 0)
+             || domaintype == "GEOM_WKB" || domaintype == "GEOM_WKT"
 #endif
-             ) {
-     buf->size = sizeof(int8_t);
-#if TILEDB_VERSION >= TileDB_Version(2,10,0)
+  ) {
+    buf->size = sizeof(int8_t);
+#if TILEDB_VERSION >= TileDB_Version(2, 10, 0)
   } else if (domaintype == "BOOL") {
-     buf->size = sizeof(uint8_t);
+    buf->size = sizeof(uint8_t);
 #endif
-  } else if (domaintype == "INT64" ||
-             domaintype == "UINT64" ||
-             domaintype == "DATETIME_YEAR" ||
-             domaintype == "DATETIME_MONTH" ||
-             domaintype == "DATETIME_WEEK" ||
-             domaintype == "DATETIME_DAY" ||
-             domaintype == "DATETIME_HR" ||
-             domaintype == "DATETIME_MIN" ||
-             domaintype == "DATETIME_SEC" ||
-             domaintype == "DATETIME_MS" ||
-             domaintype == "DATETIME_US" ||
-             domaintype == "DATETIME_NS" ||
-             domaintype == "DATETIME_PS" ||
-             domaintype == "DATETIME_FS" ||
+  } else if (domaintype == "INT64" || domaintype == "UINT64" ||
+             domaintype == "DATETIME_YEAR" || domaintype == "DATETIME_MONTH" ||
+             domaintype == "DATETIME_WEEK" || domaintype == "DATETIME_DAY" ||
+             domaintype == "DATETIME_HR" || domaintype == "DATETIME_MIN" ||
+             domaintype == "DATETIME_SEC" || domaintype == "DATETIME_MS" ||
+             domaintype == "DATETIME_US" || domaintype == "DATETIME_NS" ||
+             domaintype == "DATETIME_PS" || domaintype == "DATETIME_FS" ||
              domaintype == "DATETIME_AS") {
-     buf->size = sizeof(int64_t);
+    buf->size = sizeof(int64_t);
   } else if (domaintype == "FLOAT64") {
-     buf->size = sizeof(double);
+    buf->size = sizeof(double);
   } else if (domaintype == "FLOAT32") {
-     buf->size = sizeof(float);
+    buf->size = sizeof(float);
   } else {
-     Rcpp::stop("Currently unsupported domain type '%s'", domaintype.c_str());
+    Rcpp::stop("Currently unsupported domain type '%s'", domaintype.c_str());
   }
   buf->dtype = _string_to_tiledb_datatype(domaintype);
   buf->ncells = ncells;
   buf->vec.resize(ncells * buf->size);
-  if (nullable) buf->validity_map.resize(ncells/numvar);
+  if (nullable)
+    buf->validity_map.resize(ncells / numvar);
   buf->numvar = numvar;
   buf->nullable = nullable;
   return buf;
 }
 
 // [[Rcpp::export]]
-XPtr<query_buf_t> libtiledb_query_buffer_assign_ptr(XPtr<query_buf_t> buf, std::string dtype,
-                                                    SEXP vec, bool asint64 = false) {
+XPtr<query_buf_t> libtiledb_query_buffer_assign_ptr(XPtr<query_buf_t> buf,
+                                                    std::string dtype, SEXP vec,
+                                                    bool asint64 = false) {
   check_xptr_tag<query_buf_t>(buf);
   if (dtype == "INT32") {
     IntegerVector v(vec);
-    std::memcpy(buf->vec.data(), &(v[0]), buf->ncells*buf->size);
+    std::memcpy(buf->vec.data(), &(v[0]), buf->ncells * buf->size);
     if (buf->nullable)
-        getValidityMapFromInteger(v, buf->validity_map, buf->numvar);
+      getValidityMapFromInteger(v, buf->validity_map, buf->numvar);
   } else if (dtype == "FLOAT64") {
     NumericVector v(vec);
-    std::memcpy(buf->vec.data(), &(v[0]), buf->ncells*buf->size);
+    std::memcpy(buf->vec.data(), &(v[0]), buf->ncells * buf->size);
     if (buf->nullable)
-        getValidityMapFromNumeric(v, buf->validity_map, buf->numvar);
-  } else if (dtype == "INT64" ||
-             (asint64 && is_datetime_column(buf->dtype))) {
+      getValidityMapFromNumeric(v, buf->validity_map, buf->numvar);
+  } else if (dtype == "INT64" || (asint64 && is_datetime_column(buf->dtype))) {
     // integer64 from the bit64 package uses doubles, sees nanosecond
     NumericVector v(vec);
-    std::memcpy(buf->vec.data(), &(v[0]), buf->ncells*buf->size);
+    std::memcpy(buf->vec.data(), &(v[0]), buf->ncells * buf->size);
     if (buf->nullable)
-        getValidityMapFromInt64(v, buf->validity_map, buf->numvar);
-  } else if (dtype == "DATETIME_YEAR" ||
-             dtype == "DATETIME_MONTH" ||
-             dtype == "DATETIME_WEEK" ||
-             dtype == "DATETIME_DAY") {
+      getValidityMapFromInt64(v, buf->validity_map, buf->numvar);
+  } else if (dtype == "DATETIME_YEAR" || dtype == "DATETIME_MONTH" ||
+             dtype == "DATETIME_WEEK" || dtype == "DATETIME_DAY") {
     DateVector v(vec);
-    std::vector<int64_t> tt = dates_to_int64(v, _string_to_tiledb_datatype(dtype));
+    std::vector<int64_t> tt =
+        dates_to_int64(v, _string_to_tiledb_datatype(dtype));
     std::memcpy(buf->vec.data(), tt.data(), buf->ncells * buf->size);
-  } else if (dtype == "DATETIME_MS" ||
-             dtype == "DATETIME_US" ||
-             dtype == "DATETIME_SEC"||
-             dtype == "DATETIME_MIN"||
-             dtype == "DATETIME_HR"   ) {
+  } else if (dtype == "DATETIME_MS" || dtype == "DATETIME_US" ||
+             dtype == "DATETIME_SEC" || dtype == "DATETIME_MIN" ||
+             dtype == "DATETIME_HR") {
     DatetimeVector v(vec);
-    std::vector<int64_t> tt = datetimes_to_int64(v, _string_to_tiledb_datatype(dtype));
+    std::vector<int64_t> tt =
+        datetimes_to_int64(v, _string_to_tiledb_datatype(dtype));
     std::memcpy(buf->vec.data(), tt.data(), buf->ncells * buf->size);
   } else if (dtype == "DATETIME_NS") {
     // nanosecond time uses the nanotime package which uses the bit64 package
     // to store the int64_t 'payload' on 64-bit double, so memcpy does the trick
     NumericVector v(vec);
-    std::memcpy(buf->vec.data(), &(v[0]), buf->ncells*buf->size);
-  } else if (dtype == "DATETIME_PS" ||
-             dtype == "DATETIME_FS" ||
+    std::memcpy(buf->vec.data(), &(v[0]), buf->ncells * buf->size);
+  } else if (dtype == "DATETIME_PS" || dtype == "DATETIME_FS" ||
              dtype == "DATETIME_AS") {
     NumericVector v(vec);
-    std::vector<int64_t> tt = subnano_to_int64(v, _string_to_tiledb_datatype(dtype));
+    std::vector<int64_t> tt =
+        subnano_to_int64(v, _string_to_tiledb_datatype(dtype));
     std::memcpy(buf->vec.data(), tt.data(), buf->ncells * buf->size);
   } else if (dtype == "UINT64") {
-    // R has no native uint64_t representation so this comes in as numeric; we then
-    // use our int64_t <-> integer64 machinery for null maps but store as uint64_t
+    // R has no native uint64_t representation so this comes in as numeric; we
+    // then use our int64_t <-> integer64 machinery for null maps but store as
+    // uint64_t
     NumericVector v(vec);
     std::vector<int64_t> iv = fromInteger64(v);
     if (buf->nullable)
-        getValidityMapFromInt64(v, buf->validity_map, buf->numvar);
+      getValidityMapFromInt64(v, buf->validity_map, buf->numvar);
     auto n = v.length();
     std::vector<uint64_t> uiv(n);
-    for (auto i=0; i<n; i++) {
+    for (auto i = 0; i < n; i++) {
       uiv[i] = static_cast<uint64_t>(iv[i]);
     }
-    std::memcpy(buf->vec.data(), &(uiv[0]), buf->ncells*buf->size);
+    std::memcpy(buf->vec.data(), &(uiv[0]), buf->ncells * buf->size);
   } else if (dtype == "UINT32") {
     IntegerVector v(vec);
     auto n = v.length();
     std::vector<uint32_t> x(n);
-    for (auto i=0; i<n; i++) {
+    for (auto i = 0; i < n; i++) {
       x[i] = static_cast<uint32_t>(v[i]);
     }
-    std::memcpy(buf->vec.data(), &(x[0]), buf->ncells*buf->size);
+    std::memcpy(buf->vec.data(), &(x[0]), buf->ncells * buf->size);
     if (buf->nullable)
-        getValidityMapFromInteger(v, buf->validity_map, buf->numvar);
+      getValidityMapFromInteger(v, buf->validity_map, buf->numvar);
   } else if (dtype == "INT16") {
     IntegerVector v(vec);
     auto n = v.length();
     std::vector<int16_t> x(n);
-    for (auto i=0; i<n; i++) {
+    for (auto i = 0; i < n; i++) {
       x[i] = static_cast<int16_t>(v[i]);
     }
-    std::memcpy(buf->vec.data(), &(x[0]), buf->ncells*buf->size);
+    std::memcpy(buf->vec.data(), &(x[0]), buf->ncells * buf->size);
     if (buf->nullable)
-        getValidityMapFromInteger(v, buf->validity_map, buf->numvar);
+      getValidityMapFromInteger(v, buf->validity_map, buf->numvar);
   } else if (dtype == "UINT16") {
     IntegerVector v(vec);
     auto n = v.length();
     std::vector<uint16_t> x(n);
-    for (auto i=0; i<n; i++) {
+    for (auto i = 0; i < n; i++) {
       x[i] = static_cast<uint16_t>(v[i]);
     }
-    std::memcpy(buf->vec.data(), &(x[0]), buf->ncells*buf->size);
+    std::memcpy(buf->vec.data(), &(x[0]), buf->ncells * buf->size);
     if (buf->nullable)
-        getValidityMapFromInteger(v, buf->validity_map, buf->numvar);
+      getValidityMapFromInteger(v, buf->validity_map, buf->numvar);
   } else if (dtype == "INT8") {
     IntegerVector v(vec);
     auto n = v.length();
     std::vector<int8_t> x(n);
-    for (auto i=0; i<n; i++) {
+    for (auto i = 0; i < n; i++) {
       x[i] = static_cast<int8_t>(v[i]);
     }
-    std::memcpy(buf->vec.data(), &(x[0]), buf->ncells*buf->size);
+    std::memcpy(buf->vec.data(), &(x[0]), buf->ncells * buf->size);
     if (buf->nullable)
-        getValidityMapFromInteger(v, buf->validity_map, buf->numvar);
+      getValidityMapFromInteger(v, buf->validity_map, buf->numvar);
   } else if (dtype == "UINT8") {
     IntegerVector v(vec);
     auto n = v.length();
     std::vector<uint8_t> x(n);
-    for (auto i=0; i<n; i++) {
+    for (auto i = 0; i < n; i++) {
       x[i] = static_cast<uint8_t>(v[i]);
     }
-    std::memcpy(buf->vec.data(), &(x[0]), buf->ncells*buf->size);
+    std::memcpy(buf->vec.data(), &(x[0]), buf->ncells * buf->size);
     if (buf->nullable)
-        getValidityMapFromInteger(v, buf->validity_map, buf->numvar);
+      getValidityMapFromInteger(v, buf->validity_map, buf->numvar);
   } else if (dtype == "FLOAT32") {
     NumericVector v(vec);
     if (buf->nullable)
-        getValidityMapFromNumeric(v, buf->validity_map, buf->numvar);
+      getValidityMapFromNumeric(v, buf->validity_map, buf->numvar);
     auto n = v.length();
     std::vector<float> x(n);
-    for (auto i=0; i<n; i++) {
+    for (auto i = 0; i < n; i++) {
       x[i] = static_cast<float>(v[i]);
     }
-    std::memcpy(buf->vec.data(), &(x[0]), buf->ncells*buf->size);
-#if TILEDB_VERSION >= TileDB_Version(2,10,0)
+    std::memcpy(buf->vec.data(), &(x[0]), buf->ncells * buf->size);
+#if TILEDB_VERSION >= TileDB_Version(2, 10, 0)
   } else if (dtype == "BOOL") {
     LogicalVector v(vec);
     auto n = v.length();
     std::vector<uint8_t> x(n);
-    for (auto i=0; i<n; i++) {
+    for (auto i = 0; i < n; i++) {
       x[i] = static_cast<uint8_t>(v[i]);
     }
-    std::memcpy(buf->vec.data(), &(x[0]), buf->ncells*buf->size);
+    std::memcpy(buf->vec.data(), &(x[0]), buf->ncells * buf->size);
     if (buf->nullable)
-        getValidityMapFromLogical(v, buf->validity_map, buf->numvar);
+      getValidityMapFromLogical(v, buf->validity_map, buf->numvar);
 #endif
   } else {
     Rcpp::stop("Assignment to '%s' currently unsupported.", dtype.c_str());
@@ -3456,168 +3604,170 @@ XPtr<query_buf_t> libtiledb_query_buffer_assign_ptr(XPtr<query_buf_t> buf, std::
 XPtr<tiledb::Query> libtiledb_query_set_buffer_ptr(XPtr<tiledb::Query> query,
                                                    std::string attr,
                                                    XPtr<query_buf_t> buf) {
-    check_xptr_tag<tiledb::Query>(query);
-    if (buf->nullable) {
-        query->set_validity_buffer(attr, buf->validity_map);
-    }
-    query->set_data_buffer(attr, static_cast<void*>(buf->vec.data()), buf->ncells);
-    return query;
+  check_xptr_tag<tiledb::Query>(query);
+  if (buf->nullable) {
+    query->set_validity_buffer(attr, buf->validity_map);
+  }
+  query->set_data_buffer(attr, static_cast<void *>(buf->vec.data()),
+                         buf->ncells);
+  return query;
 }
 
 // [[Rcpp::export]]
 IntegerVector length_from_vlcbuf(XPtr<vlc_buf_t> buf) {
-    check_xptr_tag<vlc_buf_t>(buf);
-    IntegerVector v = IntegerVector::create(buf->offsets.size(), buf->str.length());
-    return v;
+  check_xptr_tag<vlc_buf_t>(buf);
+  IntegerVector v =
+      IntegerVector::create(buf->offsets.size(), buf->str.length());
+  return v;
 }
 
 // [[Rcpp::export]]
-RObject libtiledb_query_get_buffer_ptr(XPtr<query_buf_t> buf, bool asint64 = false) {
+RObject libtiledb_query_get_buffer_ptr(XPtr<query_buf_t> buf,
+                                       bool asint64 = false) {
   spdl::debug("[libtiledb_query_get_buffer_ptr] before buf type check");
   check_xptr_tag<query_buf_t>(buf);
   std::string dtype = _tiledb_datatype_to_string(buf->dtype);
-  //Rcpp::Rcout << dtype << " " << buf->ncells << " " << buf->size << " " << buf->nullable << std::endl;
+  // Rcpp::Rcout << dtype << " " << buf->ncells << " " << buf->size << " " <<
+  // buf->nullable << std::endl;
   spdl::debug(tfm::format("[libtiledb_query_get_buffer_ptr] type %s", dtype));
   if (dtype == "INT32") {
     IntegerVector v(buf->ncells);
-    std::memcpy(&(v[0]), (void*) buf->vec.data(), buf->ncells * buf->size);
+    std::memcpy(&(v[0]), (void *)buf->vec.data(), buf->ncells * buf->size);
     if (buf->nullable)
-        setValidityMapForInteger(v, buf->validity_map, buf->numvar);
+      setValidityMapForInteger(v, buf->validity_map, buf->numvar);
     return v;
   } else if (dtype == "UINT32") {
     IntegerVector v(buf->ncells);
-    std::memcpy(&(v[0]), (void*) buf->vec.data(), buf->ncells * buf->size);
+    std::memcpy(&(v[0]), (void *)buf->vec.data(), buf->ncells * buf->size);
     if (buf->nullable)
-        setValidityMapForInteger(v, buf->validity_map, buf->numvar);
+      setValidityMapForInteger(v, buf->validity_map, buf->numvar);
     return v;
   } else if (dtype == "FLOAT64") {
     NumericVector v(buf->ncells);
-    std::memcpy(&(v[0]), (void*) buf->vec.data(), buf->ncells * buf->size);
+    std::memcpy(&(v[0]), (void *)buf->vec.data(), buf->ncells * buf->size);
     if (buf->nullable)
-        setValidityMapForNumeric(v, buf->validity_map, buf->numvar);
+      setValidityMapForNumeric(v, buf->validity_map, buf->numvar);
     return v;
   } else if (dtype == "FLOAT32") {
     std::vector<float> v(buf->ncells);
-    std::memcpy(&(v[0]), (void*) buf->vec.data(), buf->ncells * buf->size);
+    std::memcpy(&(v[0]), (void *)buf->vec.data(), buf->ncells * buf->size);
     NumericVector w(wrap(v));
     if (buf->nullable)
-        setValidityMapForNumeric(w, buf->validity_map, buf->numvar);
+      setValidityMapForNumeric(w, buf->validity_map, buf->numvar);
     return w;
   } else if (dtype == "UINT64") {
     auto n = buf->ncells;
     std::vector<uint64_t> uv(n);
-    std::memcpy(&(uv[0]), (void*) buf->vec.data(), buf->ncells * buf->size);
+    std::memcpy(&(uv[0]), (void *)buf->vec.data(), buf->ncells * buf->size);
     std::vector<int64_t> iv(n);
-    for (auto i=0; i<n; i++) {
+    for (auto i = 0; i < n; i++) {
       iv[i] = static_cast<int64_t>(uv[i]);
     }
     NumericVector res = wrap(iv);
     if (buf->nullable)
-        setValidityMapForNumeric(res, buf->validity_map, buf->numvar);
-    //return toInteger64(iv); // we could return as int64,
-    return res;                 // but current 'contract' is return as NumericVector
+      setValidityMapForNumeric(res, buf->validity_map, buf->numvar);
+    // return toInteger64(iv); // we could return as int64,
+    return res; // but current 'contract' is return as NumericVector
   } else if (dtype == "INT64") {
     std::vector<int64_t> v(buf->ncells);
-    std::memcpy(&(v[0]), (void*) buf->vec.data(), buf->ncells * buf->size);
+    std::memcpy(&(v[0]), (void *)buf->vec.data(), buf->ncells * buf->size);
     if (buf->nullable)
-        setValidityMapForInt64(v, buf->validity_map, buf->numvar);
+      setValidityMapForInt64(v, buf->validity_map, buf->numvar);
     return toInteger64(v);
   } else if (asint64 && is_datetime_column(buf->dtype)) {
     std::vector<int64_t> v(buf->ncells);
-    std::memcpy(&(v[0]), (void*) buf->vec.data(), buf->ncells * buf->size);
+    std::memcpy(&(v[0]), (void *)buf->vec.data(), buf->ncells * buf->size);
     return toInteger64(v);
-  } else if (dtype == "DATETIME_FS" ||
-             dtype == "DATETIME_PS" ||
+  } else if (dtype == "DATETIME_FS" || dtype == "DATETIME_PS" ||
              dtype == "DATETIME_AS") {
     std::vector<int64_t> v(buf->ncells);
-    std::memcpy(&(v[0]), (void*) buf->vec.data(), buf->ncells * buf->size);
-    Rcpp::NumericVector dv = int64_to_subnano(v, _string_to_tiledb_datatype(dtype));
+    std::memcpy(&(v[0]), (void *)buf->vec.data(), buf->ncells * buf->size);
+    Rcpp::NumericVector dv =
+        int64_to_subnano(v, _string_to_tiledb_datatype(dtype));
     return dv;
-  } else if (dtype == "DATETIME_YEAR" ||
-             dtype == "DATETIME_MONTH" ||
-             dtype == "DATETIME_WEEK" ||
-             dtype == "DATETIME_DAY") {
+  } else if (dtype == "DATETIME_YEAR" || dtype == "DATETIME_MONTH" ||
+             dtype == "DATETIME_WEEK" || dtype == "DATETIME_DAY") {
     std::vector<int64_t> v(buf->ncells);
-    std::memcpy(&(v[0]), (void*) buf->vec.data(), buf->ncells * buf->size);
+    std::memcpy(&(v[0]), (void *)buf->vec.data(), buf->ncells * buf->size);
     DateVector dv = int64_to_dates(v, _string_to_tiledb_datatype(dtype));
     return dv;
-  } else if (dtype == "DATETIME_HR" ||
-             dtype == "DATETIME_MIN" ||
-             dtype == "DATETIME_SEC" ||
-             dtype == "DATETIME_MS" ||
+  } else if (dtype == "DATETIME_HR" || dtype == "DATETIME_MIN" ||
+             dtype == "DATETIME_SEC" || dtype == "DATETIME_MS" ||
              dtype == "DATETIME_US") {
     std::vector<int64_t> v(buf->ncells);
-    std::memcpy(&(v[0]), (void*) buf->vec.data(), buf->ncells * buf->size);
-    DatetimeVector dv = int64_to_datetimes(v, _string_to_tiledb_datatype(dtype));
+    std::memcpy(&(v[0]), (void *)buf->vec.data(), buf->ncells * buf->size);
+    DatetimeVector dv =
+        int64_to_datetimes(v, _string_to_tiledb_datatype(dtype));
     return dv;
   } else if (dtype == "DATETIME_NS") {
     int n = buf->ncells;
     std::vector<int64_t> vec(n);
-    std::memcpy(vec.data(), buf->vec.data(), n*buf->size);
+    std::memcpy(vec.data(), buf->vec.data(), n * buf->size);
     return toNanotime(vec);
   } else if (dtype == "INT16") {
     size_t n = buf->ncells;
     std::vector<int16_t> intvec(n);
-    std::memcpy(intvec.data(), buf->vec.data(), n*buf->size);
+    std::memcpy(intvec.data(), buf->vec.data(), n * buf->size);
     Rcpp::IntegerVector out(buf->ncells);
-    for (size_t i=0; i<n; i++) {
+    for (size_t i = 0; i < n; i++) {
       out[i] = static_cast<int32_t>(intvec[i]);
     }
     if (buf->nullable)
-        setValidityMapForInteger(out, buf->validity_map, buf->numvar);
+      setValidityMapForInteger(out, buf->validity_map, buf->numvar);
     return out;
   } else if (dtype == "UINT16") {
     size_t n = buf->ncells;
     std::vector<uint16_t> intvec(n);
-    std::memcpy(intvec.data(), buf->vec.data(), n*buf->size);
+    std::memcpy(intvec.data(), buf->vec.data(), n * buf->size);
     Rcpp::IntegerVector out(buf->ncells);
-    for (size_t i=0; i<n; i++) {
+    for (size_t i = 0; i < n; i++) {
       out[i] = static_cast<int32_t>(intvec[i]);
     }
     if (buf->nullable)
-        setValidityMapForInteger(out, buf->validity_map, buf->numvar);
+      setValidityMapForInteger(out, buf->validity_map, buf->numvar);
     return out;
   } else if (dtype == "INT8") {
     size_t n = buf->ncells;
     std::vector<int8_t> intvec(n);
-    std::memcpy(intvec.data(), buf->vec.data(), n*buf->size);
+    std::memcpy(intvec.data(), buf->vec.data(), n * buf->size);
     Rcpp::IntegerVector out(buf->ncells);
-    for (size_t i=0; i<n; i++) {
+    for (size_t i = 0; i < n; i++) {
       out[i] = static_cast<int32_t>(intvec[i]);
     }
     if (buf->nullable)
-        setValidityMapForInteger(out, buf->validity_map, buf->numvar);
+      setValidityMapForInteger(out, buf->validity_map, buf->numvar);
     return out;
   } else if (dtype == "UINT8") {
     size_t n = buf->ncells;
     std::vector<uint8_t> uintvec(n);
-    std::memcpy(uintvec.data(), buf->vec.data(), n*buf->size);
+    std::memcpy(uintvec.data(), buf->vec.data(), n * buf->size);
     Rcpp::IntegerVector out(buf->ncells);
-    for (size_t i=0; i<n; i++) {
+    for (size_t i = 0; i < n; i++) {
       out[i] = static_cast<int32_t>(uintvec[i]);
     }
     if (buf->nullable)
-        setValidityMapForInteger(out, buf->validity_map, buf->numvar);
+      setValidityMapForInteger(out, buf->validity_map, buf->numvar);
     return out;
   } else if (dtype == "BLOB") {
     size_t n = buf->ncells;
     Rcpp::RawVector out(n);
-    std::memcpy(out.begin(), buf->vec.data(), n*buf->size);
+    std::memcpy(out.begin(), buf->vec.data(), n * buf->size);
     // -- raw has no NA type so no mapping possible here
     // if (buf->nullable)
     //    setValidityMapForRaw(out, buf->validity_map);
     return out;
-#if TILEDB_VERSION >= TileDB_Version(2,10,0)
+#if TILEDB_VERSION >= TileDB_Version(2, 10, 0)
   } else if (dtype == "BOOL") {
     size_t n = buf->ncells;
     std::vector<uint8_t> uintvec(n);
-    std::memcpy(uintvec.data(), buf->vec.data(), n*buf->size);
+    std::memcpy(uintvec.data(), buf->vec.data(), n * buf->size);
     Rcpp::LogicalVector out(buf->ncells);
-    for (size_t i=0; i<n; i++) {
-      out[i] = static_cast<int32_t>(uintvec[i]); // logical is int32_t internally
+    for (size_t i = 0; i < n; i++) {
+      out[i] =
+          static_cast<int32_t>(uintvec[i]); // logical is int32_t internally
     }
     if (buf->nullable)
-        setValidityMapForLogical(out, buf->validity_map, buf->numvar);
+      setValidityMapForLogical(out, buf->validity_map, buf->numvar);
     return out;
 #endif
   } else {
@@ -3644,27 +3794,27 @@ XPtr<tiledb::Query> libtiledb_query_finalize(XPtr<tiledb::Query> query) {
 
 std::string _query_status_to_string(tiledb::Query::Status status) {
   switch (status) {
-    case tiledb::Query::Status::COMPLETE:
-      return "COMPLETE";
-    case tiledb::Query::Status::FAILED:
-      return "FAILED";
-    case tiledb::Query::Status::INPROGRESS:
-      return "INPROGRESS";
-    case tiledb::Query::Status::INCOMPLETE:
-      return "INCOMPLETE";
-    case tiledb::Query::Status::UNINITIALIZED:
-    default:
-      return "UNINITIALIZED";
+  case tiledb::Query::Status::COMPLETE:
+    return "COMPLETE";
+  case tiledb::Query::Status::FAILED:
+    return "FAILED";
+  case tiledb::Query::Status::INPROGRESS:
+    return "INPROGRESS";
+  case tiledb::Query::Status::INCOMPLETE:
+    return "INCOMPLETE";
+  case tiledb::Query::Status::UNINITIALIZED:
+  default:
+    return "UNINITIALIZED";
   }
 }
-
 
 // [[Rcpp::export]]
 std::string libtiledb_query_status(XPtr<tiledb::Query> query) {
   check_xptr_tag<tiledb::Query>(query);
   tiledb::Query::Status status = query->query_status();
   std::string status_text = _query_status_to_string(status);
-  spdl::debug(tfm::format("[libtiledb_query_status] status = %s", status_text.c_str()));
+  spdl::debug(
+      tfm::format("[libtiledb_query_status] status = %s", status_text.c_str()));
   return status_text;
 }
 
@@ -3672,31 +3822,30 @@ std::string libtiledb_query_status(XPtr<tiledb::Query> query) {
 R_xlen_t libtiledb_query_result_buffer_elements(XPtr<tiledb::Query> query,
                                                 std::string attribute,
                                                 int32_t which = 1) {
-    check_xptr_tag<tiledb::Query>(query);
-    auto nelements = query->result_buffer_elements()[attribute];
-    spdl::debug(tfm::format("[libtiledb_query_result_buffer_elements] attribute %s : (%d,%d)",
-                            attribute, nelements.first, nelements.second));
-    R_xlen_t nelem = (which == 0 ? nelements.first : nelements.second);
-    return nelem;
+  check_xptr_tag<tiledb::Query>(query);
+  auto nelements = query->result_buffer_elements()[attribute];
+  spdl::debug(tfm::format(
+      "[libtiledb_query_result_buffer_elements] attribute %s : (%d,%d)",
+      attribute, nelements.first, nelements.second));
+  R_xlen_t nelem = (which == 0 ? nelements.first : nelements.second);
+  return nelem;
 }
 
 // [[Rcpp::export]]
-NumericVector libtiledb_query_result_buffer_elements_vec(XPtr<tiledb::Query> query,
-                                                         std::string attribute,
-                                                         bool nullable = false) {
-    check_xptr_tag<tiledb::Query>(query);
-    if (nullable) {
-        auto nelem = query->result_buffer_elements_nullable()[attribute];
-        auto vec = NumericVector( {
-                static_cast<double>(std::get<0>(nelem)),
-                static_cast<double>(std::get<1>(nelem)),
-                static_cast<double>(std::get<2>(nelem))
-            });
-        return vec;
-    } else {
-        auto nelem = query->result_buffer_elements()[attribute];
-        return NumericVector( { static_cast<double>(nelem.first), static_cast<double>(nelem.second) });
-    }
+NumericVector libtiledb_query_result_buffer_elements_vec(
+    XPtr<tiledb::Query> query, std::string attribute, bool nullable = false) {
+  check_xptr_tag<tiledb::Query>(query);
+  if (nullable) {
+    auto nelem = query->result_buffer_elements_nullable()[attribute];
+    auto vec = NumericVector({static_cast<double>(std::get<0>(nelem)),
+                              static_cast<double>(std::get<1>(nelem)),
+                              static_cast<double>(std::get<2>(nelem))});
+    return vec;
+  } else {
+    auto nelem = query->result_buffer_elements()[attribute];
+    return NumericVector(
+        {static_cast<double>(nelem.first), static_cast<double>(nelem.second)});
+  }
 }
 
 // [[Rcpp::export]]
@@ -3709,7 +3858,8 @@ int libtiledb_query_get_fragment_num(XPtr<tiledb::Query> query) {
 }
 
 // [[Rcpp::export]]
-std::string libtiledb_query_get_fragment_uri(XPtr<tiledb::Query> query, int idx) {
+std::string libtiledb_query_get_fragment_uri(XPtr<tiledb::Query> query,
+                                             int idx) {
   check_xptr_tag<tiledb::Query>(query);
   if (query->query_type() != TILEDB_WRITE) {
     Rcpp::stop("Fragment URI only applicable to 'write' queries.");
@@ -3719,14 +3869,17 @@ std::string libtiledb_query_get_fragment_uri(XPtr<tiledb::Query> query, int idx)
 }
 
 // [[Rcpp::export]]
-Rcpp::DatetimeVector libtiledb_query_get_fragment_timestamp_range(XPtr<tiledb::Query> query, int idx) {
+Rcpp::DatetimeVector
+libtiledb_query_get_fragment_timestamp_range(XPtr<tiledb::Query> query,
+                                             int idx) {
   check_xptr_tag<tiledb::Query>(query);
   if (query->query_type() != TILEDB_WRITE) {
     Rcpp::stop("Fragment URI only applicable to 'write' queries.");
   }
   uint32_t uidx = static_cast<uint32_t>(idx);
   std::pair<uint64_t, uint64_t> range = query->fragment_timestamp_range(uidx);
-  return Rcpp::DatetimeVector::create(range.first/1000.0, range.second/1000.0);
+  return Rcpp::DatetimeVector::create(range.first / 1000.0,
+                                      range.second / 1000.0);
 }
 
 // Subarray functions replacing old Query functionality
@@ -3734,186 +3887,215 @@ Rcpp::DatetimeVector libtiledb_query_get_fragment_timestamp_range(XPtr<tiledb::Q
 
 // [[Rcpp::export]]
 XPtr<tiledb::Subarray> libtiledb_subarray(XPtr<tiledb::Query> query) {
-    return make_xptr<tiledb::Subarray>(new tiledb::Subarray(query->ctx(), query->array()));
+  return make_xptr<tiledb::Subarray>(
+      new tiledb::Subarray(query->ctx(), query->array()));
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::Subarray> libtiledb_subarray_add_range(XPtr<tiledb::Subarray> subarr,
-                                                    int iidx, SEXP starts, SEXP ends,
-                                                    SEXP strides = R_NilValue) {
-    check_xptr_tag<tiledb::Subarray>(subarr);
-    spdl::debug("libtiledb_query_add_range] setting subarray");
-    if (TYPEOF(starts) != TYPEOF(ends)) {
-        Rcpp::stop("'start' and 'end' must be of identical types");
-    }
-    uint32_t uidx = static_cast<uint32_t>(iidx);
-    if (TYPEOF(starts) == INTSXP) {
-        int32_t start = as<int32_t>(starts);
-        int32_t end = as<int32_t>(ends);
-        int32_t stride = (strides == R_NilValue) ? 0 : Rcpp::as<int32_t>(strides);
-        subarr->add_range(uidx, start, end, stride);
-    } else if (TYPEOF(starts) == REALSXP) {
-        double start = as<double>(starts);
-        double end = as<double>(ends);
-        double stride = (strides == R_NilValue) ? 0 : Rcpp::as<double_t>(strides);
-        subarr->add_range(uidx, start, end, stride);
-    } else if (TYPEOF(starts) == STRSXP) {
-        std::string start = as<std::string>(starts);
-        std::string end = as<std::string>(ends);
-        if (strides == R_NilValue) {
-            subarr->add_range(uidx, start, end);
-        } else {
-            Rcpp::stop("Non-emoty stride for string not supported yet.");
-        }
+XPtr<tiledb::Subarray>
+libtiledb_subarray_add_range(XPtr<tiledb::Subarray> subarr, int iidx,
+                             SEXP starts, SEXP ends,
+                             SEXP strides = R_NilValue) {
+  check_xptr_tag<tiledb::Subarray>(subarr);
+  spdl::debug("libtiledb_query_add_range] setting subarray");
+  if (TYPEOF(starts) != TYPEOF(ends)) {
+    Rcpp::stop("'start' and 'end' must be of identical types");
+  }
+  uint32_t uidx = static_cast<uint32_t>(iidx);
+  if (TYPEOF(starts) == INTSXP) {
+    int32_t start = as<int32_t>(starts);
+    int32_t end = as<int32_t>(ends);
+    int32_t stride = (strides == R_NilValue) ? 0 : Rcpp::as<int32_t>(strides);
+    subarr->add_range(uidx, start, end, stride);
+  } else if (TYPEOF(starts) == REALSXP) {
+    double start = as<double>(starts);
+    double end = as<double>(ends);
+    double stride = (strides == R_NilValue) ? 0 : Rcpp::as<double_t>(strides);
+    subarr->add_range(uidx, start, end, stride);
+  } else if (TYPEOF(starts) == STRSXP) {
+    std::string start = as<std::string>(starts);
+    std::string end = as<std::string>(ends);
+    if (strides == R_NilValue) {
+      subarr->add_range(uidx, start, end);
     } else {
-        Rcpp::stop("Invalid data type for query range: '%s'", Rcpp::type2name(starts));
+      Rcpp::stop("Non-emoty stride for string not supported yet.");
     }
-    return subarr;
+  } else {
+    Rcpp::stop("Invalid data type for query range: '%s'",
+               Rcpp::type2name(starts));
+  }
+  return subarr;
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::Subarray> libtiledb_subarray_add_range_with_type(XPtr<tiledb::Subarray> subarr,
-                                                              int iidx,
-                                                              std::string typestr,
-                                                              SEXP starts, SEXP ends,
-                                                              SEXP strides = R_NilValue) {
+XPtr<tiledb::Subarray>
+libtiledb_subarray_add_range_with_type(XPtr<tiledb::Subarray> subarr, int iidx,
+                                       std::string typestr, SEXP starts,
+                                       SEXP ends, SEXP strides = R_NilValue) {
 
-    check_xptr_tag<tiledb::Subarray>(subarr);
-    if (TYPEOF(starts) != TYPEOF(ends)) {
-        Rcpp::stop("'start' and 'end' must be of identical types");
-    }
-    uint32_t uidx = static_cast<uint32_t>(iidx);
+  check_xptr_tag<tiledb::Subarray>(subarr);
+  if (TYPEOF(starts) != TYPEOF(ends)) {
+    Rcpp::stop("'start' and 'end' must be of identical types");
+  }
+  uint32_t uidx = static_cast<uint32_t>(iidx);
 
-    if (typestr == "INT32") {
-        int32_t start = as<int32_t>(starts);
-        int32_t end = as<int32_t>(ends);
-        int32_t stride = (strides == R_NilValue) ? 0 : Rcpp::as<int32_t>(strides);
-        subarr->add_range(uidx, start, end, stride);
-        spdl::debug(tfm::format("[libtiledb_subarry_add_range_with type] %s dim %d added %d to %d by %d", typestr, uidx, start, end, stride));
-    } else if (typestr == "FLOAT64") {
-        double start = as<double>(starts);
-        double end = as<double>(ends);
-        double stride = (strides == R_NilValue) ? 0 : Rcpp::as<double_t>(strides);
-        subarr->add_range(uidx, start, end, stride);
-        spdl::debug(tfm::format("[libtiledb_subarry_add_range_with type] %s dim %d added %f to %f by %f", typestr, uidx, start, end, stride));
-    } else if (typestr == "INT64") {
-        int64_t start = fromInteger64(as<double>(starts));
-        int64_t end = fromInteger64(as<double>(ends));
-        int64_t stride = (strides == R_NilValue) ? 0 : fromInteger64(as<double>(strides));
-        subarr->add_range(uidx, start, end, stride);
-        spdl::debug(tfm::format("[libtiledb_subarry_add_range_with type] %s dim %d added %d to %d by %d", typestr, uidx, start, end, stride));
-    } else if (typestr == "UINT64") {
-        uint64_t start = static_cast<uint64_t>(fromInteger64(as<double>(starts)));
-        uint64_t end = static_cast<uint64_t>(fromInteger64(as<double>(ends)));
-        uint64_t stride = (strides == R_NilValue) ? 0 : fromInteger64(as<double>(strides));
-        subarr->add_range(uidx, start, end, stride);
-        spdl::debug(tfm::format("[libtiledb_subarry_add_range_with type] %s dim %d added %d to %d by %d", typestr, uidx, start, end, stride));
-    } else if (typestr == "UINT32") {
-        uint32_t start = as<uint32_t>(starts);
-        uint32_t end   = as<uint32_t>(ends);
-        uint32_t stride = (strides == R_NilValue) ? 0 : as<int32_t>(strides);
-        subarr->add_range(uidx, start, end, stride);
-        spdl::debug(tfm::format("[libtiledb_subarry_add_range_with type] %s dim %d added %d to %d by %d", typestr, uidx, start, end, stride));
-    } else if (typestr == "INT16") {
-        int16_t start = as<int16_t>(starts);
-        int16_t end   = as<int16_t>(ends);
-        int16_t stride = (strides == R_NilValue) ? 0 : as<int16_t>(strides);
-        subarr->add_range(uidx, start, end, stride);
-        spdl::debug(tfm::format("[libtiledb_subarry_add_range_with type] %s dim %d added %d to %d by %d", typestr, uidx, start, end, stride));
-    } else if (typestr == "UINT16") {
-        uint16_t start = as<uint16_t>(starts);
-        uint16_t end   = as<uint16_t>(ends);
-        uint16_t stride = (strides == R_NilValue) ? 0 : as<uint16_t>(strides);
-        subarr->add_range(uidx, start, end, stride);
-        spdl::debug(tfm::format("[libtiledb_subarry_add_range_with type] %s dim %d added %d to %d by %d", typestr, uidx, start, end, stride));
-    } else if (typestr == "INT8") {
-        int8_t start = as<int16_t>(starts);
-        int8_t end   = as<int16_t>(ends);
-        int8_t stride = (strides == R_NilValue) ? 0 : as<int16_t>(strides);
-        subarr->add_range(uidx, start, end, stride);
-        spdl::debug(tfm::format("[libtiledb_subarry_add_range_with type] %s dim %d added %d to %d by %d", typestr, uidx, start, end, stride));
-    } else if (typestr == "UINT8") {
-        uint8_t start = as<uint16_t>(starts);
-        uint8_t end   = as<uint16_t>(ends);
-        uint8_t stride = (strides == R_NilValue) ? 0 : as<uint16_t>(strides);
-        subarr->add_range(uidx, start, end, stride);
-        spdl::debug(tfm::format("[libtiledb_subarry_add_range_with type] %s dim %d added %d to %d by %d", typestr, uidx, start, end, stride));
-    } else if (typestr == "DATETIME_YEAR"  ||
-               typestr == "DATETIME_MONTH" ||
-               typestr == "DATETIME_WEEK"  ||
-               typestr == "DATETIME_DAY"   ||
-               typestr == "DATETIME_HR"    ||
-               typestr == "DATETIME_MIN"   ||
-               typestr == "DATETIME_SEC"   ||
-               typestr == "DATETIME_MS"    ||
-               typestr == "DATETIME_US"    ||
-               typestr == "DATETIME_NS"    ||
-               typestr == "DATETIME_FS"    ||
-               typestr == "DATETIME_PS"    ||
-               typestr == "DATETIME_AS") {
-        int64_t start = fromInteger64(as<double>(starts));
-        int64_t end = fromInteger64(as<double>(ends));
-        int64_t stride = (strides == R_NilValue) ? 0 : fromInteger64(as<double>(strides));
-        subarr->add_range(uidx, start, end, stride);
-        spdl::debug(tfm::format("[libtiledb_subarry_add_range_with type] %s dim %d added %d to %d by %d", typestr, uidx, start, end, stride));
-    } else if (typestr == "ASCII" || typestr == "CHAR") {
-        std::string start = as<std::string>(starts);
-        std::string end = as<std::string>(ends);
-        if (strides != R_NilValue) {
-            Rcpp::stop("Non-empty stride for string not supported yet.");
-        }
-        subarr->add_range(uidx, start, end);
-        spdl::debug(tfm::format("[libtiledb_subarry_add_range_with type] %s dim %d added %s to %s", typestr, uidx, start, end));
-    } else if (typestr == "FLOAT32") {
-        float start = as<float>(starts);
-        float end = as<float>(ends);
-        float stride = (strides == R_NilValue) ? 0 : Rcpp::as<float>(strides);
-        subarr->add_range(uidx, start, end, stride);
-        spdl::debug(tfm::format("[libtiledb_subarry_add_range_with type] %s dim %d added %f to %f by %f", typestr, uidx, start, end, stride));
+  if (typestr == "INT32") {
+    int32_t start = as<int32_t>(starts);
+    int32_t end = as<int32_t>(ends);
+    int32_t stride = (strides == R_NilValue) ? 0 : Rcpp::as<int32_t>(strides);
+    subarr->add_range(uidx, start, end, stride);
+    spdl::debug(tfm::format("[libtiledb_subarry_add_range_with type] %s dim %d "
+                            "added %d to %d by %d",
+                            typestr, uidx, start, end, stride));
+  } else if (typestr == "FLOAT64") {
+    double start = as<double>(starts);
+    double end = as<double>(ends);
+    double stride = (strides == R_NilValue) ? 0 : Rcpp::as<double_t>(strides);
+    subarr->add_range(uidx, start, end, stride);
+    spdl::debug(tfm::format("[libtiledb_subarry_add_range_with type] %s dim %d "
+                            "added %f to %f by %f",
+                            typestr, uidx, start, end, stride));
+  } else if (typestr == "INT64") {
+    int64_t start = fromInteger64(as<double>(starts));
+    int64_t end = fromInteger64(as<double>(ends));
+    int64_t stride =
+        (strides == R_NilValue) ? 0 : fromInteger64(as<double>(strides));
+    subarr->add_range(uidx, start, end, stride);
+    spdl::debug(tfm::format("[libtiledb_subarry_add_range_with type] %s dim %d "
+                            "added %d to %d by %d",
+                            typestr, uidx, start, end, stride));
+  } else if (typestr == "UINT64") {
+    uint64_t start = static_cast<uint64_t>(fromInteger64(as<double>(starts)));
+    uint64_t end = static_cast<uint64_t>(fromInteger64(as<double>(ends)));
+    uint64_t stride =
+        (strides == R_NilValue) ? 0 : fromInteger64(as<double>(strides));
+    subarr->add_range(uidx, start, end, stride);
+    spdl::debug(tfm::format("[libtiledb_subarry_add_range_with type] %s dim %d "
+                            "added %d to %d by %d",
+                            typestr, uidx, start, end, stride));
+  } else if (typestr == "UINT32") {
+    uint32_t start = as<uint32_t>(starts);
+    uint32_t end = as<uint32_t>(ends);
+    uint32_t stride = (strides == R_NilValue) ? 0 : as<int32_t>(strides);
+    subarr->add_range(uidx, start, end, stride);
+    spdl::debug(tfm::format("[libtiledb_subarry_add_range_with type] %s dim %d "
+                            "added %d to %d by %d",
+                            typestr, uidx, start, end, stride));
+  } else if (typestr == "INT16") {
+    int16_t start = as<int16_t>(starts);
+    int16_t end = as<int16_t>(ends);
+    int16_t stride = (strides == R_NilValue) ? 0 : as<int16_t>(strides);
+    subarr->add_range(uidx, start, end, stride);
+    spdl::debug(tfm::format("[libtiledb_subarry_add_range_with type] %s dim %d "
+                            "added %d to %d by %d",
+                            typestr, uidx, start, end, stride));
+  } else if (typestr == "UINT16") {
+    uint16_t start = as<uint16_t>(starts);
+    uint16_t end = as<uint16_t>(ends);
+    uint16_t stride = (strides == R_NilValue) ? 0 : as<uint16_t>(strides);
+    subarr->add_range(uidx, start, end, stride);
+    spdl::debug(tfm::format("[libtiledb_subarry_add_range_with type] %s dim %d "
+                            "added %d to %d by %d",
+                            typestr, uidx, start, end, stride));
+  } else if (typestr == "INT8") {
+    int8_t start = as<int16_t>(starts);
+    int8_t end = as<int16_t>(ends);
+    int8_t stride = (strides == R_NilValue) ? 0 : as<int16_t>(strides);
+    subarr->add_range(uidx, start, end, stride);
+    spdl::debug(tfm::format("[libtiledb_subarry_add_range_with type] %s dim %d "
+                            "added %d to %d by %d",
+                            typestr, uidx, start, end, stride));
+  } else if (typestr == "UINT8") {
+    uint8_t start = as<uint16_t>(starts);
+    uint8_t end = as<uint16_t>(ends);
+    uint8_t stride = (strides == R_NilValue) ? 0 : as<uint16_t>(strides);
+    subarr->add_range(uidx, start, end, stride);
+    spdl::debug(tfm::format("[libtiledb_subarry_add_range_with type] %s dim %d "
+                            "added %d to %d by %d",
+                            typestr, uidx, start, end, stride));
+  } else if (typestr == "DATETIME_YEAR" || typestr == "DATETIME_MONTH" ||
+             typestr == "DATETIME_WEEK" || typestr == "DATETIME_DAY" ||
+             typestr == "DATETIME_HR" || typestr == "DATETIME_MIN" ||
+             typestr == "DATETIME_SEC" || typestr == "DATETIME_MS" ||
+             typestr == "DATETIME_US" || typestr == "DATETIME_NS" ||
+             typestr == "DATETIME_FS" || typestr == "DATETIME_PS" ||
+             typestr == "DATETIME_AS") {
+    int64_t start = fromInteger64(as<double>(starts));
+    int64_t end = fromInteger64(as<double>(ends));
+    int64_t stride =
+        (strides == R_NilValue) ? 0 : fromInteger64(as<double>(strides));
+    subarr->add_range(uidx, start, end, stride);
+    spdl::debug(tfm::format("[libtiledb_subarry_add_range_with type] %s dim %d "
+                            "added %d to %d by %d",
+                            typestr, uidx, start, end, stride));
+  } else if (typestr == "ASCII" || typestr == "CHAR") {
+    std::string start = as<std::string>(starts);
+    std::string end = as<std::string>(ends);
+    if (strides != R_NilValue) {
+      Rcpp::stop("Non-empty stride for string not supported yet.");
     }
-    return subarr;
+    subarr->add_range(uidx, start, end);
+    spdl::debug(tfm::format(
+        "[libtiledb_subarry_add_range_with type] %s dim %d added %s to %s",
+        typestr, uidx, start, end));
+  } else if (typestr == "FLOAT32") {
+    float start = as<float>(starts);
+    float end = as<float>(ends);
+    float stride = (strides == R_NilValue) ? 0 : Rcpp::as<float>(strides);
+    subarr->add_range(uidx, start, end, stride);
+    spdl::debug(tfm::format("[libtiledb_subarry_add_range_with type] %s dim %d "
+                            "added %f to %f by %f",
+                            typestr, uidx, start, end, stride));
+  }
+  return subarr;
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::Query> libtiledb_query_set_subarray_object(XPtr<tiledb::Query> query, XPtr<tiledb::Subarray> subarr) {
-    check_xptr_tag<tiledb::Query>(query);
-    check_xptr_tag<tiledb::Subarray>(subarr);
-    query->set_subarray(*subarr.get());
-    return query;
+XPtr<tiledb::Query>
+libtiledb_query_set_subarray_object(XPtr<tiledb::Query> query,
+                                    XPtr<tiledb::Subarray> subarr) {
+  check_xptr_tag<tiledb::Query>(query);
+  check_xptr_tag<tiledb::Subarray>(subarr);
+  query->set_subarray(*subarr.get());
+  return query;
 }
 
-
 // [[Rcpp::export]]
-R_xlen_t libtiledb_query_get_est_result_size(XPtr<tiledb::Query> query, std::string attr) {
+R_xlen_t libtiledb_query_get_est_result_size(XPtr<tiledb::Query> query,
+                                             std::string attr) {
   check_xptr_tag<tiledb::Query>(query);
   uint64_t est = query->est_result_size(attr);
   return static_cast<R_xlen_t>(est);
 }
 
-
 // [[Rcpp::export]]
-NumericVector libtiledb_query_get_est_result_size_nullable(XPtr<tiledb::Query> query, std::string attr) {
-    check_xptr_tag<tiledb::Query>(query);
-    std::array<uint64_t, 2> est = query->est_result_size_nullable(attr);
-    return Rcpp::NumericVector::create(static_cast<R_xlen_t>(est[0]),
-                                       static_cast<R_xlen_t>(est[1]));
+NumericVector
+libtiledb_query_get_est_result_size_nullable(XPtr<tiledb::Query> query,
+                                             std::string attr) {
+  check_xptr_tag<tiledb::Query>(query);
+  std::array<uint64_t, 2> est = query->est_result_size_nullable(attr);
+  return Rcpp::NumericVector::create(static_cast<R_xlen_t>(est[0]),
+                                     static_cast<R_xlen_t>(est[1]));
 }
 
-
 // [[Rcpp::export]]
-NumericVector libtiledb_query_get_est_result_size_var(XPtr<tiledb::Query> query, std::string attr) {
+NumericVector libtiledb_query_get_est_result_size_var(XPtr<tiledb::Query> query,
+                                                      std::string attr) {
   check_xptr_tag<tiledb::Query>(query);
   std::array<uint64_t, 2> est = query->est_result_size_var(attr);
-  return NumericVector::create(static_cast<R_xlen_t>(est[0]), static_cast<R_xlen_t>(est[1]));
+  return NumericVector::create(static_cast<R_xlen_t>(est[0]),
+                               static_cast<R_xlen_t>(est[1]));
 }
 
 // [[Rcpp::export]]
-NumericVector libtiledb_query_get_est_result_size_var_nullable(XPtr<tiledb::Query> query, std::string attr) {
-    check_xptr_tag<tiledb::Query>(query);
-    std::array<uint64_t, 3> est = query->est_result_size_var_nullable(attr);
-    return Rcpp::NumericVector::create(static_cast<R_xlen_t>(est[0]),
-                                       static_cast<R_xlen_t>(est[1]),
-                                       static_cast<R_xlen_t>(est[2]));
+NumericVector
+libtiledb_query_get_est_result_size_var_nullable(XPtr<tiledb::Query> query,
+                                                 std::string attr) {
+  check_xptr_tag<tiledb::Query>(query);
+  std::array<uint64_t, 3> est = query->est_result_size_var_nullable(attr);
+  return Rcpp::NumericVector::create(static_cast<R_xlen_t>(est[0]),
+                                     static_cast<R_xlen_t>(est[1]),
+                                     static_cast<R_xlen_t>(est[2]));
 }
 
 // [[Rcpp::export]]
@@ -3928,84 +4110,93 @@ double libtiledb_query_get_range_num(XPtr<tiledb::Query> query, int dim_idx) {
 }
 
 // [[Rcpp::export]]
-IntegerVector libtiledb_query_get_range(XPtr<tiledb::Query> query, int dim_idx, int rng_idx) {
+IntegerVector libtiledb_query_get_range(XPtr<tiledb::Query> query, int dim_idx,
+                                        int rng_idx) {
   check_xptr_tag<tiledb::Query>(query);
   tiledb::Array arr = query->array();
   tiledb::Context ctx = query->ctx();
   tiledb::Subarray sub(ctx, arr);
   query->update_subarray_from_query(&sub);
-  std::array<int32_t, 3> rng = sub.range<int32_t>(static_cast<unsigned int>(dim_idx),
-                                                  static_cast<unsigned int>(rng_idx));
-  return IntegerVector::create(rng[0], 	// start
+  std::array<int32_t, 3> rng = sub.range<int32_t>(
+      static_cast<unsigned int>(dim_idx), static_cast<unsigned int>(rng_idx));
+  return IntegerVector::create(rng[0],  // start
                                rng[1],  // end
                                rng[2]); // stride
 }
 
 // [[Rcpp::export]]
-CharacterVector libtiledb_query_get_range_var(XPtr<tiledb::Query> query, int dim_idx, int rng_idx) {
+CharacterVector libtiledb_query_get_range_var(XPtr<tiledb::Query> query,
+                                              int dim_idx, int rng_idx) {
   check_xptr_tag<tiledb::Query>(query);
   tiledb::Array arr = query->array();
   tiledb::Context ctx = query->ctx();
   tiledb::Subarray sub(ctx, arr);
   query->update_subarray_from_query(&sub);
-  std::array<std::string, 2> rng = sub.range(static_cast<unsigned int>(dim_idx), static_cast<uint64_t>(rng_idx));
-  return CharacterVector::create(rng[0], rng[1]);	 // start and end
+  std::array<std::string, 2> rng = sub.range(static_cast<unsigned int>(dim_idx),
+                                             static_cast<uint64_t>(rng_idx));
+  return CharacterVector::create(rng[0], rng[1]); // start and end
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::Query> libtiledb_query_set_condition(XPtr<tiledb::Query> query,
-                                                  XPtr<tiledb::QueryCondition> query_cond) {
+XPtr<tiledb::Query>
+libtiledb_query_set_condition(XPtr<tiledb::Query> query,
+                              XPtr<tiledb::QueryCondition> query_cond) {
   check_xptr_tag<tiledb::Query>(query);
   query->set_condition(*query_cond.get());
   return query;
 }
 
-// Note that the Array pointer returned here from a Query object is not owned and will not
-// outlive the query object
+// Note that the Array pointer returned here from a Query object is not owned
+// and will not outlive the query object
 //
 // [[Rcpp::export]]
-XPtr<tiledb::Array> libtiledb_query_get_array(XPtr<tiledb::Query> query, XPtr<tiledb::Context> ctx) {
-    check_xptr_tag<tiledb::Query>(query);
-    check_xptr_tag<tiledb::Context>(ctx);
-    auto arr = query->array();
-    auto cptr = arr.ptr().get();
-    return make_xptr<tiledb::Array>(new tiledb::Array(*ctx.get(), cptr, false));
+XPtr<tiledb::Array> libtiledb_query_get_array(XPtr<tiledb::Query> query,
+                                              XPtr<tiledb::Context> ctx) {
+  check_xptr_tag<tiledb::Query>(query);
+  check_xptr_tag<tiledb::Context>(ctx);
+  auto arr = query->array();
+  auto cptr = arr.ptr().get();
+  return make_xptr<tiledb::Array>(new tiledb::Array(*ctx.get(), cptr, false));
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::ArraySchema> libtiledb_query_get_schema(XPtr<tiledb::Query> query,
-                                                     XPtr<tiledb::Context> ctx) {
-    check_xptr_tag<tiledb::Query>(query);
-    auto arr = query->array();
-    return libtiledb_array_schema_load(ctx, arr.uri()); // returns an XPtr<tiledb::ArraySchema>
+XPtr<tiledb::ArraySchema>
+libtiledb_query_get_schema(XPtr<tiledb::Query> query,
+                           XPtr<tiledb::Context> ctx) {
+  check_xptr_tag<tiledb::Query>(query);
+  auto arr = query->array();
+  return libtiledb_array_schema_load(
+      ctx, arr.uri()); // returns an XPtr<tiledb::ArraySchema>
 }
 
 // [[Rcpp::export]]
 std::string libtiledb_query_stats(XPtr<tiledb::Query> query) {
-    check_xptr_tag<tiledb::Query>(query);
-    return query->stats();
+  check_xptr_tag<tiledb::Query>(query);
+  return query->stats();
 }
 
 // [[Rcpp::export]]
 XPtr<tiledb::Context> libtiledb_query_get_ctx(XPtr<tiledb::Query> query) {
-    check_xptr_tag<tiledb::Query>(query);
-    auto ctx = query->ctx();
-    return make_xptr<tiledb::Context>(new tiledb::Context(ctx));
+  check_xptr_tag<tiledb::Query>(query);
+  auto ctx = query->ctx();
+  return make_xptr<tiledb::Context>(new tiledb::Context(ctx));
 }
 
 template <typename T>
-SEXP apply_unary_aggregate(XPtr<tiledb::Query> query, std::string operator_name, bool nullable = false) {
-#if TILEDB_VERSION >= TileDB_Version(2,18,0)
-    T result = 0;
-    std::vector<uint8_t> nulls = { 0 };
-    uint64_t size = 1;
-    query->set_data_buffer(operator_name, &result, size);
-    if (nullable) query->set_validity_buffer(operator_name, nulls);
-    query->submit();
-    SEXP res = Rcpp::wrap(result);
-    return res;
+SEXP apply_unary_aggregate(XPtr<tiledb::Query> query, std::string operator_name,
+                           bool nullable = false) {
+#if TILEDB_VERSION >= TileDB_Version(2, 18, 0)
+  T result = 0;
+  std::vector<uint8_t> nulls = {0};
+  uint64_t size = 1;
+  query->set_data_buffer(operator_name, &result, size);
+  if (nullable)
+    query->set_validity_buffer(operator_name, nulls);
+  query->submit();
+  SEXP res = Rcpp::wrap(result);
+  return res;
 #else
-    return Rcpp::wrap(R_NaReal);
+  return Rcpp::wrap(R_NaReal);
 #endif
 }
 
@@ -4014,285 +4205,328 @@ SEXP libtiledb_query_apply_aggregate(XPtr<tiledb::Query> query,
                                      std::string attribute_name,
                                      std::string operator_name,
                                      bool nullable = false) {
-#if TILEDB_VERSION >= TileDB_Version(2,18,0)
-    check_xptr_tag<tiledb::Query>(query);
-    tiledb::QueryChannel channel = tiledb::QueryExperimental::get_default_channel(*query.get());
-    if (operator_name == "Sum") {
-        tiledb::ChannelOperation operation = tiledb::QueryExperimental::create_unary_aggregate<tiledb::SumOperator>(*query.get(), attribute_name);
-        channel.apply_aggregate(operator_name, operation);
-    } else if (operator_name == "Min") {
-        tiledb::ChannelOperation operation = tiledb::QueryExperimental::create_unary_aggregate<tiledb::MinOperator>(*query.get(), attribute_name);
-        channel.apply_aggregate(operator_name, operation);
-    } else if (operator_name == "Max") {
-        tiledb::ChannelOperation operation = tiledb::QueryExperimental::create_unary_aggregate<tiledb::MaxOperator>(*query.get(), attribute_name);
-        channel.apply_aggregate(operator_name, operation);
-    } else if (operator_name == "Mean") {
-        tiledb::ChannelOperation operation = tiledb::QueryExperimental::create_unary_aggregate<tiledb::MeanOperator>(*query.get(), attribute_name);
-        channel.apply_aggregate(operator_name, operation);
-    } else if (operator_name == "NullCount") {
-        tiledb::ChannelOperation operation = tiledb::QueryExperimental::create_unary_aggregate<tiledb::NullCountOperator>(*query.get(), attribute_name);
-        channel.apply_aggregate(operator_name, operation);
-    } else if (operator_name == "Count") {
-        channel.apply_aggregate(operator_name, tiledb::CountOperation());
-    } else {
-        Rcpp::stop("Invalid aggregation operator '%s' specified.", operator_name.c_str());
+#if TILEDB_VERSION >= TileDB_Version(2, 18, 0)
+  check_xptr_tag<tiledb::Query>(query);
+  tiledb::QueryChannel channel =
+      tiledb::QueryExperimental::get_default_channel(*query.get());
+  if (operator_name == "Sum") {
+    tiledb::ChannelOperation operation =
+        tiledb::QueryExperimental::create_unary_aggregate<tiledb::SumOperator>(
+            *query.get(), attribute_name);
+    channel.apply_aggregate(operator_name, operation);
+  } else if (operator_name == "Min") {
+    tiledb::ChannelOperation operation =
+        tiledb::QueryExperimental::create_unary_aggregate<tiledb::MinOperator>(
+            *query.get(), attribute_name);
+    channel.apply_aggregate(operator_name, operation);
+  } else if (operator_name == "Max") {
+    tiledb::ChannelOperation operation =
+        tiledb::QueryExperimental::create_unary_aggregate<tiledb::MaxOperator>(
+            *query.get(), attribute_name);
+    channel.apply_aggregate(operator_name, operation);
+  } else if (operator_name == "Mean") {
+    tiledb::ChannelOperation operation =
+        tiledb::QueryExperimental::create_unary_aggregate<tiledb::MeanOperator>(
+            *query.get(), attribute_name);
+    channel.apply_aggregate(operator_name, operation);
+  } else if (operator_name == "NullCount") {
+    tiledb::ChannelOperation operation =
+        tiledb::QueryExperimental::create_unary_aggregate<
+            tiledb::NullCountOperator>(*query.get(), attribute_name);
+    channel.apply_aggregate(operator_name, operation);
+  } else if (operator_name == "Count") {
+    channel.apply_aggregate(operator_name, tiledb::CountOperation());
+  } else {
+    Rcpp::stop("Invalid aggregation operator '%s' specified.",
+               operator_name.c_str());
+  }
+  std::vector<uint8_t> nulls = {0};
+  uint64_t size = 1;
+  if (operator_name == "NullCount" || operator_name == "Count") {
+    // Count and null count take uint64_t.
+    uint64_t result = 0;
+    query->set_data_buffer(operator_name, &result, size);
+    if (nullable &&
+        operator_name != "NullCount") { // no validity buffer for NullCount
+      query->set_validity_buffer(operator_name, nulls);
     }
-    std::vector<uint8_t> nulls = { 0 };
-    uint64_t size = 1;
-    if (operator_name == "NullCount" || operator_name == "Count") {
-        // Count and null count take uint64_t.
-        uint64_t result = 0;
-        query->set_data_buffer(operator_name, &result, size);
-        if (nullable && operator_name != "NullCount") {   // no validity buffer for NullCount
-            query->set_validity_buffer(operator_name, nulls);
-        }
-        query->submit();
-        return Rcpp::wrap(result);
-    } else if (operator_name == "Mean") {
-        // Mean always takes in a double.
-        return apply_unary_aggregate<double>(query, operator_name, nullable);
-    } else if (operator_name == "Sum") {
-        // Sum will take int64_t for signed integers, uint64_t for unsigned integers
-        // and double for floating point values.
-        tiledb::Context ctx = query->ctx();
-        auto arr = query->array();
-        auto sch = tiledb::ArraySchema(ctx, arr.uri());
-        auto attr = tiledb::Attribute(sch.attribute(attribute_name));
-        std::string type_name = _tiledb_datatype_to_string(attr.type());
-        if (type_name == "INT8" || type_name == "INT16" ||
-            type_name == "INT32" || type_name == "INT64") {
-            return apply_unary_aggregate<int64_t>(query, operator_name, nullable);
-        } else if (type_name == "UINT8" || type_name == "UINT16" ||
-                   type_name == "UINT32" || type_name == "UINT64") {
-            return apply_unary_aggregate<uint64_t>(query, operator_name, nullable);
-        } else if (type_name == "FLOAT32" || type_name == "FLOAT64") {
-            return apply_unary_aggregate<double>(query, operator_name, nullable);
-        } else {
-            Rcpp::stop("'Sum' operator not valid for attribute '%s' of type '%s'",
-                       attribute_name, type_name);
-        }
-    } else if (operator_name == "Min" || operator_name == "Max") {
-        // Min/max will take whatever the datatype of the column is.
-        tiledb::Context ctx = query->ctx();
-        auto arr = query->array();
-        auto sch = tiledb::ArraySchema(ctx, arr.uri());
-        auto attr = tiledb::Attribute(sch.attribute(attribute_name));
-        std::string type_name = _tiledb_datatype_to_string(attr.type());
-        switch (attr.type()) {
-        case TILEDB_INT8:    return apply_unary_aggregate<int16_t>(query, operator_name, nullable);  // int8_t bites char
-        case TILEDB_INT16:   return apply_unary_aggregate<int16_t>(query, operator_name, nullable);
-        case TILEDB_INT32:   return apply_unary_aggregate<int32_t>(query, operator_name, nullable);
-        case TILEDB_INT64:   return apply_unary_aggregate<int64_t>(query, operator_name, nullable);
-        case TILEDB_UINT8:   return apply_unary_aggregate<uint16_t>(query, operator_name, nullable); // uint8_t bites char
-        case TILEDB_UINT16:  return apply_unary_aggregate<uint16_t>(query, operator_name, nullable);
-        case TILEDB_UINT32:  return apply_unary_aggregate<uint32_t>(query, operator_name, nullable);
-        case TILEDB_UINT64:  return apply_unary_aggregate<uint64_t>(query, operator_name, nullable);
-        case TILEDB_FLOAT32: return apply_unary_aggregate<float>(query, operator_name, nullable);
-        case TILEDB_FLOAT64: return apply_unary_aggregate<double>(query, operator_name, nullable);
-        default: Rcpp::stop("'%s' is not defined for attribute '%s' of type '%s'",
-                            operator_name, attribute_name, type_name);
-        }
+    query->submit();
+    return Rcpp::wrap(result);
+  } else if (operator_name == "Mean") {
+    // Mean always takes in a double.
+    return apply_unary_aggregate<double>(query, operator_name, nullable);
+  } else if (operator_name == "Sum") {
+    // Sum will take int64_t for signed integers, uint64_t for unsigned integers
+    // and double for floating point values.
+    tiledb::Context ctx = query->ctx();
+    auto arr = query->array();
+    auto sch = tiledb::ArraySchema(ctx, arr.uri());
+    auto attr = tiledb::Attribute(sch.attribute(attribute_name));
+    std::string type_name = _tiledb_datatype_to_string(attr.type());
+    if (type_name == "INT8" || type_name == "INT16" || type_name == "INT32" ||
+        type_name == "INT64") {
+      return apply_unary_aggregate<int64_t>(query, operator_name, nullable);
+    } else if (type_name == "UINT8" || type_name == "UINT16" ||
+               type_name == "UINT32" || type_name == "UINT64") {
+      return apply_unary_aggregate<uint64_t>(query, operator_name, nullable);
+    } else if (type_name == "FLOAT32" || type_name == "FLOAT64") {
+      return apply_unary_aggregate<double>(query, operator_name, nullable);
     } else {
-        Rcpp::stop("'%s' is not implemented for '%s'", operator_name, attribute_name);
+      Rcpp::stop("'Sum' operator not valid for attribute '%s' of type '%s'",
+                 attribute_name, type_name);
     }
+  } else if (operator_name == "Min" || operator_name == "Max") {
+    // Min/max will take whatever the datatype of the column is.
+    tiledb::Context ctx = query->ctx();
+    auto arr = query->array();
+    auto sch = tiledb::ArraySchema(ctx, arr.uri());
+    auto attr = tiledb::Attribute(sch.attribute(attribute_name));
+    std::string type_name = _tiledb_datatype_to_string(attr.type());
+    switch (attr.type()) {
+    case TILEDB_INT8:
+      return apply_unary_aggregate<int16_t>(query, operator_name,
+                                            nullable); // int8_t bites char
+    case TILEDB_INT16:
+      return apply_unary_aggregate<int16_t>(query, operator_name, nullable);
+    case TILEDB_INT32:
+      return apply_unary_aggregate<int32_t>(query, operator_name, nullable);
+    case TILEDB_INT64:
+      return apply_unary_aggregate<int64_t>(query, operator_name, nullable);
+    case TILEDB_UINT8:
+      return apply_unary_aggregate<uint16_t>(query, operator_name,
+                                             nullable); // uint8_t bites char
+    case TILEDB_UINT16:
+      return apply_unary_aggregate<uint16_t>(query, operator_name, nullable);
+    case TILEDB_UINT32:
+      return apply_unary_aggregate<uint32_t>(query, operator_name, nullable);
+    case TILEDB_UINT64:
+      return apply_unary_aggregate<uint64_t>(query, operator_name, nullable);
+    case TILEDB_FLOAT32:
+      return apply_unary_aggregate<float>(query, operator_name, nullable);
+    case TILEDB_FLOAT64:
+      return apply_unary_aggregate<double>(query, operator_name, nullable);
+    default:
+      Rcpp::stop("'%s' is not defined for attribute '%s' of type '%s'",
+                 operator_name, attribute_name, type_name);
+    }
+  } else {
+    Rcpp::stop("'%s' is not implemented for '%s'", operator_name,
+               attribute_name);
+  }
 #else
-    return Rcpp::wrap(R_NaReal);
+  return Rcpp::wrap(R_NaReal);
 #endif
 }
 
 /**
  * Query Condition
  */
-const char* _tiledb_query_condition_op_to_string(tiledb_query_condition_op_t op) {
-    switch (op) {
-    case TILEDB_LT:
-        return "LT";
-    case TILEDB_LE:
-        return "LE";
-    case TILEDB_GT:
-        return "GT";
-    case TILEDB_GE:
-        return "GE";
-    case TILEDB_EQ:
-        return "EQ";
-    case TILEDB_NE:
-        return "NE";
-#if TILEDB_VERSION >= TileDB_Version(2,17,0)
-    case TILEDB_IN:
-        return "IN";
-    case TILEDB_NOT_IN:
-        return "NOT_IN";
+const char *
+_tiledb_query_condition_op_to_string(tiledb_query_condition_op_t op) {
+  switch (op) {
+  case TILEDB_LT:
+    return "LT";
+  case TILEDB_LE:
+    return "LE";
+  case TILEDB_GT:
+    return "GT";
+  case TILEDB_GE:
+    return "GE";
+  case TILEDB_EQ:
+    return "EQ";
+  case TILEDB_NE:
+    return "NE";
+#if TILEDB_VERSION >= TileDB_Version(2, 17, 0)
+  case TILEDB_IN:
+    return "IN";
+  case TILEDB_NOT_IN:
+    return "NOT_IN";
 #endif
-    default:
-        Rcpp::stop("Unknown condition op (%d)", op);
-    }
+  default:
+    Rcpp::stop("Unknown condition op (%d)", op);
+  }
 }
 
-tiledb_query_condition_op_t _tiledb_query_string_to_condition_op(const std::string& opstr) {
-    if (opstr == "LT") {
-        return TILEDB_LT;
-    } else if (opstr == "LE") {
-        return TILEDB_LE;
-    } else if (opstr == "GT") {
-        return TILEDB_GT;
-    } else if (opstr == "GE") {
-        return TILEDB_GE;
-    } else if (opstr == "EQ") {
-        return TILEDB_EQ;
-    } else if (opstr == "NE") {
-        return TILEDB_NE;
-#if TILEDB_VERSION >= TileDB_Version(2,17,0)
-    } else if (opstr == "IN") {
-        return TILEDB_IN;
-    } else if (opstr == "NOT_IN") {
-        return TILEDB_NOT_IN;
+tiledb_query_condition_op_t
+_tiledb_query_string_to_condition_op(const std::string &opstr) {
+  if (opstr == "LT") {
+    return TILEDB_LT;
+  } else if (opstr == "LE") {
+    return TILEDB_LE;
+  } else if (opstr == "GT") {
+    return TILEDB_GT;
+  } else if (opstr == "GE") {
+    return TILEDB_GE;
+  } else if (opstr == "EQ") {
+    return TILEDB_EQ;
+  } else if (opstr == "NE") {
+    return TILEDB_NE;
+#if TILEDB_VERSION >= TileDB_Version(2, 17, 0)
+  } else if (opstr == "IN") {
+    return TILEDB_IN;
+  } else if (opstr == "NOT_IN") {
+    return TILEDB_NOT_IN;
 #endif
-    } else {
-        Rcpp::stop("Unknown TileDB op string '%s'", opstr.c_str());
-    }
+  } else {
+    Rcpp::stop("Unknown TileDB op string '%s'", opstr.c_str());
+  }
 }
 
-const char* _tiledb_query_condition_combination_op_to_string(tiledb_query_condition_combination_op_t op) {
-    switch (op) {
-    case TILEDB_AND:
-        return "AND";
-    case TILEDB_OR:
-        return "OR";
-    case TILEDB_NOT:
-        return "NOT";
-    default:
-        Rcpp::stop("Unknown condition combination op (%d)", op);
-    }
+const char *_tiledb_query_condition_combination_op_to_string(
+    tiledb_query_condition_combination_op_t op) {
+  switch (op) {
+  case TILEDB_AND:
+    return "AND";
+  case TILEDB_OR:
+    return "OR";
+  case TILEDB_NOT:
+    return "NOT";
+  default:
+    Rcpp::stop("Unknown condition combination op (%d)", op);
+  }
 }
 
-tiledb_query_condition_combination_op_t _tiledb_query_string_to_condition_combination_op(const std::string& opstr) {
-    if (opstr == "AND") {
-        return TILEDB_AND;
-    } else if (opstr == "OR") {
-        return TILEDB_OR;
-    } else if (opstr == "NOT") {
-        return TILEDB_NOT;
-    } else {
-        Rcpp::stop("Unknown TileDB combination op string '%s'", opstr.c_str());
-    }
+tiledb_query_condition_combination_op_t
+_tiledb_query_string_to_condition_combination_op(const std::string &opstr) {
+  if (opstr == "AND") {
+    return TILEDB_AND;
+  } else if (opstr == "OR") {
+    return TILEDB_OR;
+  } else if (opstr == "NOT") {
+    return TILEDB_NOT;
+  } else {
+    Rcpp::stop("Unknown TileDB combination op string '%s'", opstr.c_str());
+  }
 }
-
 
 // [[Rcpp::export]]
-XPtr<tiledb::QueryCondition> libtiledb_query_condition(XPtr<tiledb::Context> ctx) {
-    check_xptr_tag<tiledb::Context>(ctx);
-    auto ptr = make_xptr<tiledb::QueryCondition>(new tiledb::QueryCondition(*ctx.get()));
-    return ptr;
+XPtr<tiledb::QueryCondition>
+libtiledb_query_condition(XPtr<tiledb::Context> ctx) {
+  check_xptr_tag<tiledb::Context>(ctx);
+  auto ptr =
+      make_xptr<tiledb::QueryCondition>(new tiledb::QueryCondition(*ctx.get()));
+  return ptr;
 }
 
 // [[Rcpp::export]]
 void libtiledb_query_condition_init(XPtr<tiledb::QueryCondition> query_cond,
-                                    const std::string& attr_name,
+                                    const std::string &attr_name,
                                     SEXP condition_value,
-                                    const std::string& cond_val_type,
-                                    const std::string& cond_op_string) {
-    check_xptr_tag<tiledb::QueryCondition>(query_cond);
-    tiledb_query_condition_op_t op = _tiledb_query_string_to_condition_op(cond_op_string);
-    if (cond_val_type == "INT32"  || cond_val_type == "UINT32") {
-        int v = as<int>(condition_value);
-        uint64_t cond_val_size = sizeof(int);
-        query_cond->init(attr_name, (void*) &v, cond_val_size, op);
-    } else if (cond_val_type == "FLOAT64") {
-        double v = as<double>(condition_value);
-        uint64_t cond_val_size = sizeof(double);
-        query_cond->init(attr_name, (void*) &v, cond_val_size, op);
-    } else if (cond_val_type == "INT64" || cond_val_type == "UINT64") {
-        int64_t v = fromInteger64( as<double>(condition_value) );
-        uint64_t cond_val_size = sizeof(int64_t);
-        query_cond->init(attr_name, (void*) &v, cond_val_size, op);
-    } else if (cond_val_type == "INT8" || cond_val_type == "UINT8") {
-        int v = as<int>(condition_value);
-        uint64_t cond_val_size = sizeof(int8_t);
-        query_cond->init(attr_name, (void*) &v, cond_val_size, op);
-    } else if (cond_val_type == "INT16" || cond_val_type == "UINT16") {
-        int v = as<int>(condition_value);
-        uint64_t cond_val_size = sizeof(int16_t);
-        query_cond->init(attr_name, (void*) &v, cond_val_size, op);
-    } else if (cond_val_type == "FLOAT32") {
-        float v = static_cast<float>(as<double>(condition_value));
-        uint64_t cond_val_size = sizeof(float);
-        query_cond->init(attr_name, (void*) &v, cond_val_size, op);
-    } else if (cond_val_type == "ASCII" || cond_val_type == "UTF8") {
-        std::string v = as<std::string>(condition_value);
-        query_cond->init(attr_name, v, op);
-    } else if (cond_val_type == "BOOL") {
-        bool v = as<bool>(condition_value);
-        uint64_t cond_val_size = sizeof(bool);
-        query_cond->init(attr_name, (void*) &v, cond_val_size, op);
-    } else if (cond_val_type == "DATETIME_MS") {
-        int64_t v = static_cast<int64_t>(as<double>(condition_value) * 1000);
-        uint64_t cond_val_size = sizeof(int64_t);
-        query_cond->init(attr_name, (void*) &v, cond_val_size, op);
-    } else if (cond_val_type == "DATETIME_DAY") {
-        int64_t v = static_cast<int64_t>(as<double>(condition_value));
-        uint64_t cond_val_size = sizeof(int64_t);
-        query_cond->init(attr_name, (void*) &v, cond_val_size, op);
-    } else {
-        Rcpp::stop("Currently unsupported type: %s", cond_val_type);
-    }
+                                    const std::string &cond_val_type,
+                                    const std::string &cond_op_string) {
+  check_xptr_tag<tiledb::QueryCondition>(query_cond);
+  tiledb_query_condition_op_t op =
+      _tiledb_query_string_to_condition_op(cond_op_string);
+  if (cond_val_type == "INT32" || cond_val_type == "UINT32") {
+    int v = as<int>(condition_value);
+    uint64_t cond_val_size = sizeof(int);
+    query_cond->init(attr_name, (void *)&v, cond_val_size, op);
+  } else if (cond_val_type == "FLOAT64") {
+    double v = as<double>(condition_value);
+    uint64_t cond_val_size = sizeof(double);
+    query_cond->init(attr_name, (void *)&v, cond_val_size, op);
+  } else if (cond_val_type == "INT64" || cond_val_type == "UINT64") {
+    int64_t v = fromInteger64(as<double>(condition_value));
+    uint64_t cond_val_size = sizeof(int64_t);
+    query_cond->init(attr_name, (void *)&v, cond_val_size, op);
+  } else if (cond_val_type == "INT8" || cond_val_type == "UINT8") {
+    int v = as<int>(condition_value);
+    uint64_t cond_val_size = sizeof(int8_t);
+    query_cond->init(attr_name, (void *)&v, cond_val_size, op);
+  } else if (cond_val_type == "INT16" || cond_val_type == "UINT16") {
+    int v = as<int>(condition_value);
+    uint64_t cond_val_size = sizeof(int16_t);
+    query_cond->init(attr_name, (void *)&v, cond_val_size, op);
+  } else if (cond_val_type == "FLOAT32") {
+    float v = static_cast<float>(as<double>(condition_value));
+    uint64_t cond_val_size = sizeof(float);
+    query_cond->init(attr_name, (void *)&v, cond_val_size, op);
+  } else if (cond_val_type == "ASCII" || cond_val_type == "UTF8") {
+    std::string v = as<std::string>(condition_value);
+    query_cond->init(attr_name, v, op);
+  } else if (cond_val_type == "BOOL") {
+    bool v = as<bool>(condition_value);
+    uint64_t cond_val_size = sizeof(bool);
+    query_cond->init(attr_name, (void *)&v, cond_val_size, op);
+  } else if (cond_val_type == "DATETIME_MS") {
+    int64_t v = static_cast<int64_t>(as<double>(condition_value) * 1000);
+    uint64_t cond_val_size = sizeof(int64_t);
+    query_cond->init(attr_name, (void *)&v, cond_val_size, op);
+  } else if (cond_val_type == "DATETIME_DAY") {
+    int64_t v = static_cast<int64_t>(as<double>(condition_value));
+    uint64_t cond_val_size = sizeof(int64_t);
+    query_cond->init(attr_name, (void *)&v, cond_val_size, op);
+  } else {
+    Rcpp::stop("Currently unsupported type: %s", cond_val_type);
+  }
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::QueryCondition> libtiledb_query_condition_combine(XPtr<tiledb::QueryCondition> lhs,
-                                                               XPtr<tiledb::QueryCondition> rhs,
-                                                               const std::string& str) {
-    check_xptr_tag<tiledb::QueryCondition>(lhs);
-    check_xptr_tag<tiledb::QueryCondition>(lhs);
-    tiledb_query_condition_combination_op_t op = _tiledb_query_string_to_condition_combination_op(str);
-    tiledb::QueryCondition res = lhs->combine(*rhs.get(), op);
-    auto query_cond = make_xptr<tiledb::QueryCondition>(new tiledb::QueryCondition(res));
-    return query_cond;
+XPtr<tiledb::QueryCondition>
+libtiledb_query_condition_combine(XPtr<tiledb::QueryCondition> lhs,
+                                  XPtr<tiledb::QueryCondition> rhs,
+                                  const std::string &str) {
+  check_xptr_tag<tiledb::QueryCondition>(lhs);
+  check_xptr_tag<tiledb::QueryCondition>(lhs);
+  tiledb_query_condition_combination_op_t op =
+      _tiledb_query_string_to_condition_combination_op(str);
+  tiledb::QueryCondition res = lhs->combine(*rhs.get(), op);
+  auto query_cond =
+      make_xptr<tiledb::QueryCondition>(new tiledb::QueryCondition(res));
+  return query_cond;
 }
 
 // [[Rcpp::export]]
-void libtiledb_query_condition_set_use_enumeration(XPtr<tiledb::Context> ctx,
-                                                   XPtr<tiledb::QueryCondition> cond,
-                                                   bool use_enumeration) {
-    check_xptr_tag<tiledb::Context>(ctx);
-    check_xptr_tag<tiledb::QueryCondition>(cond);
-#if TILEDB_VERSION >= TileDB_Version(2,17,0)
-    tiledb::QueryConditionExperimental::set_use_enumeration(*ctx.get(), *cond.get(), use_enumeration);
+void libtiledb_query_condition_set_use_enumeration(
+    XPtr<tiledb::Context> ctx, XPtr<tiledb::QueryCondition> cond,
+    bool use_enumeration) {
+  check_xptr_tag<tiledb::Context>(ctx);
+  check_xptr_tag<tiledb::QueryCondition>(cond);
+#if TILEDB_VERSION >= TileDB_Version(2, 17, 0)
+  tiledb::QueryConditionExperimental::set_use_enumeration(
+      *ctx.get(), *cond.get(), use_enumeration);
 #endif
 }
 
 // [[Rcpp::export]]
 XPtr<tiledb::QueryCondition>
-libtiledb_query_condition_create(XPtr<tiledb::Context> ctx, const std::string& name,
-                                 SEXP vec, const std::string& cond_op_string) {
-    check_xptr_tag<tiledb::Context>(ctx);
-#if TILEDB_VERSION >= TileDB_Version(2,17,0)
-    tiledb_query_condition_op_t op = _tiledb_query_string_to_condition_op(cond_op_string);
-    // consider three cases of 'vec' based on R types:  int, double and int64-as-double
-    if (TYPEOF(vec) == INTSXP) {
-        std::vector<int32_t> iv = Rcpp::as<std::vector<int32_t>>(vec);
-        auto qc = tiledb::QueryConditionExperimental::create<int32_t>(*ctx.get(), name, iv, op);
-        return make_xptr<tiledb::QueryCondition>(new tiledb::QueryCondition(qc));
-    } else if (TYPEOF(vec) == REALSXP) {
-        if (Rcpp::isInteger64(vec)) {
-            std::vector<int64_t> dv = Rcpp::fromInteger64(Rcpp::NumericVector(vec));
-            auto qc = tiledb::QueryConditionExperimental::create<int64_t>(*ctx.get(), name, dv, op);
-            return make_xptr<tiledb::QueryCondition>(new tiledb::QueryCondition(qc));
-        } else {
-            std::vector<double> dv = Rcpp::as<std::vector<double>>(vec);
-            auto qc = tiledb::QueryConditionExperimental::create<double>(*ctx.get(), name, dv, op);
-            return make_xptr<tiledb::QueryCondition>(new tiledb::QueryCondition(qc));
-        }
-    } else if (TYPEOF(vec) == STRSXP) {
-        std::vector<std::string> sv = Rcpp::as<std::vector<std::string>>(vec);
-        auto qc = tiledb::QueryConditionExperimental::create(*ctx.get(), name, sv, op);
-        return make_xptr<tiledb::QueryCondition>(new tiledb::QueryCondition(qc));
+libtiledb_query_condition_create(XPtr<tiledb::Context> ctx,
+                                 const std::string &name, SEXP vec,
+                                 const std::string &cond_op_string) {
+  check_xptr_tag<tiledb::Context>(ctx);
+#if TILEDB_VERSION >= TileDB_Version(2, 17, 0)
+  tiledb_query_condition_op_t op =
+      _tiledb_query_string_to_condition_op(cond_op_string);
+  // consider three cases of 'vec' based on R types:  int, double and
+  // int64-as-double
+  if (TYPEOF(vec) == INTSXP) {
+    std::vector<int32_t> iv = Rcpp::as<std::vector<int32_t>>(vec);
+    auto qc = tiledb::QueryConditionExperimental::create<int32_t>(*ctx.get(),
+                                                                  name, iv, op);
+    return make_xptr<tiledb::QueryCondition>(new tiledb::QueryCondition(qc));
+  } else if (TYPEOF(vec) == REALSXP) {
+    if (Rcpp::isInteger64(vec)) {
+      std::vector<int64_t> dv = Rcpp::fromInteger64(Rcpp::NumericVector(vec));
+      auto qc = tiledb::QueryConditionExperimental::create<int64_t>(
+          *ctx.get(), name, dv, op);
+      return make_xptr<tiledb::QueryCondition>(new tiledb::QueryCondition(qc));
     } else {
-        Rcpp::stop("No support (yet) for type '%s'.", Rcpp::type2name(vec));
+      std::vector<double> dv = Rcpp::as<std::vector<double>>(vec);
+      auto qc = tiledb::QueryConditionExperimental::create<double>(
+          *ctx.get(), name, dv, op);
+      return make_xptr<tiledb::QueryCondition>(new tiledb::QueryCondition(qc));
     }
+  } else if (TYPEOF(vec) == STRSXP) {
+    std::vector<std::string> sv = Rcpp::as<std::vector<std::string>>(vec);
+    auto qc =
+        tiledb::QueryConditionExperimental::create(*ctx.get(), name, sv, op);
+    return make_xptr<tiledb::QueryCondition>(new tiledb::QueryCondition(qc));
+  } else {
+    Rcpp::stop("No support (yet) for type '%s'.", Rcpp::type2name(vec));
+  }
 #endif
-    return make_xptr<tiledb::QueryCondition>(R_NilValue);
+  return make_xptr<tiledb::QueryCondition>(R_NilValue);
 }
-
 
 /**
  * Array helper functions
@@ -4333,7 +4567,6 @@ IntegerVector libtiledb_zip_coords_integer(List coords, R_xlen_t coord_length) {
   return result;
 }
 
-
 /**
  * Object functionality
  */
@@ -4346,13 +4579,13 @@ std::string libtiledb_create_group(XPtr<tiledb::Context> ctx, std::string uri) {
 
 std::string _object_type_to_string(tiledb::Object::Type otype) {
   switch (otype) {
-    case tiledb::Object::Type::Array:
-      return "ARRAY";
-    case tiledb::Object::Type::Group:
-      return "GROUP";
-    case tiledb::Object::Type::Invalid:
-    default:
-      return "INVALID";
+  case tiledb::Object::Type::Array:
+    return "ARRAY";
+  case tiledb::Object::Type::Group:
+    return "GROUP";
+  case tiledb::Object::Type::Invalid:
+  default:
+    return "INVALID";
   }
 }
 
@@ -4364,14 +4597,16 @@ std::string libtiledb_object_type(XPtr<tiledb::Context> ctx, std::string uri) {
 }
 
 // [[Rcpp::export]]
-std::string libtiledb_object_remove(XPtr<tiledb::Context> ctx, std::string uri) {
+std::string libtiledb_object_remove(XPtr<tiledb::Context> ctx,
+                                    std::string uri) {
   check_xptr_tag<tiledb::Context>(ctx);
   tiledb::Object::remove(*ctx.get(), uri);
   return uri;
 }
 
 // [[Rcpp::export]]
-std::string libtiledb_object_move(XPtr<tiledb::Context> ctx, std::string old_uri, std::string new_uri) {
+std::string libtiledb_object_move(XPtr<tiledb::Context> ctx,
+                                  std::string old_uri, std::string new_uri) {
   check_xptr_tag<tiledb::Context>(ctx);
   tiledb::Object::move(*ctx.get(), old_uri, new_uri);
   return new_uri;
@@ -4388,53 +4623,59 @@ tiledb::Object::Type _string_to_object_type(std::string otype) {
 }
 
 // [[Rcpp::export]]
-DataFrame libtiledb_object_walk(XPtr<tiledb::Context> ctx,
-                                std::string uri, std::string order, bool recursive = false) {
-    check_xptr_tag<tiledb::Context>(ctx);
-    std::vector<std::string> uris;
-    std::vector<std::string> types;
-    tiledb::ObjectIter obj_iter(*ctx.get(), uri);
-    if (recursive) {
-        if (! ((order == "PREORDER") || (order == "POSTORDER"))) {
-            Rcpp::stop("invalid recursive walk order, must be \"PREORDER\" or \"POSTORDER\"");
-        }
-        tiledb_walk_order_t walk_order = (order == "PREORDER") ? TILEDB_PREORDER : TILEDB_POSTORDER;
-        obj_iter.set_recursive(walk_order);
-    } else {
-        obj_iter.set_non_recursive();
+DataFrame libtiledb_object_walk(XPtr<tiledb::Context> ctx, std::string uri,
+                                std::string order, bool recursive = false) {
+  check_xptr_tag<tiledb::Context>(ctx);
+  std::vector<std::string> uris;
+  std::vector<std::string> types;
+  tiledb::ObjectIter obj_iter(*ctx.get(), uri);
+  if (recursive) {
+    if (!((order == "PREORDER") || (order == "POSTORDER"))) {
+      Rcpp::stop("invalid recursive walk order, must be \"PREORDER\" or "
+                 "\"POSTORDER\"");
     }
-    for (const auto& object : obj_iter) {
-        uris.push_back(object.uri());
-        types.push_back(_object_type_to_string(object.type()));
-    }
-    return Rcpp::DataFrame::create(Rcpp::Named("TYPE") = types,
-                                   Rcpp::Named("URI") = uris);
+    tiledb_walk_order_t walk_order =
+        (order == "PREORDER") ? TILEDB_PREORDER : TILEDB_POSTORDER;
+    obj_iter.set_recursive(walk_order);
+  } else {
+    obj_iter.set_non_recursive();
+  }
+  for (const auto &object : obj_iter) {
+    uris.push_back(object.uri());
+    types.push_back(_object_type_to_string(object.type()));
+  }
+  return Rcpp::DataFrame::create(Rcpp::Named("TYPE") = types,
+                                 Rcpp::Named("URI") = uris);
 }
 
 /**
  * VFS functionality
  */
 // [[Rcpp::export]]
-XPtr<tiledb::VFS> libtiledb_vfs(XPtr<tiledb::Context> ctx,
-                                Nullable<XPtr<tiledb::Config>> config=R_NilValue) {
+XPtr<tiledb::VFS>
+libtiledb_vfs(XPtr<tiledb::Context> ctx,
+              Nullable<XPtr<tiledb::Config>> config = R_NilValue) {
   check_xptr_tag<tiledb::Context>(ctx);
   if (config.isNull()) {
     return make_xptr<tiledb::VFS>(new tiledb::VFS(*ctx.get()));
   } else {
     XPtr<tiledb::Config> config_xptr(config);
-    return make_xptr<tiledb::VFS>(new tiledb::VFS(*ctx.get(), *config_xptr.get()));
+    return make_xptr<tiledb::VFS>(
+        new tiledb::VFS(*ctx.get(), *config_xptr.get()));
   }
 }
 
 // [[Rcpp::export]]
-std::string libtiledb_vfs_create_bucket(XPtr<tiledb::VFS> vfs, std::string uri) {
+std::string libtiledb_vfs_create_bucket(XPtr<tiledb::VFS> vfs,
+                                        std::string uri) {
   check_xptr_tag<tiledb::VFS>(vfs);
   vfs->create_bucket(uri);
   return uri;
 }
 
 // [[Rcpp::export]]
-std::string libtiledb_vfs_remove_bucket(XPtr<tiledb::VFS> vfs, std::string uri) {
+std::string libtiledb_vfs_remove_bucket(XPtr<tiledb::VFS> vfs,
+                                        std::string uri) {
   check_xptr_tag<tiledb::VFS>(vfs);
   vfs->remove_bucket(uri);
   return uri;
@@ -4468,8 +4709,8 @@ std::string libtiledb_vfs_create_dir(XPtr<tiledb::VFS> vfs, std::string uri) {
 
 // [[Rcpp::export]]
 bool libtiledb_vfs_is_dir(XPtr<tiledb::VFS> vfs, std::string uri) {
-    check_xptr_tag<tiledb::VFS>(vfs);
-    return vfs->is_dir(uri);
+  check_xptr_tag<tiledb::VFS>(vfs);
+  return vfs->is_dir(uri);
 }
 
 // [[Rcpp::export]]
@@ -4503,14 +4744,16 @@ R_xlen_t libtiledb_vfs_file_size(XPtr<tiledb::VFS> vfs, std::string uri) {
 }
 
 // [[Rcpp::export]]
-std::string libtiledb_vfs_move_file(XPtr<tiledb::VFS> vfs, std::string old_uri, std::string new_uri) {
+std::string libtiledb_vfs_move_file(XPtr<tiledb::VFS> vfs, std::string old_uri,
+                                    std::string new_uri) {
   check_xptr_tag<tiledb::VFS>(vfs);
   vfs->move_file(old_uri, new_uri);
   return new_uri;
 }
 
 // [[Rcpp::export]]
-std::string libtiledb_vfs_move_dir(XPtr<tiledb::VFS> vfs, std::string old_uri, std::string new_uri) {
+std::string libtiledb_vfs_move_dir(XPtr<tiledb::VFS> vfs, std::string old_uri,
+                                   std::string new_uri) {
   check_xptr_tag<tiledb::VFS>(vfs);
   vfs->move_dir(old_uri, new_uri);
   return new_uri;
@@ -4523,15 +4766,15 @@ std::string libtiledb_vfs_touch(XPtr<tiledb::VFS> vfs, std::string uri) {
   return uri;
 }
 
-
 // [[Rcpp::export]]
-XPtr<vfs_fh_t> libtiledb_vfs_open(XPtr<tiledb::Context> ctxxp, XPtr<tiledb::VFS> vfsxp,
-                                  std::string uri, std::string mode) {
+XPtr<vfs_fh_t> libtiledb_vfs_open(XPtr<tiledb::Context> ctxxp,
+                                  XPtr<tiledb::VFS> vfsxp, std::string uri,
+                                  std::string mode) {
   check_xptr_tag<tiledb::Context>(ctxxp);
   check_xptr_tag<tiledb::VFS>(vfsxp);
   std::shared_ptr<tiledb_ctx_t> ctx = ctxxp.get()->ptr();
   std::shared_ptr<tiledb_vfs_t> vfs = vfsxp.get()->ptr();
-#if TILEDB_VERSION >= TileDB_Version(2,15,0)
+#if TILEDB_VERSION >= TileDB_Version(2, 15, 0)
   tiledb_vfs_fh_handle_t *fh = nullptr;
 #else
   tiledb_vfs_fh_t *fh = nullptr;
@@ -4557,12 +4800,13 @@ void libtiledb_vfs_write(XPtr<tiledb::Context> ctxxp, XPtr<vfs_fh_t> fh,
   check_xptr_tag<tiledb::Context>(ctxxp);
   check_xptr_tag<vfs_fh_t>(fh);
   std::shared_ptr<tiledb_ctx_t> ctx = ctxxp.get()->ptr();
-  tiledb_vfs_write(ctx.get(), fh->fh, &(vec[0]), vec.size()*sizeof(int));
+  tiledb_vfs_write(ctx.get(), fh->fh, &(vec[0]), vec.size() * sizeof(int));
 }
 
 // [[Rcpp::export]]
-Rcpp::IntegerVector libtiledb_vfs_read(XPtr<tiledb::Context> ctxxp, XPtr<vfs_fh_t> fh,
-                                       double offset, double nbytes) {
+Rcpp::IntegerVector libtiledb_vfs_read(XPtr<tiledb::Context> ctxxp,
+                                       XPtr<vfs_fh_t> fh, double offset,
+                                       double nbytes) {
   check_xptr_tag<tiledb::Context>(ctxxp);
   check_xptr_tag<vfs_fh_t>(fh);
   std::shared_ptr<tiledb_ctx_t> ctx = ctxxp.get()->ptr();
@@ -4583,63 +4827,67 @@ void libtiledb_vfs_sync(XPtr<tiledb::Context> ctxxp, XPtr<vfs_fh_t> fh) {
 
 // [[Rcpp::export]]
 double libtiledb_vfs_dir_size(XPtr<tiledb::VFS> vfs, std::string uri) {
-    check_xptr_tag<tiledb::VFS>(vfs);
-    return static_cast<double>(vfs->dir_size(uri)); // uint64_t to double for R
+  check_xptr_tag<tiledb::VFS>(vfs);
+  return static_cast<double>(vfs->dir_size(uri)); // uint64_t to double for R
 }
 
 // [[Rcpp::export]]
-std::vector<std::string> libtiledb_vfs_ls(XPtr<tiledb::VFS> vfs, std::string uri) {
-    check_xptr_tag<tiledb::VFS>(vfs);
-    return vfs->ls(uri);
+std::vector<std::string> libtiledb_vfs_ls(XPtr<tiledb::VFS> vfs,
+                                          std::string uri) {
+  check_xptr_tag<tiledb::VFS>(vfs);
+  return vfs->ls(uri);
 }
 
 // [[Rcpp::export]]
-std::string libtiledb_vfs_copy_file(XPtr<tiledb::VFS> vfs, std::string old_uri, std::string new_uri) {
-    check_xptr_tag<tiledb::VFS>(vfs);
-    vfs->copy_file(old_uri, new_uri);
-    return new_uri;
+std::string libtiledb_vfs_copy_file(XPtr<tiledb::VFS> vfs, std::string old_uri,
+                                    std::string new_uri) {
+  check_xptr_tag<tiledb::VFS>(vfs);
+  vfs->copy_file(old_uri, new_uri);
+  return new_uri;
 }
 
 // [[Rcpp::export]]
 void libtiledb_vfs_fh_free(XPtr<vfs_fh_t> fhxp) {
-    check_xptr_tag<vfs_fh_t>(fhxp);
-    spdl::trace("[libtiledb_vfs_clear_handle] entered");
-    vfs_fh_t* strptr = fhxp.get();
-#if TILEDB_VERSION >= TileDB_Version(2,15,0)
-    tiledb_vfs_fh_handle_t *fh = strptr->fh;
-    tiledb_vfs_fh_free(&fh);
+  check_xptr_tag<vfs_fh_t>(fhxp);
+  spdl::trace("[libtiledb_vfs_clear_handle] entered");
+  vfs_fh_t *strptr = fhxp.get();
+#if TILEDB_VERSION >= TileDB_Version(2, 15, 0)
+  tiledb_vfs_fh_handle_t *fh = strptr->fh;
+  tiledb_vfs_fh_free(&fh);
 #endif
 }
 
 // [[Rcpp::export]]
 Rcpp::DataFrame libtiledb_vfs_ls_recursive(XPtr<tiledb::Context> ctx,
                                            XPtr<tiledb::VFS> vfs,
-                                           const std::string& uri) {
-    check_xptr_tag<tiledb::Context>(ctx);
-    check_xptr_tag<tiledb::VFS>(vfs);
+                                           const std::string &uri) {
+  check_xptr_tag<tiledb::Context>(ctx);
+  check_xptr_tag<tiledb::VFS>(vfs);
 
-#if TILEDB_VERSION >= TileDB_Version(2,22,0)
-    // standard / default list object (a vector of a pair<string, uint64_t?>) and callback
-    tiledb::VFSExperimental::LsObjects ls_objects;
-    tiledb::VFSExperimental::LsCallback cb = [&](const std::string_view& path, uint64_t size) {
-        ls_objects.emplace_back(path, size);
-        return true;  // Continue traversal to next entry.
-    };
-    tiledb::VFSExperimental::ls_recursive(*ctx.get(), *vfs.get(), uri, cb);
+#if TILEDB_VERSION >= TileDB_Version(2, 22, 0)
+  // standard / default list object (a vector of a pair<string, uint64_t?>) and
+  // callback
+  tiledb::VFSExperimental::LsObjects ls_objects;
+  tiledb::VFSExperimental::LsCallback cb = [&](const std::string_view &path,
+                                               uint64_t size) {
+    ls_objects.emplace_back(path, size);
+    return true; // Continue traversal to next entry.
+  };
+  tiledb::VFSExperimental::ls_recursive(*ctx.get(), *vfs.get(), uri, cb);
 
-    size_t n = ls_objects.size();
-    Rcpp::CharacterVector path(n);
-    std::vector<int64_t> size(n);
-    for (size_t i=0; i<n; i++) {
-        auto obj = ls_objects[i];
-        path[i] = obj.first;
-        size[i] = static_cast<int64_t>(obj.second);
-    }
-    return Rcpp::DataFrame::create(Rcpp::Named("path") = path,
-                                   Rcpp::Named("size") = Rcpp::toInteger64(size));
+  size_t n = ls_objects.size();
+  Rcpp::CharacterVector path(n);
+  std::vector<int64_t> size(n);
+  for (size_t i = 0; i < n; i++) {
+    auto obj = ls_objects[i];
+    path[i] = obj.first;
+    size[i] = static_cast<int64_t>(obj.second);
+  }
+  return Rcpp::DataFrame::create(Rcpp::Named("path") = path,
+                                 Rcpp::Named("size") = Rcpp::toInteger64(size));
 #else
-    return Rcpp::DataFrame::create(Rcpp::Named("path") = Rcpp::CharacterVector(),
-                                   Rcpp::Named("size") = Rcpp::NumericVector());
+  return Rcpp::DataFrame::create(Rcpp::Named("path") = Rcpp::CharacterVector(),
+                                 Rcpp::Named("size") = Rcpp::NumericVector());
 #endif
 }
 
@@ -4648,26 +4896,20 @@ Rcpp::DataFrame libtiledb_vfs_ls_recursive(XPtr<tiledb::Context> ctx,
  */
 
 // [[Rcpp::export]]
-void libtiledb_stats_enable() {
-  tiledb::Stats::enable();
-}
+void libtiledb_stats_enable() { tiledb::Stats::enable(); }
 
 // [[Rcpp::export]]
-void libtiledb_stats_disable() {
-  tiledb::Stats::disable();
-}
+void libtiledb_stats_disable() { tiledb::Stats::disable(); }
 
 // [[Rcpp::export]]
-void libtiledb_stats_reset() {
-  tiledb::Stats::reset();
-}
+void libtiledb_stats_reset() { tiledb::Stats::reset(); }
 
 // [[Rcpp::export]]
 void libtiledb_stats_dump(std::string path = "") {
   if (path == "") {
     tiledb::Stats::dump();
   } else {
-    FILE* fptr = nullptr;
+    FILE *fptr = nullptr;
     fptr = fopen(path.c_str(), "w");
     if (fptr == nullptr) {
       Rcpp::stop("error opening stats dump file for writing");
@@ -4679,15 +4921,16 @@ void libtiledb_stats_dump(std::string path = "") {
 
 // [[Rcpp::export]]
 std::string libtiledb_stats_raw_dump() {
-    std::string txt;
-    tiledb::Stats::raw_dump(&txt);
-    return txt;
+  std::string txt;
+  tiledb::Stats::raw_dump(&txt);
+  return txt;
 }
 
 // [[Rcpp::export]]
 std::string libtiledb_stats_raw_get() {
-    Rcpp::message(Rcpp::wrap("This function is deprecated, please use 'libtiledb_stats_raw_dump'."));
-    return libtiledb_stats_raw_dump();
+  Rcpp::message(Rcpp::wrap(
+      "This function is deprecated, please use 'libtiledb_stats_raw_dump'."));
+  return libtiledb_stats_raw_dump();
 }
 
 /**
@@ -4695,586 +4938,592 @@ std::string libtiledb_stats_raw_get() {
  */
 // [[Rcpp::export]]
 XPtr<tiledb::FragmentInfo> libtiledb_fragment_info(XPtr<tiledb::Context> ctx,
-                                                   const std::string& uri) {
-    auto ptr = make_xptr<tiledb::FragmentInfo>(new tiledb::FragmentInfo(*ctx.get(), uri));
-    ptr->load();                // also load
-    return ptr;
+                                                   const std::string &uri) {
+  auto ptr = make_xptr<tiledb::FragmentInfo>(
+      new tiledb::FragmentInfo(*ctx.get(), uri));
+  ptr->load(); // also load
+  return ptr;
 }
 
 // [[Rcpp::export]]
-std::string libtiledb_fragment_info_uri(XPtr<tiledb::FragmentInfo> fi, int32_t fid) {
-    check_xptr_tag<tiledb::FragmentInfo>(fi);
-    return fi->fragment_uri(static_cast<uint32_t>(fid));
+std::string libtiledb_fragment_info_uri(XPtr<tiledb::FragmentInfo> fi,
+                                        int32_t fid) {
+  check_xptr_tag<tiledb::FragmentInfo>(fi);
+  return fi->fragment_uri(static_cast<uint32_t>(fid));
 }
 
 // [[Rcpp::export]]
-Rcpp::NumericVector libtiledb_fragment_info_get_non_empty_domain_index(XPtr<tiledb::FragmentInfo> fi,
-                                                                       int32_t fid, int32_t did,
-                                                                       const std::string& typestr) {
-    check_xptr_tag<tiledb::FragmentInfo>(fi);
-    if (typestr == "INT64") {
-        std::vector<int64_t> non_empty_dom(2);
-        fi->get_non_empty_domain(fid, did, &non_empty_dom[0]);
-        return toInteger64(non_empty_dom);
-    } else if (typestr == "UINT64") {
-        std::vector<uint64_t> ned(2);
-        fi->get_non_empty_domain(fid, did, &ned[0]);
-        std::vector<int64_t> v{ static_cast<int64_t>(ned[0]), static_cast<int64_t>(ned[1]) };
-        return toInteger64(v);
-    } else if (typestr == "INT32") {
-        std::vector<int32_t> non_empty_dom(2);
-        fi->get_non_empty_domain(fid, did, &non_empty_dom[0]);
-        return NumericVector::create(non_empty_dom[0], non_empty_dom[1]);
-    } else if (typestr == "UINT32") {
-        std::vector<uint32_t> non_empty_dom(2);
-        fi->get_non_empty_domain(fid, did, &non_empty_dom[0]);
-        return NumericVector::create(non_empty_dom[0], non_empty_dom[1]);
-    } else if (typestr == "INT16") {
-        std::vector<int16_t> non_empty_dom(2);
-        fi->get_non_empty_domain(fid, did, &non_empty_dom[0]);
-        return NumericVector::create(non_empty_dom[0], non_empty_dom[1]);
-    } else if (typestr == "UINT16") {
-        std::vector<uint16_t> non_empty_dom(2);
-        fi->get_non_empty_domain(fid, did, &non_empty_dom[0]);
-        return NumericVector::create(non_empty_dom[0], non_empty_dom[1]);
-    } else if (typestr == "INT8") {
-        std::vector<int8_t> non_empty_dom(2);
-        fi->get_non_empty_domain(fid, did, &non_empty_dom[0]);
-        return NumericVector::create(non_empty_dom[0], non_empty_dom[1]);
-    } else if (typestr == "UINT8") {
-        std::vector<uint8_t> non_empty_dom(2);
-        fi->get_non_empty_domain(fid, did, &non_empty_dom[0]);
-        return NumericVector::create(non_empty_dom[0], non_empty_dom[1]);
-    } else if (typestr == "FLOAT64") {
-        std::vector<double> non_empty_dom(2);
-        fi->get_non_empty_domain(fid, did, &non_empty_dom[0]);
-        return NumericVector::create(non_empty_dom[0], non_empty_dom[1]);
-    } else if (typestr == "FLOAT32") {
-        std::vector<float> non_empty_dom(2);
-        fi->get_non_empty_domain(fid, did, &non_empty_dom[0]);
-        return NumericVector::create(non_empty_dom[0], non_empty_dom[1]);
-    } else if (typestr == "DATETIME_YEAR" ||
-             typestr == "DATETIME_MONTH" ||
-             typestr == "DATETIME_WEEK" ||
-             typestr == "DATETIME_DAY" ||
-             typestr == "DATETIME_HR"  ||
-             typestr == "DATETIME_MIN" ||
-             typestr == "DATETIME_SEC" ||
-             typestr == "DATETIME_MS"  ||
-             typestr == "DATETIME_US"  ||
-             typestr == "DATETIME_PS"  ||
-             typestr == "DATETIME_FS"  ||
-             typestr == "DATETIME_AS"    ) {
-        // type_check() from exception.h gets invoked and wants an int64_t
-        std::vector<int64_t> non_empty_dom(2);
-        fi->get_non_empty_domain(fid, did, &non_empty_dom[0]);
-        return toInteger64(non_empty_dom);
-    } else if (typestr == "DATETIME_NS") {
-        std::vector<int64_t> non_empty_dom(2);
-        fi->get_non_empty_domain(fid, did, &non_empty_dom[0]);
-        return toNanotime(non_empty_dom);
-    } else {
-        Rcpp::stop("Currently unsupported tiledb domain type: '%s'", typestr.c_str());
-        return NumericVector::create(NA_REAL, NA_REAL); // not reached
-    }
-}
-
-// [[Rcpp::export]]
-Rcpp::NumericVector libtiledb_fragment_info_get_non_empty_domain_name(XPtr<tiledb::FragmentInfo> fi,
-                                                                      int32_t fid,
-                                                                      const std::string& dim_name,
-                                                                      const std::string& typestr) {
-    check_xptr_tag<tiledb::FragmentInfo>(fi);
-    if (typestr == "INT64") {
-        std::vector<int64_t> non_empty_dom(2);
-        fi->get_non_empty_domain(fid, dim_name, &non_empty_dom[0]);
-        return toInteger64(non_empty_dom);
-    } else if (typestr == "UINT64") {
-        std::vector<uint64_t> ned(2);
-        fi->get_non_empty_domain(fid, dim_name, &ned[0]);
-        std::vector<int64_t> v{ static_cast<int64_t>(ned[0]), static_cast<int64_t>(ned[1]) };
-        return toInteger64(v);
-    } else if (typestr == "INT32") {
-        std::vector<int32_t> non_empty_dom(2);
-        fi->get_non_empty_domain(fid, dim_name, &non_empty_dom[0]);
-        return NumericVector::create(non_empty_dom[0], non_empty_dom[1]);
-    } else if (typestr == "UINT32") {
-        std::vector<uint32_t> non_empty_dom(2);
-        fi->get_non_empty_domain(fid, dim_name, &non_empty_dom[0]);
-        return NumericVector::create(non_empty_dom[0], non_empty_dom[1]);
-    } else if (typestr == "INT16") {
-        std::vector<int16_t> non_empty_dom(2);
-        fi->get_non_empty_domain(fid, dim_name, &non_empty_dom[0]);
-        return NumericVector::create(non_empty_dom[0], non_empty_dom[1]);
-    } else if (typestr == "UINT16") {
-        std::vector<uint16_t> non_empty_dom(2);
-        fi->get_non_empty_domain(fid, dim_name, &non_empty_dom[0]);
-        return NumericVector::create(non_empty_dom[0], non_empty_dom[1]);
+Rcpp::NumericVector libtiledb_fragment_info_get_non_empty_domain_index(
+    XPtr<tiledb::FragmentInfo> fi, int32_t fid, int32_t did,
+    const std::string &typestr) {
+  check_xptr_tag<tiledb::FragmentInfo>(fi);
+  if (typestr == "INT64") {
+    std::vector<int64_t> non_empty_dom(2);
+    fi->get_non_empty_domain(fid, did, &non_empty_dom[0]);
+    return toInteger64(non_empty_dom);
+  } else if (typestr == "UINT64") {
+    std::vector<uint64_t> ned(2);
+    fi->get_non_empty_domain(fid, did, &ned[0]);
+    std::vector<int64_t> v{static_cast<int64_t>(ned[0]),
+                           static_cast<int64_t>(ned[1])};
+    return toInteger64(v);
+  } else if (typestr == "INT32") {
+    std::vector<int32_t> non_empty_dom(2);
+    fi->get_non_empty_domain(fid, did, &non_empty_dom[0]);
+    return NumericVector::create(non_empty_dom[0], non_empty_dom[1]);
+  } else if (typestr == "UINT32") {
+    std::vector<uint32_t> non_empty_dom(2);
+    fi->get_non_empty_domain(fid, did, &non_empty_dom[0]);
+    return NumericVector::create(non_empty_dom[0], non_empty_dom[1]);
+  } else if (typestr == "INT16") {
+    std::vector<int16_t> non_empty_dom(2);
+    fi->get_non_empty_domain(fid, did, &non_empty_dom[0]);
+    return NumericVector::create(non_empty_dom[0], non_empty_dom[1]);
+  } else if (typestr == "UINT16") {
+    std::vector<uint16_t> non_empty_dom(2);
+    fi->get_non_empty_domain(fid, did, &non_empty_dom[0]);
+    return NumericVector::create(non_empty_dom[0], non_empty_dom[1]);
   } else if (typestr == "INT8") {
-        std::vector<int8_t> non_empty_dom(2);
-        fi->get_non_empty_domain(fid, dim_name, &non_empty_dom[0]);
-        return NumericVector::create(non_empty_dom[0], non_empty_dom[1]);
+    std::vector<int8_t> non_empty_dom(2);
+    fi->get_non_empty_domain(fid, did, &non_empty_dom[0]);
+    return NumericVector::create(non_empty_dom[0], non_empty_dom[1]);
   } else if (typestr == "UINT8") {
-        std::vector<uint8_t> non_empty_dom(2);
-        fi->get_non_empty_domain(fid, dim_name, &non_empty_dom[0]);
-        return NumericVector::create(non_empty_dom[0], non_empty_dom[1]);
+    std::vector<uint8_t> non_empty_dom(2);
+    fi->get_non_empty_domain(fid, did, &non_empty_dom[0]);
+    return NumericVector::create(non_empty_dom[0], non_empty_dom[1]);
   } else if (typestr == "FLOAT64") {
-        std::vector<double> non_empty_dom(2);
-        fi->get_non_empty_domain(fid, dim_name, &non_empty_dom[0]);
-        return NumericVector::create(non_empty_dom[0], non_empty_dom[1]);
+    std::vector<double> non_empty_dom(2);
+    fi->get_non_empty_domain(fid, did, &non_empty_dom[0]);
+    return NumericVector::create(non_empty_dom[0], non_empty_dom[1]);
   } else if (typestr == "FLOAT32") {
-        std::vector<float> non_empty_dom(2);
-        fi->get_non_empty_domain(fid, dim_name, &non_empty_dom[0]);
-        return NumericVector::create(non_empty_dom[0], non_empty_dom[1]);
-  } else if (typestr == "DATETIME_YEAR" ||
-             typestr == "DATETIME_MONTH" ||
-             typestr == "DATETIME_WEEK" ||
-             typestr == "DATETIME_DAY" ||
-             typestr == "DATETIME_HR"  ||
-             typestr == "DATETIME_MIN" ||
-             typestr == "DATETIME_SEC" ||
-             typestr == "DATETIME_MS"  ||
-             typestr == "DATETIME_US"  ||
-             typestr == "DATETIME_PS"  ||
-             typestr == "DATETIME_FS"  ||
-             typestr == "DATETIME_AS"    ) {
-        // type_check() from exception.h gets invoked and wants an int64_t
-        std::vector<int64_t> non_empty_dom(2);
-        fi->get_non_empty_domain(fid, dim_name, &non_empty_dom[0]);
-        return toInteger64(non_empty_dom);
-    } else if (typestr == "DATETIME_NS") {
-        std::vector<int64_t> non_empty_dom(2);
-        fi->get_non_empty_domain(fid, dim_name, &non_empty_dom[0]);
-        return toNanotime(non_empty_dom);
-    } else {
-        Rcpp::stop("Currently unsupported tiledb domain type: '%s'", typestr.c_str());
-        return NumericVector::create(NA_REAL, NA_REAL); // not reached
-    }
+    std::vector<float> non_empty_dom(2);
+    fi->get_non_empty_domain(fid, did, &non_empty_dom[0]);
+    return NumericVector::create(non_empty_dom[0], non_empty_dom[1]);
+  } else if (typestr == "DATETIME_YEAR" || typestr == "DATETIME_MONTH" ||
+             typestr == "DATETIME_WEEK" || typestr == "DATETIME_DAY" ||
+             typestr == "DATETIME_HR" || typestr == "DATETIME_MIN" ||
+             typestr == "DATETIME_SEC" || typestr == "DATETIME_MS" ||
+             typestr == "DATETIME_US" || typestr == "DATETIME_PS" ||
+             typestr == "DATETIME_FS" || typestr == "DATETIME_AS") {
+    // type_check() from exception.h gets invoked and wants an int64_t
+    std::vector<int64_t> non_empty_dom(2);
+    fi->get_non_empty_domain(fid, did, &non_empty_dom[0]);
+    return toInteger64(non_empty_dom);
+  } else if (typestr == "DATETIME_NS") {
+    std::vector<int64_t> non_empty_dom(2);
+    fi->get_non_empty_domain(fid, did, &non_empty_dom[0]);
+    return toNanotime(non_empty_dom);
+  } else {
+    Rcpp::stop("Currently unsupported tiledb domain type: '%s'",
+               typestr.c_str());
+    return NumericVector::create(NA_REAL, NA_REAL); // not reached
+  }
 }
 
 // [[Rcpp::export]]
-Rcpp::CharacterVector
-libtiledb_fragment_info_get_non_empty_domain_var_index(XPtr<tiledb::FragmentInfo> fi,
-                                                       int32_t fid, int32_t did) {
-    check_xptr_tag<tiledb::FragmentInfo>(fi);
-    auto sp = fi->non_empty_domain_var(static_cast<uint32_t>(fid), static_cast<uint32_t>(did));
-    return CharacterVector::create(sp.first, sp.second);
+Rcpp::NumericVector libtiledb_fragment_info_get_non_empty_domain_name(
+    XPtr<tiledb::FragmentInfo> fi, int32_t fid, const std::string &dim_name,
+    const std::string &typestr) {
+  check_xptr_tag<tiledb::FragmentInfo>(fi);
+  if (typestr == "INT64") {
+    std::vector<int64_t> non_empty_dom(2);
+    fi->get_non_empty_domain(fid, dim_name, &non_empty_dom[0]);
+    return toInteger64(non_empty_dom);
+  } else if (typestr == "UINT64") {
+    std::vector<uint64_t> ned(2);
+    fi->get_non_empty_domain(fid, dim_name, &ned[0]);
+    std::vector<int64_t> v{static_cast<int64_t>(ned[0]),
+                           static_cast<int64_t>(ned[1])};
+    return toInteger64(v);
+  } else if (typestr == "INT32") {
+    std::vector<int32_t> non_empty_dom(2);
+    fi->get_non_empty_domain(fid, dim_name, &non_empty_dom[0]);
+    return NumericVector::create(non_empty_dom[0], non_empty_dom[1]);
+  } else if (typestr == "UINT32") {
+    std::vector<uint32_t> non_empty_dom(2);
+    fi->get_non_empty_domain(fid, dim_name, &non_empty_dom[0]);
+    return NumericVector::create(non_empty_dom[0], non_empty_dom[1]);
+  } else if (typestr == "INT16") {
+    std::vector<int16_t> non_empty_dom(2);
+    fi->get_non_empty_domain(fid, dim_name, &non_empty_dom[0]);
+    return NumericVector::create(non_empty_dom[0], non_empty_dom[1]);
+  } else if (typestr == "UINT16") {
+    std::vector<uint16_t> non_empty_dom(2);
+    fi->get_non_empty_domain(fid, dim_name, &non_empty_dom[0]);
+    return NumericVector::create(non_empty_dom[0], non_empty_dom[1]);
+  } else if (typestr == "INT8") {
+    std::vector<int8_t> non_empty_dom(2);
+    fi->get_non_empty_domain(fid, dim_name, &non_empty_dom[0]);
+    return NumericVector::create(non_empty_dom[0], non_empty_dom[1]);
+  } else if (typestr == "UINT8") {
+    std::vector<uint8_t> non_empty_dom(2);
+    fi->get_non_empty_domain(fid, dim_name, &non_empty_dom[0]);
+    return NumericVector::create(non_empty_dom[0], non_empty_dom[1]);
+  } else if (typestr == "FLOAT64") {
+    std::vector<double> non_empty_dom(2);
+    fi->get_non_empty_domain(fid, dim_name, &non_empty_dom[0]);
+    return NumericVector::create(non_empty_dom[0], non_empty_dom[1]);
+  } else if (typestr == "FLOAT32") {
+    std::vector<float> non_empty_dom(2);
+    fi->get_non_empty_domain(fid, dim_name, &non_empty_dom[0]);
+    return NumericVector::create(non_empty_dom[0], non_empty_dom[1]);
+  } else if (typestr == "DATETIME_YEAR" || typestr == "DATETIME_MONTH" ||
+             typestr == "DATETIME_WEEK" || typestr == "DATETIME_DAY" ||
+             typestr == "DATETIME_HR" || typestr == "DATETIME_MIN" ||
+             typestr == "DATETIME_SEC" || typestr == "DATETIME_MS" ||
+             typestr == "DATETIME_US" || typestr == "DATETIME_PS" ||
+             typestr == "DATETIME_FS" || typestr == "DATETIME_AS") {
+    // type_check() from exception.h gets invoked and wants an int64_t
+    std::vector<int64_t> non_empty_dom(2);
+    fi->get_non_empty_domain(fid, dim_name, &non_empty_dom[0]);
+    return toInteger64(non_empty_dom);
+  } else if (typestr == "DATETIME_NS") {
+    std::vector<int64_t> non_empty_dom(2);
+    fi->get_non_empty_domain(fid, dim_name, &non_empty_dom[0]);
+    return toNanotime(non_empty_dom);
+  } else {
+    Rcpp::stop("Currently unsupported tiledb domain type: '%s'",
+               typestr.c_str());
+    return NumericVector::create(NA_REAL, NA_REAL); // not reached
+  }
 }
 
 // [[Rcpp::export]]
-Rcpp::CharacterVector
-libtiledb_fragment_info_get_non_empty_domain_var_name(XPtr<tiledb::FragmentInfo> fi,
-                                                      int32_t fid,
-                                                      const std::string& dim_name) {
-    check_xptr_tag<tiledb::FragmentInfo>(fi);
-    auto sp = fi->non_empty_domain_var(static_cast<uint32_t>(fid), dim_name);
-    return CharacterVector::create(sp.first, sp.second);
+Rcpp::CharacterVector libtiledb_fragment_info_get_non_empty_domain_var_index(
+    XPtr<tiledb::FragmentInfo> fi, int32_t fid, int32_t did) {
+  check_xptr_tag<tiledb::FragmentInfo>(fi);
+  auto sp = fi->non_empty_domain_var(static_cast<uint32_t>(fid),
+                                     static_cast<uint32_t>(did));
+  return CharacterVector::create(sp.first, sp.second);
+}
+
+// [[Rcpp::export]]
+Rcpp::CharacterVector libtiledb_fragment_info_get_non_empty_domain_var_name(
+    XPtr<tiledb::FragmentInfo> fi, int32_t fid, const std::string &dim_name) {
+  check_xptr_tag<tiledb::FragmentInfo>(fi);
+  auto sp = fi->non_empty_domain_var(static_cast<uint32_t>(fid), dim_name);
+  return CharacterVector::create(sp.first, sp.second);
 }
 
 // [[Rcpp::export]]
 double libtiledb_fragment_info_num(XPtr<tiledb::FragmentInfo> fi) {
-    check_xptr_tag<tiledb::FragmentInfo>(fi);
-    return static_cast<double>(fi->fragment_num());
+  check_xptr_tag<tiledb::FragmentInfo>(fi);
+  return static_cast<double>(fi->fragment_num());
 }
 
 // [[Rcpp::export]]
-double libtiledb_fragment_info_size(XPtr<tiledb::FragmentInfo> fi, int32_t fid) {
-    check_xptr_tag<tiledb::FragmentInfo>(fi);
-    return static_cast<double>(fi->fragment_size(static_cast<uint32_t>(fid)));
+double libtiledb_fragment_info_size(XPtr<tiledb::FragmentInfo> fi,
+                                    int32_t fid) {
+  check_xptr_tag<tiledb::FragmentInfo>(fi);
+  return static_cast<double>(fi->fragment_size(static_cast<uint32_t>(fid)));
 }
 
 // [[Rcpp::export]]
 bool libtiledb_fragment_info_dense(XPtr<tiledb::FragmentInfo> fi, int32_t fid) {
-    check_xptr_tag<tiledb::FragmentInfo>(fi);
-    return fi->dense(static_cast<uint32_t>(fid));
+  check_xptr_tag<tiledb::FragmentInfo>(fi);
+  return fi->dense(static_cast<uint32_t>(fid));
 }
 
 // [[Rcpp::export]]
-bool libtiledb_fragment_info_sparse(XPtr<tiledb::FragmentInfo> fi, int32_t fid) {
-    check_xptr_tag<tiledb::FragmentInfo>(fi);
-    return fi->sparse(static_cast<uint32_t>(fid));
+bool libtiledb_fragment_info_sparse(XPtr<tiledb::FragmentInfo> fi,
+                                    int32_t fid) {
+  check_xptr_tag<tiledb::FragmentInfo>(fi);
+  return fi->sparse(static_cast<uint32_t>(fid));
 }
 
 // [[Rcpp::export]]
 Rcpp::DatetimeVector
-libtiledb_fragment_info_timestamp_range(XPtr<tiledb::FragmentInfo> fi, int32_t fid) {
-    check_xptr_tag<tiledb::FragmentInfo>(fi);
-    auto range = fi->timestamp_range(static_cast<uint32_t>(fid));
-    return Rcpp::DatetimeVector::create(range.first/1000.0, range.second/1000.0);
+libtiledb_fragment_info_timestamp_range(XPtr<tiledb::FragmentInfo> fi,
+                                        int32_t fid) {
+  check_xptr_tag<tiledb::FragmentInfo>(fi);
+  auto range = fi->timestamp_range(static_cast<uint32_t>(fid));
+  return Rcpp::DatetimeVector::create(range.first / 1000.0,
+                                      range.second / 1000.0);
 }
 
 // [[Rcpp::export]]
-double libtiledb_fragment_info_cell_num(XPtr<tiledb::FragmentInfo> fi, int32_t fid) {
-    check_xptr_tag<tiledb::FragmentInfo>(fi);
-    return static_cast<double>(fi->cell_num(static_cast<uint32_t>(fid)));
+double libtiledb_fragment_info_cell_num(XPtr<tiledb::FragmentInfo> fi,
+                                        int32_t fid) {
+  check_xptr_tag<tiledb::FragmentInfo>(fi);
+  return static_cast<double>(fi->cell_num(static_cast<uint32_t>(fid)));
 }
 
 // [[Rcpp::export]]
-int libtiledb_fragment_info_version(XPtr<tiledb::FragmentInfo> fi, int32_t fid) {
-    check_xptr_tag<tiledb::FragmentInfo>(fi);
-    return static_cast<int>(fi->version(static_cast<uint32_t>(fid)));
+int libtiledb_fragment_info_version(XPtr<tiledb::FragmentInfo> fi,
+                                    int32_t fid) {
+  check_xptr_tag<tiledb::FragmentInfo>(fi);
+  return static_cast<int>(fi->version(static_cast<uint32_t>(fid)));
 }
 
 // [[Rcpp::export]]
-bool libtiledb_fragment_info_has_consolidated_metadata(XPtr<tiledb::FragmentInfo> fi, int32_t fid) {
-    check_xptr_tag<tiledb::FragmentInfo>(fi);
-    return fi->has_consolidated_metadata(static_cast<uint32_t>(fid));
+bool libtiledb_fragment_info_has_consolidated_metadata(
+    XPtr<tiledb::FragmentInfo> fi, int32_t fid) {
+  check_xptr_tag<tiledb::FragmentInfo>(fi);
+  return fi->has_consolidated_metadata(static_cast<uint32_t>(fid));
 }
 
 // [[Rcpp::export]]
-double libtiledb_fragment_info_unconsolidated_metadata_num(XPtr<tiledb::FragmentInfo> fi) {
-    check_xptr_tag<tiledb::FragmentInfo>(fi);
-    return static_cast<double>(fi->unconsolidated_metadata_num());
+double libtiledb_fragment_info_unconsolidated_metadata_num(
+    XPtr<tiledb::FragmentInfo> fi) {
+  check_xptr_tag<tiledb::FragmentInfo>(fi);
+  return static_cast<double>(fi->unconsolidated_metadata_num());
 }
 
 // [[Rcpp::export]]
 double libtiledb_fragment_info_to_vacuum_num(XPtr<tiledb::FragmentInfo> fi) {
-    check_xptr_tag<tiledb::FragmentInfo>(fi);
-    return static_cast<double>(fi->to_vacuum_num());
+  check_xptr_tag<tiledb::FragmentInfo>(fi);
+  return static_cast<double>(fi->to_vacuum_num());
 }
 
 // [[Rcpp::export]]
-std::string libtiledb_fragment_info_to_vacuum_uri(XPtr<tiledb::FragmentInfo> fi, int32_t fid) {
-    check_xptr_tag<tiledb::FragmentInfo>(fi);
-    return fi->to_vacuum_uri(static_cast<uint32_t>(fid));
+std::string libtiledb_fragment_info_to_vacuum_uri(XPtr<tiledb::FragmentInfo> fi,
+                                                  int32_t fid) {
+  check_xptr_tag<tiledb::FragmentInfo>(fi);
+  return fi->to_vacuum_uri(static_cast<uint32_t>(fid));
 }
 
 // [[Rcpp::export]]
 void libtiledb_fragment_info_dump(XPtr<tiledb::FragmentInfo> fi) {
-    check_xptr_tag<tiledb::FragmentInfo>(fi);
-#if TILEDB_VERSION >= TileDB_Version(2,27,0)
-    std::stringstream ss;
-    ss << *fi;
-    Rcpp::Rcout << ss.str();
+  check_xptr_tag<tiledb::FragmentInfo>(fi);
+#if TILEDB_VERSION >= TileDB_Version(2, 27, 0)
+  std::stringstream ss;
+  ss << *fi;
+  Rcpp::Rcout << ss.str();
 #else
-    fi->dump();
+  fi->dump();
 #endif
 }
 
 // [[Rcpp::export]]
 std::string libtiledb_error_message(XPtr<tiledb::Context> ctx) {
-    check_xptr_tag<tiledb::Context>(ctx);
-    tiledb::Error error(*ctx.get());
-    std::string txt(error.error_message());
-    return txt;
+  check_xptr_tag<tiledb::Context>(ctx);
+  tiledb::Error error(*ctx.get());
+  std::string txt(error.error_message());
+  return txt;
 }
-
-
 
 /**
  * Groups
  */
 // [[Rcpp::export]]
 XPtr<tiledb::Group> libtiledb_group(XPtr<tiledb::Context> ctx,
-                                    const std::string& uri,
-                                    const std::string& querytypestr) {
-    check_xptr_tag<tiledb::Context>(ctx);
-#if TILEDB_VERSION >= TileDB_Version(2,8,0)
-    tiledb_query_type_t querytype = _string_to_tiledb_query_type(querytypestr);
-    auto p = new tiledb::Group(*ctx.get(), uri, querytype);
-    XPtr<tiledb::Group> ptr = make_xptr<tiledb::Group>(p);
+                                    const std::string &uri,
+                                    const std::string &querytypestr) {
+  check_xptr_tag<tiledb::Context>(ctx);
+#if TILEDB_VERSION >= TileDB_Version(2, 8, 0)
+  tiledb_query_type_t querytype = _string_to_tiledb_query_type(querytypestr);
+  auto p = new tiledb::Group(*ctx.get(), uri, querytype);
+  XPtr<tiledb::Group> ptr = make_xptr<tiledb::Group>(p);
 #else
-    XPtr<tiledb::Group> ptr(new tiledb::Group()); // placeholder
+  XPtr<tiledb::Group> ptr(new tiledb::Group()); // placeholder
 #endif
-    return ptr;
+  return ptr;
 }
 
 // Interfaces to R are C-based so we cannot overload just on signature
 // [[Rcpp::export]]
 XPtr<tiledb::Group> libtiledb_group_with_config(XPtr<tiledb::Context> ctx,
-                                                const std::string& uri,
-                                                const std::string& querytypestr,
+                                                const std::string &uri,
+                                                const std::string &querytypestr,
                                                 XPtr<tiledb::Config> cfg) {
-    check_xptr_tag<tiledb::Context>(ctx);
-    check_xptr_tag<tiledb::Config>(cfg);
-    tiledb_query_type_t querytype = _string_to_tiledb_query_type(querytypestr);
-#if TILEDB_VERSION >= TileDB_Version(2,15,1)
-    auto p = new tiledb::Group(*ctx.get(), uri, querytype, *cfg.get());
-    XPtr<tiledb::Group> ptr = make_xptr<tiledb::Group>(p);
-#elif TILEDB_VERSION >= TileDB_Version(2,8,0)
-    Rcpp::warning("libtiledb_group_with_config should only called with TileDB 2.15.1 or later");
-    auto p = new tiledb::Group(*ctx.get(), uri, querytype); // placeholder
-    XPtr<tiledb::Group> ptr = make_xptr<tiledb::Group>(p);
+  check_xptr_tag<tiledb::Context>(ctx);
+  check_xptr_tag<tiledb::Config>(cfg);
+  tiledb_query_type_t querytype = _string_to_tiledb_query_type(querytypestr);
+#if TILEDB_VERSION >= TileDB_Version(2, 15, 1)
+  auto p = new tiledb::Group(*ctx.get(), uri, querytype, *cfg.get());
+  XPtr<tiledb::Group> ptr = make_xptr<tiledb::Group>(p);
+#elif TILEDB_VERSION >= TileDB_Version(2, 8, 0)
+  Rcpp::warning("libtiledb_group_with_config should only called with TileDB "
+                "2.15.1 or later");
+  auto p = new tiledb::Group(*ctx.get(), uri, querytype); // placeholder
+  XPtr<tiledb::Group> ptr = make_xptr<tiledb::Group>(p);
 #else
-    XPtr<tiledb::Group> ptr(new tiledb::Group()); // placeholder
+  XPtr<tiledb::Group> ptr(new tiledb::Group()); // placeholder
 #endif
-    return ptr;
+  return ptr;
 }
-
 
 // [[Rcpp::export]]
 XPtr<tiledb::Group> libtiledb_group_open(XPtr<tiledb::Group> grp,
-                                         const std::string& querytypestr) {
-    check_xptr_tag<tiledb::Group>(grp);
-#if TILEDB_VERSION >= TileDB_Version(2,8,0)
-    tiledb_query_type_t querytype = _string_to_tiledb_query_type(querytypestr);
-    grp->open(querytype);
+                                         const std::string &querytypestr) {
+  check_xptr_tag<tiledb::Group>(grp);
+#if TILEDB_VERSION >= TileDB_Version(2, 8, 0)
+  tiledb_query_type_t querytype = _string_to_tiledb_query_type(querytypestr);
+  grp->open(querytype);
 #endif
-    return grp;
+  return grp;
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::Group> libtiledb_group_set_config(XPtr<tiledb::Group> grp, XPtr<tiledb::Config> cfg) {
-    check_xptr_tag<tiledb::Group>(grp);
-    check_xptr_tag<tiledb::Config>(cfg);
-#if TILEDB_VERSION >= TileDB_Version(2,8,0)
-    grp->set_config(*cfg.get());
+XPtr<tiledb::Group> libtiledb_group_set_config(XPtr<tiledb::Group> grp,
+                                               XPtr<tiledb::Config> cfg) {
+  check_xptr_tag<tiledb::Group>(grp);
+  check_xptr_tag<tiledb::Config>(cfg);
+#if TILEDB_VERSION >= TileDB_Version(2, 8, 0)
+  grp->set_config(*cfg.get());
 #endif
-    return grp;
+  return grp;
 }
 
 // [[Rcpp::export]]
 XPtr<tiledb::Config> libtiledb_group_get_config(XPtr<tiledb::Group> grp) {
-    check_xptr_tag<tiledb::Group>(grp);
-#if TILEDB_VERSION >= TileDB_Version(2,8,0)
-    auto ptr = make_xptr<tiledb::Config>(new tiledb::Config(grp.get()->config()));
-    return ptr;
+  check_xptr_tag<tiledb::Group>(grp);
+#if TILEDB_VERSION >= TileDB_Version(2, 8, 0)
+  auto ptr = make_xptr<tiledb::Config>(new tiledb::Config(grp.get()->config()));
+  return ptr;
 #else
-    return make_xptr<tiledb::Config>(new tiledb::Config());
+  return make_xptr<tiledb::Config>(new tiledb::Config());
 #endif
 }
 
 // [[Rcpp::export]]
 XPtr<tiledb::Group> libtiledb_group_close(XPtr<tiledb::Group> grp) {
-    check_xptr_tag<tiledb::Group>(grp);
-#if TILEDB_VERSION >= TileDB_Version(2,8,0)
-    grp->close();
+  check_xptr_tag<tiledb::Group>(grp);
+#if TILEDB_VERSION >= TileDB_Version(2, 8, 0)
+  grp->close();
 #endif
-    return grp;
+  return grp;
 }
 
 // [[Rcpp::export]]
-std::string libtiledb_group_create(XPtr<tiledb::Context> ctx, const std::string& uri) {
-    check_xptr_tag<tiledb::Context>(ctx);
-#if TILEDB_VERSION >= TileDB_Version(2,8,0)
-    tiledb::Group::create(*ctx.get(), uri);
+std::string libtiledb_group_create(XPtr<tiledb::Context> ctx,
+                                   const std::string &uri) {
+  check_xptr_tag<tiledb::Context>(ctx);
+#if TILEDB_VERSION >= TileDB_Version(2, 8, 0)
+  tiledb::Group::create(*ctx.get(), uri);
 #endif
-    return uri;
+  return uri;
 }
 
 // [[Rcpp::export]]
 bool libtiledb_group_is_open(XPtr<tiledb::Group> grp) {
-    check_xptr_tag<tiledb::Group>(grp);
-#if TILEDB_VERSION >= TileDB_Version(2,8,0)
-    return grp->is_open();
+  check_xptr_tag<tiledb::Group>(grp);
+#if TILEDB_VERSION >= TileDB_Version(2, 8, 0)
+  return grp->is_open();
 #else
-    return FALSE;
+  return FALSE;
 #endif
 }
 
 // [[Rcpp::export]]
 std::string libtiledb_group_uri(XPtr<tiledb::Group> grp) {
-    check_xptr_tag<tiledb::Group>(grp);
-#if TILEDB_VERSION >= TileDB_Version(2,8,0)
-    return grp->uri();
+  check_xptr_tag<tiledb::Group>(grp);
+#if TILEDB_VERSION >= TileDB_Version(2, 8, 0)
+  return grp->uri();
 #else
-    return std::string("");
+  return std::string("");
 #endif
 }
 
 // [[Rcpp::export]]
 std::string libtiledb_group_query_type(XPtr<tiledb::Group> grp) {
-    check_xptr_tag<tiledb::Group>(grp);
-#if TILEDB_VERSION >= TileDB_Version(2,8,0)
-    return _tiledb_query_type_to_string(grp->query_type());
+  check_xptr_tag<tiledb::Group>(grp);
+#if TILEDB_VERSION >= TileDB_Version(2, 8, 0)
+  return _tiledb_query_type_to_string(grp->query_type());
 #else
-    return std::string("");
+  return std::string("");
 #endif
 }
 
 // [[Rcpp::export]]
-bool libtiledb_group_put_metadata(XPtr<tiledb::Group> grp, std::string key, SEXP obj) {
-    check_xptr_tag<tiledb::Group>(grp);
-#if TILEDB_VERSION >= TileDB_Version(2,8,0)
-    // we implement a simpler interface here as the 'type' is given from
-    // the supplied SEXP, as is the extent
-    switch(TYPEOF(obj)) {
-    case VECSXP: {
-        Rcpp::stop("List objects are not supported.");
-        break;// not reached
-        }
-    case REALSXP: {
-        Rcpp::NumericVector v(obj);
-        grp->put_metadata(key, TILEDB_FLOAT64, v.size(), v.begin());
-        break;
-    }
-    case INTSXP: {
-        Rcpp::IntegerVector v(obj);
-        grp->put_metadata(key, TILEDB_INT32, v.size(), v.begin());
-        break;
-    }
-    case STRSXP: {
-        Rcpp::CharacterVector v(obj);
-        std::string s(v[0]);
-        // We use TILEDB_CHAR interchangeably with TILEDB_STRING_ASCII is this best string type?
-        grp->put_metadata(key, TILEDB_STRING_ASCII, s.length(), s.c_str());
-        break;
-    }
-    case LGLSXP: {              // experimental: map R logical (ie TRUE, FALSE, NA) to int8
-        Rcpp::stop("Logical vector objects are not supported.");
-        break;// not reached
-    }
-    default: {
-        Rcpp::stop("No support (yet) for type '%s'.", Rf_type2char(TYPEOF(obj)));
-        break; // not reached
-    }
-    }
+bool libtiledb_group_put_metadata(XPtr<tiledb::Group> grp, std::string key,
+                                  SEXP obj) {
+  check_xptr_tag<tiledb::Group>(grp);
+#if TILEDB_VERSION >= TileDB_Version(2, 8, 0)
+  // we implement a simpler interface here as the 'type' is given from
+  // the supplied SEXP, as is the extent
+  switch (TYPEOF(obj)) {
+  case VECSXP: {
+    Rcpp::stop("List objects are not supported.");
+    break; // not reached
+  }
+  case REALSXP: {
+    Rcpp::NumericVector v(obj);
+    grp->put_metadata(key, TILEDB_FLOAT64, v.size(), v.begin());
+    break;
+  }
+  case INTSXP: {
+    Rcpp::IntegerVector v(obj);
+    grp->put_metadata(key, TILEDB_INT32, v.size(), v.begin());
+    break;
+  }
+  case STRSXP: {
+    Rcpp::CharacterVector v(obj);
+    std::string s(v[0]);
+    // We use TILEDB_CHAR interchangeably with TILEDB_STRING_ASCII is this best
+    // string type?
+    grp->put_metadata(key, TILEDB_STRING_ASCII, s.length(), s.c_str());
+    break;
+  }
+  case LGLSXP: { // experimental: map R logical (ie TRUE, FALSE, NA) to int8
+    Rcpp::stop("Logical vector objects are not supported.");
+    break; // not reached
+  }
+  default: {
+    Rcpp::stop("No support (yet) for type '%s'.", Rf_type2char(TYPEOF(obj)));
+    break; // not reached
+  }
+  }
 #endif
-    return true;
+  return true;
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::Group> libtiledb_group_delete_metadata(XPtr<tiledb::Group> grp, std::string key) {
-    check_xptr_tag<tiledb::Group>(grp);
-#if TILEDB_VERSION >= TileDB_Version(2,8,0)
-    grp->delete_metadata(key);
+XPtr<tiledb::Group> libtiledb_group_delete_metadata(XPtr<tiledb::Group> grp,
+                                                    std::string key) {
+  check_xptr_tag<tiledb::Group>(grp);
+#if TILEDB_VERSION >= TileDB_Version(2, 8, 0)
+  grp->delete_metadata(key);
 #endif
-    return grp;
+  return grp;
 }
 
 // [[Rcpp::export]]
 SEXP libtiledb_group_get_metadata(XPtr<tiledb::Group> grp, std::string key) {
-    check_xptr_tag<tiledb::Group>(grp);
-#if TILEDB_VERSION >= TileDB_Version(2,8,0)
-    tiledb_datatype_t v_type;
-    uint32_t v_num;
-    const void* v;
-    grp->get_metadata(key, &v_type, &v_num, &v);
-    if (v == NULL) {
-        return R_NilValue;
-    }
-    RObject vec = _metadata_to_sexp(v_type, v_num, v);
-    vec.attr("key") = Rcpp::CharacterVector::create(key);
-    return vec;
-#else
+  check_xptr_tag<tiledb::Group>(grp);
+#if TILEDB_VERSION >= TileDB_Version(2, 8, 0)
+  tiledb_datatype_t v_type;
+  uint32_t v_num;
+  const void *v;
+  grp->get_metadata(key, &v_type, &v_num, &v);
+  if (v == NULL) {
     return R_NilValue;
+  }
+  RObject vec = _metadata_to_sexp(v_type, v_num, v);
+  vec.attr("key") = Rcpp::CharacterVector::create(key);
+  return vec;
+#else
+  return R_NilValue;
 #endif
 }
 
 // [[Rcpp::export]]
 bool libtiledb_group_has_metadata(XPtr<tiledb::Group> grp, std::string key) {
-    check_xptr_tag<tiledb::Group>(grp);
-#if TILEDB_VERSION >= TileDB_Version(2,8,0)
-    tiledb_datatype_t value_type; // set by C++ API on return, not returned to R
-    return grp->has_metadata(key, &value_type);
+  check_xptr_tag<tiledb::Group>(grp);
+#if TILEDB_VERSION >= TileDB_Version(2, 8, 0)
+  tiledb_datatype_t value_type; // set by C++ API on return, not returned to R
+  return grp->has_metadata(key, &value_type);
 #else
-    return false;
+  return false;
 #endif
 }
 
 // [[Rcpp::export]]
 double libtiledb_group_metadata_num(XPtr<tiledb::Group> grp) {
-    check_xptr_tag<tiledb::Group>(grp);
-#if TILEDB_VERSION >= TileDB_Version(2,8,0)
-    return grp->metadata_num();
+  check_xptr_tag<tiledb::Group>(grp);
+#if TILEDB_VERSION >= TileDB_Version(2, 8, 0)
+  return grp->metadata_num();
 #else
-    return 0;
+  return 0;
 #endif
 }
 
 // [[Rcpp::export]]
 SEXP libtiledb_group_get_metadata_from_index(XPtr<tiledb::Group> grp, int idx) {
-    check_xptr_tag<tiledb::Group>(grp);
-#if TILEDB_VERSION >= TileDB_Version(2,8,0)
-    std::string key;
-    tiledb_datatype_t v_type;
-    uint32_t v_num;
-    const void* v;
-    grp->get_metadata_from_index(static_cast<uint64_t>(idx), &key, &v_type, &v_num, &v);
-    if (v == NULL) {
-        return R_NilValue;
-    }
-    RObject vec = _metadata_to_sexp(v_type, v_num, v);
-    vec.attr("key") = Rcpp::CharacterVector::create(key);
-    return vec;
-#else
+  check_xptr_tag<tiledb::Group>(grp);
+#if TILEDB_VERSION >= TileDB_Version(2, 8, 0)
+  std::string key;
+  tiledb_datatype_t v_type;
+  uint32_t v_num;
+  const void *v;
+  grp->get_metadata_from_index(static_cast<uint64_t>(idx), &key, &v_type,
+                               &v_num, &v);
+  if (v == NULL) {
     return R_NilValue;
+  }
+  RObject vec = _metadata_to_sexp(v_type, v_num, v);
+  vec.attr("key") = Rcpp::CharacterVector::create(key);
+  return vec;
+#else
+  return R_NilValue;
 #endif
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::Group> libtiledb_group_add_member(XPtr<tiledb::Group> grp,
-                                               std::string uri, bool relative,
-                                               Nullable<Rcpp::String> optional_name = R_NilValue) {
-    check_xptr_tag<tiledb::Group>(grp);
-#if TILEDB_VERSION >= TileDB_Version(2,8,0)
-    if (optional_name.isNotNull()) {
-        Rcpp::String string_name(optional_name);
-        std::string name(string_name);
-        grp->add_member(uri, relative, name);
-    } else {
-        grp->add_member(uri, relative);
-    }
+XPtr<tiledb::Group>
+libtiledb_group_add_member(XPtr<tiledb::Group> grp, std::string uri,
+                           bool relative,
+                           Nullable<Rcpp::String> optional_name = R_NilValue) {
+  check_xptr_tag<tiledb::Group>(grp);
+#if TILEDB_VERSION >= TileDB_Version(2, 8, 0)
+  if (optional_name.isNotNull()) {
+    Rcpp::String string_name(optional_name);
+    std::string name(string_name);
+    grp->add_member(uri, relative, name);
+  } else {
+    grp->add_member(uri, relative);
+  }
 #endif
-    return grp;
+  return grp;
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::Group> libtiledb_group_remove_member(XPtr<tiledb::Group> grp, std::string uri) {
-    check_xptr_tag<tiledb::Group>(grp);
-#if TILEDB_VERSION >= TileDB_Version(2,8,0)
-    grp->remove_member(uri);
+XPtr<tiledb::Group> libtiledb_group_remove_member(XPtr<tiledb::Group> grp,
+                                                  std::string uri) {
+  check_xptr_tag<tiledb::Group>(grp);
+#if TILEDB_VERSION >= TileDB_Version(2, 8, 0)
+  grp->remove_member(uri);
 #endif
-    return grp;
+  return grp;
 }
 
 // [[Rcpp::export]]
 double libtiledb_group_member_count(XPtr<tiledb::Group> grp) {
-    check_xptr_tag<tiledb::Group>(grp);
-#if TILEDB_VERSION >= TileDB_Version(2,8,0)
-    return grp->member_count();
+  check_xptr_tag<tiledb::Group>(grp);
+#if TILEDB_VERSION >= TileDB_Version(2, 8, 0)
+  return grp->member_count();
 #else
-    return 0;
+  return 0;
 #endif
 }
 
 // [[Rcpp::export]]
 CharacterVector libtiledb_group_member(XPtr<tiledb::Group> grp, int idx) {
-    check_xptr_tag<tiledb::Group>(grp);
-#if TILEDB_VERSION >= TileDB_Version(2,8,0)
-    tiledb::Object obj = grp->member(idx);
-    CharacterVector v = CharacterVector::create(_object_type_to_string(obj.type()), obj.uri(), obj.name().value_or(""));
+  check_xptr_tag<tiledb::Group>(grp);
+#if TILEDB_VERSION >= TileDB_Version(2, 8, 0)
+  tiledb::Object obj = grp->member(idx);
+  CharacterVector v = CharacterVector::create(
+      _object_type_to_string(obj.type()), obj.uri(), obj.name().value_or(""));
 #else
-    CharacterVector v = CharacterVector::create("", "", "");
+  CharacterVector v = CharacterVector::create("", "", "");
 #endif
-    return v;
+  return v;
 }
 
 // [[Rcpp::export]]
 std::string libtiledb_group_dump(XPtr<tiledb::Group> grp, bool recursive) {
-    check_xptr_tag<tiledb::Group>(grp);
-#if TILEDB_VERSION >= TileDB_Version(2,8,0)
-    return grp->dump(recursive);
+  check_xptr_tag<tiledb::Group>(grp);
+#if TILEDB_VERSION >= TileDB_Version(2, 8, 0)
+  return grp->dump(recursive);
 #else
-    return std::string("");
+  return std::string("");
 #endif
 }
 
 // [[Rcpp::export]]
-bool libtiledb_group_is_relative(XPtr<tiledb::Group> grp, const std::string &name) {
-    check_xptr_tag<tiledb::Group>(grp);
-#if TILEDB_VERSION >= TileDB_Version(2,12,0)
-    return grp->is_relative(name);
+bool libtiledb_group_is_relative(XPtr<tiledb::Group> grp,
+                                 const std::string &name) {
+  check_xptr_tag<tiledb::Group>(grp);
+#if TILEDB_VERSION >= TileDB_Version(2, 12, 0)
+  return grp->is_relative(name);
 #else
-    return false;
+  return false;
 #endif
 }
 
 // See comments in group.h: the group has to be opened in MODIFY_EXCLUSIVE mode
 // The function throws (creating an R error) is that condition is not met
 // [[Rcpp::export]]
-void libtiledb_group_delete(XPtr<tiledb::Group> grp,
-                            const std::string& uri,
+void libtiledb_group_delete(XPtr<tiledb::Group> grp, const std::string &uri,
                             const bool recursive = false) {
-    check_xptr_tag<tiledb::Group>(grp);
-#if TILEDB_VERSION >= TileDB_Version(2,14,0)
-    grp->delete_group(uri, recursive);
+  check_xptr_tag<tiledb::Group>(grp);
+#if TILEDB_VERSION >= TileDB_Version(2, 14, 0)
+  grp->delete_group(uri, recursive);
 #else
-    Rcpp::message(Rcpp::wrap("This function is only available with TileDB Core 2.14.0 or later"));
+  Rcpp::message(Rcpp::wrap(
+      "This function is only available with TileDB Core 2.14.0 or later"));
 #endif
 }
-
-
 
 /**
  * Filestore (via tiledb_experimental.h)
@@ -5282,23 +5531,23 @@ void libtiledb_group_delete(XPtr<tiledb::Group> grp,
 
 // Creates array schema based on URL, or default schema if no URI provided
 // [[Rcpp::export]]
-XPtr<tiledb::ArraySchema> libtiledb_filestore_schema_create(XPtr<tiledb::Context> ctx,
-                                                            std::string uri) {
-#if TILEDB_VERSION >= TileDB_Version(2,9,0)
-    tiledb_ctx_t* ctx_ptr = ctx->ptr().get();
-    tiledb_array_schema_t* schema_type_ptr;
-    if (tiledb_filestore_schema_create(ctx_ptr,
-                                       (uri == "" ? nullptr : uri.c_str()),
-                                       &schema_type_ptr) == TILEDB_ERR) {
-        Rcpp::stop("Error creating array schema from defaults");
-    }
-    auto schptr = new tiledb::ArraySchema(*ctx.get(), schema_type_ptr);
-    auto schema = make_xptr<tiledb::ArraySchema>(schptr);
-    return schema;
+XPtr<tiledb::ArraySchema>
+libtiledb_filestore_schema_create(XPtr<tiledb::Context> ctx, std::string uri) {
+#if TILEDB_VERSION >= TileDB_Version(2, 9, 0)
+  tiledb_ctx_t *ctx_ptr = ctx->ptr().get();
+  tiledb_array_schema_t *schema_type_ptr;
+  if (tiledb_filestore_schema_create(ctx_ptr,
+                                     (uri == "" ? nullptr : uri.c_str()),
+                                     &schema_type_ptr) == TILEDB_ERR) {
+    Rcpp::stop("Error creating array schema from defaults");
+  }
+  auto schptr = new tiledb::ArraySchema(*ctx.get(), schema_type_ptr);
+  auto schema = make_xptr<tiledb::ArraySchema>(schptr);
+  return schema;
 #else
-    auto schptr = new tiledb::ArraySchema(*ctx.get(), TILEDB_SPARSE);
-    auto schema = make_xptr<tiledb::ArraySchema>(schptr);
-    return schema;
+  auto schptr = new tiledb::ArraySchema(*ctx.get(), TILEDB_SPARSE);
+  auto schema = make_xptr<tiledb::ArraySchema>(schptr);
+  return schema;
 #endif
 }
 
@@ -5307,18 +5556,18 @@ XPtr<tiledb::ArraySchema> libtiledb_filestore_schema_create(XPtr<tiledb::Context
 bool libtiledb_filestore_uri_import(XPtr<tiledb::Context> ctx,
                                     std::string filestore_uri,
                                     std::string file_uri) {
-#if TILEDB_VERSION >= TileDB_Version(2,9,0)
-    tiledb_ctx_t* ctx_ptr = ctx->ptr().get();
-    if (tiledb_filestore_uri_import(ctx_ptr, filestore_uri.c_str(),
-                                    file_uri.c_str(), TILEDB_MIME_AUTODETECT) == TILEDB_ERR) {
-        Rcpp::stop("Error importing file into filestore");
-        return false;           // not reached
-    }
-    return true;
+#if TILEDB_VERSION >= TileDB_Version(2, 9, 0)
+  tiledb_ctx_t *ctx_ptr = ctx->ptr().get();
+  if (tiledb_filestore_uri_import(ctx_ptr, filestore_uri.c_str(),
+                                  file_uri.c_str(),
+                                  TILEDB_MIME_AUTODETECT) == TILEDB_ERR) {
+    Rcpp::stop("Error importing file into filestore");
+    return false; // not reached
+  }
+  return true;
 #else
-    return false;
+  return false;
 #endif
-
 }
 
 // Export from a TileDB filestore array into a file uri
@@ -5326,15 +5575,16 @@ bool libtiledb_filestore_uri_import(XPtr<tiledb::Context> ctx,
 bool libtiledb_filestore_uri_export(XPtr<tiledb::Context> ctx,
                                     std::string file_uri,
                                     std::string filestore_uri) {
-#if TILEDB_VERSION >= TileDB_Version(2,9,0)
-    tiledb_ctx_t* ctx_ptr = ctx->ptr().get();
-    if (tiledb_filestore_uri_export(ctx_ptr, file_uri.c_str(), filestore_uri.c_str())  == TILEDB_ERR) {
-        Rcpp::stop("Error exporting file from filestore");
-        return false;           // not reached
-    }
-    return true;
+#if TILEDB_VERSION >= TileDB_Version(2, 9, 0)
+  tiledb_ctx_t *ctx_ptr = ctx->ptr().get();
+  if (tiledb_filestore_uri_export(ctx_ptr, file_uri.c_str(),
+                                  filestore_uri.c_str()) == TILEDB_ERR) {
+    Rcpp::stop("Error exporting file from filestore");
+    return false; // not reached
+  }
+  return true;
 #else
-    return false;
+  return false;
 #endif
 }
 
@@ -5343,17 +5593,17 @@ bool libtiledb_filestore_uri_export(XPtr<tiledb::Context> ctx,
 bool libtiledb_filestore_buffer_import(XPtr<tiledb::Context> ctx,
                                        std::string filestore_uri,
                                        std::string buf, size_t size) {
-#if TILEDB_VERSION >= TileDB_Version(2,9,0)
-    tiledb_ctx_t* ctx_ptr = ctx->ptr().get();
-    if (tiledb_filestore_buffer_import(ctx_ptr, filestore_uri.c_str(),
-                                       static_cast<void*>(buf.data()), size,
-                                       TILEDB_MIME_AUTODETECT) == TILEDB_ERR) {
-        Rcpp::stop("Error importing file into filestore");
-        return false;           // not reached
-    }
-    return true;
+#if TILEDB_VERSION >= TileDB_Version(2, 9, 0)
+  tiledb_ctx_t *ctx_ptr = ctx->ptr().get();
+  if (tiledb_filestore_buffer_import(ctx_ptr, filestore_uri.c_str(),
+                                     static_cast<void *>(buf.data()), size,
+                                     TILEDB_MIME_AUTODETECT) == TILEDB_ERR) {
+    Rcpp::stop("Error importing file into filestore");
+    return false; // not reached
+  }
+  return true;
 #else
-    return false;
+  return false;
 #endif
 }
 
@@ -5362,281 +5612,290 @@ bool libtiledb_filestore_buffer_import(XPtr<tiledb::Context> ctx,
 std::string libtiledb_filestore_buffer_export(XPtr<tiledb::Context> ctx,
                                               std::string filestore_uri,
                                               size_t offset, size_t size) {
-    std::string buf("");
-#if TILEDB_VERSION >= TileDB_Version(2,9,0)
-    tiledb_ctx_t* ctx_ptr = ctx->ptr().get();
-    buf.resize(size);
-    if (tiledb_filestore_buffer_export(ctx_ptr, filestore_uri.c_str(), offset,
-                                       static_cast<void*>(buf.data()), size) == TILEDB_ERR) {
-        Rcpp::stop("Error exporting file from filestore");
-    }
+  std::string buf("");
+#if TILEDB_VERSION >= TileDB_Version(2, 9, 0)
+  tiledb_ctx_t *ctx_ptr = ctx->ptr().get();
+  buf.resize(size);
+  if (tiledb_filestore_buffer_export(ctx_ptr, filestore_uri.c_str(), offset,
+                                     static_cast<void *>(buf.data()),
+                                     size) == TILEDB_ERR) {
+    Rcpp::stop("Error exporting file from filestore");
+  }
 #endif
-    return buf;
-
+  return buf;
 }
 
 // Get size of uncompressed TileDB filestore array
 // [[Rcpp::export]]
-size_t libtiledb_filestore_size(XPtr<tiledb::Context> ctx, std::string filestore_uri) {
-    size_t sz = 0;
-#if TILEDB_VERSION >= TileDB_Version(2,9,0)
-    tiledb_ctx_t* ctx_ptr = ctx->ptr().get();
-    if (tiledb_filestore_size(ctx_ptr, filestore_uri.c_str(), &sz) == TILEDB_ERR) {
-        Rcpp::stop("Error accessize filestore uri size");
-    }
+size_t libtiledb_filestore_size(XPtr<tiledb::Context> ctx,
+                                std::string filestore_uri) {
+  size_t sz = 0;
+#if TILEDB_VERSION >= TileDB_Version(2, 9, 0)
+  tiledb_ctx_t *ctx_ptr = ctx->ptr().get();
+  if (tiledb_filestore_size(ctx_ptr, filestore_uri.c_str(), &sz) ==
+      TILEDB_ERR) {
+    Rcpp::stop("Error accessize filestore uri size");
+  }
 #endif
-    return sz;
+  return sz;
 }
 
 // Get MIME type of TileDB filestore as string
 // [[Rcpp::export]]
 std::string libtiledb_mime_type_to_str(int32_t mime_type) {
-#if TILEDB_VERSION >= TileDB_Version(2,9,0)
-    const char* ptr;
-    if (tiledb_mime_type_to_str(static_cast<tiledb_mime_type_t>(mime_type),
-                                &ptr) == TILEDB_ERR) {
-        Rcpp::stop("Error converting mime type to string");
-    }
-    return std::string(ptr);
+#if TILEDB_VERSION >= TileDB_Version(2, 9, 0)
+  const char *ptr;
+  if (tiledb_mime_type_to_str(static_cast<tiledb_mime_type_t>(mime_type),
+                              &ptr) == TILEDB_ERR) {
+    Rcpp::stop("Error converting mime type to string");
+  }
+  return std::string(ptr);
 #else
-    return std::string("");
+  return std::string("");
 #endif
 }
 
 // Create MIME type of TileDB filestore from string
 // [[Rcpp::export]]
 int32_t libtiledb_mime_type_from_str(std::string mime_type) {
-#if TILEDB_VERSION >= TileDB_Version(2,9,0)
-    tiledb_mime_type_t mt;
-    if (tiledb_mime_type_from_str(mime_type.c_str(), &mt) == TILEDB_ERR) {
-        Rcpp::stop("Error converting mime type from string");
-    }
-    return static_cast<int32_t>(mt);
+#if TILEDB_VERSION >= TileDB_Version(2, 9, 0)
+  tiledb_mime_type_t mt;
+  if (tiledb_mime_type_from_str(mime_type.c_str(), &mt) == TILEDB_ERR) {
+    Rcpp::stop("Error converting mime type from string");
+  }
+  return static_cast<int32_t>(mt);
 #else
-    return -1;
+  return -1;
 #endif
 }
-
 
 /**
  * NDRectangle (2.25.0 or later)
  */
 
 // [[Rcpp::export]]
-XPtr<tiledb::NDRectangle> libtiledb_ndrectangle_create(XPtr<tiledb::Context> ctx,
-                                                       XPtr<tiledb::Domain> dom) {
-    check_xptr_tag<tiledb::Context>(ctx);
-    check_xptr_tag<tiledb::Domain>(dom);
-#if TILEDB_VERSION >= TileDB_Version(2,25,0)
-    auto ndr = new tiledb::NDRectangle(*ctx.get(), *dom.get());
+XPtr<tiledb::NDRectangle>
+libtiledb_ndrectangle_create(XPtr<tiledb::Context> ctx,
+                             XPtr<tiledb::Domain> dom) {
+  check_xptr_tag<tiledb::Context>(ctx);
+  check_xptr_tag<tiledb::Domain>(dom);
+#if TILEDB_VERSION >= TileDB_Version(2, 25, 0)
+  auto ndr = new tiledb::NDRectangle(*ctx.get(), *dom.get());
 #else
-    auto ndr = new tiledb::NDRectangle();
+  auto ndr = new tiledb::NDRectangle();
 #endif
-    auto ptr = make_xptr<tiledb::NDRectangle>(ndr);
-    return ptr;
+  auto ptr = make_xptr<tiledb::NDRectangle>(ndr);
+  return ptr;
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::NDRectangle> libtiledb_ndrectangle_set_range(XPtr<tiledb::NDRectangle> ndr,
-                                                          std::string& datatype,
-                                                          std::string& dimname,
-                                                          SEXP start, SEXP end) {
-    check_xptr_tag<tiledb::NDRectangle>(ndr);
-#if TILEDB_VERSION >= TileDB_Version(2,25,0)
-    auto dtype = _string_to_tiledb_datatype(datatype);
-    if (dtype == TILEDB_CHAR ||         // branch for 'string'
-        dtype == TILEDB_STRING_ASCII ||
-        dtype == TILEDB_STRING_UTF8) {
-        ndr->set_range(dimname, Rcpp::as<std::string>(start), Rcpp::as<std::string>(end));
-    } else if (dtype == TILEDB_INT64) {
-        ndr->set_range<int64_t>(dimname, Rcpp::fromInteger64(start), Rcpp::fromInteger64(end));
-    } else if (dtype == TILEDB_UINT64) {
-        ndr->set_range<int64_t>(dimname,
-                                static_cast<uint64_t>(Rcpp::fromInteger64(Rcpp::as<double>(start))),
-                                static_cast<uint64_t>(Rcpp::fromInteger64(Rcpp::as<double>(end))));
-    } else if (dtype == TILEDB_INT32) {
-        ndr->set_range<int32_t>(dimname, Rcpp::as<int32_t>(start), Rcpp::as<int32_t>(end));
-    } else if (dtype == TILEDB_UINT32) {
-        ndr->set_range<uint32_t>(dimname,
-                                 static_cast<uint32_t>(Rcpp::as<int32_t>(start)),
-                                 static_cast<uint32_t>(Rcpp::as<int32_t>(end)));
-    } else if (dtype == TILEDB_INT16) {
-        ndr->set_range<int16_t>(dimname,
-                                static_cast<int16_t>(Rcpp::as<int32_t>(start)),
-                                static_cast<int16_t>(Rcpp::as<int32_t>(end)));
-    } else if (dtype == TILEDB_UINT16) {
-        ndr->set_range<uint16_t>(dimname,
-                                 static_cast<uint16_t>(Rcpp::as<int32_t>(start)),
-                                 static_cast<uint16_t>(Rcpp::as<int32_t>(end)));
-    } else if (dtype == TILEDB_INT8) {
-        ndr->set_range<int8_t>(dimname,
-                               static_cast<int8_t>(Rcpp::as<int32_t>(start)),
-                               static_cast<int8_t>(Rcpp::as<int32_t>(end)));
-    } else if (dtype == TILEDB_UINT8) {
-        ndr->set_range<uint8_t>(dimname,
-                                static_cast<uint8_t>(Rcpp::as<int32_t>(start)),
-                                static_cast<uint8_t>(Rcpp::as<int32_t>(end)));
-    } else if (dtype == TILEDB_FLOAT64) {
-        ndr->set_range<double>(dimname, Rcpp::as<double>(start), Rcpp::as<double>(end));
-    } else if (dtype == TILEDB_FLOAT32) {
-        ndr->set_range<float>(dimname,
-                              static_cast<float>(Rcpp::as<double>(start)),
-                              static_cast<float>(Rcpp::as<double>(end)));
-    } else {
-        Rcpp::stop("Domain datatype '%s' of dimname '%s' is not currently supported",
-                   _tiledb_datatype_to_string(dtype), dimname);
-    }
+XPtr<tiledb::NDRectangle>
+libtiledb_ndrectangle_set_range(XPtr<tiledb::NDRectangle> ndr,
+                                std::string &datatype, std::string &dimname,
+                                SEXP start, SEXP end) {
+  check_xptr_tag<tiledb::NDRectangle>(ndr);
+#if TILEDB_VERSION >= TileDB_Version(2, 25, 0)
+  auto dtype = _string_to_tiledb_datatype(datatype);
+  if (dtype == TILEDB_CHAR || // branch for 'string'
+      dtype == TILEDB_STRING_ASCII || dtype == TILEDB_STRING_UTF8) {
+    ndr->set_range(dimname, Rcpp::as<std::string>(start),
+                   Rcpp::as<std::string>(end));
+  } else if (dtype == TILEDB_INT64) {
+    ndr->set_range<int64_t>(dimname, Rcpp::fromInteger64(start),
+                            Rcpp::fromInteger64(end));
+  } else if (dtype == TILEDB_UINT64) {
+    ndr->set_range<int64_t>(
+        dimname,
+        static_cast<uint64_t>(Rcpp::fromInteger64(Rcpp::as<double>(start))),
+        static_cast<uint64_t>(Rcpp::fromInteger64(Rcpp::as<double>(end))));
+  } else if (dtype == TILEDB_INT32) {
+    ndr->set_range<int32_t>(dimname, Rcpp::as<int32_t>(start),
+                            Rcpp::as<int32_t>(end));
+  } else if (dtype == TILEDB_UINT32) {
+    ndr->set_range<uint32_t>(dimname,
+                             static_cast<uint32_t>(Rcpp::as<int32_t>(start)),
+                             static_cast<uint32_t>(Rcpp::as<int32_t>(end)));
+  } else if (dtype == TILEDB_INT16) {
+    ndr->set_range<int16_t>(dimname,
+                            static_cast<int16_t>(Rcpp::as<int32_t>(start)),
+                            static_cast<int16_t>(Rcpp::as<int32_t>(end)));
+  } else if (dtype == TILEDB_UINT16) {
+    ndr->set_range<uint16_t>(dimname,
+                             static_cast<uint16_t>(Rcpp::as<int32_t>(start)),
+                             static_cast<uint16_t>(Rcpp::as<int32_t>(end)));
+  } else if (dtype == TILEDB_INT8) {
+    ndr->set_range<int8_t>(dimname,
+                           static_cast<int8_t>(Rcpp::as<int32_t>(start)),
+                           static_cast<int8_t>(Rcpp::as<int32_t>(end)));
+  } else if (dtype == TILEDB_UINT8) {
+    ndr->set_range<uint8_t>(dimname,
+                            static_cast<uint8_t>(Rcpp::as<int32_t>(start)),
+                            static_cast<uint8_t>(Rcpp::as<int32_t>(end)));
+  } else if (dtype == TILEDB_FLOAT64) {
+    ndr->set_range<double>(dimname, Rcpp::as<double>(start),
+                           Rcpp::as<double>(end));
+  } else if (dtype == TILEDB_FLOAT32) {
+    ndr->set_range<float>(dimname, static_cast<float>(Rcpp::as<double>(start)),
+                          static_cast<float>(Rcpp::as<double>(end)));
+  } else {
+    Rcpp::stop(
+        "Domain datatype '%s' of dimname '%s' is not currently supported",
+        _tiledb_datatype_to_string(dtype), dimname);
+  }
 #endif
-    return ndr;
+  return ndr;
 }
 
 // NB maybe not exporting as we need a type which we get from current domain
 // [[Rcpp::export]]
 SEXP libtiledb_ndrectangle_get_range(XPtr<tiledb::NDRectangle> ndr,
-                                     std::string& dimname, std::string& dtype) {
-    check_xptr_tag<tiledb::NDRectangle>(ndr);
-#if TILEDB_VERSION >= TileDB_Version(2,25,0)
-    if (dtype == "CHAR" || dtype == "ASCII" || dtype == "UTF8") {
-        auto range = ndr->range<std::string>(dimname);
-        return Rcpp::CharacterVector::create(range[0], range[1]);
-    } else if (dtype == "INT64") {
-        auto range = ndr->range<int64_t>(dimname);
-        return Rcpp::toInteger64( std::vector<int64_t>{range[0], range[1] } );
-    } else if (dtype == "UINT64") {
-        auto range = ndr->range<uint64_t>(dimname);
-        return Rcpp::toInteger64( std::vector<int64_t>{ static_cast<int64_t>(range[0]),
-                                                        static_cast<int64_t>(range[1]) } );
-    } else if (dtype == "INT32") {
-        auto range = ndr->range<int32_t>(dimname);
-        return Rcpp::IntegerVector::create(range[0], range[1]);
-    } else if (dtype == "UINT32") {
-        auto range = ndr->range<uint32_t>(dimname);
-        return Rcpp::IntegerVector::create( static_cast<int32_t>(range[0]),
-                                            static_cast<int32_t>(range[1]) );
-    } else if (dtype == "INT16") {
-        auto range = ndr->range<int16_t>(dimname);
-        return Rcpp::IntegerVector::create( static_cast<int32_t>(range[0]),
-                                            static_cast<int32_t>(range[1]) );
-    } else if (dtype == "UINT16") {
-        auto range = ndr->range<uint16_t>(dimname);
-        return Rcpp::IntegerVector::create( static_cast<int32_t>(range[0]),
-                                            static_cast<int32_t>(range[1]) );
-    } else if (dtype == "INT8") {
-        auto range = ndr->range<int8_t>(dimname);
-        return Rcpp::IntegerVector::create( static_cast<int32_t>(range[0]),
-                                            static_cast<int32_t>(range[1]) );
-    } else if (dtype == "UINT8") {
-        auto range = ndr->range<uint8_t>(dimname);
-        return Rcpp::IntegerVector::create( static_cast<int32_t>(range[0]),
-                                            static_cast<int32_t>(range[1]) );
-    } else if (dtype == "FLOAT64") {
-        auto range = ndr->range<double>(dimname);
-        return Rcpp::NumericVector::create(range[0], range[1]);
-    } else if (dtype == "FLOAT32") {
-        auto range = ndr->range<float>(dimname);
-        return Rcpp::NumericVector::create( static_cast<double>(range[0]),
-                                            static_cast<double>(range[1]));
-    } else {
-        Rcpp::stop("Domain datatype '%s' of dimname '%s' is not currently supported", dtype, dimname);
-    }
+                                     std::string &dimname, std::string &dtype) {
+  check_xptr_tag<tiledb::NDRectangle>(ndr);
+#if TILEDB_VERSION >= TileDB_Version(2, 25, 0)
+  if (dtype == "CHAR" || dtype == "ASCII" || dtype == "UTF8") {
+    auto range = ndr->range<std::string>(dimname);
+    return Rcpp::CharacterVector::create(range[0], range[1]);
+  } else if (dtype == "INT64") {
+    auto range = ndr->range<int64_t>(dimname);
+    return Rcpp::toInteger64(std::vector<int64_t>{range[0], range[1]});
+  } else if (dtype == "UINT64") {
+    auto range = ndr->range<uint64_t>(dimname);
+    return Rcpp::toInteger64(std::vector<int64_t>{
+        static_cast<int64_t>(range[0]), static_cast<int64_t>(range[1])});
+  } else if (dtype == "INT32") {
+    auto range = ndr->range<int32_t>(dimname);
+    return Rcpp::IntegerVector::create(range[0], range[1]);
+  } else if (dtype == "UINT32") {
+    auto range = ndr->range<uint32_t>(dimname);
+    return Rcpp::IntegerVector::create(static_cast<int32_t>(range[0]),
+                                       static_cast<int32_t>(range[1]));
+  } else if (dtype == "INT16") {
+    auto range = ndr->range<int16_t>(dimname);
+    return Rcpp::IntegerVector::create(static_cast<int32_t>(range[0]),
+                                       static_cast<int32_t>(range[1]));
+  } else if (dtype == "UINT16") {
+    auto range = ndr->range<uint16_t>(dimname);
+    return Rcpp::IntegerVector::create(static_cast<int32_t>(range[0]),
+                                       static_cast<int32_t>(range[1]));
+  } else if (dtype == "INT8") {
+    auto range = ndr->range<int8_t>(dimname);
+    return Rcpp::IntegerVector::create(static_cast<int32_t>(range[0]),
+                                       static_cast<int32_t>(range[1]));
+  } else if (dtype == "UINT8") {
+    auto range = ndr->range<uint8_t>(dimname);
+    return Rcpp::IntegerVector::create(static_cast<int32_t>(range[0]),
+                                       static_cast<int32_t>(range[1]));
+  } else if (dtype == "FLOAT64") {
+    auto range = ndr->range<double>(dimname);
+    return Rcpp::NumericVector::create(range[0], range[1]);
+  } else if (dtype == "FLOAT32") {
+    auto range = ndr->range<float>(dimname);
+    return Rcpp::NumericVector::create(static_cast<double>(range[0]),
+                                       static_cast<double>(range[1]));
+  } else {
+    Rcpp::stop(
+        "Domain datatype '%s' of dimname '%s' is not currently supported",
+        dtype, dimname);
+  }
 #endif
-    return R_NilValue;          // not reached
+  return R_NilValue; // not reached
 }
 
 // [[Rcpp::export]]
 int libtiledb_ndrectangle_dim_num(XPtr<tiledb::NDRectangle> ndr) {
-    check_xptr_tag<tiledb::NDRectangle>(ndr);
-#if TILEDB_VERSION >= TileDB_Version(2,26,0)
-    return static_cast<int32_t>(ndr->dim_num());
+  check_xptr_tag<tiledb::NDRectangle>(ndr);
+#if TILEDB_VERSION >= TileDB_Version(2, 26, 0)
+  return static_cast<int32_t>(ndr->dim_num());
 #else
-    return R_NaInt;
+  return R_NaInt;
 #endif
 }
 
 // [[Rcpp::export]]
-std::string libtiledb_ndrectangle_datatype(XPtr<tiledb::NDRectangle> ndr, const std::string& name) {
-    check_xptr_tag<tiledb::NDRectangle>(ndr);
-#if TILEDB_VERSION >= TileDB_Version(2,26,0)
-    return _tiledb_datatype_to_string(ndr->range_dtype(name));
+std::string libtiledb_ndrectangle_datatype(XPtr<tiledb::NDRectangle> ndr,
+                                           const std::string &name) {
+  check_xptr_tag<tiledb::NDRectangle>(ndr);
+#if TILEDB_VERSION >= TileDB_Version(2, 26, 0)
+  return _tiledb_datatype_to_string(ndr->range_dtype(name));
 #else
-    Rcpp::stop("This function requires TileDB 2.26.0 or later.");
-    return std::string{Rcpp::as<std::string>(R_NaString)}; // not reached
+  Rcpp::stop("This function requires TileDB 2.26.0 or later.");
+  return std::string{Rcpp::as<std::string>(R_NaString)}; // not reached
 #endif
 }
 
 // [[Rcpp::export]]
-std::string libtiledb_ndrectangle_datatype_by_ind(XPtr<tiledb::NDRectangle> ndr, int dim) {
-    check_xptr_tag<tiledb::NDRectangle>(ndr);
-#if TILEDB_VERSION >= TileDB_Version(2,26,0)
-    return _tiledb_datatype_to_string(ndr->range_dtype(static_cast<uint32_t>(dim)));
+std::string libtiledb_ndrectangle_datatype_by_ind(XPtr<tiledb::NDRectangle> ndr,
+                                                  int dim) {
+  check_xptr_tag<tiledb::NDRectangle>(ndr);
+#if TILEDB_VERSION >= TileDB_Version(2, 26, 0)
+  return _tiledb_datatype_to_string(
+      ndr->range_dtype(static_cast<uint32_t>(dim)));
 #else
-    Rcpp::stop("This function requires TileDB 2.26.0 or later.");
-    return std::string{Rcpp::as<std::string>(R_NaString)}; // not reached
+  Rcpp::stop("This function requires TileDB 2.26.0 or later.");
+  return std::string{Rcpp::as<std::string>(R_NaString)}; // not reached
 #endif
 }
-
-
-
-
 
 /**
  * Current Domain (2.25.0 or later)
  */
 
 // [[Rcpp::export]]
-XPtr<tiledb::CurrentDomain> libtiledb_current_domain_create(XPtr<tiledb::Context> ctx) {
-    check_xptr_tag<tiledb::Context>(ctx);
-#if TILEDB_VERSION >= TileDB_Version(2,25,0)
-    auto cd = new tiledb::CurrentDomain(*ctx.get());
+XPtr<tiledb::CurrentDomain>
+libtiledb_current_domain_create(XPtr<tiledb::Context> ctx) {
+  check_xptr_tag<tiledb::Context>(ctx);
+#if TILEDB_VERSION >= TileDB_Version(2, 25, 0)
+  auto cd = new tiledb::CurrentDomain(*ctx.get());
 #else
-    auto cd = new tiledb::CurrentDomain();
+  auto cd = new tiledb::CurrentDomain();
 #endif
-    auto ptr = make_xptr<tiledb::CurrentDomain>(cd);
-    return ptr;
+  auto ptr = make_xptr<tiledb::CurrentDomain>(cd);
+  return ptr;
 }
 
 // [[Rcpp::export]]
 std::string libtiledb_current_domain_type(XPtr<tiledb::CurrentDomain> cd) {
-    check_xptr_tag<tiledb::CurrentDomain>(cd);
-#if TILEDB_VERSION >= TileDB_Version(2,25,0)
-    auto tp = cd->type();
-    auto str = std::string(_tiledb_current_domain_type_to_string(tp));
-    return str;
+  check_xptr_tag<tiledb::CurrentDomain>(cd);
+#if TILEDB_VERSION >= TileDB_Version(2, 25, 0)
+  auto tp = cd->type();
+  auto str = std::string(_tiledb_current_domain_type_to_string(tp));
+  return str;
 #else
-    return std::string();
+  return std::string();
 #endif
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::CurrentDomain> libtiledb_current_domain_set_ndrectangle(XPtr<tiledb::CurrentDomain> cd,
-                                                                     XPtr<tiledb::NDRectangle> ndr) {
-    check_xptr_tag<tiledb::CurrentDomain>(cd);
-    check_xptr_tag<tiledb::NDRectangle>(ndr);
-#if TILEDB_VERSION >= TileDB_Version(2,25,0)
-    cd->set_ndrectangle(*ndr.get());
+XPtr<tiledb::CurrentDomain>
+libtiledb_current_domain_set_ndrectangle(XPtr<tiledb::CurrentDomain> cd,
+                                         XPtr<tiledb::NDRectangle> ndr) {
+  check_xptr_tag<tiledb::CurrentDomain>(cd);
+  check_xptr_tag<tiledb::NDRectangle>(ndr);
+#if TILEDB_VERSION >= TileDB_Version(2, 25, 0)
+  cd->set_ndrectangle(*ndr.get());
 #endif
-    return cd;
+  return cd;
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::NDRectangle> libtiledb_current_domain_get_ndrectangle(XPtr<tiledb::CurrentDomain> cd) {
-    check_xptr_tag<tiledb::CurrentDomain>(cd);
-#if TILEDB_VERSION >= TileDB_Version(2,25,0)
-    auto nd = new tiledb::NDRectangle(cd->ndrectangle());
+XPtr<tiledb::NDRectangle>
+libtiledb_current_domain_get_ndrectangle(XPtr<tiledb::CurrentDomain> cd) {
+  check_xptr_tag<tiledb::CurrentDomain>(cd);
+#if TILEDB_VERSION >= TileDB_Version(2, 25, 0)
+  auto nd = new tiledb::NDRectangle(cd->ndrectangle());
 #else
-    auto nd = new tiledb::NDRectangle;
+  auto nd = new tiledb::NDRectangle;
 #endif
-    auto ptr = make_xptr<tiledb::NDRectangle>(nd);
-    return ptr;
-
+  auto ptr = make_xptr<tiledb::NDRectangle>(nd);
+  return ptr;
 }
 
 // [[Rcpp::export]]
 bool libtiledb_current_domain_is_empty(XPtr<tiledb::CurrentDomain> cd) {
-    check_xptr_tag<tiledb::CurrentDomain>(cd);
-#if TILEDB_VERSION >= TileDB_Version(2,25,0)
-    return cd->is_empty();
+  check_xptr_tag<tiledb::CurrentDomain>(cd);
+#if TILEDB_VERSION >= TileDB_Version(2, 25, 0)
+  return cd->is_empty();
 #else
-    return false;
+  return false;
 #endif
 }

--- a/src/libtiledb.cpp
+++ b/src/libtiledb.cpp
@@ -3,22 +3,22 @@
 //  Copyright (c) 2017-2024 TileDB Inc.
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
-//  of this software and associated documentation files (the "Software"), to
-//  deal in the Software without restriction, including without limitation the
-//  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
-//  sell copies of the Software, and to permit persons to whom the Software is
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
 //  furnished to do so, subject to the following conditions:
 //
-//  The above copyright notice and this permission notice shall be included in
-//  all copies or substantial portions of the Software.
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
 //
 //  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 //  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 //  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 //  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
-//  IN THE SOFTWARE.
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
 
 #include "libtiledb.h"
 #include "tiledb_version.h"
@@ -28,89 +28,89 @@
 
 using namespace Rcpp;
 
-const char *_tiledb_datatype_to_string(tiledb_datatype_t dtype) {
+const char* _tiledb_datatype_to_string(tiledb_datatype_t dtype) {
   switch (dtype) {
-  case TILEDB_INT8:
-    return "INT8";
-  case TILEDB_UINT8:
-    return "UINT8";
-  case TILEDB_INT16:
-    return "INT16";
-  case TILEDB_UINT16:
-    return "UINT16";
-  case TILEDB_INT32:
-    return "INT32";
-  case TILEDB_UINT32:
-    return "UINT32";
-  case TILEDB_INT64:
-    return "INT64";
-  case TILEDB_UINT64:
-    return "UINT64";
-  case TILEDB_FLOAT32:
-    return "FLOAT32";
-  case TILEDB_FLOAT64:
-    return "FLOAT64";
-  case TILEDB_CHAR:
-    return "CHAR";
-  case TILEDB_STRING_ASCII:
-    return "ASCII";
-  case TILEDB_STRING_UTF8:
-    return "UTF8";
-  case TILEDB_STRING_UTF16:
-    return "UTF16";
-  case TILEDB_STRING_UTF32:
-    return "UTF32";
-  case TILEDB_STRING_UCS2:
-    return "UCS2";
-  case TILEDB_STRING_UCS4:
-    return "UCS4";
-  case TILEDB_ANY:
-    return "ANY";
-  case TILEDB_DATETIME_YEAR:
-    return "DATETIME_YEAR";
-  case TILEDB_DATETIME_MONTH:
-    return "DATETIME_MONTH";
-  case TILEDB_DATETIME_WEEK:
-    return "DATETIME_WEEK";
-  case TILEDB_DATETIME_DAY:
-    return "DATETIME_DAY";
-  case TILEDB_DATETIME_HR:
-    return "DATETIME_HR";
-  case TILEDB_DATETIME_MIN:
-    return "DATETIME_MIN";
-  case TILEDB_DATETIME_SEC:
-    return "DATETIME_SEC";
-  case TILEDB_DATETIME_MS:
-    return "DATETIME_MS";
-  case TILEDB_DATETIME_US:
-    return "DATETIME_US";
-  case TILEDB_DATETIME_NS:
-    return "DATETIME_NS";
-  case TILEDB_DATETIME_PS:
-    return "DATETIME_PS";
-  case TILEDB_DATETIME_FS:
-    return "DATETIME_FS";
-  case TILEDB_DATETIME_AS:
-    return "DATETIME_AS";
-  case TILEDB_BLOB:
-    return "BLOB";
-#if TILEDB_VERSION >= TileDB_Version(2, 10, 0)
-  case TILEDB_BOOL:
-    return "BOOL";
+    case TILEDB_INT8:
+      return "INT8";
+    case TILEDB_UINT8:
+      return "UINT8";
+    case TILEDB_INT16:
+      return "INT16";
+    case TILEDB_UINT16:
+      return "UINT16";
+    case TILEDB_INT32:
+      return "INT32";
+    case TILEDB_UINT32:
+      return "UINT32";
+    case TILEDB_INT64:
+      return "INT64";
+    case TILEDB_UINT64:
+      return "UINT64";
+    case TILEDB_FLOAT32:
+      return "FLOAT32";
+    case TILEDB_FLOAT64:
+      return "FLOAT64";
+    case TILEDB_CHAR:
+      return "CHAR";
+    case TILEDB_STRING_ASCII:
+      return "ASCII";
+    case TILEDB_STRING_UTF8:
+      return "UTF8";
+    case TILEDB_STRING_UTF16:
+      return "UTF16";
+    case TILEDB_STRING_UTF32:
+      return "UTF32";
+    case TILEDB_STRING_UCS2:
+      return "UCS2";
+    case TILEDB_STRING_UCS4:
+      return "UCS4";
+    case TILEDB_ANY:
+      return "ANY";
+    case TILEDB_DATETIME_YEAR:
+      return "DATETIME_YEAR";
+    case TILEDB_DATETIME_MONTH:
+      return "DATETIME_MONTH";
+    case TILEDB_DATETIME_WEEK:
+      return "DATETIME_WEEK";
+    case TILEDB_DATETIME_DAY:
+      return "DATETIME_DAY";
+    case TILEDB_DATETIME_HR:
+      return "DATETIME_HR";
+    case TILEDB_DATETIME_MIN:
+      return "DATETIME_MIN";
+    case TILEDB_DATETIME_SEC:
+      return "DATETIME_SEC";
+    case TILEDB_DATETIME_MS:
+      return "DATETIME_MS";
+    case TILEDB_DATETIME_US:
+      return "DATETIME_US";
+    case TILEDB_DATETIME_NS:
+      return "DATETIME_NS";
+    case TILEDB_DATETIME_PS:
+      return "DATETIME_PS";
+    case TILEDB_DATETIME_FS:
+      return "DATETIME_FS";
+    case TILEDB_DATETIME_AS:
+      return "DATETIME_AS";
+    case TILEDB_BLOB:
+      return "BLOB";
+#if TILEDB_VERSION >= TileDB_Version(2,10,0)
+    case TILEDB_BOOL:
+      return "BOOL";
 #endif
-#if TILEDB_VERSION >= TileDB_Version(2, 21, 0)
-  case TILEDB_GEOM_WKB:
-    return "GEOM_WKB";
-  case TILEDB_GEOM_WKT:
-    return "GEOM_WKT";
+#if TILEDB_VERSION >= TileDB_Version(2,21,0)
+    case TILEDB_GEOM_WKB:
+      return "GEOM_WKB";
+    case TILEDB_GEOM_WKT:
+      return "GEOM_WKT";
 #endif
-  default:
-    Rcpp::stop("unknown tiledb_datatype_t (%d)", dtype);
+    default:
+      Rcpp::stop("unknown tiledb_datatype_t (%d)", dtype);
   }
 }
 
 tiledb_datatype_t _string_to_tiledb_datatype(std::string typestr) {
-  if (typestr == "FLOAT32") {
+  if (typestr == "FLOAT32")  {
     return TILEDB_FLOAT32;
   } else if (typestr == "FLOAT64") {
     return TILEDB_FLOAT64;
@@ -123,7 +123,7 @@ tiledb_datatype_t _string_to_tiledb_datatype(std::string typestr) {
   } else if (typestr == "UINT8") {
     return TILEDB_UINT8;
   } else if (typestr == "INT16") {
-    return TILEDB_INT16;
+    return  TILEDB_INT16;
   } else if (typestr == "UINT16") {
     return TILEDB_UINT16;
   } else if (typestr == "INT32") {
@@ -164,11 +164,11 @@ tiledb_datatype_t _string_to_tiledb_datatype(std::string typestr) {
     return TILEDB_STRING_UTF8;
   } else if (typestr == "BLOB") {
     return TILEDB_BLOB;
-#if TILEDB_VERSION >= TileDB_Version(2, 10, 0)
+#if TILEDB_VERSION >= TileDB_Version(2,10,0)
   } else if (typestr == "BOOL") {
     return TILEDB_BOOL;
 #endif
-#if TILEDB_VERSION >= TileDB_Version(2, 21, 0)
+#if TILEDB_VERSION >= TileDB_Version(2,21,0)
   } else if (typestr == "GEOM_WKB") {
     return TILEDB_GEOM_WKB;
   } else if (typestr == "GEOM_WKT") {
@@ -181,88 +181,85 @@ tiledb_datatype_t _string_to_tiledb_datatype(std::string typestr) {
 
 // [[Rcpp::export]]
 int32_t tiledb_datatype_string_to_sizeof(const std::string str) {
-  return static_cast<int32_t>(
-      tiledb_datatype_size(_string_to_tiledb_datatype(str)));
+    return static_cast<int32_t>(tiledb_datatype_size(_string_to_tiledb_datatype(str)));
 }
 
 //' Map from TileDB type to R datatype
 //'
-//' This function maps from the TileDB types to the (fewer) key datatypes in R.
-//' This can be lossy as TileDB integers range from (signed and unsigned) 8 to
-//' 64 bit whereas R only has (signed) 32 bit values. Similarly, R only has 64
-//' bit doubles whereas TileDB has 32 and 64 bit floating point types. TileDB
-//' also has more character encodings, and the full range of (NumPy) date and
-//' time types.
+//' This function maps from the TileDB types to the (fewer) key datatypes in R. This
+//' can be lossy as TileDB integers range from (signed and unsigned) 8 to 64 bit whereas
+//' R only has (signed) 32 bit values. Similarly, R only has 64 bit doubles whereas TileDB
+//' has 32 and 64 bit floating point types. TileDB also has more character encodings, and the
+//' full range of (NumPy) date and time types.
 //'
 //' @param datatype A string describing one TileDB datatype
 //' @return A string describing the closest match for an R datatype
 //' @export
 // [[Rcpp::export]]
-
 std::string tiledb_datatype_R_type(std::string datatype) {
   tiledb_datatype_t dtype = _string_to_tiledb_datatype(datatype);
   switch (dtype) {
-  case TILEDB_INT8:
-  case TILEDB_UINT8:
-  case TILEDB_INT16:
-  case TILEDB_UINT16:
-  case TILEDB_INT32:
-  case TILEDB_UINT32:
-  case TILEDB_INT64:
-  case TILEDB_UINT64:
-    return "integer";
-  case TILEDB_FLOAT32:
-  case TILEDB_FLOAT64:
-    return "double";
-  case TILEDB_CHAR:
-    return "raw";
-  case TILEDB_STRING_ASCII:
-  case TILEDB_STRING_UTF8:
-  case TILEDB_STRING_UTF16:
-  case TILEDB_STRING_UTF32:
-  case TILEDB_STRING_UCS2:
-  case TILEDB_STRING_UCS4:
-    return "character";
-  case TILEDB_ANY:
-    return "any";
-  case TILEDB_DATETIME_DAY:
-    return "DATETIME_DAY";
-  case TILEDB_DATETIME_SEC:
-    return "DATETIME_SEC";
-  case TILEDB_DATETIME_MS:
-    return "DATETIME_MS";
-  case TILEDB_DATETIME_US:
-    return "DATETIME_US";
-  case TILEDB_DATETIME_NS:
-    return "DATETIME_NS";
-#if TILEDB_VERSION >= TileDB_Version(2, 10, 0)
-  case TILEDB_BOOL:
-    return "BOOL";
+    case TILEDB_INT8:
+    case TILEDB_UINT8:
+    case TILEDB_INT16:
+    case TILEDB_UINT16:
+    case TILEDB_INT32:
+    case TILEDB_UINT32:
+    case TILEDB_INT64:
+    case TILEDB_UINT64:
+      return "integer";
+    case TILEDB_FLOAT32:
+    case TILEDB_FLOAT64:
+      return "double";
+    case TILEDB_CHAR:
+      return "raw";
+    case TILEDB_STRING_ASCII:
+    case TILEDB_STRING_UTF8:
+    case TILEDB_STRING_UTF16:
+    case TILEDB_STRING_UTF32:
+    case TILEDB_STRING_UCS2:
+    case TILEDB_STRING_UCS4:
+      return "character";
+    case TILEDB_ANY:
+      return "any";
+    case TILEDB_DATETIME_DAY:
+      return "DATETIME_DAY";
+    case TILEDB_DATETIME_SEC:
+      return "DATETIME_SEC";
+    case TILEDB_DATETIME_MS:
+      return "DATETIME_MS";
+    case TILEDB_DATETIME_US:
+      return "DATETIME_US";
+    case TILEDB_DATETIME_NS:
+      return "DATETIME_NS";
+#if TILEDB_VERSION >= TileDB_Version(2,10,0)
+    case TILEDB_BOOL:
+      return "BOOL";
 #endif
-  default:
-    Rcpp::stop("unknown tiledb_datatype_t (%d)", dtype);
+    default:
+      Rcpp::stop("unknown tiledb_datatype_t (%d)", dtype);
   }
 }
 
-const char *_tiledb_layout_to_string(tiledb_layout_t layout) {
-  switch (layout) {
-  case TILEDB_ROW_MAJOR:
-    return "ROW_MAJOR";
-  case TILEDB_COL_MAJOR:
-    return "COL_MAJOR";
-  case TILEDB_GLOBAL_ORDER:
-    return "GLOBAL_ORDER";
-  case TILEDB_UNORDERED:
-    return "UNORDERED";
-  case TILEDB_HILBERT:
-    return "HILBERT";
-  default:
-    Rcpp::stop("unknown tiledb_layout_t (%d)", layout);
+const char* _tiledb_layout_to_string(tiledb_layout_t layout) {
+  switch(layout) {
+    case TILEDB_ROW_MAJOR:
+      return "ROW_MAJOR";
+    case TILEDB_COL_MAJOR:
+      return "COL_MAJOR";
+    case TILEDB_GLOBAL_ORDER:
+      return "GLOBAL_ORDER";
+    case TILEDB_UNORDERED:
+      return "UNORDERED";
+    case TILEDB_HILBERT:
+      return "HILBERT";
+    default:
+      Rcpp::stop("unknown tiledb_layout_t (%d)", layout);
   }
 }
 
 tiledb_layout_t _string_to_tiledb_layout(std::string lstr) {
-  if (lstr == "ROW_MAJOR") {
+  if (lstr == "ROW_MAJOR")  {
     return TILEDB_ROW_MAJOR;
   } else if (lstr == "COL_MAJOR") {
     return TILEDB_COL_MAJOR;
@@ -304,15 +301,15 @@ tiledb_filter_type_t _string_to_tiledb_filter(std::string filter) {
     return TILEDB_FILTER_CHECKSUM_MD5;
   } else if (filter == "CHECKSUM_SHA256") {
     return TILEDB_FILTER_CHECKSUM_SHA256;
-#if TILEDB_VERSION >= TileDB_Version(2, 9, 0)
+#if TILEDB_VERSION >= TileDB_Version(2,9,0)
   } else if (filter == "DICTIONARY_ENCODING") {
     return TILEDB_FILTER_DICTIONARY;
 #endif
-#if TILEDB_VERSION >= TileDB_Version(2, 11, 0)
+#if TILEDB_VERSION >= TileDB_Version(2,11,0)
   } else if (filter == "SCALE_FLOAT") {
     return TILEDB_FILTER_SCALE_FLOAT;
 #endif
-#if TILEDB_VERSION >= TileDB_Version(2, 12, 0)
+#if TILEDB_VERSION >= TileDB_Version(2,12,0)
   } else if (filter == "FILTER_XOR") {
     return TILEDB_FILTER_XOR;
 #endif
@@ -321,61 +318,60 @@ tiledb_filter_type_t _string_to_tiledb_filter(std::string filter) {
   }
 }
 
-const char *_tiledb_filter_to_string(tiledb_filter_type_t filter) {
-  switch (filter) {
-  case TILEDB_FILTER_NONE:
-    return "NONE";
-  case TILEDB_FILTER_GZIP:
-    return "GZIP";
-  case TILEDB_FILTER_ZSTD:
-    return "ZSTD";
-  case TILEDB_FILTER_LZ4:
-    return "LZ4";
-  case TILEDB_FILTER_RLE:
-    return "RLE";
-  case TILEDB_FILTER_BZIP2:
-    return "BZIP2";
-  case TILEDB_FILTER_DOUBLE_DELTA:
-    return "DOUBLE_DELTA";
-  case TILEDB_FILTER_BIT_WIDTH_REDUCTION:
-    return "BIT_WIDTH_REDUCTION";
-  case TILEDB_FILTER_BITSHUFFLE:
-    return "BITSHUFFLE";
-  case TILEDB_FILTER_BYTESHUFFLE:
-    return "BYTESHUFFLE";
-  case TILEDB_FILTER_POSITIVE_DELTA:
-    return "POSITIVE_DELTA";
-  case TILEDB_FILTER_CHECKSUM_MD5:
-    return "CHECKSUM_MD5";
-  case TILEDB_FILTER_CHECKSUM_SHA256:
-    return "CHECKSUM_SHA256";
-#if TILEDB_VERSION >= TileDB_Version(2, 9, 0)
-  case TILEDB_FILTER_DICTIONARY:
-    return "DICTIONARY_ENCODING";
+const char* _tiledb_filter_to_string(tiledb_filter_type_t filter) {
+  switch(filter) {
+    case TILEDB_FILTER_NONE:
+     return "NONE";
+    case TILEDB_FILTER_GZIP:
+      return "GZIP";
+    case TILEDB_FILTER_ZSTD:
+      return "ZSTD";
+    case TILEDB_FILTER_LZ4:
+      return "LZ4";
+    case TILEDB_FILTER_RLE:
+      return "RLE";
+    case TILEDB_FILTER_BZIP2:
+      return "BZIP2";
+    case TILEDB_FILTER_DOUBLE_DELTA:
+      return "DOUBLE_DELTA";
+    case TILEDB_FILTER_BIT_WIDTH_REDUCTION:
+      return "BIT_WIDTH_REDUCTION";
+    case TILEDB_FILTER_BITSHUFFLE:
+      return "BITSHUFFLE";
+    case TILEDB_FILTER_BYTESHUFFLE:
+      return "BYTESHUFFLE";
+    case TILEDB_FILTER_POSITIVE_DELTA:
+      return "POSITIVE_DELTA";
+    case TILEDB_FILTER_CHECKSUM_MD5:
+      return "CHECKSUM_MD5";
+    case TILEDB_FILTER_CHECKSUM_SHA256:
+      return "CHECKSUM_SHA256";
+#if TILEDB_VERSION >= TileDB_Version(2,9,0)
+    case TILEDB_FILTER_DICTIONARY:
+      return "DICTIONARY_ENCODING";
 #endif
-#if TILEDB_VERSION >= TileDB_Version(2, 11, 0)
-  case TILEDB_FILTER_SCALE_FLOAT:
-    return "SCALE_FLOAT";
+#if TILEDB_VERSION >= TileDB_Version(2,11,0)
+    case TILEDB_FILTER_SCALE_FLOAT:
+      return "SCALE_FLOAT";
 #endif
-#if TILEDB_VERSION >= TileDB_Version(2, 12, 0)
+#if TILEDB_VERSION >= TileDB_Version(2,12,0)
   case TILEDB_FILTER_XOR:
     return "FILTER_XOR";
 #endif
   default: {
-    Rcpp::stop("unknown tiledb_filter_t (%d)", filter);
-  }
+      Rcpp::stop("unknown tiledb_filter_t (%d)", filter);
+    }
   }
 }
 
-tiledb_filter_option_t
-_string_to_tiledb_filter_option(std::string filter_option) {
+tiledb_filter_option_t _string_to_tiledb_filter_option(std::string filter_option) {
   if (filter_option == "COMPRESSION_LEVEL") {
     return TILEDB_COMPRESSION_LEVEL;
   } else if (filter_option == "BIT_WIDTH_MAX_WINDOW") {
     return TILEDB_BIT_WIDTH_MAX_WINDOW;
   } else if (filter_option == "POSITIVE_DELTA_MAX_WINDOW") {
     return TILEDB_POSITIVE_DELTA_MAX_WINDOW;
-#if TILEDB_VERSION >= TileDB_Version(2, 11, 0)
+#if TILEDB_VERSION >= TileDB_Version(2,11,0)
   } else if (filter_option == "SCALE_FLOAT_BYTEWIDTH") {
     return TILEDB_SCALE_FLOAT_BYTEWIDTH;
   } else if (filter_option == "SCALE_FLOAT_FACTOR") {
@@ -388,16 +384,15 @@ _string_to_tiledb_filter_option(std::string filter_option) {
   }
 }
 
-const char *
-_tiledb_filter_option_to_string(tiledb_filter_option_t filter_option) {
-  switch (filter_option) {
+const char* _tiledb_filter_option_to_string(tiledb_filter_option_t filter_option) {
+  switch(filter_option) {
   case TILEDB_COMPRESSION_LEVEL:
     return "COMPRESSION_LEVEL";
   case TILEDB_BIT_WIDTH_MAX_WINDOW:
     return "BIT_WIDTH_MAX_WINDOW";
   case TILEDB_POSITIVE_DELTA_MAX_WINDOW:
     return "POSITIVE_DELTA_MAX_WINDOW";
-#if TILEDB_VERSION >= TileDB_Version(2, 11, 0)
+#if TILEDB_VERSION >= TileDB_Version(2,11,0)
   case TILEDB_SCALE_FLOAT_BYTEWIDTH:
     return "SCALE_FLOAT_BYTEWIDTH";
   case TILEDB_SCALE_FLOAT_FACTOR:
@@ -415,7 +410,7 @@ tiledb_query_type_t _string_to_tiledb_query_type(std::string qtstr) {
     return TILEDB_READ;
   } else if (qtstr == "WRITE") {
     return TILEDB_WRITE;
-#if TILEDB_VERSION >= TileDB_Version(2, 12, 0)
+#if TILEDB_VERSION >= TileDB_Version(2,12,0)
   } else if (qtstr == "MODIFY_EXCLUSIVE") {
     return TILEDB_MODIFY_EXCLUSIVE;
   } else if (qtstr == "DELETE") {
@@ -428,29 +423,29 @@ tiledb_query_type_t _string_to_tiledb_query_type(std::string qtstr) {
 
 std::string _tiledb_query_type_to_string(tiledb_query_type_t qtype) {
   switch (qtype) {
-  case TILEDB_READ:
-    return "READ";
-  case TILEDB_WRITE:
-    return "WRITE";
-#if TILEDB_VERSION >= TileDB_Version(2, 12, 0)
-  case TILEDB_DELETE:
-    return "DELETE";
-  case TILEDB_MODIFY_EXCLUSIVE:
-    return "MODIFY_EXCLUSIVE";
+    case TILEDB_READ:
+      return "READ";
+    case TILEDB_WRITE:
+      return "WRITE";
+#if TILEDB_VERSION >= TileDB_Version(2,12,0)
+    case TILEDB_DELETE:
+      return "DELETE";
+    case TILEDB_MODIFY_EXCLUSIVE:
+      return "MODIFY_EXCLUSIVE";
 #endif
-  default:
-    Rcpp::stop("unknown tiledb_query_type_t (%d)", qtype);
+    default:
+      Rcpp::stop("unknown tiledb_query_type_t (%d)", qtype);
   }
 }
 
-const char *_tiledb_array_type_to_string(tiledb_array_type_t atype) {
+const char* _tiledb_array_type_to_string(tiledb_array_type_t atype) {
   switch (atype) {
-  case TILEDB_DENSE:
-    return "dense";
-  case TILEDB_SPARSE:
-    return "sparse";
-  default:
-    Rcpp::stop("Unknown tiledb_array_type_t");
+    case TILEDB_DENSE:
+      return "dense";
+    case TILEDB_SPARSE:
+      return "sparse";
+    default:
+      Rcpp::stop("Unknown tiledb_array_type_t");
   }
 }
 
@@ -476,43 +471,39 @@ tiledb_vfs_mode_t _string_to_tiledb_vfs_mode_t(std::string modestr) {
   }
 }
 
-#if TILEDB_VERSION >= TileDB_Version(2, 25, 0)
-std::string
-_tiledb_current_domain_type_to_string(tiledb_current_domain_type_t type) {
-  if (type == TILEDB_NDRECTANGLE) {
-    return std::string{"NDRECTANGLE"};
-  } else {
-    Rcpp::stop("Unknown TileDB CurrentDomain type (%d)", (int32_t)type);
-  }
-  return std::string();
+#if TILEDB_VERSION >= TileDB_Version(2,25,0)
+std::string _tiledb_current_domain_type_to_string(tiledb_current_domain_type_t type) {
+    if (type == TILEDB_NDRECTANGLE) {
+        return std::string{"NDRECTANGLE"};
+    } else {
+        Rcpp::stop("Unknown TileDB CurrentDomain type (%d)", (int32_t) type);
+    }
+    return std::string();
 }
 #endif
 
-#if TILEDB_VERSION >= TileDB_Version(2, 25, 0)
-tiledb_current_domain_type_t
-_string_to_tiledb_current_domain_type(std::string typestr) {
-  if (typestr == "NDRECTANGLE") {
-    return TILEDB_NDRECTANGLE;
-  } else {
-    Rcpp::stop("Unknown TileDB CurrentDomain type '%s'", typestr.c_str());
-  }
+#if TILEDB_VERSION >= TileDB_Version(2,25,0)
+tiledb_current_domain_type_t _string_to_tiledb_current_domain_type(std::string typestr) {
+    if (typestr == "NDRECTANGLE") {
+        return TILEDB_NDRECTANGLE;
+    } else {
+        Rcpp::stop("Unknown TileDB CurrentDomain type '%s'", typestr.c_str());
+    }
 }
 #endif
 
-// NB Limited type coverage here as aimed to sizing R allocations of either int,
-// double or char Also note that there is 'inline size_t
-// type_size(tiledb_datatype_t type)' in core_interface.h
+// NB Limited type coverage here as aimed to sizing R allocations of either int, double or char
+// Also note that there is 'inline size_t type_size(tiledb_datatype_t type)' in core_interface.h
 const size_t _tiledb_datatype_sizeof(const tiledb_datatype_t dtype) {
-  switch (dtype) {
-  case TILEDB_FLOAT64:
-    return sizeof(double);
-  case TILEDB_INT32:
-    return sizeof(int32_t);
-  case TILEDB_CHAR:
-    return sizeof(char);
-  default:
-    Rcpp::stop("Unsupported tiledb_datatype_t '%s'",
-               _tiledb_datatype_to_string(dtype));
+  switch(dtype) {
+    case TILEDB_FLOAT64:
+      return sizeof(double);
+    case TILEDB_INT32:
+      return sizeof(int32_t);
+    case TILEDB_CHAR:
+      return sizeof(char);
+    default:
+      Rcpp::stop("Unsupported tiledb_datatype_t '%s'", _tiledb_datatype_to_string(dtype));
   }
 }
 
@@ -525,28 +516,19 @@ NumericVector libtiledb_version() {
 }
 
 // [[Rcpp::export]]
-size_t tiledb_datatype_max_value(const std::string &datatype) {
-  tiledb_datatype_t dtype = _string_to_tiledb_datatype(datatype);
-  switch (dtype) {
-  case TILEDB_INT8:
-    return std::numeric_limits<int8_t>::max();
-  case TILEDB_UINT8:
-    return std::numeric_limits<uint8_t>::max();
-  case TILEDB_INT16:
-    return std::numeric_limits<int16_t>::max();
-  case TILEDB_UINT16:
-    return std::numeric_limits<uint16_t>::max();
-  case TILEDB_INT32:
-    return std::numeric_limits<int32_t>::max();
-  case TILEDB_UINT32:
-    return std::numeric_limits<uint32_t>::max();
-  case TILEDB_INT64:
-    return std::numeric_limits<int64_t>::max();
-  case TILEDB_UINT64:
-    return std::numeric_limits<uint64_t>::max();
-  default:
-    Rcpp::stop("currently unsupported datatype (%s)", datatype);
-  }
+size_t tiledb_datatype_max_value(const std::string& datatype) {
+    tiledb_datatype_t dtype = _string_to_tiledb_datatype(datatype);
+    switch (dtype) {
+    case TILEDB_INT8:    return std::numeric_limits<int8_t>::max();
+    case TILEDB_UINT8:   return std::numeric_limits<uint8_t>::max();
+    case TILEDB_INT16:   return std::numeric_limits<int16_t>::max();
+    case TILEDB_UINT16:  return std::numeric_limits<uint16_t>::max();
+    case TILEDB_INT32:   return std::numeric_limits<int32_t>::max();
+    case TILEDB_UINT32:  return std::numeric_limits<uint32_t>::max();
+    case TILEDB_INT64:   return std::numeric_limits<int64_t>::max();
+    case TILEDB_UINT64:  return std::numeric_limits<uint64_t>::max();
+    default: Rcpp::stop("currently unsupported datatype (%s)", datatype);
+    }
 }
 
 /**
@@ -554,29 +536,27 @@ size_t tiledb_datatype_max_value(const std::string &datatype) {
  */
 
 // [[Rcpp::export]]
-XPtr<tiledb::Context>
-libtiledb_ctx(Nullable<XPtr<tiledb::Config>> config = R_NilValue) {
-  if (config.isNull()) {
-    return make_xptr<tiledb::Context>(new tiledb::Context());
-  } else {
-    XPtr<tiledb::Config> config_xptr(config);
-    return make_xptr<tiledb::Context>(new tiledb::Context(*config_xptr.get()));
-  }
+XPtr<tiledb::Context> libtiledb_ctx(Nullable<XPtr<tiledb::Config>> config = R_NilValue) {
+    if (config.isNull()) {
+        return make_xptr<tiledb::Context>(new tiledb::Context());
+    } else {
+        XPtr<tiledb::Config> config_xptr(config);
+        return make_xptr<tiledb::Context>(new tiledb::Context(*config_xptr.get()));
+    }
 }
 
 // [[Rcpp::export]]
 XPtr<tiledb::Config> libtiledb_ctx_config(XPtr<tiledb::Context> ctx) {
-  check_xptr_tag<tiledb::Context>(ctx);
-  return make_xptr<tiledb::Config>(new tiledb::Config(ctx.get()->config()));
+    check_xptr_tag<tiledb::Context>(ctx);
+    return make_xptr<tiledb::Config>(new tiledb::Config(ctx.get()->config()));
 }
 
 // [[Rcpp::export]]
-bool libtiledb_ctx_is_supported_fs(XPtr<tiledb::Context> ctx,
-                                   std::string scheme) {
+bool libtiledb_ctx_is_supported_fs(XPtr<tiledb::Context> ctx, std::string scheme) {
   check_xptr_tag<tiledb::Context>(ctx);
   if (scheme == "file") {
     return true;
-  } else if (scheme == "s3") {
+  } else if  (scheme == "s3") {
     return ctx->is_supported_fs(TILEDB_S3);
   } else if (scheme == "hdfs") {
     return ctx->is_supported_fs(TILEDB_HDFS);
@@ -592,16 +572,15 @@ bool libtiledb_ctx_is_supported_fs(XPtr<tiledb::Context> ctx,
 }
 
 // [[Rcpp::export]]
-void libtiledb_ctx_set_tag(XPtr<tiledb::Context> ctx, std::string key,
-                           std::string value) {
+void libtiledb_ctx_set_tag(XPtr<tiledb::Context> ctx, std::string key, std::string value) {
   check_xptr_tag<tiledb::Context>(ctx);
   ctx->set_tag(key, value);
 }
 
 // [[Rcpp::export]]
 std::string libtiledb_ctx_stats(XPtr<tiledb::Context> ctx) {
-  check_xptr_tag<tiledb::Context>(ctx);
-  return ctx->stats();
+    check_xptr_tag<tiledb::Context>(ctx);
+    return ctx->stats();
 }
 
 /**
@@ -609,8 +588,7 @@ std::string libtiledb_ctx_stats(XPtr<tiledb::Context> ctx) {
  */
 
 // [[Rcpp::export]]
-XPtr<tiledb::Config>
-libtiledb_config(Nullable<CharacterVector> config = R_NilValue) {
+XPtr<tiledb::Config> libtiledb_config(Nullable<CharacterVector> config = R_NilValue) {
   XPtr<tiledb::Config> ptr = make_xptr<tiledb::Config>(new tiledb::Config());
   if (config.isNotNull()) {
     auto config_vec = config.as();
@@ -625,8 +603,7 @@ libtiledb_config(Nullable<CharacterVector> config = R_NilValue) {
 }
 
 // [[Rcpp::export]]
-std::string libtiledb_config_save_to_file(XPtr<tiledb::Config> config,
-                                          std::string filename) {
+std::string libtiledb_config_save_to_file(XPtr<tiledb::Config> config, std::string filename) {
   check_xptr_tag<tiledb::Config>(config);
   config->save_to_file(filename);
   return filename;
@@ -634,8 +611,7 @@ std::string libtiledb_config_save_to_file(XPtr<tiledb::Config> config,
 
 // [[Rcpp::export]]
 XPtr<tiledb::Config> libtiledb_config_load_from_file(std::string filename) {
-  XPtr<tiledb::Config> ptr =
-      make_xptr<tiledb::Config>(new tiledb::Config(filename));
+  XPtr<tiledb::Config> ptr = make_xptr<tiledb::Config>(new tiledb::Config(filename));
   return ptr;
 }
 
@@ -643,31 +619,29 @@ XPtr<tiledb::Config> libtiledb_config_load_from_file(std::string filename) {
 CharacterVector libtiledb_config_vector(XPtr<tiledb::Config> config) {
   check_xptr_tag<tiledb::Config>(config);
   CharacterVector config_vec;
-  for (auto &p : *config) {
-    config_vec[p.first] = p.second;
+  for (auto& p : *config) {
+    config_vec[p.first]  = p.second;
   }
   return config_vec;
 }
 
 // [[Rcpp::export]]
 XPtr<tiledb::Config> libtiledb_config_set(XPtr<tiledb::Config> config,
-                                          std::string param,
-                                          std::string value) {
+                                          std::string param, std::string value) {
   check_xptr_tag<tiledb::Config>(config);
   (*config)[param] = value;
   return config;
 }
 
 // [[Rcpp::export]]
-CharacterVector libtiledb_config_get(XPtr<tiledb::Config> config,
-                                     CharacterVector params) {
+CharacterVector libtiledb_config_get(XPtr<tiledb::Config> config, CharacterVector params) {
   check_xptr_tag<tiledb::Config>(config);
   CharacterVector result;
-  for (auto const &p : params) {
+  for (auto const& p : params) {
     auto param = as<std::string>(p);
     try {
       result.push_back(config->get(param), param);
-    } catch (std::exception &err) {
+    } catch (std::exception& err) {
       result.push_back(NA_STRING, as<std::string>(NA_STRING));
     }
   }
@@ -675,8 +649,7 @@ CharacterVector libtiledb_config_get(XPtr<tiledb::Config> config,
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::Config> libtiledb_config_unset(XPtr<tiledb::Config> config,
-                                            std::string param) {
+XPtr<tiledb::Config> libtiledb_config_unset(XPtr<tiledb::Config> config, std::string param) {
   check_xptr_tag<tiledb::Config>(config);
   config->unset(param);
   return config;
@@ -686,20 +659,19 @@ XPtr<tiledb::Config> libtiledb_config_unset(XPtr<tiledb::Config> config,
 void libtiledb_config_dump(XPtr<tiledb::Config> config) {
   check_xptr_tag<tiledb::Config>(config);
   Rcout << "Config settings:\n";
-  for (auto &p : *config) {
+  for (auto& p : *config) {
     Rcout << "\"" << p.first << "\" : \"" << p.second << "\"\n";
   }
 }
 
-// Placed here as it relates to config. (New as of 2.17, uses experimental
-// header)
+// Placed here as it relates to config. (New as of 2.17, uses experimental header)
 // [[Rcpp::export]]
 std::string libtiledb_as_built_dump() {
-  std::string str = "";
-#if TILEDB_VERSION >= TileDB_Version(2, 17, 0)
-  str = tiledb::AsBuilt::dump();
+    std::string str = "";
+#if TILEDB_VERSION >= TileDB_Version(2,17,0)
+    str = tiledb::AsBuilt::dump();
 #endif
-  return str;
+    return str;
 }
 
 /**
@@ -707,228 +679,209 @@ std::string libtiledb_as_built_dump() {
  */
 // [[Rcpp::export]]
 XPtr<tiledb::Dimension> libtiledb_dim(XPtr<tiledb::Context> ctx,
-                                      std::string name, std::string type,
-                                      SEXP domain, SEXP tile_extent) {
-  check_xptr_tag<tiledb::Context>(ctx);
-  // check that the dimension type is supported
-  const tiledb_datatype_t dtype = _string_to_tiledb_datatype(type);
-  if (dtype != TILEDB_INT8 && dtype != TILEDB_INT16 && dtype != TILEDB_INT32 &&
-      dtype != TILEDB_INT64 && dtype != TILEDB_UINT8 &&
-      dtype != TILEDB_UINT16 && dtype != TILEDB_UINT32 &&
-      dtype != TILEDB_UINT64 && dtype != TILEDB_FLOAT32 &&
-      dtype != TILEDB_FLOAT64 && dtype != TILEDB_DATETIME_YEAR &&
-      dtype != TILEDB_DATETIME_MONTH && dtype != TILEDB_DATETIME_WEEK &&
-      dtype != TILEDB_DATETIME_DAY && dtype != TILEDB_DATETIME_HR &&
-      dtype != TILEDB_DATETIME_MIN && dtype != TILEDB_DATETIME_SEC &&
-      dtype != TILEDB_DATETIME_MS && dtype != TILEDB_DATETIME_US &&
-      dtype != TILEDB_DATETIME_NS && dtype != TILEDB_DATETIME_PS &&
-      dtype != TILEDB_DATETIME_FS && dtype != TILEDB_DATETIME_AS &&
-      dtype != TILEDB_STRING_ASCII) {
-    Rcpp::stop("only integer ((U)INT{8,16,32,64}), real (FLOAT{32,64}), "
-               "DATETIME_{YEAR,MONTH,WEEK,DAY,HR,MIN,SEC,MS,US,NS,PS,FS,AS}, "
-               "STRING_ASCII domains supported");
-  }
-  // check that the dimension type aligns with the domain and tiledb_extent type
-  if (dtype == TILEDB_INT32 &&
-      (TYPEOF(domain) != INTSXP || TYPEOF(tile_extent) != INTSXP)) {
-    Rcpp::stop("domain or tile_extent does not match dimension type");
-  } else if (dtype == TILEDB_FLOAT64 &&
-             (TYPEOF(domain) != REALSXP || TYPEOF(tile_extent) != REALSXP)) {
-    Rcpp::stop("domain or tile_extent does not match dimension type");
-  }
-  if (dtype == TILEDB_INT32) {
-    Rcpp::IntegerVector domain_vec = Rcpp::IntegerVector(domain);
-    if (domain_vec.length() != 2) {
-      Rcpp::stop("dimension domain must be a c(lower bound, upper bound) pair");
+                                      std::string name,
+                                      std::string type,
+                                      SEXP domain,
+                                      SEXP tile_extent) {
+    check_xptr_tag<tiledb::Context>(ctx);
+    // check that the dimension type is supported
+    const tiledb_datatype_t dtype = _string_to_tiledb_datatype(type);
+    if (dtype != TILEDB_INT8 &&
+        dtype != TILEDB_INT16 &&
+        dtype != TILEDB_INT32 &&
+        dtype != TILEDB_INT64 &&
+        dtype != TILEDB_UINT8 &&
+        dtype != TILEDB_UINT16 &&
+        dtype != TILEDB_UINT32 &&
+        dtype != TILEDB_UINT64 &&
+        dtype != TILEDB_FLOAT32 &&
+        dtype != TILEDB_FLOAT64 &&
+        dtype != TILEDB_DATETIME_YEAR &&
+        dtype != TILEDB_DATETIME_MONTH &&
+        dtype != TILEDB_DATETIME_WEEK &&
+        dtype != TILEDB_DATETIME_DAY &&
+        dtype != TILEDB_DATETIME_HR &&
+        dtype != TILEDB_DATETIME_MIN &&
+        dtype != TILEDB_DATETIME_SEC &&
+        dtype != TILEDB_DATETIME_MS &&
+        dtype != TILEDB_DATETIME_US &&
+        dtype != TILEDB_DATETIME_NS &&
+        dtype != TILEDB_DATETIME_PS &&
+        dtype != TILEDB_DATETIME_FS &&
+        dtype != TILEDB_DATETIME_AS &&
+        dtype != TILEDB_STRING_ASCII) {
+        Rcpp::stop("only integer ((U)INT{8,16,32,64}), real (FLOAT{32,64}), DATETIME_{YEAR,MONTH,WEEK,DAY,HR,MIN,SEC,MS,US,NS,PS,FS,AS}, STRING_ASCII domains supported");
     }
-    std::array<int32_t, 2> _domain = {domain_vec[0], domain_vec[1]};
-    int32_t _tile_extent = Rcpp::as<int32_t>(tile_extent);
-    auto dim = new tiledb::Dimension(tiledb::Dimension::create<int32_t>(
-        *ctx.get(), name, _domain, _tile_extent));
-    auto ptr = make_xptr<tiledb::Dimension>(dim);
-    return ptr;
+    // check that the dimension type aligns with the domain and tiledb_extent type
+    if (dtype == TILEDB_INT32 && (TYPEOF(domain) != INTSXP || TYPEOF(tile_extent) != INTSXP)) {
+        Rcpp::stop("domain or tile_extent does not match dimension type");
+    } else if (dtype == TILEDB_FLOAT64 && (TYPEOF(domain) != REALSXP || TYPEOF(tile_extent) != REALSXP)) {
+        Rcpp::stop("domain or tile_extent does not match dimension type");
+    }
+    if (dtype == TILEDB_INT32) {
+        Rcpp::IntegerVector domain_vec = Rcpp::IntegerVector(domain);
+        if (domain_vec.length() != 2) {
+            Rcpp::stop("dimension domain must be a c(lower bound, upper bound) pair");
+        }
+        std::array<int32_t, 2> _domain = {domain_vec[0], domain_vec[1]};
+        int32_t _tile_extent = Rcpp::as<int32_t>(tile_extent);
+        auto dim = new tiledb::Dimension(tiledb::Dimension::create<int32_t>(*ctx.get(), name, _domain, _tile_extent));
+        auto ptr = make_xptr<tiledb::Dimension>(dim);
+        return ptr;
 
-  } else if (dtype == TILEDB_UINT32) {
-    Rcpp::IntegerVector domain_vec = Rcpp::IntegerVector(domain);
-    if (domain_vec.length() != 2) {
-      Rcpp::stop("dimension domain must be a c(lower bound, upper bound) pair");
-    }
-    std::array<uint32_t, 2> _domain = {static_cast<uint32_t>(domain_vec[0]),
-                                       static_cast<uint32_t>(domain_vec[1])};
-    uint32_t _tile_extent = Rcpp::as<uint32_t>(tile_extent);
-    auto dim = new tiledb::Dimension(tiledb::Dimension::create<uint32_t>(
-        *ctx.get(), name, _domain, _tile_extent));
-    auto ptr = make_xptr<tiledb::Dimension>(dim);
-    return ptr;
+    } else if (dtype == TILEDB_UINT32) {
+        Rcpp::IntegerVector domain_vec = Rcpp::IntegerVector(domain);
+        if (domain_vec.length() != 2) {
+            Rcpp::stop("dimension domain must be a c(lower bound, upper bound) pair");
+        }
+        std::array<uint32_t, 2> _domain = {static_cast<uint32_t>(domain_vec[0]), static_cast<uint32_t>(domain_vec[1])};
+        uint32_t _tile_extent = Rcpp::as<uint32_t>(tile_extent);
+        auto dim = new tiledb::Dimension(tiledb::Dimension::create<uint32_t>(*ctx.get(), name, _domain, _tile_extent));
+        auto ptr = make_xptr<tiledb::Dimension>(dim);
+        return ptr;
 
-  } else if (dtype == TILEDB_INT16) {
-    Rcpp::IntegerVector domain_vec = Rcpp::IntegerVector(domain);
-    if (domain_vec.length() != 2) {
-      Rcpp::stop("dimension domain must be a c(lower bound, upper bound) pair");
-    }
-    std::array<int16_t, 2> _domain = {static_cast<int16_t>(domain_vec[0]),
-                                      static_cast<int16_t>(domain_vec[1])};
-    int16_t _tile_extent = Rcpp::as<int16_t>(tile_extent);
-    auto dim = new tiledb::Dimension(tiledb::Dimension::create<int16_t>(
-        *ctx.get(), name, _domain, _tile_extent));
-    auto ptr = make_xptr<tiledb::Dimension>(dim);
-    return ptr;
+    } else if (dtype == TILEDB_INT16) {
+        Rcpp::IntegerVector domain_vec = Rcpp::IntegerVector(domain);
+        if (domain_vec.length() != 2) {
+            Rcpp::stop("dimension domain must be a c(lower bound, upper bound) pair");
+        }
+        std::array<int16_t, 2> _domain = {static_cast<int16_t>(domain_vec[0]), static_cast<int16_t>(domain_vec[1])};
+        int16_t _tile_extent = Rcpp::as<int16_t>(tile_extent);
+        auto dim = new tiledb::Dimension(tiledb::Dimension::create<int16_t>(*ctx.get(), name, _domain, _tile_extent));
+        auto ptr = make_xptr<tiledb::Dimension>(dim);
+        return ptr;
 
-  } else if (dtype == TILEDB_UINT16) {
-    Rcpp::IntegerVector domain_vec = Rcpp::IntegerVector(domain);
-    if (domain_vec.length() != 2) {
-      Rcpp::stop("dimension domain must be a c(lower bound, upper bound) pair");
-    }
-    std::array<uint16_t, 2> _domain = {static_cast<uint16_t>(domain_vec[0]),
-                                       static_cast<uint16_t>(domain_vec[1])};
-    int16_t _tile_extent = Rcpp::as<int16_t>(tile_extent);
-    auto dim = new tiledb::Dimension(tiledb::Dimension::create<uint16_t>(
-        *ctx.get(), name, _domain, _tile_extent));
-    auto ptr = make_xptr<tiledb::Dimension>(dim);
-    return ptr;
+    } else if (dtype == TILEDB_UINT16) {
+        Rcpp::IntegerVector domain_vec = Rcpp::IntegerVector(domain);
+        if (domain_vec.length() != 2) {
+            Rcpp::stop("dimension domain must be a c(lower bound, upper bound) pair");
+        }
+        std::array<uint16_t, 2> _domain = {static_cast<uint16_t>(domain_vec[0]), static_cast<uint16_t>(domain_vec[1])};
+        uint16_t _tile_extent = Rcpp::as<uint16_t>(tile_extent);
+        auto dim = new tiledb::Dimension(tiledb::Dimension::create<uint16_t>(*ctx.get(), name, _domain, _tile_extent));
+        auto ptr = make_xptr<tiledb::Dimension>(dim);
+        return ptr;
 
-  } else if (dtype == TILEDB_UINT16) {
-    Rcpp::IntegerVector domain_vec = Rcpp::IntegerVector(domain);
-    if (domain_vec.length() != 2) {
-      Rcpp::stop("dimension domain must be a c(lower bound, upper bound) pair");
-    }
-    std::array<uint16_t, 2> _domain = {static_cast<uint16_t>(domain_vec[0]),
-                                       static_cast<uint16_t>(domain_vec[1])};
-    uint16_t _tile_extent = Rcpp::as<uint16_t>(tile_extent);
-    auto dim = new tiledb::Dimension(tiledb::Dimension::create<uint16_t>(
-        *ctx.get(), name, _domain, _tile_extent));
-    auto ptr = make_xptr<tiledb::Dimension>(dim);
-    return ptr;
-
-  } else if (dtype == TILEDB_INT8) {
-    Rcpp::IntegerVector domain_vec = Rcpp::IntegerVector(domain);
-    if (domain_vec.length() != 2) {
-      Rcpp::stop("dimension domain must be a c(lower bound, upper bound) pair");
-    }
-    std::array<int8_t, 2> _domain = {static_cast<int8_t>(domain_vec[0]),
-                                     static_cast<int8_t>(domain_vec[1])};
-    int8_t _tile_extent = static_cast<int8_t>(Rcpp::as<int16_t>(tile_extent));
-    auto dim = new tiledb::Dimension(tiledb::Dimension::create<int8_t>(
-        *ctx.get(), name, _domain, _tile_extent));
-    auto ptr = make_xptr<tiledb::Dimension>(dim);
-    return ptr;
+    } else if (dtype == TILEDB_INT8) {
+        Rcpp::IntegerVector domain_vec = Rcpp::IntegerVector(domain);
+        if (domain_vec.length() != 2) {
+            Rcpp::stop("dimension domain must be a c(lower bound, upper bound) pair");
+        }
+        std::array<int8_t, 2> _domain = {static_cast<int8_t>(domain_vec[0]), static_cast<int8_t>(domain_vec[1])};
+        int8_t _tile_extent = static_cast<int8_t>(Rcpp::as<int16_t>(tile_extent));
+        auto dim = new tiledb::Dimension(tiledb::Dimension::create<int8_t>(*ctx.get(), name, _domain, _tile_extent));
+        auto ptr = make_xptr<tiledb::Dimension>(dim);
+        return ptr;
 
   } else if (dtype == TILEDB_UINT8) {
-    Rcpp::IntegerVector domain_vec = Rcpp::IntegerVector(domain);
-    if (domain_vec.length() != 2) {
-      Rcpp::stop("dimension domain must be a c(lower bound, upper bound) pair");
-    }
-    std::array<uint8_t, 2> _domain = {static_cast<uint8_t>(domain_vec[0]),
-                                      static_cast<uint8_t>(domain_vec[1])};
-    uint8_t _tile_extent = Rcpp::as<uint8_t>(tile_extent);
-    auto dim = new tiledb::Dimension(tiledb::Dimension::create<uint8_t>(
-        *ctx.get(), name, _domain, _tile_extent));
-    auto ptr = make_xptr<tiledb::Dimension>(dim);
-    return ptr;
+        Rcpp::IntegerVector domain_vec = Rcpp::IntegerVector(domain);
+        if (domain_vec.length() != 2) {
+            Rcpp::stop("dimension domain must be a c(lower bound, upper bound) pair");
+        }
+        std::array<uint8_t, 2> _domain = {static_cast<uint8_t>(domain_vec[0]), static_cast<uint8_t>(domain_vec[1])};
+        uint8_t _tile_extent = Rcpp::as<uint8_t>(tile_extent);
+        auto dim = new tiledb::Dimension(tiledb::Dimension::create<uint8_t>(*ctx.get(), name, _domain, _tile_extent));
+        auto ptr = make_xptr<tiledb::Dimension>(dim);
+        return ptr;
 
   } else if (dtype == TILEDB_INT64) {
-    // for int64 domains and extents we require integer64 types which are
-    // internally memmap'ed from double
-    Rcpp::NumericVector dv(domain);
-    if (!isInteger64(dv)) {
-      Rcpp::stop("dimension domain for INT64 must be an integer64 type in R");
-    }
-    if (dv.size() != 2) {
-      Rcpp::stop("dimension domain must be a c(lower bound, upper bound) pair");
-    }
-    std::vector<int64_t> domain_vec = fromInteger64(Rcpp::NumericVector(dv));
-    std::array<int64_t, 2> _domain = {domain_vec[0], domain_vec[1]};
-    Rcpp::NumericVector ext(tile_extent);
-    if (!isInteger64(ext)) {
-      Rcpp::stop("tile exent for INT64 domain must be an integer64 type in R");
-    }
-    int64_t _tile_extent = fromInteger64(ext[0]);
-    auto dim = new tiledb::Dimension(tiledb::Dimension::create<int64_t>(
-        *ctx.get(), name, _domain, _tile_extent));
-    auto ptr = make_xptr<tiledb::Dimension>(dim);
-    return ptr;
+        // for int64 domains and extents we require integer64 types which are internally memmap'ed from double
+        Rcpp::NumericVector dv(domain);
+        if (!isInteger64(dv)) {
+            Rcpp::stop("dimension domain for INT64 must be an integer64 type in R");
+        }
+        if (dv.size() != 2) {
+            Rcpp::stop("dimension domain must be a c(lower bound, upper bound) pair");
+        }
+        std::vector<int64_t> domain_vec = fromInteger64(Rcpp::NumericVector(dv));
+        std::array<int64_t, 2> _domain = {domain_vec[0], domain_vec[1]};
+        Rcpp::NumericVector ext(tile_extent);
+        if (!isInteger64(ext)) {
+            Rcpp::stop("tile exent for INT64 domain must be an integer64 type in R");
+        }
+        int64_t _tile_extent = fromInteger64(ext[0]);
+        auto dim = new tiledb::Dimension(tiledb::Dimension::create<int64_t>(*ctx.get(), name, _domain, _tile_extent));
+        auto ptr = make_xptr<tiledb::Dimension>(dim);
+        return ptr;
 
-  } else if (dtype == TILEDB_UINT64) {
-    // for uint64 domains and extents we require integer64 types which are
-    // internally memmap'ed from double
-    Rcpp::NumericVector dv(domain);
-    if (!isInteger64(dv)) {
-      Rcpp::stop("dimension domain for UINT64 must be an integer64 type in R");
-    }
-    if (dv.size() != 2) {
-      Rcpp::stop("dimension domain must be a c(lower bound, upper bound) pair");
-    }
-    std::vector<int64_t> domain_vec = fromInteger64(Rcpp::NumericVector(dv));
-    std::array<uint64_t, 2> _domain = {static_cast<uint64_t>(domain_vec[0]),
-                                       static_cast<uint64_t>(domain_vec[1])};
-    Rcpp::NumericVector ext(tile_extent);
-    if (!isInteger64(ext)) {
-      Rcpp::stop("tile exent for UINT64 domain must be an integer64 type in R");
-    }
-    uint64_t _tile_extent = static_cast<uint64_t>(fromInteger64(ext[0]));
-    auto dim = new tiledb::Dimension(tiledb::Dimension::create<uint64_t>(
-        *ctx.get(), name, _domain, _tile_extent));
-    auto ptr = make_xptr<tiledb::Dimension>(dim);
-    return ptr;
+    } else if (dtype == TILEDB_UINT64) {
+        // for uint64 domains and extents we require integer64 types which are internally memmap'ed from double
+        Rcpp::NumericVector dv(domain);
+        if (!isInteger64(dv)) {
+            Rcpp::stop("dimension domain for UINT64 must be an integer64 type in R");
+        }
+        if (dv.size() != 2) {
+            Rcpp::stop("dimension domain must be a c(lower bound, upper bound) pair");
+        }
+        std::vector<int64_t> domain_vec = fromInteger64(Rcpp::NumericVector(dv));
+        std::array<uint64_t, 2> _domain = { static_cast<uint64_t>(domain_vec[0]), static_cast<uint64_t>(domain_vec[1])};
+        Rcpp::NumericVector ext(tile_extent);
+        if (!isInteger64(ext)) {
+            Rcpp::stop("tile exent for UINT64 domain must be an integer64 type in R");
+        }
+        uint64_t _tile_extent = static_cast<uint64_t>(fromInteger64(ext[0]));
+        auto dim = new tiledb::Dimension(tiledb::Dimension::create<uint64_t>(*ctx.get(), name, _domain, _tile_extent));
+        auto ptr = make_xptr<tiledb::Dimension>(dim);
+        return ptr;
 
-  } else if (dtype == TILEDB_FLOAT32) {
-    Rcpp::NumericVector domain_vec = Rcpp::NumericVector(domain);
-    if (domain_vec.length() != 2) {
-      Rcpp::stop("dimension domain must be a c(lower bound, upper bound) pair");
-    }
-    std::array<float, 2> _domain = {static_cast<float>(domain_vec[0]),
-                                    static_cast<float>(domain_vec[1])};
-    float_t _tile_extent = Rcpp::as<float>(tile_extent);
-    auto d = new tiledb::Dimension(tiledb::Dimension::create<float>(
-        *ctx.get(), name, _domain, _tile_extent));
-    auto ptr = make_xptr<tiledb::Dimension>(d);
-    return ptr;
+    } else if (dtype == TILEDB_FLOAT32) {
+        Rcpp::NumericVector domain_vec = Rcpp::NumericVector(domain);
+        if (domain_vec.length() != 2) {
+            Rcpp::stop("dimension domain must be a c(lower bound, upper bound) pair");
+        }
+        std::array<float, 2> _domain = {static_cast<float>(domain_vec[0]), static_cast<float>(domain_vec[1])};
+        float_t _tile_extent = Rcpp::as<float>(tile_extent);
+        auto d = new tiledb::Dimension(tiledb::Dimension::create<float>(*ctx.get(), name, _domain, _tile_extent));
+        auto ptr = make_xptr<tiledb::Dimension>(d);
+        return ptr;
 
-  } else if (dtype == TILEDB_FLOAT64) {
-    Rcpp::NumericVector domain_vec = Rcpp::NumericVector(domain);
-    if (domain_vec.length() != 2) {
-      Rcpp::stop("dimension domain must be a c(lower bound, upper bound) pair");
-    }
-    std::array<double, 2> _domain = {static_cast<double>(domain_vec[0]),
-                                     static_cast<double>(domain_vec[1])};
-    double_t _tile_extent = Rcpp::as<double>(tile_extent);
-    auto d = new tiledb::Dimension(tiledb::Dimension::create<double>(
-        *ctx.get(), name, _domain, _tile_extent));
-    auto ptr = make_xptr<tiledb::Dimension>(d);
-    return ptr;
+    } else if (dtype == TILEDB_FLOAT64) {
+        Rcpp::NumericVector domain_vec = Rcpp::NumericVector(domain);
+        if (domain_vec.length() != 2) {
+            Rcpp::stop("dimension domain must be a c(lower bound, upper bound) pair");
+        }
+        std::array<double, 2> _domain = {static_cast<double>(domain_vec[0]), static_cast<double>(domain_vec[1])};
+        double_t _tile_extent = Rcpp::as<double>(tile_extent);
+        auto d = new tiledb::Dimension(tiledb::Dimension::create<double>(*ctx.get(), name, _domain, _tile_extent));
+        auto ptr = make_xptr<tiledb::Dimension>(d);
+        return ptr;
 
-  } else if (dtype == TILEDB_DATETIME_YEAR || dtype == TILEDB_DATETIME_MONTH ||
-             dtype == TILEDB_DATETIME_WEEK || dtype == TILEDB_DATETIME_DAY ||
-             dtype == TILEDB_DATETIME_HR || dtype == TILEDB_DATETIME_MIN ||
-             dtype == TILEDB_DATETIME_SEC || dtype == TILEDB_DATETIME_MS ||
-             dtype == TILEDB_DATETIME_US || dtype == TILEDB_DATETIME_NS ||
-             dtype == TILEDB_DATETIME_PS || dtype == TILEDB_DATETIME_FS ||
-             dtype == TILEDB_DATETIME_AS) {
-    auto domain_vec = as<std::vector<int64_t>>(domain);
-    if (domain_vec.size() != 2) {
-      Rcpp::stop("dimension domain must be a c(lower bound, upper bound) pair");
-    }
-    int64_t domain[] = {domain_vec[0], domain_vec[1]};
-    int64_t extent = Rcpp::as<int64_t>(tile_extent);
-    auto dim = new tiledb::Dimension(
-        tiledb::Dimension::create(*ctx.get(), name, dtype, domain, &extent));
-    auto ptr = make_xptr<tiledb::Dimension>(dim);
-    return ptr;
+    } else if (dtype == TILEDB_DATETIME_YEAR ||
+               dtype == TILEDB_DATETIME_MONTH ||
+               dtype == TILEDB_DATETIME_WEEK ||
+               dtype == TILEDB_DATETIME_DAY ||
+               dtype == TILEDB_DATETIME_HR  ||
+               dtype == TILEDB_DATETIME_MIN ||
+               dtype == TILEDB_DATETIME_SEC ||
+               dtype == TILEDB_DATETIME_MS  ||
+               dtype == TILEDB_DATETIME_US  ||
+               dtype == TILEDB_DATETIME_NS  ||
+               dtype == TILEDB_DATETIME_PS  ||
+               dtype == TILEDB_DATETIME_FS  ||
+               dtype == TILEDB_DATETIME_AS    ) {
+        auto domain_vec = as<std::vector<int64_t>>(domain);
+        if (domain_vec.size() != 2) {
+            Rcpp::stop("dimension domain must be a c(lower bound, upper bound) pair");
+        }
+        int64_t domain[] = {domain_vec[0], domain_vec[1]};
+        int64_t extent = Rcpp::as<int64_t>(tile_extent);
+        auto dim = new tiledb::Dimension(tiledb::Dimension::create(*ctx.get(), name, dtype, domain, &extent));
+        auto ptr = make_xptr<tiledb::Dimension>(dim);
+        return ptr;
 
-  } else if (dtype == TILEDB_STRING_ASCII) {
-    if (Rf_isNull(domain) && Rf_isNull(tile_extent)) {
-      auto d =
-          tiledb::Dimension::create(*ctx.get(), name, dtype, nullptr, nullptr);
-      auto dim = new tiledb::Dimension(d);
-      auto ptr = make_xptr<tiledb::Dimension>(dim);
-      return ptr;
+    } else if (dtype == TILEDB_STRING_ASCII) {
+        if (Rf_isNull(domain) && Rf_isNull(tile_extent)) {
+            auto d = tiledb::Dimension::create(*ctx.get(), name, dtype, nullptr, nullptr);
+            auto dim = new tiledb::Dimension(d);
+            auto ptr = make_xptr<tiledb::Dimension>(dim);
+            return ptr;
 
+        } else {
+            Rcpp::stop("Non-null domain or extent to be added.");
+        }
     } else {
-      Rcpp::stop("Non-null domain or extent to be added.");
+        Rcpp::stop("Unsupported tiledb type (%d) this should not happen!", dtype);
     }
-  } else {
-    Rcpp::stop("Unsupported tiledb type (%d) this should not happen!", dtype);
-  }
 }
 
 // [[Rcpp::export]]
@@ -942,125 +895,105 @@ SEXP libtiledb_dim_get_domain(XPtr<tiledb::Dimension> dim) {
   check_xptr_tag<tiledb::Dimension>(dim);
   auto dim_type = dim->type();
   switch (dim_type) {
-  case TILEDB_FLOAT32: {
-    using DataType = tiledb::impl::tiledb_to_type<TILEDB_FLOAT32>::type;
-    return NumericVector(
-        {dim->domain<DataType>().first, dim->domain<DataType>().second});
-  }
-  case TILEDB_FLOAT64: {
-    using DataType = tiledb::impl::tiledb_to_type<TILEDB_FLOAT64>::type;
-    auto d1 = dim->domain<DataType>().first;
-    auto d2 = dim->domain<DataType>().second;
-    if (d1 == R_NaReal || d2 == R_NaReal) {
-      Rcpp::stop(
-          "tiledb_dim domain FLOAT64 value not representable as an R double");
+    case TILEDB_FLOAT32: {
+      using DataType = tiledb::impl::tiledb_to_type<TILEDB_FLOAT32>::type;
+      return NumericVector({dim->domain<DataType>().first,
+                            dim->domain<DataType>().second});
     }
-    return NumericVector({d1, d2});
-  }
-  case TILEDB_INT8: {
-    using DataType = tiledb::impl::tiledb_to_type<TILEDB_INT8>::type;
-    return IntegerVector(
-        {dim->domain<DataType>().first, dim->domain<DataType>().second});
-  }
-  case TILEDB_UINT8: {
-    using DataType = tiledb::impl::tiledb_to_type<TILEDB_UINT8>::type;
-    return IntegerVector(
-        {dim->domain<DataType>().first, dim->domain<DataType>().second});
-  }
-  case TILEDB_INT16: {
-    using DataType = tiledb::impl::tiledb_to_type<TILEDB_INT16>::type;
-    return IntegerVector(
-        {dim->domain<DataType>().first, dim->domain<DataType>().second});
-  }
-  case TILEDB_UINT16: {
-    using DataType = tiledb::impl::tiledb_to_type<TILEDB_INT16>::type;
-    return IntegerVector(
-        {dim->domain<DataType>().first, dim->domain<DataType>().second});
-  }
-  case TILEDB_INT32: {
-    using DataType = tiledb::impl::tiledb_to_type<TILEDB_INT32>::type;
-    auto d1 = dim->domain<DataType>().first;
-    auto d2 = dim->domain<DataType>().second;
-    if (d1 == R_NaInt || d2 == R_NaInt) {
-      Rcpp::stop(
-          "tiledb_dim domain INT32 value not representable as an R integer");
+    case TILEDB_FLOAT64: {
+      using DataType = tiledb::impl::tiledb_to_type<TILEDB_FLOAT64>::type;
+      auto d1 = dim->domain<DataType>().first;
+      auto d2 = dim->domain<DataType>().second;
+      if (d1 == R_NaReal || d2 == R_NaReal) {
+        Rcpp::stop("tiledb_dim domain FLOAT64 value not representable as an R double");
+      }
+      return NumericVector({d1, d2});
     }
-    return IntegerVector({d1, d2});
-  }
-  case TILEDB_UINT32: {
-    using DataType = tiledb::impl::tiledb_to_type<TILEDB_UINT32>::type;
-    auto d1 = dim->domain<DataType>().first;
-    auto d2 = dim->domain<DataType>().second;
-    if (d1 > std::numeric_limits<uint32_t>::max() ||
-        d2 > std::numeric_limits<uint32_t>::max()) {
-      Rcpp::stop("tiledb_dim domain UINT32 value not representable as an R "
-                 "integer64 type");
+    case TILEDB_INT8: {
+      using DataType = tiledb::impl::tiledb_to_type<TILEDB_INT8>::type;
+      return IntegerVector({dim->domain<DataType>().first,
+                            dim->domain<DataType>().second});
     }
-    std::vector<int64_t> v = {static_cast<int64_t>(d1),
-                              static_cast<int64_t>(d2)};
-    return toInteger64(v);
-  }
-  case TILEDB_INT64: {
-    using DataType = tiledb::impl::tiledb_to_type<TILEDB_INT64>::type;
-    auto d1 = dim->domain<DataType>().first;
-    auto d2 = dim->domain<DataType>().second;
-    if (d1 > std::numeric_limits<int64_t>::max() ||
-        d2 > std::numeric_limits<int64_t>::max()) {
-      return NumericVector({static_cast<double>(d1), static_cast<double>(d2)});
+    case TILEDB_UINT8: {
+      using DataType = tiledb::impl::tiledb_to_type<TILEDB_UINT8>::type;
+      return IntegerVector({dim->domain<DataType>().first,
+                            dim->domain<DataType>().second});
     }
-    std::vector<int64_t> v = {d1, d2};
-    return toInteger64(v);
-  }
-  case TILEDB_UINT64: {
-    using DataType = tiledb::impl::tiledb_to_type<TILEDB_UINT64>::type;
-    auto d1 = dim->domain<DataType>().first;
-    auto d2 = dim->domain<DataType>().second;
-    if (d1 > std::numeric_limits<int64_t>::max() ||
-        d2 > std::numeric_limits<int64_t>::max()) {
-      return NumericVector({static_cast<double>(d1), static_cast<double>(d2)});
+    case TILEDB_INT16: {
+      using DataType = tiledb::impl::tiledb_to_type<TILEDB_INT16>::type;
+      return IntegerVector({dim->domain<DataType>().first,
+                            dim->domain<DataType>().second});
     }
-<<<<<<< HEAD
-  case TILEDB_UINT16: {
-    using DataType = tiledb::impl::tiledb_to_type<TILEDB_UINT16>::type;
-    return IntegerVector(
-        {dim->domain<DataType>().first, dim->domain<DataType>().second});
-||||||| parent of 11968568 (clang-format src/libtiledb.cpp)
-  case TILEDB_UINT16: {
-    using DataType = tiledb::impl::tiledb_to_type<TILEDB_INT16>::type;
-    return IntegerVector(
-        {dim->domain<DataType>().first, dim->domain<DataType>().second});
-=======
-    std::vector<int64_t> v = {static_cast<int64_t>(d1),
-                              static_cast<int64_t>(d2)};
-    return toInteger64(v);
-  }
-  case TILEDB_DATETIME_YEAR:
-  case TILEDB_DATETIME_MONTH:
-  case TILEDB_DATETIME_WEEK:
-  case TILEDB_DATETIME_DAY:
-  case TILEDB_DATETIME_HR:
-  case TILEDB_DATETIME_MIN:
-  case TILEDB_DATETIME_SEC:
-  case TILEDB_DATETIME_MS:
-  case TILEDB_DATETIME_US:
-  case TILEDB_DATETIME_NS:
-  case TILEDB_DATETIME_PS:
-  case TILEDB_DATETIME_FS:
-  case TILEDB_DATETIME_AS: {
-    using DataType = tiledb::impl::tiledb_to_type<TILEDB_INT64>::type;
-    auto d1 = dim->domain<DataType>().first;
-    auto d2 = dim->domain<DataType>().second;
-    if (d1 <= R_NaInt || d1 > std::numeric_limits<int32_t>::max() ||
-        d2 <= R_NaInt || d2 > std::numeric_limits<int32_t>::max()) {
-      std::vector<int64_t> v{d1, d2}; // return as int64
-      return toInteger64(v);          // which 'travels' as a double
->>>>>>> 11968568 (clang-format src/libtiledb.cpp)
-  }
-    return IntegerVector({static_cast<int32_t>(d1), static_cast<int32_t>(d2)});
-  }
-  default:
-    Rcpp::stop("invalid tiledb_dim domain type (%s)",
-               _tiledb_datatype_to_string(dim_type));
+    case TILEDB_UINT16: {
+      using DataType = tiledb::impl::tiledb_to_type<TILEDB_UINT16>::type;
+      return IntegerVector({dim->domain<DataType>().first,
+                            dim->domain<DataType>().second});
+    }
+    case TILEDB_INT32: {
+      using DataType = tiledb::impl::tiledb_to_type<TILEDB_INT32>::type;
+      auto d1 = dim->domain<DataType>().first;
+      auto d2 = dim->domain<DataType>().second;
+      if (d1 == R_NaInt || d2 == R_NaInt) {
+        Rcpp::stop("tiledb_dim domain INT32 value not representable as an R integer");
+      }
+      return IntegerVector({d1, d2});
+    }
+    case TILEDB_UINT32: {
+      using DataType = tiledb::impl::tiledb_to_type<TILEDB_UINT32>::type;
+      auto d1 = dim->domain<DataType>().first;
+      auto d2 = dim->domain<DataType>().second;
+      if (d1 > std::numeric_limits<uint32_t>::max() ||
+          d2 > std::numeric_limits<uint32_t>::max()) {
+        Rcpp::stop("tiledb_dim domain UINT32 value not representable as an R integer64 type");
+      }
+      std::vector<int64_t> v = { static_cast<int64_t>(d1), static_cast<int64_t>(d2) };
+      return toInteger64(v);
+    }
+    case TILEDB_INT64: {
+      using DataType = tiledb::impl::tiledb_to_type<TILEDB_INT64>::type;
+      auto d1 = dim->domain<DataType>().first;
+      auto d2 = dim->domain<DataType>().second;
+      if (d1 > std::numeric_limits<int64_t>::max() || d2 > std::numeric_limits<int64_t>::max()) {
+          return NumericVector({static_cast<double>(d1), static_cast<double>(d2)});
+      }
+      std::vector<int64_t> v = { d1, d2 };
+      return toInteger64(v);
+    }
+    case TILEDB_UINT64: {
+      using DataType = tiledb::impl::tiledb_to_type<TILEDB_UINT64>::type;
+      auto d1 = dim->domain<DataType>().first;
+      auto d2 = dim->domain<DataType>().second;
+      if (d1 > std::numeric_limits<int64_t>::max() || d2 > std::numeric_limits<int64_t>::max()) {
+          return NumericVector({static_cast<double>(d1), static_cast<double>(d2)});
+      }
+      std::vector<int64_t> v = { static_cast<int64_t>(d1), static_cast<int64_t>(d2) };
+      return toInteger64(v);
+    }
+    case TILEDB_DATETIME_YEAR:
+    case TILEDB_DATETIME_MONTH:
+    case TILEDB_DATETIME_WEEK:
+    case TILEDB_DATETIME_DAY:
+    case TILEDB_DATETIME_HR:
+    case TILEDB_DATETIME_MIN:
+    case TILEDB_DATETIME_SEC:
+    case TILEDB_DATETIME_MS:
+    case TILEDB_DATETIME_US:
+    case TILEDB_DATETIME_NS:
+    case TILEDB_DATETIME_PS:
+    case TILEDB_DATETIME_FS:
+    case TILEDB_DATETIME_AS: {
+      using DataType = tiledb::impl::tiledb_to_type<TILEDB_INT64>::type;
+      auto d1 = dim->domain<DataType>().first;
+      auto d2 = dim->domain<DataType>().second;
+      if (d1 <= R_NaInt || d1 > std::numeric_limits<int32_t>::max() ||
+          d2 <= R_NaInt || d2 > std::numeric_limits<int32_t>::max()) {
+          std::vector<int64_t> v{d1, d2};     // return as int64
+          return toInteger64(v);              // which 'travels' as a double
+      }
+      return IntegerVector({static_cast<int32_t>(d1), static_cast<int32_t>(d2)});
+    }
+    default:
+      Rcpp::stop("invalid tiledb_dim domain type (%s)", _tiledb_datatype_to_string(dim_type));
   }
 }
 
@@ -1069,146 +1002,91 @@ SEXP libtiledb_dim_get_tile_extent(XPtr<tiledb::Dimension> dim) {
   check_xptr_tag<tiledb::Dimension>(dim);
   auto dim_type = dim->type();
   switch (dim_type) {
-  case TILEDB_FLOAT32: {
-    using DataType = tiledb::impl::tiledb_to_type<TILEDB_FLOAT32>::type;
-    return Rcpp::wrap(static_cast<double>(dim->tile_extent<DataType>()));
-  }
-  case TILEDB_FLOAT64: {
-    using DataType = tiledb::impl::tiledb_to_type<TILEDB_FLOAT64>::type;
-    auto t = dim->tile_extent<DataType>();
-    if (t == R_NaReal) {
-      Rcpp::stop(
-          "tiledb_dim tile FLOAT64 value not representable as an R double");
+    case TILEDB_FLOAT32: {
+      using DataType = tiledb::impl::tiledb_to_type<TILEDB_FLOAT32>::type;
+      return Rcpp::wrap(static_cast<double>(dim->tile_extent<DataType>()));
     }
-    return Rcpp::wrap(static_cast<double>(dim->tile_extent<DataType>()));
-  }
-  case TILEDB_INT8: {
-    using DataType = tiledb::impl::tiledb_to_type<TILEDB_INT8>::type;
-    return Rcpp::wrap(static_cast<int32_t>(dim->tile_extent<DataType>()));
-  }
-  case TILEDB_UINT8: {
-    using DataType = tiledb::impl::tiledb_to_type<TILEDB_UINT8>::type;
-    return Rcpp::wrap(static_cast<int32_t>(dim->tile_extent<DataType>()));
-  }
-  case TILEDB_INT16: {
-    using DataType = tiledb::impl::tiledb_to_type<TILEDB_INT16>::type;
-    return Rcpp::wrap(static_cast<int32_t>(dim->tile_extent<DataType>()));
-  }
-  case TILEDB_UINT16: {
-    using DataType = tiledb::impl::tiledb_to_type<TILEDB_INT16>::type;
-    return Rcpp::wrap(static_cast<int32_t>(dim->tile_extent<DataType>()));
-  }
-  case TILEDB_INT32: {
-    using DataType = tiledb::impl::tiledb_to_type<TILEDB_INT32>::type;
-    auto t = dim->tile_extent<DataType>();
-    if (t == R_NaInt) {
-      Rcpp::stop(
-          "tiledb_dim tile INT32 value not representable as an R integer");
+    case TILEDB_FLOAT64: {
+      using DataType = tiledb::impl::tiledb_to_type<TILEDB_FLOAT64>::type;
+      auto t = dim->tile_extent<DataType>();
+      if (t == R_NaReal) {
+        Rcpp::stop("tiledb_dim tile FLOAT64 value not representable as an R double");
+      }
+      return Rcpp::wrap(static_cast<double>(dim->tile_extent<DataType>()));
     }
-<<<<<<< HEAD
-  case TILEDB_INT8: {
-    using DataType = tiledb::impl::tiledb_to_type<TILEDB_INT8>::type;
-    return Rcpp::wrap(static_cast<int32_t>(dim->tile_extent<DataType>()));
-  }
-  case TILEDB_UINT8: {
-    using DataType = tiledb::impl::tiledb_to_type<TILEDB_UINT8>::type;
-    return Rcpp::wrap(static_cast<int32_t>(dim->tile_extent<DataType>()));
-  }
-  case TILEDB_INT16: {
-    using DataType = tiledb::impl::tiledb_to_type<TILEDB_INT16>::type;
-    return Rcpp::wrap(static_cast<int32_t>(dim->tile_extent<DataType>()));
-  }
-  case TILEDB_UINT16: {
-    using DataType = tiledb::impl::tiledb_to_type<TILEDB_UINT16>::type;
-    return Rcpp::wrap(static_cast<int32_t>(dim->tile_extent<DataType>()));
-  }
-  case TILEDB_INT32: {
-    using DataType = tiledb::impl::tiledb_to_type<TILEDB_INT32>::type;
-    auto t = dim->tile_extent<DataType>();
-    if (t == R_NaInt) {
-      Rcpp::stop(
-          "tiledb_dim tile INT32 value not representable as an R integer");
+    case TILEDB_INT8: {
+      using DataType = tiledb::impl::tiledb_to_type<TILEDB_INT8>::type;
+      return Rcpp::wrap(static_cast<int32_t>(dim->tile_extent<DataType>()));
     }
-||||||| parent of 11968568 (clang-format src/libtiledb.cpp)
-  case TILEDB_INT8: {
-    using DataType = tiledb::impl::tiledb_to_type<TILEDB_INT8>::type;
-    return Rcpp::wrap(static_cast<int32_t>(dim->tile_extent<DataType>()));
-  }
-  case TILEDB_UINT8: {
-    using DataType = tiledb::impl::tiledb_to_type<TILEDB_UINT8>::type;
-    return Rcpp::wrap(static_cast<int32_t>(dim->tile_extent<DataType>()));
-  }
-  case TILEDB_INT16: {
-    using DataType = tiledb::impl::tiledb_to_type<TILEDB_INT16>::type;
-    return Rcpp::wrap(static_cast<int32_t>(dim->tile_extent<DataType>()));
-  }
-  case TILEDB_UINT16: {
-    using DataType = tiledb::impl::tiledb_to_type<TILEDB_INT16>::type;
-    return Rcpp::wrap(static_cast<int32_t>(dim->tile_extent<DataType>()));
-  }
-  case TILEDB_INT32: {
-    using DataType = tiledb::impl::tiledb_to_type<TILEDB_INT32>::type;
-    auto t = dim->tile_extent<DataType>();
-    if (t == R_NaInt) {
-      Rcpp::stop(
-          "tiledb_dim tile INT32 value not representable as an R integer");
+    case TILEDB_UINT8: {
+      using DataType = tiledb::impl::tiledb_to_type<TILEDB_UINT8>::type;
+      return Rcpp::wrap(static_cast<int32_t>(dim->tile_extent<DataType>()));
     }
-=======
-    return Rcpp::wrap(static_cast<int32_t>(t));
-  }
-  case TILEDB_UINT32: {
-    using DataType = tiledb::impl::tiledb_to_type<TILEDB_UINT32>::type;
-    auto t = dim->tile_extent<DataType>();
-    if (t > std::numeric_limits<int32_t>::max()) {
-      Rcpp::warning("tiledb_dim tile UINT32 value not representable as an R "
-                    "integer, returning double");
-      return Rcpp::wrap(static_cast<double>(t));
-    } else {
->>>>>>> 11968568 (clang-format src/libtiledb.cpp)
-    return Rcpp::wrap(static_cast<int32_t>(t));
-  }
-  }
-  case TILEDB_DATETIME_YEAR:
-  case TILEDB_DATETIME_MONTH:
-  case TILEDB_DATETIME_WEEK:
-  case TILEDB_DATETIME_DAY:
-  case TILEDB_DATETIME_HR:
-  case TILEDB_DATETIME_MIN:
-  case TILEDB_DATETIME_SEC:
-  case TILEDB_DATETIME_MS:
-  case TILEDB_DATETIME_US:
-  case TILEDB_DATETIME_NS:
-  case TILEDB_DATETIME_PS:
-  case TILEDB_DATETIME_FS:
-  case TILEDB_DATETIME_AS:
-  case TILEDB_INT64: {
-    using DataType = tiledb::impl::tiledb_to_type<TILEDB_INT64>::type;
-    auto t = dim->tile_extent<DataType>();
-    if (t <= R_NaInt || t > std::numeric_limits<int32_t>::max()) {
-      std::vector<int64_t> v{t}; // return as int64
-      return toInteger64(v);     // which 'travels' as a double
+    case TILEDB_INT16: {
+      using DataType = tiledb::impl::tiledb_to_type<TILEDB_INT16>::type;
+      return Rcpp::wrap(static_cast<int32_t>(dim->tile_extent<DataType>()));
     }
-    // 'else' i.e. default cast to int32
-    return Rcpp::wrap(static_cast<int32_t>(t));
-  }
-  case TILEDB_UINT64: {
-    using DataType = tiledb::impl::tiledb_to_type<TILEDB_UINT64>::type;
-    auto t = dim->tile_extent<DataType>();
-    if (t > std::numeric_limits<int64_t>::max()) {
-      Rcpp::warning("tiledb_dim tile UINT32 value not representable as an "
-                    "INT64, returning double");
-      return Rcpp::wrap(static_cast<double>(t));
+    case TILEDB_UINT16: {
+      using DataType = tiledb::impl::tiledb_to_type<TILEDB_UINT16>::type;
+      return Rcpp::wrap(static_cast<int32_t>(dim->tile_extent<DataType>()));
     }
-    if (t > std::numeric_limits<int32_t>::max()) {
-      auto tt = static_cast<int64_t>(t); // avoids a 'narrowing' watnings
-      std::vector<int64_t> v{tt};        // return as int64
-      return toInteger64(v);             // which 'travels' as a double
+    case TILEDB_INT32: {
+      using DataType = tiledb::impl::tiledb_to_type<TILEDB_INT32>::type;
+      auto t = dim->tile_extent<DataType>();
+      if (t == R_NaInt) {
+        Rcpp::stop("tiledb_dim tile INT32 value not representable as an R integer");
+      }
+      return Rcpp::wrap(static_cast<int32_t>(t));
     }
-    return Rcpp::wrap(static_cast<int32_t>(t));
-  }
-  default:
-    Rcpp::stop("invalid tiledb_dim domain type (%s)",
-               _tiledb_datatype_to_string(dim_type));
+    case TILEDB_UINT32: {
+      using DataType = tiledb::impl::tiledb_to_type<TILEDB_UINT32>::type;
+      auto t = dim->tile_extent<DataType>();
+      if (t > std::numeric_limits<int32_t>::max()) {
+        Rcpp::warning("tiledb_dim tile UINT32 value not representable as an R integer, returning double");
+        return Rcpp::wrap(static_cast<double>(t));
+      } else {
+        return Rcpp::wrap(static_cast<int32_t>(t));
+      }
+    }
+    case TILEDB_DATETIME_YEAR:
+    case TILEDB_DATETIME_MONTH:
+    case TILEDB_DATETIME_WEEK:
+    case TILEDB_DATETIME_DAY:
+    case TILEDB_DATETIME_HR:
+    case TILEDB_DATETIME_MIN:
+    case TILEDB_DATETIME_SEC:
+    case TILEDB_DATETIME_MS:
+    case TILEDB_DATETIME_US:
+    case TILEDB_DATETIME_NS:
+    case TILEDB_DATETIME_PS:
+    case TILEDB_DATETIME_FS:
+    case TILEDB_DATETIME_AS:
+    case TILEDB_INT64: {
+      using DataType = tiledb::impl::tiledb_to_type<TILEDB_INT64>::type;
+      auto t = dim->tile_extent<DataType>();
+      if (t <= R_NaInt || t > std::numeric_limits<int32_t>::max()) {
+          std::vector<int64_t> v{t};         // return as int64
+          return toInteger64(v);             // which 'travels' as a double
+      }
+      // 'else' i.e. default cast to int32
+      return Rcpp::wrap(static_cast<int32_t>(t));
+    }
+    case TILEDB_UINT64: {
+      using DataType = tiledb::impl::tiledb_to_type<TILEDB_UINT64>::type;
+      auto t = dim->tile_extent<DataType>();
+      if (t > std::numeric_limits<int64_t>::max()) {
+          Rcpp::warning("tiledb_dim tile UINT32 value not representable as an INT64, returning double");
+          return Rcpp::wrap(static_cast<double>(t));
+      }
+      if (t > std::numeric_limits<int32_t>::max()) {
+          auto tt = static_cast<int64_t>(t); // avoids a 'narrowing' watnings
+          std::vector<int64_t> v{ tt };      // return as int64
+          return toInteger64(v);             // which 'travels' as a double
+      }
+      return Rcpp::wrap(static_cast<int32_t>(t));
+    }
+    default:
+      Rcpp::stop("invalid tiledb_dim domain type (%s)", _tiledb_datatype_to_string(dim_type));
   }
 }
 
@@ -1220,8 +1098,7 @@ std::string libtiledb_dim_get_datatype(XPtr<tiledb::Dimension> dim) {
 
 // Computes the TileDB subarray for a given dimension domain
 // [[Rcpp::export]]
-NumericVector dim_domain_subarray(NumericVector domain,
-                                  NumericVector subscript) {
+NumericVector dim_domain_subarray(NumericVector domain, NumericVector subscript) {
   if (domain.length() != 2) {
     Rcpp::stop("invalid tiledb_dim domain");
   }
@@ -1248,8 +1125,8 @@ NumericVector dim_domain_subarray(NumericVector domain,
       Rcpp::stop("NA subscripting not supported");
     }
     if (high < domain_lb || high > domain_ub) {
-      Rcpp::stop("subscript out of domain bounds: (at index: [%d] %f < %f", i,
-                 high, domain_lb);
+      Rcpp::stop("subscript out of domain bounds: (at index: [%d] %f < %f",
+                 i, high, domain_lb);
     }
     double diff = high - low;
     if (diff > 1.0 || diff < 1.0) {
@@ -1270,7 +1147,7 @@ int libtiledb_dim_get_cell_val_num(XPtr<tiledb::Dimension> dim) {
   check_xptr_tag<tiledb::Dimension>(dim);
   unsigned int ncells = dim->cell_val_num();
   if (ncells == TILEDB_VAR_NUM) {
-    return R_NaInt; // set to R's NA for integer
+    return R_NaInt;          // set to R's NA for integer
   } else if (ncells > std::numeric_limits<int32_t>::max()) {
     Rcpp::stop("tiledb_attr ncells value not representable as an R integer");
   }
@@ -1278,22 +1155,20 @@ int libtiledb_dim_get_cell_val_num(XPtr<tiledb::Dimension> dim) {
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::FilterList>
-libtiledb_dimension_get_filter_list(XPtr<tiledb::Dimension> dim) {
+XPtr<tiledb::FilterList> libtiledb_dimension_get_filter_list(XPtr<tiledb::Dimension> dim) {
   check_xptr_tag<tiledb::Dimension>(dim);
-  return make_xptr<tiledb::FilterList>(
-      new tiledb::FilterList(dim->filter_list()));
+  return make_xptr<tiledb::FilterList>(new tiledb::FilterList(dim->filter_list()));
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::Dimension>
-libtiledb_dimension_set_filter_list(XPtr<tiledb::Dimension> dim,
-                                    XPtr<tiledb::FilterList> fltrlst) {
+XPtr<tiledb::Dimension> libtiledb_dimension_set_filter_list(XPtr<tiledb::Dimension> dim,
+                                                            XPtr<tiledb::FilterList> fltrlst) {
   check_xptr_tag<tiledb::Dimension>(dim);
   check_xptr_tag<tiledb::FilterList>(fltrlst);
   dim->set_filter_list(*fltrlst);
   return dim;
 }
+
 
 /**
  * TileDB Domain
@@ -1305,18 +1180,15 @@ XPtr<tiledb::Domain> libtiledb_domain(XPtr<tiledb::Context> ctx, List dims) {
   if (ndims == 0) {
     Rcpp::stop("domain must have one or more dimensions");
   }
-  for (R_xlen_t i = 0; i < ndims; i++) {
+  for (R_xlen_t i=0; i < ndims; i++) {
     SEXP d = dims[i];
     if (TYPEOF(d) != EXTPTRSXP) {
-      Rcpp::stop("Invalid tiledb_dim object at index %d (type %s)", i,
-                 Rcpp::type2name(d));
+      Rcpp::stop("Invalid tiledb_dim object at index %d (type %s)", i, Rcpp::type2name(d));
     }
   }
-  XPtr<tiledb::Domain> domain =
-      make_xptr<tiledb::Domain>(new tiledb::Domain(*ctx.get()));
-  for (auto &val : dims) {
-    // TODO: we can't do much type checking for the cast here until we wrap
-    // EXTPTRSXP in S4 classes
+  XPtr<tiledb::Domain> domain = make_xptr<tiledb::Domain>(new tiledb::Domain(*ctx.get()));
+  for (auto& val : dims) {
+    // TODO: we can't do much type checking for the cast here until we wrap EXTPTRSXP in S4 classes
     auto dim = as<XPtr<tiledb::Dimension>>(val);
     check_xptr_tag<tiledb::Dimension>(dim);
     domain->add_dimension(*dim.get());
@@ -1342,8 +1214,7 @@ int libtiledb_domain_get_ndim(XPtr<tiledb::Domain> domain) {
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::Dimension>
-libtiledb_domain_get_dimension_from_index(XPtr<tiledb::Domain> dom, int idx) {
+XPtr<tiledb::Dimension> libtiledb_domain_get_dimension_from_index(XPtr<tiledb::Domain> dom, int idx) {
   check_xptr_tag<tiledb::Domain>(dom);
   auto dim = dom->dimension(idx);
   auto ptr = make_xptr<tiledb::Dimension>(new tiledb::Dimension(dim));
@@ -1351,9 +1222,8 @@ libtiledb_domain_get_dimension_from_index(XPtr<tiledb::Domain> dom, int idx) {
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::Dimension>
-libtiledb_domain_get_dimension_from_name(XPtr<tiledb::Domain> dom,
-                                         std::string name) {
+XPtr<tiledb::Dimension> libtiledb_domain_get_dimension_from_name(XPtr<tiledb::Domain> dom,
+                                                                 std::string name) {
   check_xptr_tag<tiledb::Domain>(dom);
   auto dim = dom->dimension(name.c_str());
   auto ptr = make_xptr<tiledb::Dimension>(new tiledb::Dimension(dim));
@@ -1364,16 +1234,14 @@ libtiledb_domain_get_dimension_from_name(XPtr<tiledb::Domain> dom,
 List libtiledb_domain_get_dimensions(XPtr<tiledb::Domain> domain) {
   check_xptr_tag<tiledb::Domain>(domain);
   List dimensions;
-  for (auto &dim : domain->dimensions()) {
-    dimensions.push_back(
-        make_xptr<tiledb::Dimension>(new tiledb::Dimension(dim)));
+  for (auto& dim : domain->dimensions()) {
+    dimensions.push_back(make_xptr<tiledb::Dimension>(new tiledb::Dimension(dim)));
   }
   return dimensions;
 }
 
 // [[Rcpp::export]]
-bool libtiledb_domain_has_dimension(XPtr<tiledb::Domain> domain,
-                                    std::string name) {
+bool libtiledb_domain_has_dimension(XPtr<tiledb::Domain> domain, std::string name) {
   check_xptr_tag<tiledb::Domain>(domain);
   return domain->has_dimension(name.c_str());
 }
@@ -1381,7 +1249,7 @@ bool libtiledb_domain_has_dimension(XPtr<tiledb::Domain> domain,
 // [[Rcpp::export]]
 void libtiledb_domain_dump(XPtr<tiledb::Domain> domain) {
   check_xptr_tag<tiledb::Domain>(domain);
-#if TILEDB_VERSION >= TileDB_Version(2, 25, 0)
+#if TILEDB_VERSION >= TileDB_Version(2,25,0)
   std::stringstream ss;
   ss << *domain;
   Rcpp::Rcout << ss.str();
@@ -1391,8 +1259,7 @@ void libtiledb_domain_dump(XPtr<tiledb::Domain> domain) {
 }
 
 double _domain_datatype_time_scale_factor(tiledb_datatype_t dtype) {
-  // Rcpp::Rcout << "In _domain_datatype_time_scale_factor " << dtype <<
-  // std::endl;
+  //Rcpp::Rcout << "In _domain_datatype_time_scale_factor " << dtype << std::endl;
   switch (dtype) {
   case TILEDB_INT8:
   case TILEDB_UINT8:
@@ -1412,11 +1279,11 @@ double _domain_datatype_time_scale_factor(tiledb_datatype_t dtype) {
   case TILEDB_STRING_UCS2:
   case TILEDB_STRING_UCS4:
   case TILEDB_ANY:
-    return 1.0; // fallback, could also error here
+    return 1.0;               // fallback, could also error here
   case TILEDB_DATETIME_YEAR:
   case TILEDB_DATETIME_MONTH:
   case TILEDB_DATETIME_WEEK:
-    return 1.0; // also fallback
+    return 1.0;                 // also fallback
   case TILEDB_DATETIME_DAY:
     return 24 * 60 * 60 * 1e9;
   case TILEDB_DATETIME_HR:
@@ -1443,12 +1310,12 @@ double _domain_datatype_time_scale_factor(tiledb_datatype_t dtype) {
   return R_NaReal; // not reached
 }
 
+
 /**
  * TileDB Filter
  */
 //[[Rcpp::export]]
-XPtr<tiledb::Filter> libtiledb_filter(XPtr<tiledb::Context> ctx,
-                                      std::string filter) {
+XPtr<tiledb::Filter> libtiledb_filter(XPtr<tiledb::Context> ctx, std::string filter) {
   check_xptr_tag<tiledb::Context>(ctx);
   tiledb_filter_type_t fltr = _string_to_tiledb_filter(filter);
   return make_xptr<tiledb::Filter>(new tiledb::Filter(*ctx.get(), fltr));
@@ -1461,13 +1328,10 @@ std::string libtiledb_filter_get_type(XPtr<tiledb::Filter> filter) {
 }
 
 //[[Rcpp::export]]
-R_xlen_t libtiledb_filter_get_option(XPtr<tiledb::Filter> filter,
-                                     std::string filter_option_str) {
+R_xlen_t libtiledb_filter_get_option(XPtr<tiledb::Filter> filter, std::string filter_option_str) {
   check_xptr_tag<tiledb::Filter>(filter);
-  tiledb_filter_option_t filter_option =
-      _string_to_tiledb_filter_option(filter_option_str);
-  if (filter_option == TILEDB_BIT_WIDTH_MAX_WINDOW ||
-      filter_option == TILEDB_POSITIVE_DELTA_MAX_WINDOW) {
+  tiledb_filter_option_t filter_option = _string_to_tiledb_filter_option(filter_option_str);
+  if (filter_option == TILEDB_BIT_WIDTH_MAX_WINDOW || filter_option == TILEDB_POSITIVE_DELTA_MAX_WINDOW) {
     uint32_t value;
     filter->get_option(filter_option, &value);
     return static_cast<R_xlen_t>(value);
@@ -1478,46 +1342,39 @@ R_xlen_t libtiledb_filter_get_option(XPtr<tiledb::Filter> filter,
 }
 
 //[[Rcpp::export]]
-XPtr<tiledb::Filter> libtiledb_filter_set_option(XPtr<tiledb::Filter> filter,
-                                                 std::string filter_option_str,
-                                                 SEXP valuesxp) {
-  check_xptr_tag<tiledb::Filter>(filter);
-  tiledb_filter_option_t filter_option =
-      _string_to_tiledb_filter_option(filter_option_str);
-#if TILEDB_VERSION >= TileDB_Version(2, 11, 0)
-  // For scale_float filters we need either a double, or an
-  if (filter_option == TILEDB_SCALE_FLOAT_FACTOR ||
-      filter_option == TILEDB_SCALE_FLOAT_OFFSET) {
-    double value = Rcpp::as<double>(valuesxp);
-    spdl::debug(tfm::format("[libtiledb_filter_set_option] setting %s to %f",
-                            filter_option_str, value));
-    filter->set_option(filter_option, &value);
-    return filter;
-  } else if (filter_option == TILEDB_SCALE_FLOAT_BYTEWIDTH) {
-    double dblval = Rcpp::as<double>(valuesxp);
-    int64_t int64val = fromInteger64(dblval);
-    uint64_t value = static_cast<uint64_t>(int64val);
-    spdl::debug(tfm::format("[libtiledb_filter_set_option] setting %s to %ld",
-                            filter_option_str, value));
-    filter->set_option(filter_option, &value);
-    return filter;
-  }
+XPtr<tiledb::Filter> libtiledb_filter_set_option(XPtr<tiledb::Filter> filter, std::string filter_option_str, SEXP valuesxp) {
+    check_xptr_tag<tiledb::Filter>(filter);
+    tiledb_filter_option_t filter_option = _string_to_tiledb_filter_option(filter_option_str);
+#if TILEDB_VERSION >= TileDB_Version(2,11,0)
+    // For scale_float filters we need either a double, or an
+    if (filter_option == TILEDB_SCALE_FLOAT_FACTOR || filter_option == TILEDB_SCALE_FLOAT_OFFSET) {
+        double value = Rcpp::as<double>(valuesxp);
+        spdl::debug(tfm::format("[libtiledb_filter_set_option] setting %s to %f", filter_option_str, value));
+        filter->set_option(filter_option, &value);
+        return filter;
+    } else if (filter_option == TILEDB_SCALE_FLOAT_BYTEWIDTH) {
+        double dblval = Rcpp::as<double>(valuesxp);
+        int64_t int64val = fromInteger64(dblval);
+        uint64_t value = static_cast<uint64_t>(int64val);
+        spdl::debug(tfm::format("[libtiledb_filter_set_option] setting %s to %ld", filter_option_str, value));
+        filter->set_option(filter_option, &value);
+        return filter;
+    }
 #endif
-  // all others set an int value
-  int32_t value = Rcpp::as<int32_t>(valuesxp);
-  filter->set_option(filter_option, &value);
-  return filter;
+    // all others set an int value
+    int32_t value = Rcpp::as<int32_t>(valuesxp);
+    filter->set_option(filter_option, &value);
+    return filter;
 }
+
 
 /**
  * TileDB Filter List
  */
 //[[Rcpp::export]]
-XPtr<tiledb::FilterList> libtiledb_filter_list(XPtr<tiledb::Context> ctx,
-                                               List filters) {
+XPtr<tiledb::FilterList> libtiledb_filter_list(XPtr<tiledb::Context> ctx, List filters) {
   check_xptr_tag<tiledb::Context>(ctx);
-  XPtr<tiledb::FilterList> fltrlst =
-      make_xptr<tiledb::FilterList>(new tiledb::FilterList(*ctx.get()));
+  XPtr<tiledb::FilterList> fltrlst = make_xptr<tiledb::FilterList>(new tiledb::FilterList(*ctx.get()));
   // check that external pointers are supported
   R_xlen_t nfilters = filters.length();
   if (nfilters > 0) {
@@ -1531,15 +1388,13 @@ XPtr<tiledb::FilterList> libtiledb_filter_list(XPtr<tiledb::Context> ctx,
 }
 
 //[[Rcpp::export]]
-void libtiledb_filter_list_set_max_chunk_size(
-    XPtr<tiledb::FilterList> filterList, uint32_t max_chunk_size) {
+void libtiledb_filter_list_set_max_chunk_size(XPtr<tiledb::FilterList> filterList, uint32_t max_chunk_size) {
   check_xptr_tag<tiledb::FilterList>(filterList);
   filterList->set_max_chunk_size(max_chunk_size);
 }
 
 //[[Rcpp::export]]
-int libtiledb_filter_list_get_max_chunk_size(
-    XPtr<tiledb::FilterList> filterList) {
+int libtiledb_filter_list_get_max_chunk_size(XPtr<tiledb::FilterList> filterList) {
   check_xptr_tag<tiledb::FilterList>(filterList);
   return filterList->max_chunk_size();
 }
@@ -1551,78 +1406,82 @@ int libtiledb_filter_list_get_nfilters(XPtr<tiledb::FilterList> filterList) {
 }
 
 //[[Rcpp::export]]
-XPtr<tiledb::Filter>
-libtiledb_filter_list_get_filter_from_index(XPtr<tiledb::FilterList> filterList,
-                                            uint32_t filter_index) {
+XPtr<tiledb::Filter> libtiledb_filter_list_get_filter_from_index(XPtr<tiledb::FilterList> filterList, uint32_t filter_index) {
   check_xptr_tag<tiledb::FilterList>(filterList);
-  return make_xptr<tiledb::Filter>(
-      new tiledb::Filter(filterList->filter(filter_index)));
+  return make_xptr<tiledb::Filter>(new tiledb::Filter(filterList->filter(filter_index)));
 }
+
+
 
 /**
  * TileDB Attribute
  */
 //[[Rcpp::export]]
 XPtr<tiledb::Attribute> libtiledb_attribute(XPtr<tiledb::Context> ctx,
-                                            std::string name, std::string type,
+                                            std::string name,
+                                            std::string type,
                                             XPtr<tiledb::FilterList> fltrlst,
-                                            int ncells, bool nullable) {
-  check_xptr_tag<tiledb::Context>(ctx);
-  spdl::debug(tfm::format(
-      "[libtiledb_attribute] Attr name %s type %s ncells %d nullable %s", name,
-      type, ncells, nullable ? "true" : "false"));
-  tiledb_datatype_t attr_dtype = _string_to_tiledb_datatype(type);
-  if (ncells < 1 && ncells != R_NaInt) {
-    Rcpp::stop("ncells must be >= 1 (or NA for variable cells)");
-  }
-  // placeholder, overwritten in all branches below
-  XPtr<tiledb::Attribute> attr =
-      XPtr<tiledb::Attribute>(static_cast<tiledb::Attribute *>(nullptr));
+                                            int ncells,
+                                            bool nullable) {
+    check_xptr_tag<tiledb::Context>(ctx);
+    spdl::debug(tfm::format("[libtiledb_attribute] Attr name %s type %s ncells %d nullable %s",
+                            name, type, ncells, nullable ? "true" : "false"));
+    tiledb_datatype_t attr_dtype = _string_to_tiledb_datatype(type);
+    if (ncells < 1 && ncells != R_NaInt) {
+        Rcpp::stop("ncells must be >= 1 (or NA for variable cells)");
+    }
+    // placeholder, overwritten in all branches below
+    XPtr<tiledb::Attribute> attr = XPtr<tiledb::Attribute>(static_cast<tiledb::Attribute*>(nullptr));
 
-  if (attr_dtype == TILEDB_INT32 || attr_dtype == TILEDB_UINT32 ||
-      attr_dtype == TILEDB_FLOAT64 || attr_dtype == TILEDB_FLOAT32 ||
-      attr_dtype == TILEDB_INT64 || attr_dtype == TILEDB_UINT64 ||
-      attr_dtype == TILEDB_UINT32 || attr_dtype == TILEDB_INT16 ||
-      attr_dtype == TILEDB_UINT16 || attr_dtype == TILEDB_INT8 ||
-      attr_dtype == TILEDB_UINT8 || attr_dtype == TILEDB_DATETIME_YEAR ||
-      attr_dtype == TILEDB_DATETIME_MONTH ||
-      attr_dtype == TILEDB_DATETIME_WEEK || attr_dtype == TILEDB_DATETIME_DAY ||
-      attr_dtype == TILEDB_DATETIME_HR || attr_dtype == TILEDB_DATETIME_MIN ||
-      attr_dtype == TILEDB_DATETIME_SEC || attr_dtype == TILEDB_DATETIME_MS ||
-      attr_dtype == TILEDB_DATETIME_US || attr_dtype == TILEDB_DATETIME_NS ||
-      attr_dtype == TILEDB_DATETIME_PS || attr_dtype == TILEDB_DATETIME_FS ||
-      attr_dtype == TILEDB_DATETIME_AS) {
-    attr = make_xptr<tiledb::Attribute>(
-        new tiledb::Attribute(*ctx.get(), name, attr_dtype));
-    attr->set_cell_val_num(static_cast<uint64_t>(ncells));
-  } else if (attr_dtype == TILEDB_CHAR || attr_dtype == TILEDB_STRING_ASCII ||
-             attr_dtype == TILEDB_STRING_UTF8) {
-    attr = make_xptr<tiledb::Attribute>(
-        new tiledb::Attribute(*ctx.get(), name, attr_dtype));
-#if TILEDB_VERSION >= TileDB_Version(2, 10, 0)
-  } else if (attr_dtype == TILEDB_BOOL) {
-    attr = make_xptr<tiledb::Attribute>(
-        new tiledb::Attribute(*ctx.get(), name, attr_dtype));
+    if (attr_dtype == TILEDB_INT32 ||
+        attr_dtype == TILEDB_UINT32 ||
+        attr_dtype == TILEDB_FLOAT64 ||
+        attr_dtype == TILEDB_FLOAT32 ||
+        attr_dtype == TILEDB_INT64  ||
+        attr_dtype == TILEDB_UINT64 ||
+        attr_dtype == TILEDB_UINT32 ||
+        attr_dtype == TILEDB_INT16  ||
+        attr_dtype == TILEDB_UINT16 ||
+        attr_dtype == TILEDB_INT8   ||
+        attr_dtype == TILEDB_UINT8  ||
+        attr_dtype == TILEDB_DATETIME_YEAR ||
+        attr_dtype == TILEDB_DATETIME_MONTH ||
+        attr_dtype == TILEDB_DATETIME_WEEK ||
+        attr_dtype == TILEDB_DATETIME_DAY ||
+        attr_dtype == TILEDB_DATETIME_HR ||
+        attr_dtype == TILEDB_DATETIME_MIN ||
+        attr_dtype == TILEDB_DATETIME_SEC ||
+        attr_dtype == TILEDB_DATETIME_MS  ||
+        attr_dtype == TILEDB_DATETIME_US  ||
+        attr_dtype == TILEDB_DATETIME_NS  ||
+        attr_dtype == TILEDB_DATETIME_PS  ||
+        attr_dtype == TILEDB_DATETIME_FS  ||
+        attr_dtype == TILEDB_DATETIME_AS) {
+        attr = make_xptr<tiledb::Attribute>(new tiledb::Attribute(*ctx.get(), name, attr_dtype));
+        attr->set_cell_val_num(static_cast<uint64_t>(ncells));
+    } else if (attr_dtype == TILEDB_CHAR ||
+               attr_dtype == TILEDB_STRING_ASCII ||
+               attr_dtype == TILEDB_STRING_UTF8) {
+        attr = make_xptr<tiledb::Attribute>(new tiledb::Attribute(*ctx.get(), name, attr_dtype));
+#if TILEDB_VERSION >= TileDB_Version(2,10,0)
+    } else if (attr_dtype == TILEDB_BOOL) {
+        attr = make_xptr<tiledb::Attribute>(new tiledb::Attribute(*ctx.get(), name, attr_dtype));
 #endif
-  } else {
-    Rcpp::stop("Only integer ((U)INT{8,16,32,64}), logical (INT32), real "
-               "(FLOAT{32,64}), "
-               "Date (DATEIME_DAY), Datetime (DATETIME_{SEC,MS,US}), nanotime "
-               "(DATETIME_NS), "
-#if TILEDB_VERSION >= TileDB_Version(2, 10, 0)
-               "logical (BOOL), "
+    } else {
+        Rcpp::stop("Only integer ((U)INT{8,16,32,64}), logical (INT32), real (FLOAT{32,64}), "
+                   "Date (DATEIME_DAY), Datetime (DATETIME_{SEC,MS,US}), nanotime (DATETIME_NS), "
+#if TILEDB_VERSION >= TileDB_Version(2,10,0)
+                   "logical (BOOL), "
 #endif
-               "and character (CHAR,ASCII,UTF8) attributes are supported "
-               "-- seeing %s which is not",
-               type.c_str());
-  }
-  // R's NA is different from TileDB's NA so test for NA_integer_, else cast
-  uint64_t num =
-      (ncells == R_NaInt) ? TILEDB_VAR_NUM : static_cast<uint64_t>(ncells);
-  attr->set_cell_val_num(num);
-  attr->set_filter_list(*fltrlst);
-  attr->set_nullable(nullable);
-  return attr;
+                   "and character (CHAR,ASCII,UTF8) attributes are supported "
+                   "-- seeing %s which is not", type.c_str());
+    }
+    // R's NA is different from TileDB's NA so test for NA_integer_, else cast
+    uint64_t num = (ncells == R_NaInt) ? TILEDB_VAR_NUM : static_cast<uint64_t>(ncells);
+    attr->set_cell_val_num(num);
+    attr->set_filter_list(*fltrlst);
+    attr->set_nullable(nullable);
+    return attr;
 }
 
 // [[Rcpp::export]]
@@ -1645,17 +1504,13 @@ double libtiledb_attribute_get_cell_size(XPtr<tiledb::Attribute> attr) {
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::FilterList>
-libtiledb_attribute_get_filter_list(XPtr<tiledb::Attribute> attr) {
+XPtr<tiledb::FilterList> libtiledb_attribute_get_filter_list(XPtr<tiledb::Attribute> attr) {
   check_xptr_tag<tiledb::Attribute>(attr);
-  return make_xptr<tiledb::FilterList>(
-      new tiledb::FilterList(attr->filter_list()));
+  return make_xptr<tiledb::FilterList>(new tiledb::FilterList(attr->filter_list()));
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::Attribute>
-libtiledb_attribute_set_filter_list(XPtr<tiledb::Attribute> attr,
-                                    XPtr<tiledb::FilterList> fltrlst) {
+XPtr<tiledb::Attribute> libtiledb_attribute_set_filter_list(XPtr<tiledb::Attribute> attr, XPtr<tiledb::FilterList> fltrlst) {
   check_xptr_tag<tiledb::Attribute>(attr);
   check_xptr_tag<tiledb::FilterList>(fltrlst);
   attr->set_filter_list(*fltrlst);
@@ -1667,7 +1522,7 @@ int libtiledb_attribute_get_cell_val_num(XPtr<tiledb::Attribute> attr) {
   check_xptr_tag<tiledb::Attribute>(attr);
   unsigned int ncells = attr->cell_val_num();
   if (ncells == TILEDB_VAR_NUM) {
-    return R_NaInt; // set to R's NA for integer
+    return R_NaInt;          // set to R's NA for integer
   } else if (ncells > std::numeric_limits<int32_t>::max()) {
     Rcpp::stop("tiledb_attr ncells value not representable as an R integer");
   }
@@ -1675,17 +1530,15 @@ int libtiledb_attribute_get_cell_val_num(XPtr<tiledb::Attribute> attr) {
 }
 
 // [[Rcpp::export]]
-void libtiledb_attribute_set_cell_val_num(XPtr<tiledb::Attribute> attr,
-                                          int num) {
+void libtiledb_attribute_set_cell_val_num(XPtr<tiledb::Attribute> attr, int num) {
   check_xptr_tag<tiledb::Attribute>(attr);
   uint64_t ncells = static_cast<uint64_t>(num);
   if (num == R_NaInt) {
-    ncells = TILEDB_VAR_NUM; // R's NA is different from TileDB's NA
+    ncells = TILEDB_VAR_NUM;             // R's NA is different from TileDB's NA
   } else if (num <= 0) {
     Rcpp::stop("Variable cell number of '%d' not sensible", num);
   }
-  attr->set_cell_val_num(
-      ncells); // returns reference to self so nothing for us to return
+  attr->set_cell_val_num(ncells);        // returns reference to self so nothing for us to return
 }
 
 // [[Rcpp::export]]
@@ -1697,7 +1550,7 @@ bool libtiledb_attribute_is_variable_sized(XPtr<tiledb::Attribute> attr) {
 // [[Rcpp::export]]
 void libtiledb_attribute_dump(XPtr<tiledb::Attribute> attr) {
   check_xptr_tag<tiledb::Attribute>(attr);
-#if TILEDB_VERSION >= TileDB_Version(2, 25, 0)
+#if TILEDB_VERSION >= TileDB_Version(2,25,0)
   std::stringstream ss;
   ss << *attr;
   Rcpp::Rcout << ss.str();
@@ -1707,34 +1560,26 @@ void libtiledb_attribute_dump(XPtr<tiledb::Attribute> attr) {
 }
 
 // [[Rcpp::export]]
-void libtiledb_attribute_set_fill_value(XPtr<tiledb::Attribute> attr,
-                                        SEXP val) {
+void libtiledb_attribute_set_fill_value(XPtr<tiledb::Attribute> attr, SEXP val) {
   tiledb_datatype_t dtype = attr->type();
   check_xptr_tag<tiledb::Attribute>(attr);
   if (dtype == TILEDB_INT32) {
     IntegerVector v(val);
-    if (v.size() > 1)
-      Rcpp::stop("Setting fill values only supports scalar values for now.");
-    attr->set_fill_value((void *)&(v[0]),
-                         static_cast<uint64_t>(sizeof(int32_t)));
+    if (v.size() > 1) Rcpp::stop("Setting fill values only supports scalar values for now.");
+    attr->set_fill_value((void*) &(v[0]), static_cast<uint64_t>(sizeof(int32_t)));
   } else if (dtype == TILEDB_UINT32) {
     IntegerVector v(val);
-    if (v.size() > 1)
-      Rcpp::stop("Setting fill values only supports scalar values for now.");
-    attr->set_fill_value((void *)&(v[0]),
-                         static_cast<uint64_t>(sizeof(uint32_t)));
+    if (v.size() > 1) Rcpp::stop("Setting fill values only supports scalar values for now.");
+    attr->set_fill_value((void*) &(v[0]), static_cast<uint64_t>(sizeof(uint32_t)));
   } else if (dtype == TILEDB_FLOAT64) {
     NumericVector v(val);
-    if (v.size() > 1)
-      Rcpp::stop("Setting fill values only supports scalar values for now.");
-    attr->set_fill_value((void *)&(v[0]),
-                         static_cast<uint64_t>(sizeof(double)));
+    if (v.size() > 1) Rcpp::stop("Setting fill values only supports scalar values for now.");
+    attr->set_fill_value((void*) &(v[0]), static_cast<uint64_t>(sizeof(double)));
   } else if (dtype == TILEDB_STRING_ASCII || dtype == TILEDB_CHAR) {
     CharacterVector v(val);
-    if (v.size() > 1)
-      Rcpp::stop("Setting fill values only supports scalar values for now.");
+    if (v.size() > 1) Rcpp::stop("Setting fill values only supports scalar values for now.");
     std::string s(v[0]);
-    attr->set_fill_value((void *)s.c_str(), static_cast<uint64_t>(s.size()));
+    attr->set_fill_value((void*) s.c_str(), static_cast<uint64_t>(s.size()));
   } else {
     std::string typestr = _tiledb_datatype_to_string(dtype);
     Rcpp::stop("Type '%s' is not currently supported.", typestr.c_str());
@@ -1745,20 +1590,20 @@ void libtiledb_attribute_set_fill_value(XPtr<tiledb::Attribute> attr,
 SEXP libtiledb_attribute_get_fill_value(XPtr<tiledb::Attribute> attr) {
   check_xptr_tag<tiledb::Attribute>(attr);
   tiledb_datatype_t dtype = attr->type();
-  const void *valptr;
+  const void* valptr;
   uint64_t size = sizeof(dtype);
   attr->get_fill_value(&valptr, &size);
   if (dtype == TILEDB_INT32) {
-    int32_t v = *(const int32_t *)valptr;
+    int32_t v = *(const int32_t*)valptr;
     return wrap(v);
   } else if (dtype == TILEDB_UINT32) {
-    uint32_t v = *(const uint32_t *)valptr;
+    uint32_t v = *(const uint32_t*)valptr;
     return wrap(v);
   } else if (dtype == TILEDB_FLOAT64) {
-    double v = *(const double *)valptr;
+    double v = *(const double*)valptr;
     return wrap(v);
   } else if (dtype == TILEDB_STRING_ASCII || dtype == TILEDB_CHAR) {
-    std::string s(static_cast<const char *>(valptr), static_cast<size_t>(size));
+    std::string s(static_cast<const char*>(valptr), static_cast<size_t>(size));
     return wrap(s);
   } else {
     std::string typestr = _tiledb_datatype_to_string(dtype);
@@ -1767,257 +1612,243 @@ SEXP libtiledb_attribute_get_fill_value(XPtr<tiledb::Attribute> attr) {
 }
 
 // [[Rcpp::export]]
-void libtiledb_attribute_set_nullable(XPtr<tiledb::Attribute> attr,
-                                      const bool flag) {
-  check_xptr_tag<tiledb::Attribute>(attr);
-  attr->set_nullable(flag);
+void libtiledb_attribute_set_nullable(XPtr<tiledb::Attribute> attr, const bool flag) {
+    check_xptr_tag<tiledb::Attribute>(attr);
+    attr->set_nullable(flag);
 }
 
 // [[Rcpp::export]]
 bool libtiledb_attribute_get_nullable(XPtr<tiledb::Attribute> attr) {
-  check_xptr_tag<tiledb::Attribute>(attr);
-  return attr->nullable();
+    check_xptr_tag<tiledb::Attribute>(attr);
+    return attr->nullable();
 }
 
 // [[Rcpp::export]]
 bool libtiledb_attribute_has_enumeration(XPtr<tiledb::Context> ctx,
                                          XPtr<tiledb::Attribute> attr) {
-  check_xptr_tag<tiledb::Context>(ctx);
-  check_xptr_tag<tiledb::Attribute>(attr);
-  bool res = false;
-#if TILEDB_VERSION >= TileDB_Version(2, 17, 0)
-  auto enmr = tiledb::AttributeExperimental::get_enumeration_name(*ctx.get(),
-                                                                  *attr.get());
-  if (enmr != std::nullopt) {
-    res = true;
-  }
+    check_xptr_tag<tiledb::Context>(ctx);
+    check_xptr_tag<tiledb::Attribute>(attr);
+    bool res = false;
+#if TILEDB_VERSION >= TileDB_Version(2,17,0)
+    auto enmr = tiledb::AttributeExperimental::get_enumeration_name(*ctx.get(), *attr.get());
+    if (enmr != std::nullopt) {
+        res = true;
+    }
 #endif
-  return res;
+    return res;
 }
 
 // [[Rcpp::export]]
-Rcpp::String
-libtiledb_attribute_get_enumeration_type(XPtr<tiledb::Context> ctx,
-                                         XPtr<tiledb::Attribute> attr,
-                                         XPtr<tiledb::Array> arr) {
+Rcpp::String libtiledb_attribute_get_enumeration_type(XPtr<tiledb::Context> ctx,
+                                                      XPtr<tiledb::Attribute> attr,
+                                                      XPtr<tiledb::Array> arr) {
 
-  check_xptr_tag<tiledb::Context>(ctx);
-  check_xptr_tag<tiledb::Attribute>(attr);
-  check_xptr_tag<tiledb::Array>(arr);
-#if TILEDB_VERSION >= TileDB_Version(2, 17, 0)
-  auto enmrname = tiledb::AttributeExperimental::get_enumeration_name(
-      *ctx.get(), *attr.get());
-  if (enmrname == std::nullopt) {
-    Rcpp::stop("No enumeration name for attribute");
-  }
-  auto enmr = tiledb::ArrayExperimental::get_enumeration(*ctx.get(), *arr.get(),
-                                                         enmrname.value());
-  if (enmr.ptr() == nullptr) {
-    Rcpp::stop("No enumeration for given attribute.");
-  }
-  Rcpp::String res = Rcpp::as<Rcpp::String>(
-      Rcpp::wrap(_tiledb_datatype_to_string(enmr.type())));
+    check_xptr_tag<tiledb::Context>(ctx);
+    check_xptr_tag<tiledb::Attribute>(attr);
+    check_xptr_tag<tiledb::Array>(arr);
+#if TILEDB_VERSION >= TileDB_Version(2,17,0)
+    auto enmrname = tiledb::AttributeExperimental::get_enumeration_name(*ctx.get(), *attr.get());
+    if (enmrname == std::nullopt) {
+        Rcpp::stop("No enumeration name for attribute");
+    }
+    auto enmr = tiledb::ArrayExperimental::get_enumeration(*ctx.get(), *arr.get(), enmrname.value());
+    if (enmr.ptr() == nullptr) {
+        Rcpp::stop("No enumeration for given attribute.");
+    }
+    Rcpp::String res = Rcpp::as<Rcpp::String>(Rcpp::wrap(_tiledb_datatype_to_string(enmr.type())));
 #else
-  Rcpp::String res = Rcpp::as<Rcpp::String>(NA_STRING);
+    Rcpp::String res = Rcpp::as<Rcpp::String>(NA_STRING);
 #endif
-  return res;
+    return res;
 }
 
 // [[Rcpp::export]]
 SEXP libtiledb_attribute_get_enumeration_vector(XPtr<tiledb::Context> ctx,
                                                 XPtr<tiledb::Attribute> attr,
                                                 XPtr<tiledb::Array> arr) {
-  check_xptr_tag<tiledb::Context>(ctx);
-  check_xptr_tag<tiledb::Attribute>(attr);
-  check_xptr_tag<tiledb::Array>(arr);
-  SEXP res = R_NilValue;
-#if TILEDB_VERSION >= TileDB_Version(2, 17, 0)
-  auto enmrname = tiledb::AttributeExperimental::get_enumeration_name(
-      *ctx.get(), *attr.get());
-  if (enmrname == std::nullopt) {
-    Rcpp::stop("No enumeration name for attribute");
-  }
-  auto enmr = tiledb::ArrayExperimental::get_enumeration(*ctx.get(), *arr.get(),
-                                                         enmrname.value());
-  if (enmr.ptr() == nullptr) {
-    Rcpp::stop("No enumeration for given attribute.");
-  }
-  auto dtype = enmr.type();
-  if (dtype == TILEDB_FLOAT32 || dtype == TILEDB_FLOAT64) {
-    auto v = enmr.as_vector<double>();
-    res = Rcpp::wrap(v);
-  } else if (dtype == TILEDB_INT8 || dtype == TILEDB_INT16 ||
-             dtype == TILEDB_INT32 || dtype == TILEDB_UINT8 ||
-             dtype == TILEDB_UINT16 || dtype == TILEDB_UINT32) {
-    auto v = enmr.as_vector<int32_t>();
-    res = Rcpp::wrap(v);
-  } else if (dtype == TILEDB_INT64 || dtype == TILEDB_UINT64) {
-    auto v = enmr.as_vector<int64_t>();
-    res = Rcpp::toInteger64(v);
-  } else if (dtype == TILEDB_BOOL) {
-    auto v = enmr.as_vector<bool>();
-    res = Rcpp::wrap(v);
-  } else {
-    Rcpp::stop("Unsupported non-string type '%s'",
-               _tiledb_datatype_to_string(dtype));
-  }
+    check_xptr_tag<tiledb::Context>(ctx);
+    check_xptr_tag<tiledb::Attribute>(attr);
+    check_xptr_tag<tiledb::Array>(arr);
+    SEXP res = R_NilValue;
+#if TILEDB_VERSION >= TileDB_Version(2,17,0)
+    auto enmrname = tiledb::AttributeExperimental::get_enumeration_name(*ctx.get(), *attr.get());
+    if (enmrname == std::nullopt) {
+        Rcpp::stop("No enumeration name for attribute");
+    }
+    auto enmr = tiledb::ArrayExperimental::get_enumeration(*ctx.get(), *arr.get(), enmrname.value());
+    if (enmr.ptr() == nullptr) {
+        Rcpp::stop("No enumeration for given attribute.");
+    }
+    auto dtype = enmr.type();
+    if (dtype == TILEDB_FLOAT32 || dtype == TILEDB_FLOAT64) {
+        auto v = enmr.as_vector<double>();
+        res = Rcpp::wrap(v);
+    } else if (dtype == TILEDB_INT8 || dtype == TILEDB_INT16 || dtype == TILEDB_INT32 ||
+               dtype == TILEDB_UINT8 || dtype == TILEDB_UINT16 || dtype == TILEDB_UINT32) {
+        auto v = enmr.as_vector<int32_t>();
+        res = Rcpp::wrap(v);
+    } else if (dtype == TILEDB_INT64 || dtype == TILEDB_UINT64) {
+        auto v = enmr.as_vector<int64_t>();
+        res = Rcpp::toInteger64(v);
+    } else if (dtype == TILEDB_BOOL) {
+        auto v = enmr.as_vector<bool>();
+        res = Rcpp::wrap(v);
+    } else {
+        Rcpp::stop("Unsupported non-string type '%s'", _tiledb_datatype_to_string(dtype));
+    }
 #endif
-  return res;
+    return res;
 }
 
 // [[Rcpp::export]]
-std::vector<std::string>
-libtiledb_attribute_get_enumeration(XPtr<tiledb::Context> ctx,
-                                    XPtr<tiledb::Attribute> attr,
-                                    XPtr<tiledb::Array> arr) {
-  check_xptr_tag<tiledb::Context>(ctx);
-  check_xptr_tag<tiledb::Attribute>(attr);
-  check_xptr_tag<tiledb::Array>(arr);
-  std::vector<std::string> res;
-#if TILEDB_VERSION >= TileDB_Version(2, 17, 0)
-  auto enmrname = tiledb::AttributeExperimental::get_enumeration_name(
-      *ctx.get(), *attr.get());
-  if (enmrname == std::nullopt) {
-    Rcpp::stop("No enumeration name for attribute");
-  }
-  auto enmr = tiledb::ArrayExperimental::get_enumeration(*ctx.get(), *arr.get(),
-                                                         enmrname.value());
-  if (enmr.ptr() == nullptr) {
-    Rcpp::stop("No enumeration for given attribute.");
-  }
-  res = enmr.as_vector<std::string>();
+std::vector<std::string> libtiledb_attribute_get_enumeration(XPtr<tiledb::Context> ctx,
+                                                             XPtr<tiledb::Attribute> attr,
+                                                             XPtr<tiledb::Array> arr) {
+    check_xptr_tag<tiledb::Context>(ctx);
+    check_xptr_tag<tiledb::Attribute>(attr);
+    check_xptr_tag<tiledb::Array>(arr);
+    std::vector<std::string> res;
+#if TILEDB_VERSION >= TileDB_Version(2,17,0)
+    auto enmrname = tiledb::AttributeExperimental::get_enumeration_name(*ctx.get(), *attr.get());
+    if (enmrname == std::nullopt) {
+        Rcpp::stop("No enumeration name for attribute");
+    }
+    auto enmr = tiledb::ArrayExperimental::get_enumeration(*ctx.get(), *arr.get(), enmrname.value());
+    if (enmr.ptr() == nullptr) {
+        Rcpp::stop("No enumeration for given attribute.");
+    }
+    res = enmr.as_vector<std::string>();
 #endif
-  return res;
+    return res;
 }
 
+
 // [[Rcpp::export]]
-XPtr<tiledb::Attribute>
-libtiledb_attribute_set_enumeration(XPtr<tiledb::Context> ctx,
-                                    XPtr<tiledb::Attribute> attr,
-                                    const std::string &enum_name) {
-  check_xptr_tag<tiledb::Context>(ctx);
-  check_xptr_tag<tiledb::Attribute>(attr);
-#if TILEDB_VERSION >= TileDB_Version(2, 17, 0)
-  tiledb::AttributeExperimental::set_enumeration_name(*ctx.get(), *attr.get(),
-                                                      enum_name);
+XPtr<tiledb::Attribute> libtiledb_attribute_set_enumeration(XPtr<tiledb::Context> ctx,
+                                                            XPtr<tiledb::Attribute> attr,
+                                                            const std::string &enum_name) {
+    check_xptr_tag<tiledb::Context>(ctx);
+    check_xptr_tag<tiledb::Attribute>(attr);
+#if TILEDB_VERSION >= TileDB_Version(2,17,0)
+    tiledb::AttributeExperimental::set_enumeration_name(*ctx.get(), *attr.get(), enum_name);
 #endif
-  return attr;
+    return attr;
 }
 
 // [[Rcpp::export]]
 bool libtiledb_attribute_is_ordered_enumeration(XPtr<tiledb::Context> ctx,
                                                 XPtr<tiledb::Attribute> attr,
                                                 XPtr<tiledb::Array> arr) {
-  check_xptr_tag<tiledb::Context>(ctx);
-  check_xptr_tag<tiledb::Attribute>(attr);
-  check_xptr_tag<tiledb::Array>(arr);
-  bool res = false;
-#if TILEDB_VERSION >= TileDB_Version(2, 17, 0)
-  auto enmrname = tiledb::AttributeExperimental::get_enumeration_name(
-      *ctx.get(), *attr.get());
-  if (enmrname == std::nullopt) {
-    Rcpp::stop("No enumeration name for attribute");
-  }
-  auto enmr = tiledb::ArrayExperimental::get_enumeration(*ctx.get(), *arr.get(),
-                                                         enmrname.value());
-  if (enmr.ptr() != nullptr) {
-    res = enmr.ordered();
-  }
+    check_xptr_tag<tiledb::Context>(ctx);
+    check_xptr_tag<tiledb::Attribute>(attr);
+    check_xptr_tag<tiledb::Array>(arr);
+    bool res = false;
+#if TILEDB_VERSION >= TileDB_Version(2,17,0)
+    auto enmrname = tiledb::AttributeExperimental::get_enumeration_name(*ctx.get(), *attr.get());
+    if (enmrname == std::nullopt) {
+        Rcpp::stop("No enumeration name for attribute");
+    }
+    auto enmr = tiledb::ArrayExperimental::get_enumeration(*ctx.get(), *arr.get(), enmrname.value());
+    if (enmr.ptr() != nullptr) {
+        res = enmr.ordered();
+    }
 #endif
-  return res;
+    return res;
 }
+
 
 /**
  * TileDB Array Schema
  */
 
 // forward declaration
-XPtr<tiledb::ArraySchema> libtiledb_array_schema_set_enumeration(
-    XPtr<tiledb::Context> ctx, XPtr<tiledb::ArraySchema> schema,
-    XPtr<tiledb::Attribute> attr, const std::string enum_name,
-    std::vector<std::string> values, bool nullable, bool ordered);
+XPtr<tiledb::ArraySchema> libtiledb_array_schema_set_enumeration(XPtr<tiledb::Context> ctx,
+                                                                 XPtr<tiledb::ArraySchema> schema,
+                                                                 XPtr<tiledb::Attribute> attr,
+                                                                 const std::string enum_name,
+                                                                 std::vector<std::string> values,
+                                                                 bool nullable,
+                                                                 bool ordered);
 
 //[[Rcpp::export]]
-XPtr<tiledb::ArraySchema> libtiledb_array_schema(
-    XPtr<tiledb::Context> ctx, XPtr<tiledb::Domain> domain, List attributes,
-    std::string cell_order, std::string tile_order,
-    Nullable<XPtr<tiledb::FilterList>> coords_filter_list = R_NilValue,
-    Nullable<XPtr<tiledb::FilterList>> offsets_filter_list = R_NilValue,
-    Nullable<XPtr<tiledb::FilterList>> validity_filter_list = R_NilValue,
-    bool sparse = false, Nullable<List> enumerations_list = R_NilValue) {
-  // check that external pointers are supported
-  check_xptr_tag<tiledb::Context>(ctx);
-  check_xptr_tag<tiledb::Domain>(domain);
-  R_xlen_t nattr = attributes.length();
-  if (nattr > 0) {
-    for (R_xlen_t i = 0; i < nattr; i++) {
-      XPtr<tiledb::Attribute> attr = as<XPtr<tiledb::Attribute>>(attributes[i]);
-      check_xptr_tag<tiledb::Attribute>(attr);
-    }
-  }
-  auto _cell_order = _string_to_tiledb_layout(cell_order);
-  auto _tile_order = _string_to_tiledb_layout(tile_order);
-  auto schptr = new tiledb::ArraySchema(
-      tiledb::ArraySchema(*ctx.get(), sparse ? TILEDB_SPARSE : TILEDB_DENSE));
-  auto schema = make_xptr<tiledb::ArraySchema>(schptr);
-  schema->set_domain(*domain.get());
-
-  // Deal with enumerations before attributes (that use them) are added
-  if (enumerations_list.isNotNull()) {
-    List enumerations(enumerations_list); // instantiate from now known non-null
-                                          // Nullable<List> wrapper
-    CharacterVector enumnames = enumerations.names();
-    R_xlen_t nenum = enumerations.length();
-    for (R_xlen_t i = 0; i < nenum; i++) {
-      bool nn = enumerations[i] == R_NilValue;
-      if (nn == false) {
-        XPtr<tiledb::Attribute> attr =
-            as<XPtr<tiledb::Attribute>>(attributes[i]);
-        std::vector<std::string> enums =
-            as<std::vector<std::string>>(enumerations[i]);
-        std::string enum_name = std::string(enumnames[i]);
-        bool is_ordered = false; // default
-        // 'ordered' is an attribute off the CharacterVector
-        CharacterVector enumvect = enumerations[i];
-        if (enumvect.hasAttribute("ordered")) {
-          is_ordered = (as<bool>(enumvect.attr("ordered")) == true);
+XPtr<tiledb::ArraySchema>
+libtiledb_array_schema(XPtr<tiledb::Context> ctx,
+                       XPtr<tiledb::Domain> domain,
+                       List attributes,
+                       std::string cell_order,
+                       std::string tile_order,
+                       Nullable<XPtr<tiledb::FilterList>> coords_filter_list = R_NilValue,
+                       Nullable<XPtr<tiledb::FilterList>> offsets_filter_list = R_NilValue,
+                       Nullable<XPtr<tiledb::FilterList>> validity_filter_list = R_NilValue,
+                       bool sparse = false,
+                       Nullable<List> enumerations_list = R_NilValue) {
+    // check that external pointers are supported
+    check_xptr_tag<tiledb::Context>(ctx);
+    check_xptr_tag<tiledb::Domain>(domain);
+    R_xlen_t nattr = attributes.length();
+    if (nattr > 0) {
+        for (R_xlen_t i=0; i < nattr; i++)  {
+            XPtr<tiledb::Attribute> attr = as<XPtr<tiledb::Attribute>>(attributes[i]);
+            check_xptr_tag<tiledb::Attribute>(attr);
         }
-        libtiledb_array_schema_set_enumeration(ctx, schema, attr, enum_name,
-                                               enums, false, is_ordered);
-      }
     }
-  }
+    auto _cell_order = _string_to_tiledb_layout(cell_order);
+    auto _tile_order = _string_to_tiledb_layout(tile_order);
+    auto schptr = new tiledb::ArraySchema(tiledb::ArraySchema(*ctx.get(), sparse ? TILEDB_SPARSE : TILEDB_DENSE));
+    auto schema = make_xptr<tiledb::ArraySchema>(schptr);
+    schema->set_domain(*domain.get());
 
-  // Now add attributes
-  if (nattr > 0) {
-    for (SEXP a : attributes) {
-      auto attr = as<XPtr<tiledb::Attribute>>(a);
-      spdl::debug(tfm::format("[libtiledb_array_schema] About to attr %s",
-                              libtiledb_attribute_get_name(attr)));
-      schema->add_attribute(*attr.get());
+    // Deal with enumerations before attributes (that use them) are added
+    if (enumerations_list.isNotNull()) {
+        List enumerations(enumerations_list); // instantiate from now known non-null Nullable<List> wrapper
+        CharacterVector enumnames = enumerations.names();
+        R_xlen_t nenum = enumerations.length();
+        for (R_xlen_t i=0; i < nenum; i++)  {
+            bool nn = enumerations[i] == R_NilValue;
+            if (nn == false) {
+                XPtr<tiledb::Attribute> attr = as<XPtr<tiledb::Attribute>>(attributes[i]);
+                std::vector<std::string> enums = as<std::vector<std::string>>(enumerations[i]);
+                std::string enum_name = std::string(enumnames[i]);
+                bool is_ordered = false; // default
+                // 'ordered' is an attribute off the CharacterVector
+                CharacterVector enumvect = enumerations[i];
+                if (enumvect.hasAttribute("ordered")) {
+                    is_ordered = (as<bool>(enumvect.attr("ordered")) == true);
+                }
+                libtiledb_array_schema_set_enumeration(ctx, schema, attr, enum_name, enums,
+                                                       false, is_ordered);
+            }
+        }
     }
-  }
-  schema->set_cell_order(_cell_order);
-  schema->set_tile_order(_tile_order);
-  if (coords_filter_list.isNotNull()) {
-    XPtr<tiledb::FilterList> xptr_coords(coords_filter_list);
-    schema->set_coords_filter_list(*xptr_coords);
-  }
-  if (offsets_filter_list.isNotNull()) {
-    XPtr<tiledb::FilterList> xptr_offsets(offsets_filter_list);
-    schema->set_offsets_filter_list(*xptr_offsets);
-  }
-  if (validity_filter_list.isNotNull()) {
-    XPtr<tiledb::FilterList> xptr_validity(validity_filter_list);
-    schema->set_validity_filter_list(*xptr_validity);
-  }
-  schema->check();
-  return schema;
+
+    // Now add attributes
+    if (nattr > 0) {
+        for (SEXP a : attributes) {
+            auto attr = as<XPtr<tiledb::Attribute>>(a);
+            spdl::debug(tfm::format("[libtiledb_array_schema] About to attr %s", libtiledb_attribute_get_name(attr)));
+            schema->add_attribute(*attr.get());
+        }
+    }
+    schema->set_cell_order(_cell_order);
+    schema->set_tile_order(_tile_order);
+    if (coords_filter_list.isNotNull()) {
+        XPtr<tiledb::FilterList> xptr_coords(coords_filter_list);
+        schema->set_coords_filter_list(*xptr_coords);
+    }
+    if (offsets_filter_list.isNotNull()) {
+        XPtr<tiledb::FilterList> xptr_offsets(offsets_filter_list);
+        schema->set_offsets_filter_list(*xptr_offsets);
+    }
+    if (validity_filter_list.isNotNull()) {
+        XPtr<tiledb::FilterList> xptr_validity(validity_filter_list);
+        schema->set_validity_filter_list(*xptr_validity);
+    }
+    schema->check();
+    return schema;
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::ArraySchema>
-libtiledb_array_schema_create(XPtr<tiledb::Context> ctx, std::string atstr) {
+XPtr<tiledb::ArraySchema> libtiledb_array_schema_create(XPtr<tiledb::Context> ctx, std::string atstr) {
   check_xptr_tag<tiledb::Context>(ctx);
   auto at = _string_to_tiledb_array_type(atstr);
   auto ptr = new tiledb::ArraySchema(*ctx.get(), at);
@@ -2025,24 +1856,23 @@ libtiledb_array_schema_create(XPtr<tiledb::Context> ctx, std::string atstr) {
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::ArraySchema> libtiledb_array_schema_load(XPtr<tiledb::Context> ctx,
-                                                      std::string uri) {
-  check_xptr_tag<tiledb::Context>(ctx);
-  auto ptr = new tiledb::ArraySchema(*ctx.get(), uri);
-  return make_xptr<tiledb::ArraySchema>(ptr);
+XPtr<tiledb::ArraySchema> libtiledb_array_schema_load(XPtr<tiledb::Context> ctx, std::string uri) {
+    check_xptr_tag<tiledb::Context>(ctx);
+    auto ptr = new tiledb::ArraySchema(*ctx.get(), uri);
+    return make_xptr<tiledb::ArraySchema>(ptr);
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::ArraySchema>
-libtiledb_array_schema_load_with_key(XPtr<tiledb::Context> ctx, std::string uri,
-                                     std::string key) {
-  check_xptr_tag<tiledb::Context>(ctx);
-  spdl::debug("[libtiledb_array_schema_load_with_key] function is deprecated");
-  XPtr<tiledb::Config> cfg = libtiledb_ctx_config(ctx);
-  cfg = libtiledb_config_set(cfg, "sm.encryption_key", key);
-  cfg = libtiledb_config_set(cfg, "sm.encryption_type", "AES_256_GCM");
-  XPtr<tiledb::Context> newctx = libtiledb_ctx(cfg);
-  return libtiledb_array_schema_load(newctx, uri);
+XPtr<tiledb::ArraySchema> libtiledb_array_schema_load_with_key(XPtr<tiledb::Context> ctx,
+                                                               std::string uri,
+                                                               std::string key) {
+    check_xptr_tag<tiledb::Context>(ctx);
+    spdl::debug("[libtiledb_array_schema_load_with_key] function is deprecated");
+    XPtr<tiledb::Config> cfg = libtiledb_ctx_config(ctx);
+    cfg = libtiledb_config_set(cfg, "sm.encryption_key", key);
+    cfg = libtiledb_config_set(cfg, "sm.encryption_type", "AES_256_GCM");
+    XPtr<tiledb::Context> newctx = libtiledb_ctx(cfg);
+    return libtiledb_array_schema_load(newctx, uri);
 }
 
 // [[Rcpp::export]]
@@ -2053,8 +1883,7 @@ void libtiledb_array_schema_set_domain(XPtr<tiledb::ArraySchema> schema,
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::Domain>
-libtiledb_array_schema_get_domain(XPtr<tiledb::ArraySchema> schema) {
+XPtr<tiledb::Domain> libtiledb_array_schema_get_domain(XPtr<tiledb::ArraySchema> schema) {
   check_xptr_tag<tiledb::ArraySchema>(schema);
   auto ptr = make_xptr<tiledb::Domain>(new tiledb::Domain(schema->domain()));
   return ptr;
@@ -2073,57 +1902,50 @@ List libtiledb_array_schema_attributes(XPtr<tiledb::ArraySchema> schema) {
   check_xptr_tag<tiledb::ArraySchema>(schema);
   List result;
   int nattr = schema->attribute_num();
-  for (auto i = 0; i < nattr; i++) {
-    auto attr = make_xptr<tiledb::Attribute>(
-        new tiledb::Attribute(schema->attribute(i)));
+  for (auto i=0; i < nattr; i++) {
+    auto attr = make_xptr<tiledb::Attribute>(new tiledb::Attribute(schema->attribute(i)));
     result[attr->name()] = attr;
   }
   return result;
 }
 
 // [[Rcpp::export]]
-std::string
-libtiledb_array_schema_get_array_type(XPtr<tiledb::ArraySchema> schema) {
+std::string libtiledb_array_schema_get_array_type(XPtr<tiledb::ArraySchema> schema) {
   check_xptr_tag<tiledb::ArraySchema>(schema);
   auto type = schema->array_type();
   return _tiledb_array_type_to_string(type);
 }
 
 // [[Rcpp::export]]
-void libtiledb_array_schema_set_cell_order(XPtr<tiledb::ArraySchema> schema,
-                                           std::string ord) {
+void libtiledb_array_schema_set_cell_order(XPtr<tiledb::ArraySchema> schema, std::string ord) {
   check_xptr_tag<tiledb::ArraySchema>(schema);
   tiledb_layout_t cellorder = _string_to_tiledb_layout(ord);
   schema->set_cell_order(cellorder);
 }
 
 // [[Rcpp::export]]
-std::string
-libtiledb_array_schema_get_cell_order(XPtr<tiledb::ArraySchema> schema) {
+std::string libtiledb_array_schema_get_cell_order(XPtr<tiledb::ArraySchema> schema) {
   check_xptr_tag<tiledb::ArraySchema>(schema);
   auto order = schema->cell_order();
   return _tiledb_layout_to_string(order);
 }
 
 // [[Rcpp::export]]
-void libtiledb_array_schema_set_tile_order(XPtr<tiledb::ArraySchema> schema,
-                                           std::string ord) {
+void libtiledb_array_schema_set_tile_order(XPtr<tiledb::ArraySchema> schema, std::string ord) {
   check_xptr_tag<tiledb::ArraySchema>(schema);
   tiledb_layout_t tileorder = _string_to_tiledb_layout(ord);
   schema->set_cell_order(tileorder);
 }
 
 // [[Rcpp::export]]
-std::string
-libtiledb_array_schema_get_tile_order(XPtr<tiledb::ArraySchema> schema) {
+std::string libtiledb_array_schema_get_tile_order(XPtr<tiledb::ArraySchema> schema) {
   check_xptr_tag<tiledb::ArraySchema>(schema);
   auto order = schema->tile_order();
   return _tiledb_layout_to_string(order);
 }
 
 // [[Rcpp::export]]
-void libtiledb_array_schema_set_capacity(XPtr<tiledb::ArraySchema> schema,
-                                         int cap) {
+void libtiledb_array_schema_set_capacity(XPtr<tiledb::ArraySchema> schema, int cap) {
   check_xptr_tag<tiledb::ArraySchema>(schema);
   if (cap <= 0) {
     Rcpp::stop("Tile capacity of '%d' not sensible", cap);
@@ -2150,24 +1972,23 @@ bool libtiledb_array_schema_get_allows_dups(XPtr<tiledb::ArraySchema> schema) {
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::ArraySchema>
-libtiledb_array_schema_set_allows_dups(XPtr<tiledb::ArraySchema> schema,
-                                       bool allows_dups) {
+XPtr<tiledb::ArraySchema> libtiledb_array_schema_set_allows_dups(XPtr<tiledb::ArraySchema> schema,
+                                                                 bool allows_dups) {
   check_xptr_tag<tiledb::ArraySchema>(schema);
   schema->set_allows_dups(allows_dups);
   return schema;
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::FilterList> libtiledb_array_schema_get_coords_filter_list(
-    XPtr<tiledb::ArraySchema> schema) {
-  return make_xptr<tiledb::FilterList>(
-      new tiledb::FilterList(schema->coords_filter_list()));
+XPtr<tiledb::FilterList>
+libtiledb_array_schema_get_coords_filter_list(XPtr<tiledb::ArraySchema> schema) {
+  return make_xptr<tiledb::FilterList>(new tiledb::FilterList(schema->coords_filter_list()));
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::ArraySchema> libtiledb_array_schema_set_coords_filter_list(
-    XPtr<tiledb::ArraySchema> schema, XPtr<tiledb::FilterList> fltrlst) {
+XPtr<tiledb::ArraySchema>
+libtiledb_array_schema_set_coords_filter_list(XPtr<tiledb::ArraySchema> schema,
+                                              XPtr<tiledb::FilterList> fltrlst) {
   check_xptr_tag<tiledb::ArraySchema>(schema);
   check_xptr_tag<tiledb::FilterList>(fltrlst);
   schema->set_coords_filter_list(*fltrlst);
@@ -2175,16 +1996,16 @@ XPtr<tiledb::ArraySchema> libtiledb_array_schema_set_coords_filter_list(
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::FilterList> libtiledb_array_schema_get_offsets_filter_list(
-    XPtr<tiledb::ArraySchema> schema) {
+XPtr<tiledb::FilterList>
+libtiledb_array_schema_get_offsets_filter_list(XPtr<tiledb::ArraySchema> schema) {
   check_xptr_tag<tiledb::ArraySchema>(schema);
-  return make_xptr<tiledb::FilterList>(
-      new tiledb::FilterList(schema->offsets_filter_list()));
+  return make_xptr<tiledb::FilterList>(new tiledb::FilterList(schema->offsets_filter_list()));
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::ArraySchema> libtiledb_array_schema_set_offsets_filter_list(
-    XPtr<tiledb::ArraySchema> schema, XPtr<tiledb::FilterList> fltrlst) {
+XPtr<tiledb::ArraySchema>
+libtiledb_array_schema_set_offsets_filter_list(XPtr<tiledb::ArraySchema> schema,
+                                               XPtr<tiledb::FilterList> fltrlst) {
   check_xptr_tag<tiledb::ArraySchema>(schema);
   check_xptr_tag<tiledb::FilterList>(fltrlst);
   schema->set_offsets_filter_list(*fltrlst);
@@ -2192,21 +2013,22 @@ XPtr<tiledb::ArraySchema> libtiledb_array_schema_set_offsets_filter_list(
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::FilterList> libtiledb_array_schema_get_validity_filter_list(
-    XPtr<tiledb::ArraySchema> schema) {
-  check_xptr_tag<tiledb::ArraySchema>(schema);
-  return make_xptr<tiledb::FilterList>(
-      new tiledb::FilterList(schema->validity_filter_list()));
+XPtr<tiledb::FilterList>
+libtiledb_array_schema_get_validity_filter_list(XPtr<tiledb::ArraySchema> schema) {
+    check_xptr_tag<tiledb::ArraySchema>(schema);
+    return make_xptr<tiledb::FilterList>(new tiledb::FilterList(schema->validity_filter_list()));
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::ArraySchema> libtiledb_array_schema_set_validity_filter_list(
-    XPtr<tiledb::ArraySchema> schema, XPtr<tiledb::FilterList> fltrlst) {
-  check_xptr_tag<tiledb::ArraySchema>(schema);
-  check_xptr_tag<tiledb::FilterList>(fltrlst);
-  schema->set_validity_filter_list(*fltrlst);
-  return schema;
+XPtr<tiledb::ArraySchema>
+libtiledb_array_schema_set_validity_filter_list(XPtr<tiledb::ArraySchema> schema,
+                                                XPtr<tiledb::FilterList> fltrlst) {
+    check_xptr_tag<tiledb::ArraySchema>(schema);
+    check_xptr_tag<tiledb::FilterList>(fltrlst);
+    schema->set_validity_filter_list(*fltrlst);
+    return schema;
 }
+
 
 // [[Rcpp::export]]
 int libtiledb_array_schema_get_attribute_num(XPtr<tiledb::ArraySchema> schema) {
@@ -2219,29 +2041,25 @@ int libtiledb_array_schema_get_attribute_num(XPtr<tiledb::ArraySchema> schema) {
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::Attribute> libtiledb_array_schema_get_attribute_from_index(
-    XPtr<tiledb::ArraySchema> schema, int ind) {
+XPtr<tiledb::Attribute> libtiledb_array_schema_get_attribute_from_index(XPtr<tiledb::ArraySchema> schema,
+                                                                        int ind) {
   check_xptr_tag<tiledb::ArraySchema>(schema);
   if (ind < 0) {
     Rcpp::stop("Index must be non-negative.");
   }
   uint32_t idx = static_cast<uint32_t>(ind);
-  return make_xptr<tiledb::Attribute>(
-      new tiledb::Attribute(schema->attribute(idx)));
+  return make_xptr<tiledb::Attribute>(new tiledb::Attribute(schema->attribute(idx)));
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::Attribute>
-libtiledb_array_schema_get_attribute_from_name(XPtr<tiledb::ArraySchema> schema,
-                                               std::string name) {
+XPtr<tiledb::Attribute> libtiledb_array_schema_get_attribute_from_name(XPtr<tiledb::ArraySchema> schema,
+                                                                       std::string name) {
   check_xptr_tag<tiledb::ArraySchema>(schema);
-  return make_xptr<tiledb::Attribute>(
-      new tiledb::Attribute(schema->attribute(name)));
+  return make_xptr<tiledb::Attribute>(new tiledb::Attribute(schema->attribute(name)));
 }
 
 // [[Rcpp::export]]
-bool libtiledb_array_schema_has_attribute(XPtr<tiledb::ArraySchema> schema,
-                                          std::string name) {
+bool libtiledb_array_schema_has_attribute(XPtr<tiledb::ArraySchema> schema, std::string name) {
   check_xptr_tag<tiledb::ArraySchema>(schema);
   return schema->has_attribute(name);
 }
@@ -2255,7 +2073,7 @@ bool libtiledb_array_schema_sparse(XPtr<tiledb::ArraySchema> schema) {
 // [[Rcpp::export]]
 void libtiledb_array_schema_dump(XPtr<tiledb::ArraySchema> schema) {
   check_xptr_tag<tiledb::ArraySchema>(schema);
-#if TILEDB_VERSION >= TileDB_Version(2, 25, 0)
+#if TILEDB_VERSION >= TileDB_Version(2,25,0)
   std::stringstream ss;
   ss << *schema;
   Rcpp::Rcout << ss.str();
@@ -2267,7 +2085,7 @@ void libtiledb_array_schema_dump(XPtr<tiledb::ArraySchema> schema) {
 // [[Rcpp::export]]
 bool libtiledb_array_schema_check(XPtr<tiledb::ArraySchema> schema) {
   check_xptr_tag<tiledb::ArraySchema>(schema);
-  schema->check(); // throws, rather than returning bool
+  schema->check();   // throws, rather than returning bool
   return true;
 }
 
@@ -2278,77 +2096,75 @@ int libtiledb_array_schema_version(XPtr<tiledb::ArraySchema> schema) {
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::ArraySchema> libtiledb_array_schema_set_enumeration(
-    XPtr<tiledb::Context> ctx, XPtr<tiledb::ArraySchema> schema,
-    XPtr<tiledb::Attribute> attr, const std::string enum_name,
-    std::vector<std::string> values, bool nullable = false,
-    bool ordered = false) {
-  check_xptr_tag<tiledb::Context>(ctx);
-  check_xptr_tag<tiledb::ArraySchema>(schema);
-  check_xptr_tag<tiledb::Attribute>(attr);
-#if TILEDB_VERSION >= TileDB_Version(2, 17, 0)
-  auto enumeration =
-      tiledb::Enumeration::create(*ctx.get(), enum_name, values, ordered);
-  tiledb::ArraySchemaExperimental::add_enumeration(*ctx.get(), *schema.get(),
-                                                   enumeration);
-  tiledb::AttributeExperimental::set_enumeration_name(*ctx.get(), *attr.get(),
-                                                      enum_name);
+XPtr<tiledb::ArraySchema> libtiledb_array_schema_set_enumeration(XPtr<tiledb::Context> ctx,
+                                                                 XPtr<tiledb::ArraySchema> schema,
+                                                                 XPtr<tiledb::Attribute> attr,
+                                                                 const std::string enum_name,
+                                                                 std::vector<std::string> values,
+                                                                 bool nullable = false,
+                                                                 bool ordered = false) {
+    check_xptr_tag<tiledb::Context>(ctx);
+    check_xptr_tag<tiledb::ArraySchema>(schema);
+    check_xptr_tag<tiledb::Attribute>(attr);
+#if TILEDB_VERSION >= TileDB_Version(2,17,0)
+    auto enumeration = tiledb::Enumeration::create(*ctx.get(), enum_name, values, ordered);
+    tiledb::ArraySchemaExperimental::add_enumeration(*ctx.get(), *schema.get(), enumeration);
+    tiledb::AttributeExperimental::set_enumeration_name(*ctx.get(), *attr.get(), enum_name);
 #endif
-  return schema;
+    return schema;
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::ArraySchema> libtiledb_array_schema_set_enumeration_empty(
-    XPtr<tiledb::Context> ctx, XPtr<tiledb::ArraySchema> schema,
-    XPtr<tiledb::Attribute> attr, const std::string enum_name,
-    const std::string type_str, int cell_val_num, bool ordered) {
-  check_xptr_tag<tiledb::Context>(ctx);
-  check_xptr_tag<tiledb::ArraySchema>(schema);
-  check_xptr_tag<tiledb::Attribute>(attr);
-#if TILEDB_VERSION >= TileDB_Version(2, 17, 3)
-  tiledb_datatype_t type = _string_to_tiledb_datatype(type_str);
-  uint32_t num = static_cast<uint64_t>(cell_val_num);
-  if (cell_val_num == R_NaInt) {
-    num = TILEDB_VAR_NUM; // R's NA is different from TileDB's NA
-  }
-  auto enumeration = tiledb::Enumeration::create_empty(*ctx.get(), enum_name,
-                                                       type, num, ordered);
-  tiledb::ArraySchemaExperimental::add_enumeration(*ctx.get(), *schema.get(),
-                                                   enumeration);
-  tiledb::AttributeExperimental::set_enumeration_name(*ctx.get(), *attr.get(),
-                                                      enum_name);
+XPtr<tiledb::ArraySchema>
+libtiledb_array_schema_set_enumeration_empty(XPtr<tiledb::Context> ctx,
+                                             XPtr<tiledb::ArraySchema> schema,
+                                             XPtr<tiledb::Attribute> attr,
+                                             const std::string enum_name,
+                                             const std::string type_str,
+                                             int cell_val_num,
+                                             bool ordered) {
+    check_xptr_tag<tiledb::Context>(ctx);
+    check_xptr_tag<tiledb::ArraySchema>(schema);
+    check_xptr_tag<tiledb::Attribute>(attr);
+#if TILEDB_VERSION >= TileDB_Version(2,17,3)
+    tiledb_datatype_t type = _string_to_tiledb_datatype(type_str);
+    uint32_t num = static_cast<uint64_t>(cell_val_num);
+    if (cell_val_num == R_NaInt) {
+        num = TILEDB_VAR_NUM;           // R's NA is different from TileDB's NA
+    }
+    auto enumeration = tiledb::Enumeration::create_empty(*ctx.get(), enum_name, type, num, ordered);
+    tiledb::ArraySchemaExperimental::add_enumeration(*ctx.get(), *schema.get(), enumeration);
+    tiledb::AttributeExperimental::set_enumeration_name(*ctx.get(), *attr.get(), enum_name);
 #endif
-  return schema;
+    return schema;
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::CurrentDomain>
-libtiledb_array_schema_get_current_domain(XPtr<tiledb::Context> ctx,
-                                          XPtr<tiledb::ArraySchema> sch) {
-  check_xptr_tag<tiledb::Context>(ctx);
-  check_xptr_tag<tiledb::ArraySchema>(sch);
-#if TILEDB_VERSION >= TileDB_Version(2, 25, 0)
-  auto cd =
-      tiledb::ArraySchemaExperimental::current_domain(*ctx.get(), *sch.get());
+XPtr<tiledb::CurrentDomain> libtiledb_array_schema_get_current_domain(XPtr<tiledb::Context> ctx,
+                                                                      XPtr<tiledb::ArraySchema> sch) {
+    check_xptr_tag<tiledb::Context>(ctx);
+    check_xptr_tag<tiledb::ArraySchema>(sch);
+#if TILEDB_VERSION >= TileDB_Version(2,25,0)
+    auto cd = tiledb::ArraySchemaExperimental::current_domain(*ctx.get(), *sch.get());
 #else
-  auto cd = tiledb::CurrentDomain();
+    auto cd = tiledb::CurrentDomain();
 #endif
-  auto ptr = make_xptr<tiledb::CurrentDomain>(new tiledb::CurrentDomain(cd));
-  return ptr;
+    auto ptr = make_xptr<tiledb::CurrentDomain>(new tiledb::CurrentDomain(cd));
+    return ptr;
 }
 
 // [[Rcpp::export]]
 void libtiledb_array_schema_set_current_domain(XPtr<tiledb::Context> ctx,
                                                XPtr<tiledb::ArraySchema> sch,
                                                XPtr<tiledb::CurrentDomain> cd) {
-  check_xptr_tag<tiledb::Context>(ctx);
-  check_xptr_tag<tiledb::ArraySchema>(sch);
-  check_xptr_tag<tiledb::CurrentDomain>(cd);
-#if TILEDB_VERSION >= TileDB_Version(2, 25, 0)
-  tiledb::ArraySchemaExperimental::set_current_domain(*ctx.get(), *sch.get(),
-                                                      *cd.get());
+    check_xptr_tag<tiledb::Context>(ctx);
+    check_xptr_tag<tiledb::ArraySchema>(sch);
+    check_xptr_tag<tiledb::CurrentDomain>(cd);
+#if TILEDB_VERSION >= TileDB_Version(2,25,0)
+    tiledb::ArraySchemaExperimental::set_current_domain(*ctx.get(), *sch.get(), *cd.get());
 #endif
 }
+
 
 /**
  * TileDB Array Schema Evolution
@@ -2356,204 +2172,196 @@ void libtiledb_array_schema_set_current_domain(XPtr<tiledb::Context> ctx,
 //[[Rcpp::export]]
 XPtr<tiledb::ArraySchemaEvolution>
 libtiledb_array_schema_evolution(XPtr<tiledb::Context> ctx) {
-  check_xptr_tag<tiledb::Context>(ctx);
-  auto p = new tiledb::ArraySchemaEvolution(*ctx.get());
-  auto ptr = make_xptr<tiledb::ArraySchemaEvolution>(p);
-  return ptr;
+    check_xptr_tag<tiledb::Context>(ctx);
+    auto p = new tiledb::ArraySchemaEvolution(*ctx.get());
+    auto ptr = make_xptr<tiledb::ArraySchemaEvolution>(p);
+    return ptr;
 }
 
 //[[Rcpp::export]]
 XPtr<tiledb::ArraySchemaEvolution>
-libtiledb_array_schema_evolution_add_attribute(
-    XPtr<tiledb::ArraySchemaEvolution> ase, XPtr<tiledb::Attribute> attr) {
-  check_xptr_tag<tiledb::ArraySchemaEvolution>(ase);
-  check_xptr_tag<tiledb::Attribute>(attr);
-  tiledb::ArraySchemaEvolution res = ase->add_attribute(*attr.get());
-  auto ptr = new tiledb::ArraySchemaEvolution(res);
-  return make_xptr<tiledb::ArraySchemaEvolution>(ptr);
+libtiledb_array_schema_evolution_add_attribute(XPtr<tiledb::ArraySchemaEvolution> ase,
+                                               XPtr<tiledb::Attribute> attr) {
+    check_xptr_tag<tiledb::ArraySchemaEvolution>(ase);
+    check_xptr_tag<tiledb::Attribute>(attr);
+    tiledb::ArraySchemaEvolution res = ase->add_attribute(*attr.get());
+    auto ptr = new tiledb::ArraySchemaEvolution(res);
+    return make_xptr<tiledb::ArraySchemaEvolution>(ptr);
 }
 
 //[[Rcpp::export]]
 XPtr<tiledb::ArraySchemaEvolution>
-libtiledb_array_schema_evolution_drop_attribute(
-    XPtr<tiledb::ArraySchemaEvolution> ase, const std::string &attrname) {
-  check_xptr_tag<tiledb::ArraySchemaEvolution>(ase);
-  tiledb::ArraySchemaEvolution res = ase->drop_attribute(attrname);
-  auto ptr = new tiledb::ArraySchemaEvolution(res);
-  return make_xptr<tiledb::ArraySchemaEvolution>(ptr);
+libtiledb_array_schema_evolution_drop_attribute(XPtr<tiledb::ArraySchemaEvolution> ase,
+                                                const std::string & attrname) {
+    check_xptr_tag<tiledb::ArraySchemaEvolution>(ase);
+    tiledb::ArraySchemaEvolution res = ase->drop_attribute(attrname);
+    auto ptr = new tiledb::ArraySchemaEvolution(res);
+    return make_xptr<tiledb::ArraySchemaEvolution>(ptr);
 }
 
 //[[Rcpp::export]]
 XPtr<tiledb::ArraySchemaEvolution>
-libtiledb_array_schema_evolution_array_evolve(
-    XPtr<tiledb::ArraySchemaEvolution> ase, const std::string &uri) {
-  check_xptr_tag<tiledb::ArraySchemaEvolution>(ase);
-  tiledb::ArraySchemaEvolution res = ase->array_evolve(uri);
-  auto ptr = new tiledb::ArraySchemaEvolution(res);
-  return make_xptr<tiledb::ArraySchemaEvolution>(ptr);
+libtiledb_array_schema_evolution_array_evolve(XPtr<tiledb::ArraySchemaEvolution> ase,
+                                              const std::string & uri) {
+    check_xptr_tag<tiledb::ArraySchemaEvolution>(ase);
+    tiledb::ArraySchemaEvolution res = ase->array_evolve(uri);
+    auto ptr = new tiledb::ArraySchemaEvolution(res);
+    return make_xptr<tiledb::ArraySchemaEvolution>(ptr);
 }
 
 //[[Rcpp::export]]
 XPtr<tiledb::ArraySchemaEvolution>
-libtiledb_array_schema_evolution_add_enumeration(
-    XPtr<tiledb::Context> ctx, XPtr<tiledb::ArraySchemaEvolution> ase,
-    const std::string &enum_name, std::vector<std::string> values,
-    bool nullable = false, bool ordered = false) {
-  check_xptr_tag<tiledb::Context>(ctx);
-  check_xptr_tag<tiledb::ArraySchemaEvolution>(ase);
-#if TILEDB_VERSION >= TileDB_Version(2, 17, 0)
-  auto enumeration =
-      tiledb::Enumeration::create(*ctx.get(), enum_name, values, ordered);
-  tiledb::ArraySchemaEvolution res = ase->add_enumeration(enumeration);
-  auto ptr = new tiledb::ArraySchemaEvolution(res);
-  return make_xptr<tiledb::ArraySchemaEvolution>(ptr);
+libtiledb_array_schema_evolution_add_enumeration(XPtr<tiledb::Context> ctx,
+                                                 XPtr<tiledb::ArraySchemaEvolution> ase,
+                                                 const std::string & enum_name,
+                                                 std::vector<std::string> values,
+                                                 bool nullable = false,
+                                                 bool ordered = false) {
+    check_xptr_tag<tiledb::Context>(ctx);
+    check_xptr_tag<tiledb::ArraySchemaEvolution>(ase);
+#if TILEDB_VERSION >= TileDB_Version(2,17,0)
+    auto enumeration = tiledb::Enumeration::create(*ctx.get(), enum_name, values, ordered);
+    tiledb::ArraySchemaEvolution res = ase->add_enumeration(enumeration);
+    auto ptr = new tiledb::ArraySchemaEvolution(res);
+    return make_xptr<tiledb::ArraySchemaEvolution>(ptr);
 #endif
-  return ase;
+    return ase;
 }
 
 //[[Rcpp::export]]
 XPtr<tiledb::ArraySchemaEvolution>
-libtiledb_array_schema_evolution_add_enumeration_empty(
-    XPtr<tiledb::Context> ctx, XPtr<tiledb::ArraySchemaEvolution> ase,
-    const std::string &enum_name, const std::string type_str, int cell_val_num,
-    bool ordered = false) {
-  check_xptr_tag<tiledb::Context>(ctx);
-  check_xptr_tag<tiledb::ArraySchemaEvolution>(ase);
-#if TILEDB_VERSION >= TileDB_Version(2, 17, 3)
-  tiledb_datatype_t type = _string_to_tiledb_datatype(type_str);
-  uint32_t num = static_cast<uint32_t>(cell_val_num);
-  auto enumeration = tiledb::Enumeration::create_empty(*ctx.get(), enum_name,
-                                                       type, num, ordered);
-  tiledb::ArraySchemaEvolution res = ase->add_enumeration(enumeration);
-  auto ptr = new tiledb::ArraySchemaEvolution(res);
-  return make_xptr<tiledb::ArraySchemaEvolution>(ptr);
+libtiledb_array_schema_evolution_add_enumeration_empty(XPtr<tiledb::Context> ctx,
+                                                       XPtr<tiledb::ArraySchemaEvolution> ase,
+                                                       const std::string & enum_name,
+                                                       const std::string type_str,
+                                                       int cell_val_num,
+                                                       bool ordered = false) {
+    check_xptr_tag<tiledb::Context>(ctx);
+    check_xptr_tag<tiledb::ArraySchemaEvolution>(ase);
+#if TILEDB_VERSION >= TileDB_Version(2,17,3)
+    tiledb_datatype_t type = _string_to_tiledb_datatype(type_str);
+    uint32_t num = static_cast<uint32_t>(cell_val_num);
+    auto enumeration = tiledb::Enumeration::create_empty(*ctx.get(), enum_name, type, num, ordered);
+    tiledb::ArraySchemaEvolution res = ase->add_enumeration(enumeration);
+    auto ptr = new tiledb::ArraySchemaEvolution(res);
+    return make_xptr<tiledb::ArraySchemaEvolution>(ptr);
 #endif
-  return ase;
+    return ase;
+}
+
+
+//[[Rcpp::export]]
+XPtr<tiledb::ArraySchemaEvolution>
+libtiledb_array_schema_evolution_drop_enumeration(XPtr<tiledb::ArraySchemaEvolution> ase,
+                                                  const std::string & attrname) {
+    check_xptr_tag<tiledb::ArraySchemaEvolution>(ase);
+#if TILEDB_VERSION >= TileDB_Version(2,17,0)
+    tiledb::ArraySchemaEvolution res = ase->drop_attribute(attrname);
+    auto ptr = new tiledb::ArraySchemaEvolution(res);
+    return make_xptr<tiledb::ArraySchemaEvolution>(ptr);
+#endif
+    return ase;
 }
 
 //[[Rcpp::export]]
 XPtr<tiledb::ArraySchemaEvolution>
-libtiledb_array_schema_evolution_drop_enumeration(
-    XPtr<tiledb::ArraySchemaEvolution> ase, const std::string &attrname) {
-  check_xptr_tag<tiledb::ArraySchemaEvolution>(ase);
-#if TILEDB_VERSION >= TileDB_Version(2, 17, 0)
-  tiledb::ArraySchemaEvolution res = ase->drop_attribute(attrname);
-  auto ptr = new tiledb::ArraySchemaEvolution(res);
-  return make_xptr<tiledb::ArraySchemaEvolution>(ptr);
+libtiledb_array_schema_evolution_extend_enumeration(XPtr<tiledb::Context> ctx,
+                                                    XPtr<tiledb::ArraySchemaEvolution> ase,
+                                                    XPtr<tiledb::Array> array,
+                                                    const std::string & enum_name,
+                                                    std::vector<std::string> new_values,
+                                                    bool nullable = false,
+                                                    bool ordered = false) {
+    check_xptr_tag<tiledb::Context>(ctx);
+    check_xptr_tag<tiledb::ArraySchemaEvolution>(ase);
+    check_xptr_tag<tiledb::Array>(array);
+#if TILEDB_VERSION >= TileDB_Version(2,17,3)
+    auto old_enumeration = tiledb::ArrayExperimental::get_enumeration(*ctx.get(), *array.get(), enum_name);
+    auto new_enumeration = old_enumeration.extend(new_values);
+    tiledb::ArraySchemaEvolution res = ase->extend_enumeration(new_enumeration);
+    auto ptr = new tiledb::ArraySchemaEvolution(res);
+    return make_xptr<tiledb::ArraySchemaEvolution>(ptr);
 #endif
-  return ase;
+    return ase;
 }
 
 //[[Rcpp::export]]
 XPtr<tiledb::ArraySchemaEvolution>
-libtiledb_array_schema_evolution_extend_enumeration(
-    XPtr<tiledb::Context> ctx, XPtr<tiledb::ArraySchemaEvolution> ase,
-    XPtr<tiledb::Array> array, const std::string &enum_name,
-    std::vector<std::string> new_values, bool nullable = false,
-    bool ordered = false) {
-  check_xptr_tag<tiledb::Context>(ctx);
-  check_xptr_tag<tiledb::ArraySchemaEvolution>(ase);
-  check_xptr_tag<tiledb::Array>(array);
-#if TILEDB_VERSION >= TileDB_Version(2, 17, 3)
-  auto old_enumeration = tiledb::ArrayExperimental::get_enumeration(
-      *ctx.get(), *array.get(), enum_name);
-  auto new_enumeration = old_enumeration.extend(new_values);
-  tiledb::ArraySchemaEvolution res = ase->extend_enumeration(new_enumeration);
-  auto ptr = new tiledb::ArraySchemaEvolution(res);
-  return make_xptr<tiledb::ArraySchemaEvolution>(ptr);
+libtiledb_array_schema_evolution_expand_current_domain(XPtr<tiledb::ArraySchemaEvolution> ase,
+                                                       XPtr<tiledb::CurrentDomain> cd) {
+    check_xptr_tag<tiledb::ArraySchemaEvolution>(ase);
+    check_xptr_tag<tiledb::CurrentDomain>(cd);
+#if TILEDB_VERSION >= TileDB_Version(2,25,0)
+    ase->expand_current_domain(*cd.get());
 #endif
-  return ase;
+    return ase;
 }
 
-//[[Rcpp::export]]
-XPtr<tiledb::ArraySchemaEvolution>
-libtiledb_array_schema_evolution_expand_current_domain(
-    XPtr<tiledb::ArraySchemaEvolution> ase, XPtr<tiledb::CurrentDomain> cd) {
-  check_xptr_tag<tiledb::ArraySchemaEvolution>(ase);
-  check_xptr_tag<tiledb::CurrentDomain>(cd);
-#if TILEDB_VERSION >= TileDB_Version(2, 25, 0)
-  ase->expand_current_domain(*cd.get());
-#endif
-  return ase;
-}
 
 /**
  * TileDB Array
  */
 // [[Rcpp::export]]
-std::string libtiledb_array_create(std::string uri,
-                                   XPtr<tiledb::ArraySchema> schema) {
+std::string libtiledb_array_create(std::string uri, XPtr<tiledb::ArraySchema> schema) {
   check_xptr_tag<tiledb::ArraySchema>(schema);
   tiledb::Array::create(uri, *schema.get());
   return uri;
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::Array> libtiledb_array_open(XPtr<tiledb::Context> ctx,
-                                         std::string uri, std::string type) {
+XPtr<tiledb::Array> libtiledb_array_open(XPtr<tiledb::Context> ctx, std::string uri,
+                                         std::string type) {
   check_xptr_tag<tiledb::Context>(ctx);
   auto query_type = _string_to_tiledb_query_type(type);
-  return make_xptr<tiledb::Array>(
-      new tiledb::Array(*ctx.get(), uri, query_type));
+  return make_xptr<tiledb::Array>(new tiledb::Array(*ctx.get(), uri, query_type));
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::Array> libtiledb_array_open_at(XPtr<tiledb::Context> ctx,
-                                            std::string uri, std::string type,
-                                            Datetime tstamp) {
-  check_xptr_tag<tiledb::Context>(ctx);
-  auto query_type = _string_to_tiledb_query_type(type);
-  // get timestamp as seconds since epoch (plus fractional seconds, returns
-  // double), scale to millisec
-  uint64_t ts_ms =
-      static_cast<uint64_t>(std::round(tstamp.getFractionalTimestamp() * 1000));
-#if TILEDB_VERSION >= TileDB_Version(2, 15, 0)
-  auto ptr =
-      new tiledb::Array(*ctx.get(), uri, query_type,
-                        tiledb::TemporalPolicy(tiledb::TimeTravel, ts_ms));
-  ptr->set_open_timestamp_end(ts_ms);
+XPtr<tiledb::Array> libtiledb_array_open_at(XPtr<tiledb::Context> ctx, std::string uri,
+                                            std::string type, Datetime tstamp) {
+    check_xptr_tag<tiledb::Context>(ctx);
+    auto query_type = _string_to_tiledb_query_type(type);
+    // get timestamp as seconds since epoch (plus fractional seconds, returns double), scale to millisec
+    uint64_t ts_ms = static_cast<uint64_t>(std::round(tstamp.getFractionalTimestamp() * 1000));
+#if TILEDB_VERSION >= TileDB_Version(2,15,0)
+    auto ptr = new tiledb::Array(*ctx.get(), uri, query_type, tiledb::TemporalPolicy(tiledb::TimeTravel, ts_ms));
+    ptr->set_open_timestamp_end(ts_ms);
 #else
-  auto ptr = new tiledb::Array(*ctx.get(), uri, query_type);
-  ptr->set_open_timestamp_end(ts_ms);
+    auto ptr = new tiledb::Array(*ctx.get(), uri, query_type);
+    ptr->set_open_timestamp_end(ts_ms);
 #endif
-  return make_xptr<tiledb::Array>(ptr);
+    return make_xptr<tiledb::Array>(ptr);
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::Array> libtiledb_array_open_with_key(XPtr<tiledb::Context> ctx,
-                                                  std::string uri,
+XPtr<tiledb::Array> libtiledb_array_open_with_key(XPtr<tiledb::Context> ctx, std::string uri,
                                                   std::string type,
                                                   std::string enc_key) {
-  check_xptr_tag<tiledb::Context>(ctx);
-  spdl::debug("[libtiledb_array_open_with_key] function is deprecated");
-  XPtr<tiledb::Config> cfg = libtiledb_ctx_config(ctx);
-  cfg = libtiledb_config_set(cfg, "sm.encryption_key", enc_key);
-  cfg = libtiledb_config_set(cfg, "sm.encryption_type", "AES_256_GCM");
-  XPtr<tiledb::Context> newctx = libtiledb_ctx(cfg);
-  return libtiledb_array_open(newctx, uri, type);
+    check_xptr_tag<tiledb::Context>(ctx);
+    spdl::debug("[libtiledb_array_open_with_key] function is deprecated");
+    XPtr<tiledb::Config> cfg = libtiledb_ctx_config(ctx);
+    cfg = libtiledb_config_set(cfg, "sm.encryption_key", enc_key);
+    cfg = libtiledb_config_set(cfg, "sm.encryption_type", "AES_256_GCM");
+    XPtr<tiledb::Context> newctx = libtiledb_ctx(cfg);
+    return libtiledb_array_open(newctx, uri, type);
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::Array> libtiledb_array_open_at_with_key(XPtr<tiledb::Context> ctx,
-                                                     std::string uri,
-                                                     std::string type,
-                                                     std::string enc_key,
+XPtr<tiledb::Array> libtiledb_array_open_at_with_key(XPtr<tiledb::Context> ctx, std::string uri,
+                                                     std::string type, std::string enc_key,
                                                      Datetime tstamp) {
-  check_xptr_tag<tiledb::Context>(ctx);
-  spdl::debug("[libtiledb_array_open_at_with_key] function is deprecated");
-  auto query_type = _string_to_tiledb_query_type(type);
-  uint64_t ts_ms =
-      static_cast<uint64_t>(std::round(tstamp.getFractionalTimestamp() * 1000));
-  XPtr<tiledb::Array> ptr =
-      libtiledb_array_open_with_key(ctx, uri, type, enc_key);
-  ptr->close(); // close to reopen at timestamp, this should be revisited
-  ptr->open(query_type, TILEDB_AES_256_GCM, enc_key, ts_ms);
-  return ptr;
+    check_xptr_tag<tiledb::Context>(ctx);
+    spdl::debug("[libtiledb_array_open_at_with_key] function is deprecated");
+    auto query_type = _string_to_tiledb_query_type(type);
+    uint64_t ts_ms = static_cast<uint64_t>(std::round(tstamp.getFractionalTimestamp() * 1000));
+    XPtr<tiledb::Array> ptr = libtiledb_array_open_with_key(ctx, uri, type, enc_key);
+    ptr->close();               // close to reopen at timestamp, this should be revisited
+    ptr->open(query_type, TILEDB_AES_256_GCM, enc_key, ts_ms);
+    return ptr;
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::Array> libtiledb_array_open_with_ptr(XPtr<tiledb::Array> array,
-                                                  std::string query_type) {
+XPtr<tiledb::Array> libtiledb_array_open_with_ptr(XPtr<tiledb::Array> array, std::string query_type) {
   check_xptr_tag<tiledb::Array>(array);
   tiledb_query_type_t qtype = _string_to_tiledb_query_type(query_type);
   array->open(qtype);
@@ -2583,11 +2391,9 @@ std::string libtiledb_array_get_uri(XPtr<tiledb::Array> array) {
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::ArraySchema>
-libtiledb_array_get_schema(XPtr<tiledb::Array> array) {
+XPtr<tiledb::ArraySchema> libtiledb_array_get_schema(XPtr<tiledb::Array> array) {
   check_xptr_tag<tiledb::Array>(array);
-  return make_xptr<tiledb::ArraySchema>(
-      new tiledb::ArraySchema(array->schema()));
+  return make_xptr<tiledb::ArraySchema>(new tiledb::ArraySchema(array->schema()));
 }
 
 // [[Rcpp::export]]
@@ -2619,40 +2425,39 @@ List libtiledb_array_get_non_empty_domain(XPtr<tiledb::Array> array) {
   if (domain.type() == TILEDB_INT32) {
     using DType = tiledb::impl::tiledb_to_type<TILEDB_INT32>::type;
     auto res = array->non_empty_domain<DType>();
-    for (auto &d : res) {
+    for (auto& d: res) {
       auto dim_name = d.first;
       auto dim_domain = d.second;
-      nonempty_domain[dim_name] =
-          IntegerVector::create(dim_domain.first, dim_domain.second);
+      nonempty_domain[dim_name] = IntegerVector::create(dim_domain.first,
+                                                        dim_domain.second);
     }
   } else if (domain.type() == TILEDB_FLOAT64) {
     using DType = tiledb::impl::tiledb_to_type<TILEDB_FLOAT64>::type;
     auto res = array->non_empty_domain<DType>();
-    for (auto &d : res) {
+    for (auto& d: res) {
       auto dim_name = d.first;
       auto dim_domain = d.second;
-      nonempty_domain[dim_name] =
-          NumericVector::create(dim_domain.first, dim_domain.second);
+      nonempty_domain[dim_name] = NumericVector::create(dim_domain.first,
+                                                        dim_domain.second);
     }
   } else {
-    Rcpp::stop("Invalid tiledb_schema domain type: '%s'",
-               _tiledb_datatype_to_string(domain.type()));
+    Rcpp::stop("Invalid tiledb_schema domain type: '%s'", _tiledb_datatype_to_string(domain.type()));
   }
   return nonempty_domain;
 }
 
 // [[Rcpp::export]]
-CharacterVector
-libtiledb_array_get_non_empty_domain_var_from_name(XPtr<tiledb::Array> array,
-                                                   std::string name) {
+CharacterVector libtiledb_array_get_non_empty_domain_var_from_name(XPtr<tiledb::Array> array,
+                                                                   std::string name) {
   check_xptr_tag<tiledb::Array>(array);
   auto res = array->non_empty_domain_var(name);
   return CharacterVector::create(res.first, res.second);
 }
 
 // [[Rcpp::export]]
-CharacterVector libtiledb_array_get_non_empty_domain_var_from_index(
-    XPtr<tiledb::Array> array, int32_t idx, std::string typestr = "ASCII") {
+CharacterVector libtiledb_array_get_non_empty_domain_var_from_index(XPtr<tiledb::Array> array,
+                                                                    int32_t idx,
+                                                                    std::string typestr = "ASCII") {
   check_xptr_tag<tiledb::Array>(array);
   if (typestr == "ASCII") {
     auto res = array->non_empty_domain_var(idx);
@@ -2665,8 +2470,9 @@ CharacterVector libtiledb_array_get_non_empty_domain_var_from_index(
 }
 
 // [[Rcpp::export]]
-NumericVector libtiledb_array_get_non_empty_domain_from_name(
-    XPtr<tiledb::Array> array, std::string name, std::string typestr) {
+NumericVector libtiledb_array_get_non_empty_domain_from_name(XPtr<tiledb::Array> array,
+                                                             std::string name,
+                                                             std::string typestr) {
   check_xptr_tag<tiledb::Array>(array);
   if (typestr == "INT64") {
     auto p = array->non_empty_domain<int64_t>(name);
@@ -2674,8 +2480,7 @@ NumericVector libtiledb_array_get_non_empty_domain_from_name(
     return toInteger64(v);
   } else if (typestr == "UINT64") {
     auto p = array->non_empty_domain<uint64_t>(name);
-    std::vector<int64_t> v{static_cast<int64_t>(p.first),
-                           static_cast<int64_t>(p.second)};
+    std::vector<int64_t> v{ static_cast<int64_t>(p.first), static_cast<int64_t>(p.second) };
     return toInteger64(v);
   } else if (typestr == "INT32") {
     auto p = array->non_empty_domain<int32_t>(name);
@@ -2701,12 +2506,18 @@ NumericVector libtiledb_array_get_non_empty_domain_from_name(
   } else if (typestr == "FLOAT32") {
     auto p = array->non_empty_domain<float>(name);
     return NumericVector::create(p.first, p.second);
-  } else if (typestr == "DATETIME_YEAR" || typestr == "DATETIME_MONTH" ||
-             typestr == "DATETIME_WEEK" || typestr == "DATETIME_DAY" ||
-             typestr == "DATETIME_HR" || typestr == "DATETIME_MIN" ||
-             typestr == "DATETIME_SEC" || typestr == "DATETIME_MS" ||
-             typestr == "DATETIME_US" || typestr == "DATETIME_PS" ||
-             typestr == "DATETIME_FS" || typestr == "DATETIME_AS") {
+  } else if (typestr == "DATETIME_YEAR" ||
+             typestr == "DATETIME_MONTH" ||
+             typestr == "DATETIME_WEEK" ||
+             typestr == "DATETIME_DAY" ||
+             typestr == "DATETIME_HR"  ||
+             typestr == "DATETIME_MIN" ||
+             typestr == "DATETIME_SEC" ||
+             typestr == "DATETIME_MS"  ||
+             typestr == "DATETIME_US"  ||
+             typestr == "DATETIME_PS"  ||
+             typestr == "DATETIME_FS"  ||
+             typestr == "DATETIME_AS"    ) {
     // type_check() from exception.h gets invoked and wants an int64_t
     auto p = array->non_empty_domain<int64_t>(name);
     std::vector<int64_t> v{p.first, p.second};
@@ -2716,15 +2527,16 @@ NumericVector libtiledb_array_get_non_empty_domain_from_name(
     std::vector<int64_t> v{p.first, p.second};
     return toNanotime(v);
   } else {
-    Rcpp::stop("Currently unsupported tiledb domain type: '%s'",
-               typestr.c_str());
+    Rcpp::stop("Currently unsupported tiledb domain type: '%s'", typestr.c_str());
     return NumericVector::create(NA_REAL, NA_REAL); // not reached
   }
 }
 
+
 // [[Rcpp::export]]
-NumericVector libtiledb_array_get_non_empty_domain_from_index(
-    XPtr<tiledb::Array> array, int32_t idx, std::string typestr) {
+NumericVector libtiledb_array_get_non_empty_domain_from_index(XPtr<tiledb::Array> array,
+                                                              int32_t idx,
+                                                              std::string typestr) {
   check_xptr_tag<tiledb::Array>(array);
   if (typestr == "INT64") {
     auto p = array->non_empty_domain<int64_t>(idx);
@@ -2732,8 +2544,7 @@ NumericVector libtiledb_array_get_non_empty_domain_from_index(
     return toInteger64(v);
   } else if (typestr == "UINT64") {
     auto p = array->non_empty_domain<uint64_t>(idx);
-    std::vector<int64_t> v{static_cast<int64_t>(p.first),
-                           static_cast<int64_t>(p.second)};
+    std::vector<int64_t> v{ static_cast<int64_t>(p.first), static_cast<int64_t>(p.second) };
     return toInteger64(v);
   } else if (typestr == "INT32") {
     auto p = array->non_empty_domain<int32_t>(idx);
@@ -2759,12 +2570,18 @@ NumericVector libtiledb_array_get_non_empty_domain_from_index(
   } else if (typestr == "FLOAT32") {
     auto p = array->non_empty_domain<float>(idx);
     return NumericVector::create(p.first, p.second);
-  } else if (typestr == "DATETIME_YEAR" || typestr == "DATETIME_MONTH" ||
-             typestr == "DATETIME_WEEK" || typestr == "DATETIME_DAY" ||
-             typestr == "DATETIME_HR" || typestr == "DATETIME_MIN" ||
-             typestr == "DATETIME_SEC" || typestr == "DATETIME_MS" ||
-             typestr == "DATETIME_US" || typestr == "DATETIME_PS" ||
-             typestr == "DATETIME_FS" || typestr == "DATETIME_AS") {
+  } else if (typestr == "DATETIME_YEAR" ||
+             typestr == "DATETIME_MONTH" ||
+             typestr == "DATETIME_WEEK" ||
+             typestr == "DATETIME_DAY" ||
+             typestr == "DATETIME_HR"  ||
+             typestr == "DATETIME_MIN" ||
+             typestr == "DATETIME_SEC" ||
+             typestr == "DATETIME_MS"  ||
+             typestr == "DATETIME_US"  ||
+             typestr == "DATETIME_PS"  ||
+             typestr == "DATETIME_FS"  ||
+             typestr == "DATETIME_AS"    ) {
     // type_check() from exception.h gets invoked and wants an int64_t
     auto p = array->non_empty_domain<int64_t>(idx);
     std::vector<int64_t> v{p.first, p.second};
@@ -2774,16 +2591,16 @@ NumericVector libtiledb_array_get_non_empty_domain_from_index(
     std::vector<int64_t> v{p.first, p.second};
     return toNanotime(v);
   } else {
-    Rcpp::stop("Currently unsupported tiledb domain type: '%s'",
-               typestr.c_str());
+    Rcpp::stop("Currently unsupported tiledb domain type: '%s'", typestr.c_str());
     return NumericVector::create(NA_REAL, NA_REAL); // not reached
   }
 }
 
+
 // [[Rcpp::export]]
-void libtiledb_array_consolidate(
-    XPtr<tiledb::Context> ctx, std::string uri,
-    Nullable<XPtr<tiledb::Config>> cfgptr = R_NilValue) {
+void libtiledb_array_consolidate(XPtr<tiledb::Context> ctx,
+                                 std::string uri,
+                                 Nullable<XPtr<tiledb::Config>> cfgptr = R_NilValue) {
   check_xptr_tag<tiledb::Context>(ctx);
   if (cfgptr.isNotNull()) {
     XPtr<tiledb::Config> cfg(cfgptr);
@@ -2795,9 +2612,9 @@ void libtiledb_array_consolidate(
 }
 
 // [[Rcpp::export]]
-void libtiledb_array_vacuum(
-    XPtr<tiledb::Context> ctx, std::string uri,
-    Nullable<XPtr<tiledb::Config>> cfgptr = R_NilValue) {
+void libtiledb_array_vacuum(XPtr<tiledb::Context> ctx,
+                            std::string uri,
+                            Nullable<XPtr<tiledb::Config>> cfgptr = R_NilValue) {
   check_xptr_tag<tiledb::Context>(ctx);
   if (cfgptr.isNotNull()) {
     XPtr<tiledb::Config> cfg(cfgptr);
@@ -2808,58 +2625,55 @@ void libtiledb_array_vacuum(
   }
 }
 
+
 // [[Rcpp::export]]
-bool libtiledb_array_put_metadata(XPtr<tiledb::Array> array, std::string key,
-                                  SEXP obj) {
+bool libtiledb_array_put_metadata(XPtr<tiledb::Array> array,
+                                  std::string key, SEXP obj) {
   check_xptr_tag<tiledb::Array>(array);
   // we implement a simpler interface here as the 'type' is given from
   // the supplied SEXP, as is the extent
-  switch (TYPEOF(obj)) {
-  case VECSXP: {
-    Rcpp::stop("List objects are not supported.");
-    break; // not reached
-  }
-  case REALSXP: {
-    Rcpp::NumericVector v(obj);
-    if (isInteger64(v)) {
-      std::vector<int64_t> iv = fromInteger64(v);
-      array->put_metadata(key.c_str(), TILEDB_INT64, iv.size(), (void *)&iv[0]);
-    } else {
-      array->put_metadata(key.c_str(), TILEDB_FLOAT64, v.size(), v.begin());
+  switch(TYPEOF(obj)) {
+    case VECSXP: {
+      Rcpp::stop("List objects are not supported.");
+      break;// not reached
     }
-    break;
-  }
-  case INTSXP: {
-    Rcpp::IntegerVector v(obj);
-    array->put_metadata(key.c_str(), TILEDB_INT32, v.size(), v.begin());
-    break;
-  }
-  case STRSXP: {
-    Rcpp::CharacterVector v(obj);
-    std::string s(v[0]);
-    // We use TILEDB_CHAR interchangeably with TILEDB_STRING_ASCII is this best
-    // string type?
-    array->put_metadata(key.c_str(), TILEDB_STRING_ASCII, s.length(),
-                        s.c_str());
-    break;
-  }
-  case LGLSXP: { // experimental: map R logical (ie TRUE, FALSE, NA) to int8
-    Rcpp::LogicalVector v(obj);
-    size_t n = static_cast<size_t>(v.size());
-    std::vector<int8_t> ints(n);
-    for (size_t i = 0; i < n; i++)
-      ints[i] = static_cast<int8_t>(v[i]);
-    array->put_metadata(key.c_str(), TILEDB_INT8, ints.size(), ints.data());
-    break;
-  }
-  default: {
-    Rcpp::stop("No support (yet) for type '%s'.", Rf_type2char(TYPEOF(obj)));
-    break; // not reached
-  }
+    case REALSXP: {
+      Rcpp::NumericVector v(obj);
+      if (isInteger64(v)) {
+          std::vector<int64_t> iv = fromInteger64(v);
+          array->put_metadata(key.c_str(), TILEDB_INT64, iv.size(), (void*) &iv[0]);
+      } else {
+          array->put_metadata(key.c_str(), TILEDB_FLOAT64, v.size(), v.begin());
+      }
+      break;
+    }
+    case INTSXP: {
+      Rcpp::IntegerVector v(obj);
+      array->put_metadata(key.c_str(), TILEDB_INT32, v.size(), v.begin());
+      break;
+    }
+    case STRSXP: {
+      Rcpp::CharacterVector v(obj);
+      std::string s(v[0]);
+      // We use TILEDB_CHAR interchangeably with TILEDB_STRING_ASCII is this best string type?
+      array->put_metadata(key.c_str(), TILEDB_STRING_ASCII, s.length(), s.c_str());
+      break;
+    }
+    case LGLSXP: {              // experimental: map R logical (ie TRUE, FALSE, NA) to int8
+      Rcpp::LogicalVector v(obj);
+      size_t n = static_cast<size_t>(v.size());
+      std::vector<int8_t> ints(n);
+      for (size_t i=0; i<n; i++) ints[i] = static_cast<int8_t>(v[i]);
+      array->put_metadata(key.c_str(), TILEDB_INT8, ints.size(), ints.data());
+      break;
+    }
+    default: {
+      Rcpp::stop("No support (yet) for type '%s'.", Rf_type2char(TYPEOF(obj)));
+      break; // not reached
+    }
   }
   // Close array - Important so that the metadata get flushed
-  // not here, array opening and closing responsibility of caller:
-  // array.close();
+  // not here, array opening and closing responsibility of caller:  array.close();
   return true;
 }
 
@@ -2872,53 +2686,46 @@ R_xlen_t libtiledb_array_get_metadata_num(XPtr<tiledb::Array> array) {
 
 // helper function to copy int vector
 template <typename T>
-Rcpp::IntegerVector copy_int_vector(const uint32_t v_num, const void *v) {
-  // Strictly speaking a check for under/overflow would be needed here yet this
-  // for metadata annotation (and not data payload) so extreme ranges are less
-  // likely
+Rcpp::IntegerVector copy_int_vector(const uint32_t v_num, const void* v) {
+  // Strictly speaking a check for under/overflow would be needed here yet this for
+  // metadata annotation (and not data payload) so extreme ranges are less likely
   Rcpp::IntegerVector vec(v_num);
-  const T *ivec = static_cast<const T *>(v);
+  const T *ivec = static_cast<const T*>(v);
   size_t n = static_cast<size_t>(v_num);
-  for (size_t i = 0; i < n; i++)
-    vec[i] = static_cast<int32_t>(ivec[i]);
-  return (vec);
+  for (size_t i=0; i<n; i++) vec[i] = static_cast<int32_t>(ivec[i]);
+  return(vec);
 }
 
 // helper function to convert_metadata
-SEXP _metadata_to_sexp(const tiledb_datatype_t v_type, const uint32_t v_num,
-                       const void *v) {
+SEXP _metadata_to_sexp(const tiledb_datatype_t v_type, const uint32_t v_num, const void* v) {
   // This supports a limited set of basic types as the metadata
   // annotation is not meant to support complete serialization
   if (v_type == TILEDB_INT32) {
     Rcpp::IntegerVector vec(v_num);
-    std::memcpy(vec.begin(), v, v_num * sizeof(int32_t));
-    return (vec);
+    std::memcpy(vec.begin(), v, v_num*sizeof(int32_t));
+    return(vec);
   } else if (v_type == TILEDB_FLOAT64) {
     Rcpp::NumericVector vec(v_num);
-    std::memcpy(vec.begin(), v, v_num * sizeof(double));
-    return (vec);
+    std::memcpy(vec.begin(), v, v_num*sizeof(double));
+    return(vec);
   } else if (v_type == TILEDB_FLOAT32) {
     Rcpp::NumericVector vec(v_num);
-    const float *fvec = static_cast<const float *>(v);
+    const float *fvec = static_cast<const float*>(v);
     size_t n = static_cast<size_t>(v_num);
-    for (size_t i = 0; i < n; i++)
-      vec[i] = static_cast<double>(fvec[i]);
-    return (vec);
-  } else if (v_type == TILEDB_CHAR || v_type == TILEDB_STRING_ASCII ||
-             v_type == TILEDB_STRING_UTF8) {
-    std::string s(static_cast<const char *>(v), v_num);
-    return (Rcpp::wrap(s));
+    for (size_t i=0; i<n; i++) vec[i] = static_cast<double>(fvec[i]);
+    return(vec);
+  } else if (v_type == TILEDB_CHAR || v_type == TILEDB_STRING_ASCII || v_type == TILEDB_STRING_UTF8) {
+    std::string s(static_cast<const char*>(v), v_num);
+    return(Rcpp::wrap(s));
   } else if (v_type == TILEDB_INT8) {
     Rcpp::LogicalVector vec(v_num);
-    const int8_t *ivec = static_cast<const int8_t *>(v);
+    const int8_t *ivec = static_cast<const int8_t*>(v);
     size_t n = static_cast<size_t>(v_num);
-    for (size_t i = 0; i < n; i++)
-      vec[i] = static_cast<bool>(ivec[i]);
-    return (vec);
+    for (size_t i=0; i<n; i++) vec[i] = static_cast<bool>(ivec[i]);
+    return(vec);
   } else if (v_type == TILEDB_UINT8) {
-    // Strictly speaking a check for under/overflow would be needed here (and
-    // below) yet this is for metadata annotation (and not data payload) so
-    // extreme ranges are less likely
+    // Strictly speaking a check for under/overflow would be needed here (and below) yet this
+    // is for metadata annotation (and not data payload) so extreme ranges are less likely
     return copy_int_vector<uint8_t>(v_num, v);
   } else if (v_type == TILEDB_INT16) {
     return copy_int_vector<int16_t>(v_num, v);
@@ -2928,7 +2735,7 @@ SEXP _metadata_to_sexp(const tiledb_datatype_t v_type, const uint32_t v_num,
     return copy_int_vector<uint32_t>(v_num, v);
   } else if (v_type == TILEDB_INT64) {
     std::vector<int64_t> iv(v_num);
-    std::memcpy(&(iv[0]), v, v_num * sizeof(int64_t));
+    std::memcpy(&(iv[0]), v, v_num*sizeof(int64_t));
     return toInteger64(iv);
   } else if (v_type == TILEDB_UINT64) {
     return copy_int_vector<uint64_t>(v_num, v);
@@ -2938,15 +2745,13 @@ SEXP _metadata_to_sexp(const tiledb_datatype_t v_type, const uint32_t v_num,
 }
 
 // [[Rcpp::export]]
-SEXP libtiledb_array_get_metadata_from_index(XPtr<tiledb::Array> array,
-                                             int idx) {
+SEXP libtiledb_array_get_metadata_from_index(XPtr<tiledb::Array> array, int idx) {
   check_xptr_tag<tiledb::Array>(array);
   std::string key;
   tiledb_datatype_t v_type;
   uint32_t v_num;
-  const void *v;
-  array->get_metadata_from_index(static_cast<uint64_t>(idx), &key, &v_type,
-                                 &v_num, &v);
+  const void* v;
+  array->get_metadata_from_index(static_cast<uint64_t>(idx), &key, &v_type, &v_num, &v);
   if (v == NULL) {
     return R_NilValue;
   }
@@ -2963,10 +2768,9 @@ SEXP libtiledb_array_get_metadata_list(XPtr<tiledb::Array> array) {
   int n = static_cast<int>(num);
   Rcpp::List lst(n);
   Rcpp::CharacterVector names(n);
-  for (auto i = 0; i < n; i++) {
-    // we trick this a little by having the returned object also carry an
-    // attribute cleaner way (in a C++ pure sense) would be to return a pair of
-    // string and SEXP
+  for (auto i=0; i<n; i++) {
+    // we trick this a little by having the returned object also carry an attribute
+    // cleaner way (in a C++ pure sense) would be to return a pair of string and SEXP
     SEXP v = libtiledb_array_get_metadata_from_index(array, i);
     Rcpp::RObject obj(v);
     Rcpp::CharacterVector objnms = obj.attr("names");
@@ -2979,85 +2783,73 @@ SEXP libtiledb_array_get_metadata_list(XPtr<tiledb::Array> array) {
 }
 
 // [[Rcpp::export]]
-void libtiledb_array_delete_metadata(XPtr<tiledb::Array> array,
-                                     std::string key) {
+void libtiledb_array_delete_metadata(XPtr<tiledb::Array> array, std::string key) {
   check_xptr_tag<tiledb::Array>(array);
   array->delete_metadata(key.c_str());
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::Array>
-libtiledb_array_set_open_timestamp_start(XPtr<tiledb::Array> array,
-                                         Rcpp::Datetime tstamp) {
-  check_xptr_tag<tiledb::Array>(array);
-  uint64_t ts_ms =
-      static_cast<uint64_t>(std::round(tstamp.getFractionalTimestamp() * 1000));
-  array->set_open_timestamp_start(ts_ms);
-  return array;
+XPtr<tiledb::Array> libtiledb_array_set_open_timestamp_start(XPtr<tiledb::Array> array, Rcpp::Datetime tstamp) {
+    check_xptr_tag<tiledb::Array>(array);
+    uint64_t ts_ms = static_cast<uint64_t>(std::round(tstamp.getFractionalTimestamp() * 1000));
+    array->set_open_timestamp_start(ts_ms);
+    return array;
 }
 
 // [[Rcpp::export]]
 Rcpp::Datetime libtiledb_array_open_timestamp_start(XPtr<tiledb::Array> array) {
-  check_xptr_tag<tiledb::Array>(array);
-  uint64_t ts_ms = array->open_timestamp_start();
-  double ts = ts_ms / 1000.0;
-  return (Rcpp::Datetime(ts));
+    check_xptr_tag<tiledb::Array>(array);
+    uint64_t ts_ms = array->open_timestamp_start();
+    double ts = ts_ms / 1000.0;
+    return(Rcpp::Datetime(ts));
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::Array>
-libtiledb_array_set_open_timestamp_end(XPtr<tiledb::Array> array,
-                                       Rcpp::Datetime tstamp) {
-  check_xptr_tag<tiledb::Array>(array);
-  uint64_t ts_ms =
-      static_cast<uint64_t>(std::round(tstamp.getFractionalTimestamp() * 1000));
-  array->set_open_timestamp_end(ts_ms);
-  return array;
+XPtr<tiledb::Array> libtiledb_array_set_open_timestamp_end(XPtr<tiledb::Array> array, Rcpp::Datetime tstamp) {
+    check_xptr_tag<tiledb::Array>(array);
+    uint64_t ts_ms = static_cast<uint64_t>(std::round(tstamp.getFractionalTimestamp() * 1000));
+    array->set_open_timestamp_end(ts_ms);
+    return array;
 }
 
 // [[Rcpp::export]]
 Rcpp::Datetime libtiledb_array_open_timestamp_end(XPtr<tiledb::Array> array) {
-  check_xptr_tag<tiledb::Array>(array);
-  uint64_t ts_ms = array->open_timestamp_end();
-  double ts = ts_ms / 1000.0;
-  return (Rcpp::Datetime(ts));
+    check_xptr_tag<tiledb::Array>(array);
+    uint64_t ts_ms = array->open_timestamp_end();
+    double ts = ts_ms / 1000.0;
+    return(Rcpp::Datetime(ts));
 }
 
 // [[Rcpp::export]]
-void libtiledb_array_delete_fragments(XPtr<tiledb::Context> ctx,
-                                      XPtr<tiledb::Array> array,
-                                      Rcpp::Datetime tstamp_start,
-                                      Rcpp::Datetime tstamp_end) {
-#if TILEDB_VERSION >= TileDB_Version(2, 12, 0)
-  check_xptr_tag<tiledb::Context>(ctx);
-  check_xptr_tag<tiledb::Array>(array);
-  const std::string uri = array->uri();
-  uint64_t ts_ms_st = static_cast<uint64_t>(
-      std::round(tstamp_start.getFractionalTimestamp() * 1000));
-  uint64_t ts_ms_en = static_cast<uint64_t>(
-      std::round(tstamp_end.getFractionalTimestamp() * 1000));
-#if TILEDB_VERSION >= TileDB_Version(2, 18, 0)
-  tiledb::Array::delete_fragments(*ctx.get(), uri, ts_ms_st, ts_ms_en);
+void libtiledb_array_delete_fragments(XPtr<tiledb::Context> ctx, XPtr<tiledb::Array> array,
+                                      Rcpp::Datetime tstamp_start, Rcpp::Datetime tstamp_end) {
+#if TILEDB_VERSION >= TileDB_Version(2,12,0)
+    check_xptr_tag<tiledb::Context>(ctx);
+    check_xptr_tag<tiledb::Array>(array);
+    const std::string uri = array->uri();
+    uint64_t ts_ms_st = static_cast<uint64_t>(std::round(tstamp_start.getFractionalTimestamp() * 1000));
+    uint64_t ts_ms_en = static_cast<uint64_t>(std::round(tstamp_end.getFractionalTimestamp() * 1000));
+#if TILEDB_VERSION >= TileDB_Version(2,18,0)
+    tiledb::Array::delete_fragments(*ctx.get(), uri, ts_ms_st, ts_ms_en);
 #else
-  array->delete_fragments(uri, ts_ms_st, ts_ms_en);
+    array->delete_fragments(uri, ts_ms_st, ts_ms_en);
 #endif
 #endif
 }
 
 // [[Rcpp::export]]
-void libtiledb_array_delete_fragments_list(XPtr<tiledb::Context> ctx,
-                                           XPtr<tiledb::Array> array,
+void libtiledb_array_delete_fragments_list(XPtr<tiledb::Context> ctx, XPtr<tiledb::Array> array,
                                            std::vector<std::string> fragments) {
-  check_xptr_tag<tiledb::Context>(ctx);
-  check_xptr_tag<tiledb::Array>(array);
-  const std::string uri = array->uri();
-  size_t n = fragments.size();
-  std::vector<const char *> frags(n);
-  for (size_t i = 0; i < n; i++) {
-    frags[i] = fragments[i].c_str();
-  }
-#if TILEDB_VERSION >= TileDB_Version(2, 18, 0)
-  tiledb::Array::delete_fragments_list(*ctx.get(), uri, &frags[0], n);
+    check_xptr_tag<tiledb::Context>(ctx);
+    check_xptr_tag<tiledb::Array>(array);
+    const std::string uri = array->uri();
+    size_t n = fragments.size();
+    std::vector<const char*> frags(n);
+    for (size_t i = 0; i < n; i++) {
+        frags[i] = fragments[i].c_str();
+    }
+#if TILEDB_VERSION >= TileDB_Version(2,18,0)
+    tiledb::Array::delete_fragments_list(*ctx.get(), uri, &frags[0], n);
 #endif
 }
 
@@ -3065,71 +2857,68 @@ void libtiledb_array_delete_fragments_list(XPtr<tiledb::Context> ctx,
 bool libtiledb_array_has_enumeration(XPtr<tiledb::Context> ctx,
                                      XPtr<tiledb::Array> arr,
                                      const std::string name) {
-  check_xptr_tag<tiledb::Context>(ctx);
-  check_xptr_tag<tiledb::Array>(arr);
-  bool res = false;
-#if TILEDB_VERSION >= TileDB_Version(2, 17, 0)
-  auto enmr =
-      tiledb::ArrayExperimental::get_enumeration(*ctx.get(), *arr.get(), name);
-  if (enmr.ptr() != nullptr) {
-    res = true;
-  }
+    check_xptr_tag<tiledb::Context>(ctx);
+    check_xptr_tag<tiledb::Array>(arr);
+    bool res = false;
+#if TILEDB_VERSION >= TileDB_Version(2,17,0)
+    auto enmr = tiledb::ArrayExperimental::get_enumeration(*ctx.get(), *arr.get(), name);
+    if (enmr.ptr() != nullptr) {
+        res = true;
+    }
 #endif
-  return res;
+    return res;
 }
 
 // [[Rcpp::export]]
-std::vector<std::string>
-libtiledb_array_get_enumeration(XPtr<tiledb::Context> ctx,
-                                XPtr<tiledb::Array> arr,
-                                const std::string name) {
-  check_xptr_tag<tiledb::Context>(ctx);
-  check_xptr_tag<tiledb::Array>(arr);
-  std::vector<std::string> res;
-#if TILEDB_VERSION >= TileDB_Version(2, 17, 0)
-  auto enmr =
-      tiledb::ArrayExperimental::get_enumeration(*ctx.get(), *arr.get(), name);
-  if (enmr.ptr() == nullptr) {
-    Rcpp::stop("No enumeration named '%s' in array.");
-  }
-  res = enmr.as_vector<std::string>();
+std::vector<std::string> libtiledb_array_get_enumeration(XPtr<tiledb::Context> ctx,
+                                                         XPtr<tiledb::Array> arr,
+                                                         const std::string name) {
+    check_xptr_tag<tiledb::Context>(ctx);
+    check_xptr_tag<tiledb::Array>(arr);
+    std::vector<std::string> res;
+#if TILEDB_VERSION >= TileDB_Version(2,17,0)
+    auto enmr = tiledb::ArrayExperimental::get_enumeration(*ctx.get(), *arr.get(), name);
+    if (enmr.ptr() == nullptr) {
+        Rcpp::stop("No enumeration named '%s' in array.");
+    }
+    res = enmr.as_vector<std::string>();
 #endif
-  return res;
+    return res;
 }
 
 // quick and dirty checker for an entire array
 // [[Rcpp::export]]
-Rcpp::LogicalVector
-libtiledb_array_has_enumeration_vector(XPtr<tiledb::Context> ctx,
-                                       XPtr<tiledb::Array> array) {
-  check_xptr_tag<tiledb::Context>(ctx);
-  check_xptr_tag<tiledb::Array>(array);
-  Rcpp::XPtr<tiledb::ArraySchema> arrsch = libtiledb_array_get_schema(array);
-  Rcpp::List attrs = libtiledb_array_schema_attributes(arrsch);
-  size_t n = attrs.size();
-  Rcpp::LogicalVector has_enum = Rcpp::LogicalVector(n);
-  Rcpp::CharacterVector attr_names(n);
-  for (size_t i = 0; i < n; i++) {
-    has_enum[i] = libtiledb_attribute_has_enumeration(ctx, attrs[i]);
-    attr_names[i] = libtiledb_attribute_get_name(attrs[i]);
-  }
-  has_enum.attr("names") = attr_names;
-  return has_enum;
+Rcpp::LogicalVector libtiledb_array_has_enumeration_vector(XPtr<tiledb::Context> ctx, XPtr<tiledb::Array> array) {
+    check_xptr_tag<tiledb::Context>(ctx);
+    check_xptr_tag<tiledb::Array>(array);
+    Rcpp::XPtr<tiledb::ArraySchema> arrsch = libtiledb_array_get_schema(array);
+    Rcpp::List attrs = libtiledb_array_schema_attributes(arrsch);
+    size_t n = attrs.size();
+    Rcpp::LogicalVector has_enum = Rcpp::LogicalVector(n);
+    Rcpp::CharacterVector attr_names(n);
+    for (size_t i = 0; i < n; i++) {
+        has_enum[i] = libtiledb_attribute_has_enumeration(ctx, attrs[i]);
+        attr_names[i] = libtiledb_attribute_get_name(attrs[i]);
+    }
+    has_enum.attr("names") = attr_names;
+    return has_enum;
 }
 
 // [[Rcpp::export]]
-void libtiledb_array_upgrade_version(
-    XPtr<tiledb::Context> ctx, XPtr<tiledb::Array> array, std::string &uri,
-    Rcpp::Nullable<XPtr<tiledb::Config>> cfg = R_NilValue) {
-  check_xptr_tag<tiledb::Context>(ctx);
-  check_xptr_tag<tiledb::Array>(array);
-  if (cfg.isNull()) {
-    array->upgrade_version(*ctx.get(), uri);
-  } else {
-    XPtr<tiledb::Config> config(cfg);
-    array->upgrade_version(*ctx.get(), uri, config.get());
-  }
+void libtiledb_array_upgrade_version(XPtr<tiledb::Context> ctx,
+                                     XPtr<tiledb::Array> array,
+                                     std::string& uri,
+                                     Rcpp::Nullable<XPtr<tiledb::Config>> cfg = R_NilValue) {
+    check_xptr_tag<tiledb::Context>(ctx);
+    check_xptr_tag<tiledb::Array>(array);
+    if (cfg.isNull()) {
+        array->upgrade_version(*ctx.get(), uri);
+    } else {
+        XPtr<tiledb::Config> config(cfg);
+        array->upgrade_version(*ctx.get(), uri, config.get());
+    }
 }
+
 
 /**
  * Query
@@ -3167,85 +2956,83 @@ std::string libtiledb_query_layout(XPtr<tiledb::Query> query) {
   return _tiledb_layout_to_string(layout);
 }
 
-// NB Function XPtr<tiledb::Array> libtiledb_query_get_array(XPtr<tiledb::Query>
-// query,
-//                                                           XPtr<tiledb::Context>
-//                                                           ctx) {
+// NB Function XPtr<tiledb::Array> libtiledb_query_get_array(XPtr<tiledb::Query> query,
+//                                                           XPtr<tiledb::Context> ctx) {
 // is below along with schema getter
+
 
 // generalized version which switches
 // [[Rcpp::export]]
-XPtr<tiledb::Query>
-libtiledb_query_set_subarray_with_type(XPtr<tiledb::Query> query, SEXP subarray,
-                                       std::string typestr) {
-  check_xptr_tag<tiledb::Query>(query);
-  spdl::debug(tfm::format(
-      "libtiledb_query_set_subarray_with_type] setting subarray for type %s",
-      typestr));
-  tiledb::Subarray subarr(query->ctx(), query->array());
-  if (typestr == "INT32") {
-    IntegerVector vec(subarray);
-    subarr.set_subarray(vec.begin(), vec.length());
-  } else if (typestr == "FLOAT64") {
-    NumericVector sub(subarray);
-    subarr.set_subarray(sub.begin(), sub.length());
-  } else if (typestr == "INT64" || typestr == "UINT32" ||
-             typestr == "DATETIME_NS") {
-    NumericVector sub(subarray);
-    std::vector<int64_t> v(sub.length());
-    for (int i = 0; i < sub.length(); i++)
-      v[i] = static_cast<int64_t>(sub[i]);
-    subarr.set_subarray(v);
-  } else if (typestr == "DATETIME_YEAR" || typestr == "DATETIME_MONTH" ||
-             typestr == "DATETIME_WEEK" || typestr == "DATETIME_DAY") {
-    DateVector sub(subarray);
-    std::vector<int64_t> v =
-        dates_to_int64(sub, _string_to_tiledb_datatype(typestr));
-    subarr.set_subarray(v);
-  } else if (typestr == "DATETIME_HR" || typestr == "DATETIME_MIN" ||
-             typestr == "DATETIME_SEC" || typestr == "DATETIME_MS" ||
-             typestr == "DATETIME_US") {
-    DatetimeVector sub(subarray);
-    std::vector<int64_t> v =
-        datetimes_to_int64(sub, _string_to_tiledb_datatype(typestr));
-    subarr.set_subarray(v);
-  } else if (typestr == "UINT64") {
-    NumericVector sub(subarray);
-    std::vector<uint64_t> v(sub.length());
-    for (int i = 0; i < sub.length(); i++)
-      v[i] = static_cast<uint64_t>(sub[i]);
-    subarr.set_subarray(v);
-  } else {
-    Rcpp::stop("currently unsupported subarray datatype '%s'", typestr.c_str());
-  }
-  query->set_subarray(subarr);
-  return query;
+XPtr<tiledb::Query> libtiledb_query_set_subarray_with_type(XPtr<tiledb::Query> query,
+                                                           SEXP subarray, std::string typestr) {
+    check_xptr_tag<tiledb::Query>(query);
+    spdl::debug(tfm::format("libtiledb_query_set_subarray_with_type] setting subarray for type %s", typestr));
+    tiledb::Subarray subarr(query->ctx(), query->array());
+    if (typestr == "INT32") {
+        IntegerVector vec(subarray);
+        subarr.set_subarray(vec.begin(), vec.length());
+    } else if (typestr == "FLOAT64") {
+        NumericVector sub(subarray);
+        subarr.set_subarray(sub.begin(), sub.length());
+    } else if (typestr == "INT64" ||
+               typestr == "UINT32" ||
+               typestr == "DATETIME_NS") {
+        NumericVector sub(subarray);
+        std::vector<int64_t> v(sub.length());
+        for (int i=0; i<sub.length(); i++)
+            v[i] = static_cast<int64_t>(sub[i]);
+        subarr.set_subarray(v);
+    } else if (typestr == "DATETIME_YEAR"  ||
+               typestr == "DATETIME_MONTH" ||
+               typestr == "DATETIME_WEEK"  ||
+               typestr == "DATETIME_DAY") {
+        DateVector sub(subarray);
+        std::vector<int64_t> v = dates_to_int64(sub, _string_to_tiledb_datatype(typestr));
+        subarr.set_subarray(v);
+    } else if (typestr == "DATETIME_HR"  ||
+               typestr == "DATETIME_MIN" ||
+               typestr == "DATETIME_SEC" ||
+               typestr == "DATETIME_MS"  ||
+               typestr == "DATETIME_US") {
+        DatetimeVector sub(subarray);
+        std::vector<int64_t> v = datetimes_to_int64(sub, _string_to_tiledb_datatype(typestr));
+        subarr.set_subarray(v);
+    } else if (typestr == "UINT64") {
+        NumericVector sub(subarray);
+        std::vector<uint64_t> v(sub.length());
+        for (int i=0; i<sub.length(); i++)
+            v[i] = static_cast<uint64_t>(sub[i]);
+        subarr.set_subarray(v);
+    } else {
+        Rcpp::stop("currently unsupported subarray datatype '%s'", typestr.c_str());
+    }
+    query->set_subarray(subarr);
+    return query;
 }
 
 // [[Rcpp::export]]
 XPtr<tiledb::Query> libtiledb_query_set_subarray(XPtr<tiledb::Query> query,
                                                  SEXP subarray) {
-  check_xptr_tag<tiledb::Query>(query);
-  spdl::debug(
-      tfm::format("libtiledb_query_set_subarray] setting subarray for type %s",
-                  Rf_type2char(TYPEOF(subarray))));
-  tiledb::Subarray subarr(query->ctx(), query->array());
-  if (TYPEOF(subarray) == INTSXP) {
-    IntegerVector vec(subarray);
-    subarr.set_subarray(vec.begin(), vec.length());
-  } else if (TYPEOF(subarray) == REALSXP) {
-    NumericVector vec(subarray);
-    subarr.set_subarray(vec.begin(), vec.length());
-  } else {
-    Rcpp::stop("currently unsupported subarray datatype");
-  }
-  query->set_subarray(subarr);
-  return query;
+    check_xptr_tag<tiledb::Query>(query);
+    spdl::debug(tfm::format("libtiledb_query_set_subarray] setting subarray for type %s", Rf_type2char(TYPEOF(subarray))));
+    tiledb::Subarray subarr(query->ctx(), query->array());
+    if (TYPEOF(subarray) == INTSXP) {
+        IntegerVector vec(subarray);
+        subarr.set_subarray(vec.begin(), vec.length());
+    } else if (TYPEOF(subarray) == REALSXP) {
+        NumericVector vec(subarray);
+        subarr.set_subarray(vec.begin(), vec.length());
+    } else {
+        Rcpp::stop("currently unsupported subarray datatype");
+    }
+    query->set_subarray(subarr);
+    return query;
 }
 
 // [[Rcpp::export]]
 XPtr<tiledb::Query> libtiledb_query_set_buffer(XPtr<tiledb::Query> query,
-                                               std::string attr, SEXP buffer) {
+                                               std::string attr,
+                                               SEXP buffer) {
   check_xptr_tag<tiledb::Query>(query);
   if (TYPEOF(buffer) == INTSXP) {
     IntegerVector vec(buffer);
@@ -3256,8 +3043,7 @@ XPtr<tiledb::Query> libtiledb_query_set_buffer(XPtr<tiledb::Query> query,
     query->set_data_buffer(attr, vec.begin(), vec.length());
     return query;
   } else if (TYPEOF(buffer) == LGLSXP) {
-    LogicalVector vec(
-        buffer); // note that it is really an int at the element storage
+    LogicalVector vec(buffer);  // note that it is really an int at the element storage
     query->set_data_buffer(attr, vec.begin(), vec.length());
     return query;
   } else {
@@ -3269,151 +3055,137 @@ XPtr<tiledb::Query> libtiledb_query_set_buffer(XPtr<tiledb::Query> query,
 // -- vlc_buf_t functions below
 
 // [[Rcpp::export]]
-XPtr<vlc_buf_t> libtiledb_query_buffer_var_char_alloc_direct(double szoffsets,
-                                                             double szdata,
-                                                             bool nullable,
-                                                             int cols = 1) {
-  XPtr<vlc_buf_t> buf = make_xptr<vlc_buf_t>(new vlc_buf_t);
-  buf->offsets.resize(static_cast<size_t>(szoffsets));
-  buf->str.resize(static_cast<size_t>(szdata));
-  buf->rows = std::round(szoffsets / cols); // guess for number of elements
-  buf->cols = cols;
-  buf->nullable = nullable;
-  buf->validity_map.resize(static_cast<size_t>(szdata));
-  buf->legacy_validity = false; // for legacy validity mode
-  return buf;
+XPtr<vlc_buf_t> libtiledb_query_buffer_var_char_alloc_direct(double szoffsets, double szdata,
+                                                             bool nullable, int cols=1) {
+    XPtr<vlc_buf_t> buf = make_xptr<vlc_buf_t>(new vlc_buf_t);
+    buf->offsets.resize(static_cast<size_t>(szoffsets));
+    buf->str.resize(static_cast<size_t>(szdata));
+    buf->rows = std::round(szoffsets/cols);           // guess for number of elements
+    buf->cols = cols;
+    buf->nullable = nullable;
+    buf->validity_map.resize(static_cast<size_t>(szdata));
+    buf->legacy_validity = false; 		              // for legacy validity mode
+    return buf;
 }
 
 // [[Rcpp::export]]
-bool libtiledb_query_buffer_var_char_get_legacy_validity_value(
-    XPtr<tiledb::Context> ctx, bool validity_override = false) {
-  check_xptr_tag<tiledb::Context>(ctx);
-  XPtr<tiledb::Config> cfg = libtiledb_ctx_config(ctx);
-  Rcpp::CharacterVector vec =
-      libtiledb_config_get(cfg, "r.legacy_validity_mode");
-  bool legacy_validity =
-      std::string("true") == std::string(vec[0]) || validity_override;
-  return legacy_validity;
+bool libtiledb_query_buffer_var_char_get_legacy_validity_value(XPtr<tiledb::Context> ctx,
+                                                               bool validity_override = false) {
+    check_xptr_tag<tiledb::Context>(ctx);
+    XPtr<tiledb::Config> cfg = libtiledb_ctx_config(ctx);
+    Rcpp::CharacterVector vec = libtiledb_config_get(cfg, "r.legacy_validity_mode");
+    bool legacy_validity = std::string("true") == std::string(vec[0]) || validity_override;
+    return legacy_validity;
 }
 
 // [[Rcpp::export]]
-XPtr<vlc_buf_t> libtiledb_query_buffer_var_char_legacy_validity_mode(
-    XPtr<tiledb::Context> ctx, XPtr<vlc_buf_t> buf,
-    bool validity_override = false) {
-  buf->legacy_validity =
-      libtiledb_query_buffer_var_char_get_legacy_validity_value(
-          ctx, validity_override);
-  spdl::debug(
-      tfm::format("[libtiledb_query_buffer_var_char_legacy_validity_mode] "
-                  "legacy_validity set to %s",
-                  buf->legacy_validity ? "true" : "false"));
-  return buf;
+XPtr<vlc_buf_t> libtiledb_query_buffer_var_char_legacy_validity_mode(XPtr<tiledb::Context> ctx,
+                                                                     XPtr<vlc_buf_t> buf,
+                                                                     bool validity_override = false) {
+    buf->legacy_validity = libtiledb_query_buffer_var_char_get_legacy_validity_value(ctx,
+                                                                                     validity_override);
+    spdl::debug(tfm::format("[libtiledb_query_buffer_var_char_legacy_validity_mode] "
+                            "legacy_validity set to %s", buf->legacy_validity ? "true" : "false"));
+    return buf;
 }
 
 // assigning (for a write) allocates
 // [[Rcpp::export]]
-XPtr<vlc_buf_t>
-libtiledb_query_buffer_var_char_create(CharacterVector vec, bool nullable,
-                                       bool legacy_validity = false) {
-  size_t n = vec.size();
-  XPtr<vlc_buf_t> bufptr = make_xptr<vlc_buf_t>(new vlc_buf_t);
-  bufptr->offsets.resize(n);
-  bufptr->validity_map.resize(n);
-  bufptr->nullable = nullable;
-  bufptr->legacy_validity = legacy_validity;
-  bufptr->str = "";
-  uint64_t cumlen = 0;
-  for (size_t i = 0; i < n; i++) {
-    std::string s(vec[i]);
-    bufptr->offsets[i] = cumlen;
-    bufptr->str += s;
-    cumlen += s.length();
-    if (nullable) {
-      if (legacy_validity) {
-        bufptr->validity_map[i] = vec[i] == R_NaString;
-      } else {
-        bufptr->validity_map[i] = vec[i] != R_NaString;
-      }
+XPtr<vlc_buf_t> libtiledb_query_buffer_var_char_create(CharacterVector vec, bool nullable,
+                                                       bool legacy_validity = false) {
+    size_t n = vec.size();
+    XPtr<vlc_buf_t> bufptr = make_xptr<vlc_buf_t>(new vlc_buf_t);
+    bufptr->offsets.resize(n);
+    bufptr->validity_map.resize(n);
+    bufptr->nullable = nullable;
+    bufptr->legacy_validity = legacy_validity;
+    bufptr->str = "";
+    uint64_t cumlen = 0;
+    for (size_t i=0; i<n; i++) {
+        std::string s(vec[i]);
+        bufptr->offsets[i] = cumlen;
+        bufptr->str += s;
+        cumlen += s.length();
+        if (nullable) {
+            if (legacy_validity) {
+                bufptr->validity_map[i] = vec[i] == R_NaString;
+            } else {
+                bufptr->validity_map[i] = vec[i] != R_NaString;
+            }
+        }
     }
-  }
-  bufptr->rows = bufptr->cols = 0; // signal unassigned for the write case
-  return (bufptr);
+    bufptr->rows = bufptr->cols = 0; // signal unassigned for the write case
+    return(bufptr);
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::Query>
-libtiledb_query_set_buffer_var_char(XPtr<tiledb::Query> query, std::string attr,
-                                    XPtr<vlc_buf_t> bufptr) {
-  check_xptr_tag<tiledb::Query>(query);
-  check_xptr_tag<vlc_buf_t>(bufptr);
-  if (bufptr->nullable) {
-    query->set_validity_buffer(attr, bufptr->validity_map);
-  }
-  query->set_data_buffer(attr, bufptr->str);
-  query->set_offsets_buffer(attr, bufptr->offsets);
-  return query;
+XPtr<tiledb::Query> libtiledb_query_set_buffer_var_char(XPtr<tiledb::Query> query,
+                                                        std::string attr,
+                                                        XPtr<vlc_buf_t> bufptr) {
+    check_xptr_tag<tiledb::Query>(query);
+    check_xptr_tag<vlc_buf_t>(bufptr);
+    if (bufptr->nullable) {
+        query->set_validity_buffer(attr, bufptr->validity_map);
+    }
+    query->set_data_buffer(attr, bufptr->str);
+    query->set_offsets_buffer(attr, bufptr->offsets);
+    return query;
 }
 
-// 'len' is the length of the query result set, i.e. buffer elements for
-// standard columns 'nchar' is the length of the result set for the particular
-// column, i.e. actual (ex-post)
+// 'len' is the length of the query result set, i.e. buffer elements for standard columns
+// 'nchar' is the length of the result set for the particular column, i.e. actual (ex-post)
 //    string length in bufptr (as opposed to ex-ante guess)
 // [[Rcpp::export]]
 CharacterMatrix libtiledb_query_get_buffer_var_char(XPtr<vlc_buf_t> bufptr,
-                                                    int32_t len = 0,
-                                                    int32_t nchar = 0) {
+                                                    int32_t len=0, int32_t nchar=0) {
   check_xptr_tag<vlc_buf_t>(bufptr);
-  size_t n = (len == 0 ? bufptr->offsets.size() : len);
-  // Rprintf("n=%d, strsize=%d, row %d col %d, nchar %d, nullable %d len=%d
-  // nchar=%d\n",
-  //         n, bufptr->str.size(), bufptr->rows, bufptr->cols, nchar,
-  //         bufptr->nullable, len, nchar);
+  size_t n = (len==0 ? bufptr->offsets.size() : len);
+  //Rprintf("n=%d, strsize=%d, row %d col %d, nchar %d, nullable %d len=%d nchar=%d\n",
+  //        n, bufptr->str.size(), bufptr->rows, bufptr->cols, nchar, bufptr->nullable, len, nchar);
   std::vector<uint64_t> str_sizes(n);
-  for (size_t i = 0; i < n - 1; i++) { // all but last
-    //  Rprintf("%d %d %d\n", i, bufptr->offsets[i + 1] , bufptr->offsets[i]);
-    str_sizes[i] = bufptr->offsets[i + 1] - bufptr->offsets[i];
-  } // last is total size minus last start
-  str_sizes[n - 1] = (nchar == 0 ? bufptr->str.size() * sizeof(char) : nchar) -
-                     bufptr->offsets[n - 1];
+  for (size_t i = 0; i < n - 1; i++) {                          // all but last
+      //  Rprintf("%d %d %d\n", i, bufptr->offsets[i + 1] , bufptr->offsets[i]);
+      str_sizes[i] = bufptr->offsets[i + 1] - bufptr->offsets[i];
+  }                                                             // last is total size minus last start
+  str_sizes[n-1] = (nchar==0 ? bufptr->str.size() * sizeof(char) : nchar) - bufptr->offsets[n-1];
   // Get the strings
   CharacterMatrix mat(bufptr->rows, bufptr->cols);
   for (size_t i = 0; i < n; i++) {
-    if (bufptr->nullable) {
-      if (bufptr->legacy_validity) {
-        if (bufptr->validity_map[i] == 0)
-          mat[i] = std::string(&bufptr->str[bufptr->offsets[i]], str_sizes[i]);
-        else
-          mat[i] = R_NaString;
+      if (bufptr->nullable) {
+          if (bufptr->legacy_validity) {
+              if (bufptr->validity_map[i] == 0)
+                  mat[i] = std::string(&bufptr->str[bufptr->offsets[i]], str_sizes[i]);
+              else
+                  mat[i] = R_NaString;
+          } else {
+              if (bufptr->validity_map[i] != 0)
+                  mat[i] = std::string(&bufptr->str[bufptr->offsets[i]], str_sizes[i]);
+              else
+                  mat[i] = R_NaString;
+          }
       } else {
-        if (bufptr->validity_map[i] != 0)
           mat[i] = std::string(&bufptr->str[bufptr->offsets[i]], str_sizes[i]);
-        else
-          mat[i] = R_NaString;
       }
-    } else {
-      mat[i] = std::string(&bufptr->str[bufptr->offsets[i]], str_sizes[i]);
-    }
   }
-  return (mat);
+  return(mat);
 }
 
 // more of a debugging helper
 // [[Rcpp::export]]
 std::string libtiledb_query_get_buffer_var_char_simple(XPtr<vlc_buf_t> bufptr) {
   check_xptr_tag<vlc_buf_t>(bufptr);
-  return (bufptr->str);
+  return(bufptr->str);
 }
 
 // -- vlv_buf_t functions below
 
 // assigning (for a write) allocates
 // [[Rcpp::export]]
-XPtr<vlv_buf_t> libtiledb_query_buffer_var_vec_create(IntegerVector intoffsets,
-                                                      SEXP data) {
+XPtr<vlv_buf_t> libtiledb_query_buffer_var_vec_create(IntegerVector intoffsets, SEXP data) {
   int n = intoffsets.size();
   XPtr<vlv_buf_t> bufptr = make_xptr<vlv_buf_t>(new vlv_buf_t);
   bufptr->offsets.resize(n);
-  for (int i = 0; i < n; i++) {
+  for (int i=0; i<n; i++) {
     bufptr->offsets[i] = static_cast<uint64_t>(intoffsets[i]);
   }
   if (TYPEOF(data) == INTSXP) {
@@ -3424,251 +3196,255 @@ XPtr<vlv_buf_t> libtiledb_query_buffer_var_vec_create(IntegerVector intoffsets,
     bufptr->ddata = Rcpp::as<std::vector<double>>(data);
     bufptr->idata.clear();
     bufptr->dtype = TILEDB_FLOAT64;
-    return (bufptr);
+    return(bufptr);
   } else {
     Rcpp::stop("Invalid data type for buffer: '%s'", Rcpp::type2name(data));
   }
-  return (bufptr);
+  return(bufptr);
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::Query>
-libtiledb_query_set_buffer_var_vec(XPtr<tiledb::Query> query, std::string attr,
-                                   XPtr<vlv_buf_t> buf) {
+XPtr<tiledb::Query> libtiledb_query_set_buffer_var_vec(XPtr<tiledb::Query> query,
+                                                       std::string attr, XPtr<vlv_buf_t> buf) {
   check_xptr_tag<vlv_buf_t>(buf);
   if (buf->dtype == TILEDB_INT32) {
-    query->set_data_buffer(attr, buf->idata);
-    query->set_offsets_buffer(attr, buf->offsets);
+      query->set_data_buffer(attr, buf->idata);
+      query->set_offsets_buffer(attr, buf->offsets);
   } else if (buf->dtype == TILEDB_FLOAT64) {
-    query->set_data_buffer(attr, buf->ddata);
-    query->set_offsets_buffer(attr, buf->offsets);
+      query->set_data_buffer(attr, buf->ddata);
+      query->set_offsets_buffer(attr, buf->offsets);
   } else {
-    Rcpp::stop("Unsupported type '%s' for buffer",
-               _tiledb_datatype_to_string(buf->dtype));
+      Rcpp::stop("Unsupported type '%s' for buffer", _tiledb_datatype_to_string(buf->dtype));
   }
   return query;
 }
 
 // [[Rcpp::export]]
-List libtiledb_query_get_buffer_var_vec(XPtr<tiledb::Query> query,
-                                        std::string attr, XPtr<vlv_buf_t> buf) {
+List libtiledb_query_get_buffer_var_vec(XPtr<tiledb::Query> query, std::string attr,
+                                        XPtr<vlv_buf_t> buf) {
 
   check_xptr_tag<tiledb::Query>(query);
   check_xptr_tag<vlv_buf_t>(buf);
   int n = buf->offsets.size();
   IntegerVector ivec(n);
-  for (int i = 0; i < n; i++) {
+  for (int i=0; i<n; i++) {
     ivec[i] = static_cast<int32_t>(buf->offsets[i]);
   }
-  auto dims =
-      query->result_buffer_elements()[attr]; // actual result dims post query
-  n = dims.second;                           // actual size, not allocated size
+  auto dims = query->result_buffer_elements()[attr]; // actual result dims post query
+  n = dims.second;            // actual size, not allocated size
   if (buf->dtype == TILEDB_INT32) {
     IntegerVector dvec(n);
-    for (int i = 0; i < n; i++) {
+    for (int i=0; i<n; i++) {
       dvec[i] = static_cast<int32_t>(buf->idata[i]);
     }
-    List rl =
-        List::create(Rcpp::Named("offsets") = ivec, Rcpp::Named("data") = dvec);
-    return (rl);
+    List rl = List::create(Rcpp::Named("offsets") = ivec,
+                           Rcpp::Named("data")    = dvec);
+    return(rl);
   } else if (buf->dtype == TILEDB_FLOAT64) {
     NumericVector dvec(n);
-    for (int i = 0; i < n; i++) {
+    for (int i=0; i<n; i++) {
       dvec[i] = static_cast<double>(buf->ddata[i]);
     }
-    List rl =
-        List::create(Rcpp::Named("offsets") = ivec, Rcpp::Named("data") = dvec);
-    return (rl);
+    List rl = List::create(Rcpp::Named("offsets") = ivec,
+                           Rcpp::Named("data")    = dvec);
+    return(rl);
   } else {
-    Rcpp::stop("Unsupported type '%s' for buffer",
-               _tiledb_datatype_to_string(buf->dtype));
+    Rcpp::stop("Unsupported type '%s' for buffer", _tiledb_datatype_to_string(buf->dtype));
   }
   return Rcpp::as<Rcpp::List>(R_NilValue); // not reached
 }
 
 // -- query_buf_t aka sparse_coords_buf_t
 
-// In the following signature we cannot have a templated type as the return type
-// so we have to bring the switch between types 'inside' and make it run-time
-// dependent on the subarray type we already had
+// In the following signature we cannot have a templated type as the return type so we have
+// to bring the switch between types 'inside' and make it run-time dependent on the subarray
+// type we already had
 // [[Rcpp::export]]
 XPtr<query_buf_t> libtiledb_query_buffer_alloc_ptr(std::string domaintype,
                                                    R_xlen_t ncells,
                                                    bool nullable = false,
                                                    int32_t numvar = 1) {
   XPtr<query_buf_t> buf = make_xptr<query_buf_t>(new query_buf_t);
-  if (domaintype == "INT32" || domaintype == "UINT32") {
-    buf->size = sizeof(int32_t);
+  if (domaintype == "INT32"  || domaintype == "UINT32") {
+     buf->size = sizeof(int32_t);
   } else if (domaintype == "INT16" || domaintype == "UINT16") {
-    buf->size = sizeof(int16_t);
+     buf->size = sizeof(int16_t);
   } else if (domaintype == "INT8" || domaintype == "UINT8") {
-    buf->size = sizeof(int8_t);
+     buf->size = sizeof(int8_t);
   } else if (domaintype == "BLOB"
-#if TILEDB_VERSION >= TileDB_Version(2, 21, 0)
-             || domaintype == "GEOM_WKB" || domaintype == "GEOM_WKT"
+#if TILEDB_VERSION >= TileDB_Version(2,21,0)
+             || domaintype == "GEOM_WKB"
+             || domaintype == "GEOM_WKT"
 #endif
-  ) {
-    buf->size = sizeof(int8_t);
-#if TILEDB_VERSION >= TileDB_Version(2, 10, 0)
+             ) {
+     buf->size = sizeof(int8_t);
+#if TILEDB_VERSION >= TileDB_Version(2,10,0)
   } else if (domaintype == "BOOL") {
-    buf->size = sizeof(uint8_t);
+     buf->size = sizeof(uint8_t);
 #endif
-  } else if (domaintype == "INT64" || domaintype == "UINT64" ||
-             domaintype == "DATETIME_YEAR" || domaintype == "DATETIME_MONTH" ||
-             domaintype == "DATETIME_WEEK" || domaintype == "DATETIME_DAY" ||
-             domaintype == "DATETIME_HR" || domaintype == "DATETIME_MIN" ||
-             domaintype == "DATETIME_SEC" || domaintype == "DATETIME_MS" ||
-             domaintype == "DATETIME_US" || domaintype == "DATETIME_NS" ||
-             domaintype == "DATETIME_PS" || domaintype == "DATETIME_FS" ||
+  } else if (domaintype == "INT64" ||
+             domaintype == "UINT64" ||
+             domaintype == "DATETIME_YEAR" ||
+             domaintype == "DATETIME_MONTH" ||
+             domaintype == "DATETIME_WEEK" ||
+             domaintype == "DATETIME_DAY" ||
+             domaintype == "DATETIME_HR" ||
+             domaintype == "DATETIME_MIN" ||
+             domaintype == "DATETIME_SEC" ||
+             domaintype == "DATETIME_MS" ||
+             domaintype == "DATETIME_US" ||
+             domaintype == "DATETIME_NS" ||
+             domaintype == "DATETIME_PS" ||
+             domaintype == "DATETIME_FS" ||
              domaintype == "DATETIME_AS") {
-    buf->size = sizeof(int64_t);
+     buf->size = sizeof(int64_t);
   } else if (domaintype == "FLOAT64") {
-    buf->size = sizeof(double);
+     buf->size = sizeof(double);
   } else if (domaintype == "FLOAT32") {
-    buf->size = sizeof(float);
+     buf->size = sizeof(float);
   } else {
-    Rcpp::stop("Currently unsupported domain type '%s'", domaintype.c_str());
+     Rcpp::stop("Currently unsupported domain type '%s'", domaintype.c_str());
   }
   buf->dtype = _string_to_tiledb_datatype(domaintype);
   buf->ncells = ncells;
   buf->vec.resize(ncells * buf->size);
-  if (nullable)
-    buf->validity_map.resize(ncells / numvar);
+  if (nullable) buf->validity_map.resize(ncells/numvar);
   buf->numvar = numvar;
   buf->nullable = nullable;
   return buf;
 }
 
 // [[Rcpp::export]]
-XPtr<query_buf_t> libtiledb_query_buffer_assign_ptr(XPtr<query_buf_t> buf,
-                                                    std::string dtype, SEXP vec,
-                                                    bool asint64 = false) {
+XPtr<query_buf_t> libtiledb_query_buffer_assign_ptr(XPtr<query_buf_t> buf, std::string dtype,
+                                                    SEXP vec, bool asint64 = false) {
   check_xptr_tag<query_buf_t>(buf);
   if (dtype == "INT32") {
     IntegerVector v(vec);
-    std::memcpy(buf->vec.data(), &(v[0]), buf->ncells * buf->size);
+    std::memcpy(buf->vec.data(), &(v[0]), buf->ncells*buf->size);
     if (buf->nullable)
-      getValidityMapFromInteger(v, buf->validity_map, buf->numvar);
+        getValidityMapFromInteger(v, buf->validity_map, buf->numvar);
   } else if (dtype == "FLOAT64") {
     NumericVector v(vec);
-    std::memcpy(buf->vec.data(), &(v[0]), buf->ncells * buf->size);
+    std::memcpy(buf->vec.data(), &(v[0]), buf->ncells*buf->size);
     if (buf->nullable)
-      getValidityMapFromNumeric(v, buf->validity_map, buf->numvar);
-  } else if (dtype == "INT64" || (asint64 && is_datetime_column(buf->dtype))) {
+        getValidityMapFromNumeric(v, buf->validity_map, buf->numvar);
+  } else if (dtype == "INT64" ||
+             (asint64 && is_datetime_column(buf->dtype))) {
     // integer64 from the bit64 package uses doubles, sees nanosecond
     NumericVector v(vec);
-    std::memcpy(buf->vec.data(), &(v[0]), buf->ncells * buf->size);
+    std::memcpy(buf->vec.data(), &(v[0]), buf->ncells*buf->size);
     if (buf->nullable)
-      getValidityMapFromInt64(v, buf->validity_map, buf->numvar);
-  } else if (dtype == "DATETIME_YEAR" || dtype == "DATETIME_MONTH" ||
-             dtype == "DATETIME_WEEK" || dtype == "DATETIME_DAY") {
+        getValidityMapFromInt64(v, buf->validity_map, buf->numvar);
+  } else if (dtype == "DATETIME_YEAR" ||
+             dtype == "DATETIME_MONTH" ||
+             dtype == "DATETIME_WEEK" ||
+             dtype == "DATETIME_DAY") {
     DateVector v(vec);
-    std::vector<int64_t> tt =
-        dates_to_int64(v, _string_to_tiledb_datatype(dtype));
+    std::vector<int64_t> tt = dates_to_int64(v, _string_to_tiledb_datatype(dtype));
     std::memcpy(buf->vec.data(), tt.data(), buf->ncells * buf->size);
-  } else if (dtype == "DATETIME_MS" || dtype == "DATETIME_US" ||
-             dtype == "DATETIME_SEC" || dtype == "DATETIME_MIN" ||
-             dtype == "DATETIME_HR") {
+  } else if (dtype == "DATETIME_MS" ||
+             dtype == "DATETIME_US" ||
+             dtype == "DATETIME_SEC"||
+             dtype == "DATETIME_MIN"||
+             dtype == "DATETIME_HR"   ) {
     DatetimeVector v(vec);
-    std::vector<int64_t> tt =
-        datetimes_to_int64(v, _string_to_tiledb_datatype(dtype));
+    std::vector<int64_t> tt = datetimes_to_int64(v, _string_to_tiledb_datatype(dtype));
     std::memcpy(buf->vec.data(), tt.data(), buf->ncells * buf->size);
   } else if (dtype == "DATETIME_NS") {
     // nanosecond time uses the nanotime package which uses the bit64 package
     // to store the int64_t 'payload' on 64-bit double, so memcpy does the trick
     NumericVector v(vec);
-    std::memcpy(buf->vec.data(), &(v[0]), buf->ncells * buf->size);
-  } else if (dtype == "DATETIME_PS" || dtype == "DATETIME_FS" ||
+    std::memcpy(buf->vec.data(), &(v[0]), buf->ncells*buf->size);
+  } else if (dtype == "DATETIME_PS" ||
+             dtype == "DATETIME_FS" ||
              dtype == "DATETIME_AS") {
     NumericVector v(vec);
-    std::vector<int64_t> tt =
-        subnano_to_int64(v, _string_to_tiledb_datatype(dtype));
+    std::vector<int64_t> tt = subnano_to_int64(v, _string_to_tiledb_datatype(dtype));
     std::memcpy(buf->vec.data(), tt.data(), buf->ncells * buf->size);
   } else if (dtype == "UINT64") {
-    // R has no native uint64_t representation so this comes in as numeric; we
-    // then use our int64_t <-> integer64 machinery for null maps but store as
-    // uint64_t
+    // R has no native uint64_t representation so this comes in as numeric; we then
+    // use our int64_t <-> integer64 machinery for null maps but store as uint64_t
     NumericVector v(vec);
     std::vector<int64_t> iv = fromInteger64(v);
     if (buf->nullable)
-      getValidityMapFromInt64(v, buf->validity_map, buf->numvar);
+        getValidityMapFromInt64(v, buf->validity_map, buf->numvar);
     auto n = v.length();
     std::vector<uint64_t> uiv(n);
-    for (auto i = 0; i < n; i++) {
+    for (auto i=0; i<n; i++) {
       uiv[i] = static_cast<uint64_t>(iv[i]);
     }
-    std::memcpy(buf->vec.data(), &(uiv[0]), buf->ncells * buf->size);
+    std::memcpy(buf->vec.data(), &(uiv[0]), buf->ncells*buf->size);
   } else if (dtype == "UINT32") {
     IntegerVector v(vec);
     auto n = v.length();
     std::vector<uint32_t> x(n);
-    for (auto i = 0; i < n; i++) {
+    for (auto i=0; i<n; i++) {
       x[i] = static_cast<uint32_t>(v[i]);
     }
-    std::memcpy(buf->vec.data(), &(x[0]), buf->ncells * buf->size);
+    std::memcpy(buf->vec.data(), &(x[0]), buf->ncells*buf->size);
     if (buf->nullable)
-      getValidityMapFromInteger(v, buf->validity_map, buf->numvar);
+        getValidityMapFromInteger(v, buf->validity_map, buf->numvar);
   } else if (dtype == "INT16") {
     IntegerVector v(vec);
     auto n = v.length();
     std::vector<int16_t> x(n);
-    for (auto i = 0; i < n; i++) {
+    for (auto i=0; i<n; i++) {
       x[i] = static_cast<int16_t>(v[i]);
     }
-    std::memcpy(buf->vec.data(), &(x[0]), buf->ncells * buf->size);
+    std::memcpy(buf->vec.data(), &(x[0]), buf->ncells*buf->size);
     if (buf->nullable)
-      getValidityMapFromInteger(v, buf->validity_map, buf->numvar);
+        getValidityMapFromInteger(v, buf->validity_map, buf->numvar);
   } else if (dtype == "UINT16") {
     IntegerVector v(vec);
     auto n = v.length();
     std::vector<uint16_t> x(n);
-    for (auto i = 0; i < n; i++) {
+    for (auto i=0; i<n; i++) {
       x[i] = static_cast<uint16_t>(v[i]);
     }
-    std::memcpy(buf->vec.data(), &(x[0]), buf->ncells * buf->size);
+    std::memcpy(buf->vec.data(), &(x[0]), buf->ncells*buf->size);
     if (buf->nullable)
-      getValidityMapFromInteger(v, buf->validity_map, buf->numvar);
+        getValidityMapFromInteger(v, buf->validity_map, buf->numvar);
   } else if (dtype == "INT8") {
     IntegerVector v(vec);
     auto n = v.length();
     std::vector<int8_t> x(n);
-    for (auto i = 0; i < n; i++) {
+    for (auto i=0; i<n; i++) {
       x[i] = static_cast<int8_t>(v[i]);
     }
-    std::memcpy(buf->vec.data(), &(x[0]), buf->ncells * buf->size);
+    std::memcpy(buf->vec.data(), &(x[0]), buf->ncells*buf->size);
     if (buf->nullable)
-      getValidityMapFromInteger(v, buf->validity_map, buf->numvar);
+        getValidityMapFromInteger(v, buf->validity_map, buf->numvar);
   } else if (dtype == "UINT8") {
     IntegerVector v(vec);
     auto n = v.length();
     std::vector<uint8_t> x(n);
-    for (auto i = 0; i < n; i++) {
+    for (auto i=0; i<n; i++) {
       x[i] = static_cast<uint8_t>(v[i]);
     }
-    std::memcpy(buf->vec.data(), &(x[0]), buf->ncells * buf->size);
+    std::memcpy(buf->vec.data(), &(x[0]), buf->ncells*buf->size);
     if (buf->nullable)
-      getValidityMapFromInteger(v, buf->validity_map, buf->numvar);
+        getValidityMapFromInteger(v, buf->validity_map, buf->numvar);
   } else if (dtype == "FLOAT32") {
     NumericVector v(vec);
     if (buf->nullable)
-      getValidityMapFromNumeric(v, buf->validity_map, buf->numvar);
+        getValidityMapFromNumeric(v, buf->validity_map, buf->numvar);
     auto n = v.length();
     std::vector<float> x(n);
-    for (auto i = 0; i < n; i++) {
+    for (auto i=0; i<n; i++) {
       x[i] = static_cast<float>(v[i]);
     }
-    std::memcpy(buf->vec.data(), &(x[0]), buf->ncells * buf->size);
-#if TILEDB_VERSION >= TileDB_Version(2, 10, 0)
+    std::memcpy(buf->vec.data(), &(x[0]), buf->ncells*buf->size);
+#if TILEDB_VERSION >= TileDB_Version(2,10,0)
   } else if (dtype == "BOOL") {
     LogicalVector v(vec);
     auto n = v.length();
     std::vector<uint8_t> x(n);
-    for (auto i = 0; i < n; i++) {
+    for (auto i=0; i<n; i++) {
       x[i] = static_cast<uint8_t>(v[i]);
     }
-    std::memcpy(buf->vec.data(), &(x[0]), buf->ncells * buf->size);
+    std::memcpy(buf->vec.data(), &(x[0]), buf->ncells*buf->size);
     if (buf->nullable)
-      getValidityMapFromLogical(v, buf->validity_map, buf->numvar);
+        getValidityMapFromLogical(v, buf->validity_map, buf->numvar);
 #endif
   } else {
     Rcpp::stop("Assignment to '%s' currently unsupported.", dtype.c_str());
@@ -3680,170 +3456,168 @@ XPtr<query_buf_t> libtiledb_query_buffer_assign_ptr(XPtr<query_buf_t> buf,
 XPtr<tiledb::Query> libtiledb_query_set_buffer_ptr(XPtr<tiledb::Query> query,
                                                    std::string attr,
                                                    XPtr<query_buf_t> buf) {
-  check_xptr_tag<tiledb::Query>(query);
-  if (buf->nullable) {
-    query->set_validity_buffer(attr, buf->validity_map);
-  }
-  query->set_data_buffer(attr, static_cast<void *>(buf->vec.data()),
-                         buf->ncells);
-  return query;
+    check_xptr_tag<tiledb::Query>(query);
+    if (buf->nullable) {
+        query->set_validity_buffer(attr, buf->validity_map);
+    }
+    query->set_data_buffer(attr, static_cast<void*>(buf->vec.data()), buf->ncells);
+    return query;
 }
 
 // [[Rcpp::export]]
 IntegerVector length_from_vlcbuf(XPtr<vlc_buf_t> buf) {
-  check_xptr_tag<vlc_buf_t>(buf);
-  IntegerVector v =
-      IntegerVector::create(buf->offsets.size(), buf->str.length());
-  return v;
+    check_xptr_tag<vlc_buf_t>(buf);
+    IntegerVector v = IntegerVector::create(buf->offsets.size(), buf->str.length());
+    return v;
 }
 
 // [[Rcpp::export]]
-RObject libtiledb_query_get_buffer_ptr(XPtr<query_buf_t> buf,
-                                       bool asint64 = false) {
+RObject libtiledb_query_get_buffer_ptr(XPtr<query_buf_t> buf, bool asint64 = false) {
   spdl::debug("[libtiledb_query_get_buffer_ptr] before buf type check");
   check_xptr_tag<query_buf_t>(buf);
   std::string dtype = _tiledb_datatype_to_string(buf->dtype);
-  // Rcpp::Rcout << dtype << " " << buf->ncells << " " << buf->size << " " <<
-  // buf->nullable << std::endl;
+  //Rcpp::Rcout << dtype << " " << buf->ncells << " " << buf->size << " " << buf->nullable << std::endl;
   spdl::debug(tfm::format("[libtiledb_query_get_buffer_ptr] type %s", dtype));
   if (dtype == "INT32") {
     IntegerVector v(buf->ncells);
-    std::memcpy(&(v[0]), (void *)buf->vec.data(), buf->ncells * buf->size);
+    std::memcpy(&(v[0]), (void*) buf->vec.data(), buf->ncells * buf->size);
     if (buf->nullable)
-      setValidityMapForInteger(v, buf->validity_map, buf->numvar);
+        setValidityMapForInteger(v, buf->validity_map, buf->numvar);
     return v;
   } else if (dtype == "UINT32") {
     IntegerVector v(buf->ncells);
-    std::memcpy(&(v[0]), (void *)buf->vec.data(), buf->ncells * buf->size);
+    std::memcpy(&(v[0]), (void*) buf->vec.data(), buf->ncells * buf->size);
     if (buf->nullable)
-      setValidityMapForInteger(v, buf->validity_map, buf->numvar);
+        setValidityMapForInteger(v, buf->validity_map, buf->numvar);
     return v;
   } else if (dtype == "FLOAT64") {
     NumericVector v(buf->ncells);
-    std::memcpy(&(v[0]), (void *)buf->vec.data(), buf->ncells * buf->size);
+    std::memcpy(&(v[0]), (void*) buf->vec.data(), buf->ncells * buf->size);
     if (buf->nullable)
-      setValidityMapForNumeric(v, buf->validity_map, buf->numvar);
+        setValidityMapForNumeric(v, buf->validity_map, buf->numvar);
     return v;
   } else if (dtype == "FLOAT32") {
     std::vector<float> v(buf->ncells);
-    std::memcpy(&(v[0]), (void *)buf->vec.data(), buf->ncells * buf->size);
+    std::memcpy(&(v[0]), (void*) buf->vec.data(), buf->ncells * buf->size);
     NumericVector w(wrap(v));
     if (buf->nullable)
-      setValidityMapForNumeric(w, buf->validity_map, buf->numvar);
+        setValidityMapForNumeric(w, buf->validity_map, buf->numvar);
     return w;
   } else if (dtype == "UINT64") {
     auto n = buf->ncells;
     std::vector<uint64_t> uv(n);
-    std::memcpy(&(uv[0]), (void *)buf->vec.data(), buf->ncells * buf->size);
+    std::memcpy(&(uv[0]), (void*) buf->vec.data(), buf->ncells * buf->size);
     std::vector<int64_t> iv(n);
-    for (auto i = 0; i < n; i++) {
+    for (auto i=0; i<n; i++) {
       iv[i] = static_cast<int64_t>(uv[i]);
     }
     NumericVector res = wrap(iv);
     if (buf->nullable)
-      setValidityMapForNumeric(res, buf->validity_map, buf->numvar);
-    // return toInteger64(iv); // we could return as int64,
-    return res; // but current 'contract' is return as NumericVector
+        setValidityMapForNumeric(res, buf->validity_map, buf->numvar);
+    //return toInteger64(iv); // we could return as int64,
+    return res;                 // but current 'contract' is return as NumericVector
   } else if (dtype == "INT64") {
     std::vector<int64_t> v(buf->ncells);
-    std::memcpy(&(v[0]), (void *)buf->vec.data(), buf->ncells * buf->size);
+    std::memcpy(&(v[0]), (void*) buf->vec.data(), buf->ncells * buf->size);
     if (buf->nullable)
-      setValidityMapForInt64(v, buf->validity_map, buf->numvar);
+        setValidityMapForInt64(v, buf->validity_map, buf->numvar);
     return toInteger64(v);
   } else if (asint64 && is_datetime_column(buf->dtype)) {
     std::vector<int64_t> v(buf->ncells);
-    std::memcpy(&(v[0]), (void *)buf->vec.data(), buf->ncells * buf->size);
+    std::memcpy(&(v[0]), (void*) buf->vec.data(), buf->ncells * buf->size);
     return toInteger64(v);
-  } else if (dtype == "DATETIME_FS" || dtype == "DATETIME_PS" ||
+  } else if (dtype == "DATETIME_FS" ||
+             dtype == "DATETIME_PS" ||
              dtype == "DATETIME_AS") {
     std::vector<int64_t> v(buf->ncells);
-    std::memcpy(&(v[0]), (void *)buf->vec.data(), buf->ncells * buf->size);
-    Rcpp::NumericVector dv =
-        int64_to_subnano(v, _string_to_tiledb_datatype(dtype));
+    std::memcpy(&(v[0]), (void*) buf->vec.data(), buf->ncells * buf->size);
+    Rcpp::NumericVector dv = int64_to_subnano(v, _string_to_tiledb_datatype(dtype));
     return dv;
-  } else if (dtype == "DATETIME_YEAR" || dtype == "DATETIME_MONTH" ||
-             dtype == "DATETIME_WEEK" || dtype == "DATETIME_DAY") {
+  } else if (dtype == "DATETIME_YEAR" ||
+             dtype == "DATETIME_MONTH" ||
+             dtype == "DATETIME_WEEK" ||
+             dtype == "DATETIME_DAY") {
     std::vector<int64_t> v(buf->ncells);
-    std::memcpy(&(v[0]), (void *)buf->vec.data(), buf->ncells * buf->size);
+    std::memcpy(&(v[0]), (void*) buf->vec.data(), buf->ncells * buf->size);
     DateVector dv = int64_to_dates(v, _string_to_tiledb_datatype(dtype));
     return dv;
-  } else if (dtype == "DATETIME_HR" || dtype == "DATETIME_MIN" ||
-             dtype == "DATETIME_SEC" || dtype == "DATETIME_MS" ||
+  } else if (dtype == "DATETIME_HR" ||
+             dtype == "DATETIME_MIN" ||
+             dtype == "DATETIME_SEC" ||
+             dtype == "DATETIME_MS" ||
              dtype == "DATETIME_US") {
     std::vector<int64_t> v(buf->ncells);
-    std::memcpy(&(v[0]), (void *)buf->vec.data(), buf->ncells * buf->size);
-    DatetimeVector dv =
-        int64_to_datetimes(v, _string_to_tiledb_datatype(dtype));
+    std::memcpy(&(v[0]), (void*) buf->vec.data(), buf->ncells * buf->size);
+    DatetimeVector dv = int64_to_datetimes(v, _string_to_tiledb_datatype(dtype));
     return dv;
   } else if (dtype == "DATETIME_NS") {
     int n = buf->ncells;
     std::vector<int64_t> vec(n);
-    std::memcpy(vec.data(), buf->vec.data(), n * buf->size);
+    std::memcpy(vec.data(), buf->vec.data(), n*buf->size);
     return toNanotime(vec);
   } else if (dtype == "INT16") {
     size_t n = buf->ncells;
     std::vector<int16_t> intvec(n);
-    std::memcpy(intvec.data(), buf->vec.data(), n * buf->size);
+    std::memcpy(intvec.data(), buf->vec.data(), n*buf->size);
     Rcpp::IntegerVector out(buf->ncells);
-    for (size_t i = 0; i < n; i++) {
+    for (size_t i=0; i<n; i++) {
       out[i] = static_cast<int32_t>(intvec[i]);
     }
     if (buf->nullable)
-      setValidityMapForInteger(out, buf->validity_map, buf->numvar);
+        setValidityMapForInteger(out, buf->validity_map, buf->numvar);
     return out;
   } else if (dtype == "UINT16") {
     size_t n = buf->ncells;
     std::vector<uint16_t> intvec(n);
-    std::memcpy(intvec.data(), buf->vec.data(), n * buf->size);
+    std::memcpy(intvec.data(), buf->vec.data(), n*buf->size);
     Rcpp::IntegerVector out(buf->ncells);
-    for (size_t i = 0; i < n; i++) {
+    for (size_t i=0; i<n; i++) {
       out[i] = static_cast<int32_t>(intvec[i]);
     }
     if (buf->nullable)
-      setValidityMapForInteger(out, buf->validity_map, buf->numvar);
+        setValidityMapForInteger(out, buf->validity_map, buf->numvar);
     return out;
   } else if (dtype == "INT8") {
     size_t n = buf->ncells;
     std::vector<int8_t> intvec(n);
-    std::memcpy(intvec.data(), buf->vec.data(), n * buf->size);
+    std::memcpy(intvec.data(), buf->vec.data(), n*buf->size);
     Rcpp::IntegerVector out(buf->ncells);
-    for (size_t i = 0; i < n; i++) {
+    for (size_t i=0; i<n; i++) {
       out[i] = static_cast<int32_t>(intvec[i]);
     }
     if (buf->nullable)
-      setValidityMapForInteger(out, buf->validity_map, buf->numvar);
+        setValidityMapForInteger(out, buf->validity_map, buf->numvar);
     return out;
   } else if (dtype == "UINT8") {
     size_t n = buf->ncells;
     std::vector<uint8_t> uintvec(n);
-    std::memcpy(uintvec.data(), buf->vec.data(), n * buf->size);
+    std::memcpy(uintvec.data(), buf->vec.data(), n*buf->size);
     Rcpp::IntegerVector out(buf->ncells);
-    for (size_t i = 0; i < n; i++) {
+    for (size_t i=0; i<n; i++) {
       out[i] = static_cast<int32_t>(uintvec[i]);
     }
     if (buf->nullable)
-      setValidityMapForInteger(out, buf->validity_map, buf->numvar);
+        setValidityMapForInteger(out, buf->validity_map, buf->numvar);
     return out;
   } else if (dtype == "BLOB") {
     size_t n = buf->ncells;
     Rcpp::RawVector out(n);
-    std::memcpy(out.begin(), buf->vec.data(), n * buf->size);
+    std::memcpy(out.begin(), buf->vec.data(), n*buf->size);
     // -- raw has no NA type so no mapping possible here
     // if (buf->nullable)
     //    setValidityMapForRaw(out, buf->validity_map);
     return out;
-#if TILEDB_VERSION >= TileDB_Version(2, 10, 0)
+#if TILEDB_VERSION >= TileDB_Version(2,10,0)
   } else if (dtype == "BOOL") {
     size_t n = buf->ncells;
     std::vector<uint8_t> uintvec(n);
-    std::memcpy(uintvec.data(), buf->vec.data(), n * buf->size);
+    std::memcpy(uintvec.data(), buf->vec.data(), n*buf->size);
     Rcpp::LogicalVector out(buf->ncells);
-    for (size_t i = 0; i < n; i++) {
-      out[i] =
-          static_cast<int32_t>(uintvec[i]); // logical is int32_t internally
+    for (size_t i=0; i<n; i++) {
+      out[i] = static_cast<int32_t>(uintvec[i]); // logical is int32_t internally
     }
     if (buf->nullable)
-      setValidityMapForLogical(out, buf->validity_map, buf->numvar);
+        setValidityMapForLogical(out, buf->validity_map, buf->numvar);
     return out;
 #endif
   } else {
@@ -3870,27 +3644,27 @@ XPtr<tiledb::Query> libtiledb_query_finalize(XPtr<tiledb::Query> query) {
 
 std::string _query_status_to_string(tiledb::Query::Status status) {
   switch (status) {
-  case tiledb::Query::Status::COMPLETE:
-    return "COMPLETE";
-  case tiledb::Query::Status::FAILED:
-    return "FAILED";
-  case tiledb::Query::Status::INPROGRESS:
-    return "INPROGRESS";
-  case tiledb::Query::Status::INCOMPLETE:
-    return "INCOMPLETE";
-  case tiledb::Query::Status::UNINITIALIZED:
-  default:
-    return "UNINITIALIZED";
+    case tiledb::Query::Status::COMPLETE:
+      return "COMPLETE";
+    case tiledb::Query::Status::FAILED:
+      return "FAILED";
+    case tiledb::Query::Status::INPROGRESS:
+      return "INPROGRESS";
+    case tiledb::Query::Status::INCOMPLETE:
+      return "INCOMPLETE";
+    case tiledb::Query::Status::UNINITIALIZED:
+    default:
+      return "UNINITIALIZED";
   }
 }
+
 
 // [[Rcpp::export]]
 std::string libtiledb_query_status(XPtr<tiledb::Query> query) {
   check_xptr_tag<tiledb::Query>(query);
   tiledb::Query::Status status = query->query_status();
   std::string status_text = _query_status_to_string(status);
-  spdl::debug(
-      tfm::format("[libtiledb_query_status] status = %s", status_text.c_str()));
+  spdl::debug(tfm::format("[libtiledb_query_status] status = %s", status_text.c_str()));
   return status_text;
 }
 
@@ -3898,30 +3672,31 @@ std::string libtiledb_query_status(XPtr<tiledb::Query> query) {
 R_xlen_t libtiledb_query_result_buffer_elements(XPtr<tiledb::Query> query,
                                                 std::string attribute,
                                                 int32_t which = 1) {
-  check_xptr_tag<tiledb::Query>(query);
-  auto nelements = query->result_buffer_elements()[attribute];
-  spdl::debug(tfm::format(
-      "[libtiledb_query_result_buffer_elements] attribute %s : (%d,%d)",
-      attribute, nelements.first, nelements.second));
-  R_xlen_t nelem = (which == 0 ? nelements.first : nelements.second);
-  return nelem;
+    check_xptr_tag<tiledb::Query>(query);
+    auto nelements = query->result_buffer_elements()[attribute];
+    spdl::debug(tfm::format("[libtiledb_query_result_buffer_elements] attribute %s : (%d,%d)",
+                            attribute, nelements.first, nelements.second));
+    R_xlen_t nelem = (which == 0 ? nelements.first : nelements.second);
+    return nelem;
 }
 
 // [[Rcpp::export]]
-NumericVector libtiledb_query_result_buffer_elements_vec(
-    XPtr<tiledb::Query> query, std::string attribute, bool nullable = false) {
-  check_xptr_tag<tiledb::Query>(query);
-  if (nullable) {
-    auto nelem = query->result_buffer_elements_nullable()[attribute];
-    auto vec = NumericVector({static_cast<double>(std::get<0>(nelem)),
-                              static_cast<double>(std::get<1>(nelem)),
-                              static_cast<double>(std::get<2>(nelem))});
-    return vec;
-  } else {
-    auto nelem = query->result_buffer_elements()[attribute];
-    return NumericVector(
-        {static_cast<double>(nelem.first), static_cast<double>(nelem.second)});
-  }
+NumericVector libtiledb_query_result_buffer_elements_vec(XPtr<tiledb::Query> query,
+                                                         std::string attribute,
+                                                         bool nullable = false) {
+    check_xptr_tag<tiledb::Query>(query);
+    if (nullable) {
+        auto nelem = query->result_buffer_elements_nullable()[attribute];
+        auto vec = NumericVector( {
+                static_cast<double>(std::get<0>(nelem)),
+                static_cast<double>(std::get<1>(nelem)),
+                static_cast<double>(std::get<2>(nelem))
+            });
+        return vec;
+    } else {
+        auto nelem = query->result_buffer_elements()[attribute];
+        return NumericVector( { static_cast<double>(nelem.first), static_cast<double>(nelem.second) });
+    }
 }
 
 // [[Rcpp::export]]
@@ -3934,8 +3709,7 @@ int libtiledb_query_get_fragment_num(XPtr<tiledb::Query> query) {
 }
 
 // [[Rcpp::export]]
-std::string libtiledb_query_get_fragment_uri(XPtr<tiledb::Query> query,
-                                             int idx) {
+std::string libtiledb_query_get_fragment_uri(XPtr<tiledb::Query> query, int idx) {
   check_xptr_tag<tiledb::Query>(query);
   if (query->query_type() != TILEDB_WRITE) {
     Rcpp::stop("Fragment URI only applicable to 'write' queries.");
@@ -3945,17 +3719,14 @@ std::string libtiledb_query_get_fragment_uri(XPtr<tiledb::Query> query,
 }
 
 // [[Rcpp::export]]
-Rcpp::DatetimeVector
-libtiledb_query_get_fragment_timestamp_range(XPtr<tiledb::Query> query,
-                                             int idx) {
+Rcpp::DatetimeVector libtiledb_query_get_fragment_timestamp_range(XPtr<tiledb::Query> query, int idx) {
   check_xptr_tag<tiledb::Query>(query);
   if (query->query_type() != TILEDB_WRITE) {
     Rcpp::stop("Fragment URI only applicable to 'write' queries.");
   }
   uint32_t uidx = static_cast<uint32_t>(idx);
   std::pair<uint64_t, uint64_t> range = query->fragment_timestamp_range(uidx);
-  return Rcpp::DatetimeVector::create(range.first / 1000.0,
-                                      range.second / 1000.0);
+  return Rcpp::DatetimeVector::create(range.first/1000.0, range.second/1000.0);
 }
 
 // Subarray functions replacing old Query functionality
@@ -3963,215 +3734,186 @@ libtiledb_query_get_fragment_timestamp_range(XPtr<tiledb::Query> query,
 
 // [[Rcpp::export]]
 XPtr<tiledb::Subarray> libtiledb_subarray(XPtr<tiledb::Query> query) {
-  return make_xptr<tiledb::Subarray>(
-      new tiledb::Subarray(query->ctx(), query->array()));
+    return make_xptr<tiledb::Subarray>(new tiledb::Subarray(query->ctx(), query->array()));
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::Subarray>
-libtiledb_subarray_add_range(XPtr<tiledb::Subarray> subarr, int iidx,
-                             SEXP starts, SEXP ends,
-                             SEXP strides = R_NilValue) {
-  check_xptr_tag<tiledb::Subarray>(subarr);
-  spdl::debug("libtiledb_query_add_range] setting subarray");
-  if (TYPEOF(starts) != TYPEOF(ends)) {
-    Rcpp::stop("'start' and 'end' must be of identical types");
-  }
-  uint32_t uidx = static_cast<uint32_t>(iidx);
-  if (TYPEOF(starts) == INTSXP) {
-    int32_t start = as<int32_t>(starts);
-    int32_t end = as<int32_t>(ends);
-    int32_t stride = (strides == R_NilValue) ? 0 : Rcpp::as<int32_t>(strides);
-    subarr->add_range(uidx, start, end, stride);
-  } else if (TYPEOF(starts) == REALSXP) {
-    double start = as<double>(starts);
-    double end = as<double>(ends);
-    double stride = (strides == R_NilValue) ? 0 : Rcpp::as<double_t>(strides);
-    subarr->add_range(uidx, start, end, stride);
-  } else if (TYPEOF(starts) == STRSXP) {
-    std::string start = as<std::string>(starts);
-    std::string end = as<std::string>(ends);
-    if (strides == R_NilValue) {
-      subarr->add_range(uidx, start, end);
+XPtr<tiledb::Subarray> libtiledb_subarray_add_range(XPtr<tiledb::Subarray> subarr,
+                                                    int iidx, SEXP starts, SEXP ends,
+                                                    SEXP strides = R_NilValue) {
+    check_xptr_tag<tiledb::Subarray>(subarr);
+    spdl::debug("libtiledb_query_add_range] setting subarray");
+    if (TYPEOF(starts) != TYPEOF(ends)) {
+        Rcpp::stop("'start' and 'end' must be of identical types");
+    }
+    uint32_t uidx = static_cast<uint32_t>(iidx);
+    if (TYPEOF(starts) == INTSXP) {
+        int32_t start = as<int32_t>(starts);
+        int32_t end = as<int32_t>(ends);
+        int32_t stride = (strides == R_NilValue) ? 0 : Rcpp::as<int32_t>(strides);
+        subarr->add_range(uidx, start, end, stride);
+    } else if (TYPEOF(starts) == REALSXP) {
+        double start = as<double>(starts);
+        double end = as<double>(ends);
+        double stride = (strides == R_NilValue) ? 0 : Rcpp::as<double_t>(strides);
+        subarr->add_range(uidx, start, end, stride);
+    } else if (TYPEOF(starts) == STRSXP) {
+        std::string start = as<std::string>(starts);
+        std::string end = as<std::string>(ends);
+        if (strides == R_NilValue) {
+            subarr->add_range(uidx, start, end);
+        } else {
+            Rcpp::stop("Non-emoty stride for string not supported yet.");
+        }
     } else {
-      Rcpp::stop("Non-emoty stride for string not supported yet.");
+        Rcpp::stop("Invalid data type for query range: '%s'", Rcpp::type2name(starts));
     }
-  } else {
-    Rcpp::stop("Invalid data type for query range: '%s'",
-               Rcpp::type2name(starts));
-  }
-  return subarr;
+    return subarr;
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::Subarray>
-libtiledb_subarray_add_range_with_type(XPtr<tiledb::Subarray> subarr, int iidx,
-                                       std::string typestr, SEXP starts,
-                                       SEXP ends, SEXP strides = R_NilValue) {
+XPtr<tiledb::Subarray> libtiledb_subarray_add_range_with_type(XPtr<tiledb::Subarray> subarr,
+                                                              int iidx,
+                                                              std::string typestr,
+                                                              SEXP starts, SEXP ends,
+                                                              SEXP strides = R_NilValue) {
 
-  check_xptr_tag<tiledb::Subarray>(subarr);
-  if (TYPEOF(starts) != TYPEOF(ends)) {
-    Rcpp::stop("'start' and 'end' must be of identical types");
-  }
-  uint32_t uidx = static_cast<uint32_t>(iidx);
-
-  if (typestr == "INT32") {
-    int32_t start = as<int32_t>(starts);
-    int32_t end = as<int32_t>(ends);
-    int32_t stride = (strides == R_NilValue) ? 0 : Rcpp::as<int32_t>(strides);
-    subarr->add_range(uidx, start, end, stride);
-    spdl::debug(tfm::format("[libtiledb_subarry_add_range_with type] %s dim %d "
-                            "added %d to %d by %d",
-                            typestr, uidx, start, end, stride));
-  } else if (typestr == "FLOAT64") {
-    double start = as<double>(starts);
-    double end = as<double>(ends);
-    double stride = (strides == R_NilValue) ? 0 : Rcpp::as<double_t>(strides);
-    subarr->add_range(uidx, start, end, stride);
-    spdl::debug(tfm::format("[libtiledb_subarry_add_range_with type] %s dim %d "
-                            "added %f to %f by %f",
-                            typestr, uidx, start, end, stride));
-  } else if (typestr == "INT64") {
-    int64_t start = fromInteger64(as<double>(starts));
-    int64_t end = fromInteger64(as<double>(ends));
-    int64_t stride =
-        (strides == R_NilValue) ? 0 : fromInteger64(as<double>(strides));
-    subarr->add_range(uidx, start, end, stride);
-    spdl::debug(tfm::format("[libtiledb_subarry_add_range_with type] %s dim %d "
-                            "added %d to %d by %d",
-                            typestr, uidx, start, end, stride));
-  } else if (typestr == "UINT64") {
-    uint64_t start = static_cast<uint64_t>(fromInteger64(as<double>(starts)));
-    uint64_t end = static_cast<uint64_t>(fromInteger64(as<double>(ends)));
-    uint64_t stride =
-        (strides == R_NilValue) ? 0 : fromInteger64(as<double>(strides));
-    subarr->add_range(uidx, start, end, stride);
-    spdl::debug(tfm::format("[libtiledb_subarry_add_range_with type] %s dim %d "
-                            "added %d to %d by %d",
-                            typestr, uidx, start, end, stride));
-  } else if (typestr == "UINT32") {
-    uint32_t start = as<uint32_t>(starts);
-    uint32_t end = as<uint32_t>(ends);
-    uint32_t stride = (strides == R_NilValue) ? 0 : as<int32_t>(strides);
-    subarr->add_range(uidx, start, end, stride);
-    spdl::debug(tfm::format("[libtiledb_subarry_add_range_with type] %s dim %d "
-                            "added %d to %d by %d",
-                            typestr, uidx, start, end, stride));
-  } else if (typestr == "INT16") {
-    int16_t start = as<int16_t>(starts);
-    int16_t end = as<int16_t>(ends);
-    int16_t stride = (strides == R_NilValue) ? 0 : as<int16_t>(strides);
-    subarr->add_range(uidx, start, end, stride);
-    spdl::debug(tfm::format("[libtiledb_subarry_add_range_with type] %s dim %d "
-                            "added %d to %d by %d",
-                            typestr, uidx, start, end, stride));
-  } else if (typestr == "UINT16") {
-    uint16_t start = as<uint16_t>(starts);
-    uint16_t end = as<uint16_t>(ends);
-    uint16_t stride = (strides == R_NilValue) ? 0 : as<uint16_t>(strides);
-    subarr->add_range(uidx, start, end, stride);
-    spdl::debug(tfm::format("[libtiledb_subarry_add_range_with type] %s dim %d "
-                            "added %d to %d by %d",
-                            typestr, uidx, start, end, stride));
-  } else if (typestr == "INT8") {
-    int8_t start = as<int16_t>(starts);
-    int8_t end = as<int16_t>(ends);
-    int8_t stride = (strides == R_NilValue) ? 0 : as<int16_t>(strides);
-    subarr->add_range(uidx, start, end, stride);
-    spdl::debug(tfm::format("[libtiledb_subarry_add_range_with type] %s dim %d "
-                            "added %d to %d by %d",
-                            typestr, uidx, start, end, stride));
-  } else if (typestr == "UINT8") {
-    uint8_t start = as<uint16_t>(starts);
-    uint8_t end = as<uint16_t>(ends);
-    uint8_t stride = (strides == R_NilValue) ? 0 : as<uint16_t>(strides);
-    subarr->add_range(uidx, start, end, stride);
-    spdl::debug(tfm::format("[libtiledb_subarry_add_range_with type] %s dim %d "
-                            "added %d to %d by %d",
-                            typestr, uidx, start, end, stride));
-  } else if (typestr == "DATETIME_YEAR" || typestr == "DATETIME_MONTH" ||
-             typestr == "DATETIME_WEEK" || typestr == "DATETIME_DAY" ||
-             typestr == "DATETIME_HR" || typestr == "DATETIME_MIN" ||
-             typestr == "DATETIME_SEC" || typestr == "DATETIME_MS" ||
-             typestr == "DATETIME_US" || typestr == "DATETIME_NS" ||
-             typestr == "DATETIME_FS" || typestr == "DATETIME_PS" ||
-             typestr == "DATETIME_AS") {
-    int64_t start = fromInteger64(as<double>(starts));
-    int64_t end = fromInteger64(as<double>(ends));
-    int64_t stride =
-        (strides == R_NilValue) ? 0 : fromInteger64(as<double>(strides));
-    subarr->add_range(uidx, start, end, stride);
-    spdl::debug(tfm::format("[libtiledb_subarry_add_range_with type] %s dim %d "
-                            "added %d to %d by %d",
-                            typestr, uidx, start, end, stride));
-  } else if (typestr == "ASCII" || typestr == "CHAR") {
-    std::string start = as<std::string>(starts);
-    std::string end = as<std::string>(ends);
-    if (strides != R_NilValue) {
-      Rcpp::stop("Non-empty stride for string not supported yet.");
+    check_xptr_tag<tiledb::Subarray>(subarr);
+    if (TYPEOF(starts) != TYPEOF(ends)) {
+        Rcpp::stop("'start' and 'end' must be of identical types");
     }
-    subarr->add_range(uidx, start, end);
-    spdl::debug(tfm::format(
-        "[libtiledb_subarry_add_range_with type] %s dim %d added %s to %s",
-        typestr, uidx, start, end));
-  } else if (typestr == "FLOAT32") {
-    float start = as<float>(starts);
-    float end = as<float>(ends);
-    float stride = (strides == R_NilValue) ? 0 : Rcpp::as<float>(strides);
-    subarr->add_range(uidx, start, end, stride);
-    spdl::debug(tfm::format("[libtiledb_subarry_add_range_with type] %s dim %d "
-                            "added %f to %f by %f",
-                            typestr, uidx, start, end, stride));
-  }
-  return subarr;
+    uint32_t uidx = static_cast<uint32_t>(iidx);
+
+    if (typestr == "INT32") {
+        int32_t start = as<int32_t>(starts);
+        int32_t end = as<int32_t>(ends);
+        int32_t stride = (strides == R_NilValue) ? 0 : Rcpp::as<int32_t>(strides);
+        subarr->add_range(uidx, start, end, stride);
+        spdl::debug(tfm::format("[libtiledb_subarry_add_range_with type] %s dim %d added %d to %d by %d", typestr, uidx, start, end, stride));
+    } else if (typestr == "FLOAT64") {
+        double start = as<double>(starts);
+        double end = as<double>(ends);
+        double stride = (strides == R_NilValue) ? 0 : Rcpp::as<double_t>(strides);
+        subarr->add_range(uidx, start, end, stride);
+        spdl::debug(tfm::format("[libtiledb_subarry_add_range_with type] %s dim %d added %f to %f by %f", typestr, uidx, start, end, stride));
+    } else if (typestr == "INT64") {
+        int64_t start = fromInteger64(as<double>(starts));
+        int64_t end = fromInteger64(as<double>(ends));
+        int64_t stride = (strides == R_NilValue) ? 0 : fromInteger64(as<double>(strides));
+        subarr->add_range(uidx, start, end, stride);
+        spdl::debug(tfm::format("[libtiledb_subarry_add_range_with type] %s dim %d added %d to %d by %d", typestr, uidx, start, end, stride));
+    } else if (typestr == "UINT64") {
+        uint64_t start = static_cast<uint64_t>(fromInteger64(as<double>(starts)));
+        uint64_t end = static_cast<uint64_t>(fromInteger64(as<double>(ends)));
+        uint64_t stride = (strides == R_NilValue) ? 0 : fromInteger64(as<double>(strides));
+        subarr->add_range(uidx, start, end, stride);
+        spdl::debug(tfm::format("[libtiledb_subarry_add_range_with type] %s dim %d added %d to %d by %d", typestr, uidx, start, end, stride));
+    } else if (typestr == "UINT32") {
+        uint32_t start = as<uint32_t>(starts);
+        uint32_t end   = as<uint32_t>(ends);
+        uint32_t stride = (strides == R_NilValue) ? 0 : as<int32_t>(strides);
+        subarr->add_range(uidx, start, end, stride);
+        spdl::debug(tfm::format("[libtiledb_subarry_add_range_with type] %s dim %d added %d to %d by %d", typestr, uidx, start, end, stride));
+    } else if (typestr == "INT16") {
+        int16_t start = as<int16_t>(starts);
+        int16_t end   = as<int16_t>(ends);
+        int16_t stride = (strides == R_NilValue) ? 0 : as<int16_t>(strides);
+        subarr->add_range(uidx, start, end, stride);
+        spdl::debug(tfm::format("[libtiledb_subarry_add_range_with type] %s dim %d added %d to %d by %d", typestr, uidx, start, end, stride));
+    } else if (typestr == "UINT16") {
+        uint16_t start = as<uint16_t>(starts);
+        uint16_t end   = as<uint16_t>(ends);
+        uint16_t stride = (strides == R_NilValue) ? 0 : as<uint16_t>(strides);
+        subarr->add_range(uidx, start, end, stride);
+        spdl::debug(tfm::format("[libtiledb_subarry_add_range_with type] %s dim %d added %d to %d by %d", typestr, uidx, start, end, stride));
+    } else if (typestr == "INT8") {
+        int8_t start = as<int16_t>(starts);
+        int8_t end   = as<int16_t>(ends);
+        int8_t stride = (strides == R_NilValue) ? 0 : as<int16_t>(strides);
+        subarr->add_range(uidx, start, end, stride);
+        spdl::debug(tfm::format("[libtiledb_subarry_add_range_with type] %s dim %d added %d to %d by %d", typestr, uidx, start, end, stride));
+    } else if (typestr == "UINT8") {
+        uint8_t start = as<uint16_t>(starts);
+        uint8_t end   = as<uint16_t>(ends);
+        uint8_t stride = (strides == R_NilValue) ? 0 : as<uint16_t>(strides);
+        subarr->add_range(uidx, start, end, stride);
+        spdl::debug(tfm::format("[libtiledb_subarry_add_range_with type] %s dim %d added %d to %d by %d", typestr, uidx, start, end, stride));
+    } else if (typestr == "DATETIME_YEAR"  ||
+               typestr == "DATETIME_MONTH" ||
+               typestr == "DATETIME_WEEK"  ||
+               typestr == "DATETIME_DAY"   ||
+               typestr == "DATETIME_HR"    ||
+               typestr == "DATETIME_MIN"   ||
+               typestr == "DATETIME_SEC"   ||
+               typestr == "DATETIME_MS"    ||
+               typestr == "DATETIME_US"    ||
+               typestr == "DATETIME_NS"    ||
+               typestr == "DATETIME_FS"    ||
+               typestr == "DATETIME_PS"    ||
+               typestr == "DATETIME_AS") {
+        int64_t start = fromInteger64(as<double>(starts));
+        int64_t end = fromInteger64(as<double>(ends));
+        int64_t stride = (strides == R_NilValue) ? 0 : fromInteger64(as<double>(strides));
+        subarr->add_range(uidx, start, end, stride);
+        spdl::debug(tfm::format("[libtiledb_subarry_add_range_with type] %s dim %d added %d to %d by %d", typestr, uidx, start, end, stride));
+    } else if (typestr == "ASCII" || typestr == "CHAR") {
+        std::string start = as<std::string>(starts);
+        std::string end = as<std::string>(ends);
+        if (strides != R_NilValue) {
+            Rcpp::stop("Non-empty stride for string not supported yet.");
+        }
+        subarr->add_range(uidx, start, end);
+        spdl::debug(tfm::format("[libtiledb_subarry_add_range_with type] %s dim %d added %s to %s", typestr, uidx, start, end));
+    } else if (typestr == "FLOAT32") {
+        float start = as<float>(starts);
+        float end = as<float>(ends);
+        float stride = (strides == R_NilValue) ? 0 : Rcpp::as<float>(strides);
+        subarr->add_range(uidx, start, end, stride);
+        spdl::debug(tfm::format("[libtiledb_subarry_add_range_with type] %s dim %d added %f to %f by %f", typestr, uidx, start, end, stride));
+    }
+    return subarr;
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::Query>
-libtiledb_query_set_subarray_object(XPtr<tiledb::Query> query,
-                                    XPtr<tiledb::Subarray> subarr) {
-  check_xptr_tag<tiledb::Query>(query);
-  check_xptr_tag<tiledb::Subarray>(subarr);
-  query->set_subarray(*subarr.get());
-  return query;
+XPtr<tiledb::Query> libtiledb_query_set_subarray_object(XPtr<tiledb::Query> query, XPtr<tiledb::Subarray> subarr) {
+    check_xptr_tag<tiledb::Query>(query);
+    check_xptr_tag<tiledb::Subarray>(subarr);
+    query->set_subarray(*subarr.get());
+    return query;
 }
 
+
 // [[Rcpp::export]]
-R_xlen_t libtiledb_query_get_est_result_size(XPtr<tiledb::Query> query,
-                                             std::string attr) {
+R_xlen_t libtiledb_query_get_est_result_size(XPtr<tiledb::Query> query, std::string attr) {
   check_xptr_tag<tiledb::Query>(query);
   uint64_t est = query->est_result_size(attr);
   return static_cast<R_xlen_t>(est);
 }
 
-// [[Rcpp::export]]
-NumericVector
-libtiledb_query_get_est_result_size_nullable(XPtr<tiledb::Query> query,
-                                             std::string attr) {
-  check_xptr_tag<tiledb::Query>(query);
-  std::array<uint64_t, 2> est = query->est_result_size_nullable(attr);
-  return Rcpp::NumericVector::create(static_cast<R_xlen_t>(est[0]),
-                                     static_cast<R_xlen_t>(est[1]));
-}
 
 // [[Rcpp::export]]
-NumericVector libtiledb_query_get_est_result_size_var(XPtr<tiledb::Query> query,
-                                                      std::string attr) {
+NumericVector libtiledb_query_get_est_result_size_nullable(XPtr<tiledb::Query> query, std::string attr) {
+    check_xptr_tag<tiledb::Query>(query);
+    std::array<uint64_t, 2> est = query->est_result_size_nullable(attr);
+    return Rcpp::NumericVector::create(static_cast<R_xlen_t>(est[0]),
+                                       static_cast<R_xlen_t>(est[1]));
+}
+
+
+// [[Rcpp::export]]
+NumericVector libtiledb_query_get_est_result_size_var(XPtr<tiledb::Query> query, std::string attr) {
   check_xptr_tag<tiledb::Query>(query);
   std::array<uint64_t, 2> est = query->est_result_size_var(attr);
-  return NumericVector::create(static_cast<R_xlen_t>(est[0]),
-                               static_cast<R_xlen_t>(est[1]));
+  return NumericVector::create(static_cast<R_xlen_t>(est[0]), static_cast<R_xlen_t>(est[1]));
 }
 
 // [[Rcpp::export]]
-NumericVector
-libtiledb_query_get_est_result_size_var_nullable(XPtr<tiledb::Query> query,
-                                                 std::string attr) {
-  check_xptr_tag<tiledb::Query>(query);
-  std::array<uint64_t, 3> est = query->est_result_size_var_nullable(attr);
-  return Rcpp::NumericVector::create(static_cast<R_xlen_t>(est[0]),
-                                     static_cast<R_xlen_t>(est[1]),
-                                     static_cast<R_xlen_t>(est[2]));
+NumericVector libtiledb_query_get_est_result_size_var_nullable(XPtr<tiledb::Query> query, std::string attr) {
+    check_xptr_tag<tiledb::Query>(query);
+    std::array<uint64_t, 3> est = query->est_result_size_var_nullable(attr);
+    return Rcpp::NumericVector::create(static_cast<R_xlen_t>(est[0]),
+                                       static_cast<R_xlen_t>(est[1]),
+                                       static_cast<R_xlen_t>(est[2]));
 }
 
 // [[Rcpp::export]]
@@ -4186,93 +3928,84 @@ double libtiledb_query_get_range_num(XPtr<tiledb::Query> query, int dim_idx) {
 }
 
 // [[Rcpp::export]]
-IntegerVector libtiledb_query_get_range(XPtr<tiledb::Query> query, int dim_idx,
-                                        int rng_idx) {
+IntegerVector libtiledb_query_get_range(XPtr<tiledb::Query> query, int dim_idx, int rng_idx) {
   check_xptr_tag<tiledb::Query>(query);
   tiledb::Array arr = query->array();
   tiledb::Context ctx = query->ctx();
   tiledb::Subarray sub(ctx, arr);
   query->update_subarray_from_query(&sub);
-  std::array<int32_t, 3> rng = sub.range<int32_t>(
-      static_cast<unsigned int>(dim_idx), static_cast<unsigned int>(rng_idx));
-  return IntegerVector::create(rng[0],  // start
+  std::array<int32_t, 3> rng = sub.range<int32_t>(static_cast<unsigned int>(dim_idx),
+                                                  static_cast<unsigned int>(rng_idx));
+  return IntegerVector::create(rng[0], 	// start
                                rng[1],  // end
                                rng[2]); // stride
 }
 
 // [[Rcpp::export]]
-CharacterVector libtiledb_query_get_range_var(XPtr<tiledb::Query> query,
-                                              int dim_idx, int rng_idx) {
+CharacterVector libtiledb_query_get_range_var(XPtr<tiledb::Query> query, int dim_idx, int rng_idx) {
   check_xptr_tag<tiledb::Query>(query);
   tiledb::Array arr = query->array();
   tiledb::Context ctx = query->ctx();
   tiledb::Subarray sub(ctx, arr);
   query->update_subarray_from_query(&sub);
-  std::array<std::string, 2> rng = sub.range(static_cast<unsigned int>(dim_idx),
-                                             static_cast<uint64_t>(rng_idx));
-  return CharacterVector::create(rng[0], rng[1]); // start and end
+  std::array<std::string, 2> rng = sub.range(static_cast<unsigned int>(dim_idx), static_cast<uint64_t>(rng_idx));
+  return CharacterVector::create(rng[0], rng[1]);	 // start and end
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::Query>
-libtiledb_query_set_condition(XPtr<tiledb::Query> query,
-                              XPtr<tiledb::QueryCondition> query_cond) {
+XPtr<tiledb::Query> libtiledb_query_set_condition(XPtr<tiledb::Query> query,
+                                                  XPtr<tiledb::QueryCondition> query_cond) {
   check_xptr_tag<tiledb::Query>(query);
   query->set_condition(*query_cond.get());
   return query;
 }
 
-// Note that the Array pointer returned here from a Query object is not owned
-// and will not outlive the query object
+// Note that the Array pointer returned here from a Query object is not owned and will not
+// outlive the query object
 //
 // [[Rcpp::export]]
-XPtr<tiledb::Array> libtiledb_query_get_array(XPtr<tiledb::Query> query,
-                                              XPtr<tiledb::Context> ctx) {
-  check_xptr_tag<tiledb::Query>(query);
-  check_xptr_tag<tiledb::Context>(ctx);
-  auto arr = query->array();
-  auto cptr = arr.ptr().get();
-  return make_xptr<tiledb::Array>(new tiledb::Array(*ctx.get(), cptr, false));
+XPtr<tiledb::Array> libtiledb_query_get_array(XPtr<tiledb::Query> query, XPtr<tiledb::Context> ctx) {
+    check_xptr_tag<tiledb::Query>(query);
+    check_xptr_tag<tiledb::Context>(ctx);
+    auto arr = query->array();
+    auto cptr = arr.ptr().get();
+    return make_xptr<tiledb::Array>(new tiledb::Array(*ctx.get(), cptr, false));
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::ArraySchema>
-libtiledb_query_get_schema(XPtr<tiledb::Query> query,
-                           XPtr<tiledb::Context> ctx) {
-  check_xptr_tag<tiledb::Query>(query);
-  auto arr = query->array();
-  return libtiledb_array_schema_load(
-      ctx, arr.uri()); // returns an XPtr<tiledb::ArraySchema>
+XPtr<tiledb::ArraySchema> libtiledb_query_get_schema(XPtr<tiledb::Query> query,
+                                                     XPtr<tiledb::Context> ctx) {
+    check_xptr_tag<tiledb::Query>(query);
+    auto arr = query->array();
+    return libtiledb_array_schema_load(ctx, arr.uri()); // returns an XPtr<tiledb::ArraySchema>
 }
 
 // [[Rcpp::export]]
 std::string libtiledb_query_stats(XPtr<tiledb::Query> query) {
-  check_xptr_tag<tiledb::Query>(query);
-  return query->stats();
+    check_xptr_tag<tiledb::Query>(query);
+    return query->stats();
 }
 
 // [[Rcpp::export]]
 XPtr<tiledb::Context> libtiledb_query_get_ctx(XPtr<tiledb::Query> query) {
-  check_xptr_tag<tiledb::Query>(query);
-  auto ctx = query->ctx();
-  return make_xptr<tiledb::Context>(new tiledb::Context(ctx));
+    check_xptr_tag<tiledb::Query>(query);
+    auto ctx = query->ctx();
+    return make_xptr<tiledb::Context>(new tiledb::Context(ctx));
 }
 
 template <typename T>
-SEXP apply_unary_aggregate(XPtr<tiledb::Query> query, std::string operator_name,
-                           bool nullable = false) {
-#if TILEDB_VERSION >= TileDB_Version(2, 18, 0)
-  T result = 0;
-  std::vector<uint8_t> nulls = {0};
-  uint64_t size = 1;
-  query->set_data_buffer(operator_name, &result, size);
-  if (nullable)
-    query->set_validity_buffer(operator_name, nulls);
-  query->submit();
-  SEXP res = Rcpp::wrap(result);
-  return res;
+SEXP apply_unary_aggregate(XPtr<tiledb::Query> query, std::string operator_name, bool nullable = false) {
+#if TILEDB_VERSION >= TileDB_Version(2,18,0)
+    T result = 0;
+    std::vector<uint8_t> nulls = { 0 };
+    uint64_t size = 1;
+    query->set_data_buffer(operator_name, &result, size);
+    if (nullable) query->set_validity_buffer(operator_name, nulls);
+    query->submit();
+    SEXP res = Rcpp::wrap(result);
+    return res;
 #else
-  return Rcpp::wrap(R_NaReal);
+    return Rcpp::wrap(R_NaReal);
 #endif
 }
 
@@ -4281,328 +4014,285 @@ SEXP libtiledb_query_apply_aggregate(XPtr<tiledb::Query> query,
                                      std::string attribute_name,
                                      std::string operator_name,
                                      bool nullable = false) {
-#if TILEDB_VERSION >= TileDB_Version(2, 18, 0)
-  check_xptr_tag<tiledb::Query>(query);
-  tiledb::QueryChannel channel =
-      tiledb::QueryExperimental::get_default_channel(*query.get());
-  if (operator_name == "Sum") {
-    tiledb::ChannelOperation operation =
-        tiledb::QueryExperimental::create_unary_aggregate<tiledb::SumOperator>(
-            *query.get(), attribute_name);
-    channel.apply_aggregate(operator_name, operation);
-  } else if (operator_name == "Min") {
-    tiledb::ChannelOperation operation =
-        tiledb::QueryExperimental::create_unary_aggregate<tiledb::MinOperator>(
-            *query.get(), attribute_name);
-    channel.apply_aggregate(operator_name, operation);
-  } else if (operator_name == "Max") {
-    tiledb::ChannelOperation operation =
-        tiledb::QueryExperimental::create_unary_aggregate<tiledb::MaxOperator>(
-            *query.get(), attribute_name);
-    channel.apply_aggregate(operator_name, operation);
-  } else if (operator_name == "Mean") {
-    tiledb::ChannelOperation operation =
-        tiledb::QueryExperimental::create_unary_aggregate<tiledb::MeanOperator>(
-            *query.get(), attribute_name);
-    channel.apply_aggregate(operator_name, operation);
-  } else if (operator_name == "NullCount") {
-    tiledb::ChannelOperation operation =
-        tiledb::QueryExperimental::create_unary_aggregate<
-            tiledb::NullCountOperator>(*query.get(), attribute_name);
-    channel.apply_aggregate(operator_name, operation);
-  } else if (operator_name == "Count") {
-    channel.apply_aggregate(operator_name, tiledb::CountOperation());
-  } else {
-    Rcpp::stop("Invalid aggregation operator '%s' specified.",
-               operator_name.c_str());
-  }
-  std::vector<uint8_t> nulls = {0};
-  uint64_t size = 1;
-  if (operator_name == "NullCount" || operator_name == "Count") {
-    // Count and null count take uint64_t.
-    uint64_t result = 0;
-    query->set_data_buffer(operator_name, &result, size);
-    if (nullable &&
-        operator_name != "NullCount") { // no validity buffer for NullCount
-      query->set_validity_buffer(operator_name, nulls);
-    }
-    query->submit();
-    return Rcpp::wrap(result);
-  } else if (operator_name == "Mean") {
-    // Mean always takes in a double.
-    return apply_unary_aggregate<double>(query, operator_name, nullable);
-  } else if (operator_name == "Sum") {
-    // Sum will take int64_t for signed integers, uint64_t for unsigned integers
-    // and double for floating point values.
-    tiledb::Context ctx = query->ctx();
-    auto arr = query->array();
-    auto sch = tiledb::ArraySchema(ctx, arr.uri());
-    auto attr = tiledb::Attribute(sch.attribute(attribute_name));
-    std::string type_name = _tiledb_datatype_to_string(attr.type());
-    if (type_name == "INT8" || type_name == "INT16" || type_name == "INT32" ||
-        type_name == "INT64") {
-      return apply_unary_aggregate<int64_t>(query, operator_name, nullable);
-    } else if (type_name == "UINT8" || type_name == "UINT16" ||
-               type_name == "UINT32" || type_name == "UINT64") {
-      return apply_unary_aggregate<uint64_t>(query, operator_name, nullable);
-    } else if (type_name == "FLOAT32" || type_name == "FLOAT64") {
-      return apply_unary_aggregate<double>(query, operator_name, nullable);
+#if TILEDB_VERSION >= TileDB_Version(2,18,0)
+    check_xptr_tag<tiledb::Query>(query);
+    tiledb::QueryChannel channel = tiledb::QueryExperimental::get_default_channel(*query.get());
+    if (operator_name == "Sum") {
+        tiledb::ChannelOperation operation = tiledb::QueryExperimental::create_unary_aggregate<tiledb::SumOperator>(*query.get(), attribute_name);
+        channel.apply_aggregate(operator_name, operation);
+    } else if (operator_name == "Min") {
+        tiledb::ChannelOperation operation = tiledb::QueryExperimental::create_unary_aggregate<tiledb::MinOperator>(*query.get(), attribute_name);
+        channel.apply_aggregate(operator_name, operation);
+    } else if (operator_name == "Max") {
+        tiledb::ChannelOperation operation = tiledb::QueryExperimental::create_unary_aggregate<tiledb::MaxOperator>(*query.get(), attribute_name);
+        channel.apply_aggregate(operator_name, operation);
+    } else if (operator_name == "Mean") {
+        tiledb::ChannelOperation operation = tiledb::QueryExperimental::create_unary_aggregate<tiledb::MeanOperator>(*query.get(), attribute_name);
+        channel.apply_aggregate(operator_name, operation);
+    } else if (operator_name == "NullCount") {
+        tiledb::ChannelOperation operation = tiledb::QueryExperimental::create_unary_aggregate<tiledb::NullCountOperator>(*query.get(), attribute_name);
+        channel.apply_aggregate(operator_name, operation);
+    } else if (operator_name == "Count") {
+        channel.apply_aggregate(operator_name, tiledb::CountOperation());
     } else {
-      Rcpp::stop("'Sum' operator not valid for attribute '%s' of type '%s'",
-                 attribute_name, type_name);
+        Rcpp::stop("Invalid aggregation operator '%s' specified.", operator_name.c_str());
     }
-  } else if (operator_name == "Min" || operator_name == "Max") {
-    // Min/max will take whatever the datatype of the column is.
-    tiledb::Context ctx = query->ctx();
-    auto arr = query->array();
-    auto sch = tiledb::ArraySchema(ctx, arr.uri());
-    auto attr = tiledb::Attribute(sch.attribute(attribute_name));
-    std::string type_name = _tiledb_datatype_to_string(attr.type());
-    switch (attr.type()) {
-    case TILEDB_INT8:
-      return apply_unary_aggregate<int16_t>(query, operator_name,
-                                            nullable); // int8_t bites char
-    case TILEDB_INT16:
-      return apply_unary_aggregate<int16_t>(query, operator_name, nullable);
-    case TILEDB_INT32:
-      return apply_unary_aggregate<int32_t>(query, operator_name, nullable);
-    case TILEDB_INT64:
-      return apply_unary_aggregate<int64_t>(query, operator_name, nullable);
-    case TILEDB_UINT8:
-      return apply_unary_aggregate<uint16_t>(query, operator_name,
-                                             nullable); // uint8_t bites char
-    case TILEDB_UINT16:
-      return apply_unary_aggregate<uint16_t>(query, operator_name, nullable);
-    case TILEDB_UINT32:
-      return apply_unary_aggregate<uint32_t>(query, operator_name, nullable);
-    case TILEDB_UINT64:
-      return apply_unary_aggregate<uint64_t>(query, operator_name, nullable);
-    case TILEDB_FLOAT32:
-      return apply_unary_aggregate<float>(query, operator_name, nullable);
-    case TILEDB_FLOAT64:
-      return apply_unary_aggregate<double>(query, operator_name, nullable);
-    default:
-      Rcpp::stop("'%s' is not defined for attribute '%s' of type '%s'",
-                 operator_name, attribute_name, type_name);
+    std::vector<uint8_t> nulls = { 0 };
+    uint64_t size = 1;
+    if (operator_name == "NullCount" || operator_name == "Count") {
+        // Count and null count take uint64_t.
+        uint64_t result = 0;
+        query->set_data_buffer(operator_name, &result, size);
+        if (nullable && operator_name != "NullCount") {   // no validity buffer for NullCount
+            query->set_validity_buffer(operator_name, nulls);
+        }
+        query->submit();
+        return Rcpp::wrap(result);
+    } else if (operator_name == "Mean") {
+        // Mean always takes in a double.
+        return apply_unary_aggregate<double>(query, operator_name, nullable);
+    } else if (operator_name == "Sum") {
+        // Sum will take int64_t for signed integers, uint64_t for unsigned integers
+        // and double for floating point values.
+        tiledb::Context ctx = query->ctx();
+        auto arr = query->array();
+        auto sch = tiledb::ArraySchema(ctx, arr.uri());
+        auto attr = tiledb::Attribute(sch.attribute(attribute_name));
+        std::string type_name = _tiledb_datatype_to_string(attr.type());
+        if (type_name == "INT8" || type_name == "INT16" ||
+            type_name == "INT32" || type_name == "INT64") {
+            return apply_unary_aggregate<int64_t>(query, operator_name, nullable);
+        } else if (type_name == "UINT8" || type_name == "UINT16" ||
+                   type_name == "UINT32" || type_name == "UINT64") {
+            return apply_unary_aggregate<uint64_t>(query, operator_name, nullable);
+        } else if (type_name == "FLOAT32" || type_name == "FLOAT64") {
+            return apply_unary_aggregate<double>(query, operator_name, nullable);
+        } else {
+            Rcpp::stop("'Sum' operator not valid for attribute '%s' of type '%s'",
+                       attribute_name, type_name);
+        }
+    } else if (operator_name == "Min" || operator_name == "Max") {
+        // Min/max will take whatever the datatype of the column is.
+        tiledb::Context ctx = query->ctx();
+        auto arr = query->array();
+        auto sch = tiledb::ArraySchema(ctx, arr.uri());
+        auto attr = tiledb::Attribute(sch.attribute(attribute_name));
+        std::string type_name = _tiledb_datatype_to_string(attr.type());
+        switch (attr.type()) {
+        case TILEDB_INT8:    return apply_unary_aggregate<int16_t>(query, operator_name, nullable);  // int8_t bites char
+        case TILEDB_INT16:   return apply_unary_aggregate<int16_t>(query, operator_name, nullable);
+        case TILEDB_INT32:   return apply_unary_aggregate<int32_t>(query, operator_name, nullable);
+        case TILEDB_INT64:   return apply_unary_aggregate<int64_t>(query, operator_name, nullable);
+        case TILEDB_UINT8:   return apply_unary_aggregate<uint16_t>(query, operator_name, nullable); // uint8_t bites char
+        case TILEDB_UINT16:  return apply_unary_aggregate<uint16_t>(query, operator_name, nullable);
+        case TILEDB_UINT32:  return apply_unary_aggregate<uint32_t>(query, operator_name, nullable);
+        case TILEDB_UINT64:  return apply_unary_aggregate<uint64_t>(query, operator_name, nullable);
+        case TILEDB_FLOAT32: return apply_unary_aggregate<float>(query, operator_name, nullable);
+        case TILEDB_FLOAT64: return apply_unary_aggregate<double>(query, operator_name, nullable);
+        default: Rcpp::stop("'%s' is not defined for attribute '%s' of type '%s'",
+                            operator_name, attribute_name, type_name);
+        }
+    } else {
+        Rcpp::stop("'%s' is not implemented for '%s'", operator_name, attribute_name);
     }
-  } else {
-    Rcpp::stop("'%s' is not implemented for '%s'", operator_name,
-               attribute_name);
-  }
 #else
-  return Rcpp::wrap(R_NaReal);
+    return Rcpp::wrap(R_NaReal);
 #endif
 }
 
 /**
  * Query Condition
  */
-const char *
-_tiledb_query_condition_op_to_string(tiledb_query_condition_op_t op) {
-  switch (op) {
-  case TILEDB_LT:
-    return "LT";
-  case TILEDB_LE:
-    return "LE";
-  case TILEDB_GT:
-    return "GT";
-  case TILEDB_GE:
-    return "GE";
-  case TILEDB_EQ:
-    return "EQ";
-  case TILEDB_NE:
-    return "NE";
-#if TILEDB_VERSION >= TileDB_Version(2, 17, 0)
-  case TILEDB_IN:
-    return "IN";
-  case TILEDB_NOT_IN:
-    return "NOT_IN";
+const char* _tiledb_query_condition_op_to_string(tiledb_query_condition_op_t op) {
+    switch (op) {
+    case TILEDB_LT:
+        return "LT";
+    case TILEDB_LE:
+        return "LE";
+    case TILEDB_GT:
+        return "GT";
+    case TILEDB_GE:
+        return "GE";
+    case TILEDB_EQ:
+        return "EQ";
+    case TILEDB_NE:
+        return "NE";
+#if TILEDB_VERSION >= TileDB_Version(2,17,0)
+    case TILEDB_IN:
+        return "IN";
+    case TILEDB_NOT_IN:
+        return "NOT_IN";
 #endif
-  default:
-    Rcpp::stop("Unknown condition op (%d)", op);
-  }
+    default:
+        Rcpp::stop("Unknown condition op (%d)", op);
+    }
 }
 
-tiledb_query_condition_op_t
-_tiledb_query_string_to_condition_op(const std::string &opstr) {
-  if (opstr == "LT") {
-    return TILEDB_LT;
-  } else if (opstr == "LE") {
-    return TILEDB_LE;
-  } else if (opstr == "GT") {
-    return TILEDB_GT;
-  } else if (opstr == "GE") {
-    return TILEDB_GE;
-  } else if (opstr == "EQ") {
-    return TILEDB_EQ;
-  } else if (opstr == "NE") {
-    return TILEDB_NE;
-#if TILEDB_VERSION >= TileDB_Version(2, 17, 0)
-  } else if (opstr == "IN") {
-    return TILEDB_IN;
-  } else if (opstr == "NOT_IN") {
-    return TILEDB_NOT_IN;
+tiledb_query_condition_op_t _tiledb_query_string_to_condition_op(const std::string& opstr) {
+    if (opstr == "LT") {
+        return TILEDB_LT;
+    } else if (opstr == "LE") {
+        return TILEDB_LE;
+    } else if (opstr == "GT") {
+        return TILEDB_GT;
+    } else if (opstr == "GE") {
+        return TILEDB_GE;
+    } else if (opstr == "EQ") {
+        return TILEDB_EQ;
+    } else if (opstr == "NE") {
+        return TILEDB_NE;
+#if TILEDB_VERSION >= TileDB_Version(2,17,0)
+    } else if (opstr == "IN") {
+        return TILEDB_IN;
+    } else if (opstr == "NOT_IN") {
+        return TILEDB_NOT_IN;
 #endif
-  } else {
-    Rcpp::stop("Unknown TileDB op string '%s'", opstr.c_str());
-  }
+    } else {
+        Rcpp::stop("Unknown TileDB op string '%s'", opstr.c_str());
+    }
 }
 
-const char *_tiledb_query_condition_combination_op_to_string(
-    tiledb_query_condition_combination_op_t op) {
-  switch (op) {
-  case TILEDB_AND:
-    return "AND";
-  case TILEDB_OR:
-    return "OR";
-  case TILEDB_NOT:
-    return "NOT";
-  default:
-    Rcpp::stop("Unknown condition combination op (%d)", op);
-  }
+const char* _tiledb_query_condition_combination_op_to_string(tiledb_query_condition_combination_op_t op) {
+    switch (op) {
+    case TILEDB_AND:
+        return "AND";
+    case TILEDB_OR:
+        return "OR";
+    case TILEDB_NOT:
+        return "NOT";
+    default:
+        Rcpp::stop("Unknown condition combination op (%d)", op);
+    }
 }
 
-tiledb_query_condition_combination_op_t
-_tiledb_query_string_to_condition_combination_op(const std::string &opstr) {
-  if (opstr == "AND") {
-    return TILEDB_AND;
-  } else if (opstr == "OR") {
-    return TILEDB_OR;
-  } else if (opstr == "NOT") {
-    return TILEDB_NOT;
-  } else {
-    Rcpp::stop("Unknown TileDB combination op string '%s'", opstr.c_str());
-  }
+tiledb_query_condition_combination_op_t _tiledb_query_string_to_condition_combination_op(const std::string& opstr) {
+    if (opstr == "AND") {
+        return TILEDB_AND;
+    } else if (opstr == "OR") {
+        return TILEDB_OR;
+    } else if (opstr == "NOT") {
+        return TILEDB_NOT;
+    } else {
+        Rcpp::stop("Unknown TileDB combination op string '%s'", opstr.c_str());
+    }
 }
+
 
 // [[Rcpp::export]]
-XPtr<tiledb::QueryCondition>
-libtiledb_query_condition(XPtr<tiledb::Context> ctx) {
-  check_xptr_tag<tiledb::Context>(ctx);
-  auto ptr =
-      make_xptr<tiledb::QueryCondition>(new tiledb::QueryCondition(*ctx.get()));
-  return ptr;
+XPtr<tiledb::QueryCondition> libtiledb_query_condition(XPtr<tiledb::Context> ctx) {
+    check_xptr_tag<tiledb::Context>(ctx);
+    auto ptr = make_xptr<tiledb::QueryCondition>(new tiledb::QueryCondition(*ctx.get()));
+    return ptr;
 }
 
 // [[Rcpp::export]]
 void libtiledb_query_condition_init(XPtr<tiledb::QueryCondition> query_cond,
-                                    const std::string &attr_name,
+                                    const std::string& attr_name,
                                     SEXP condition_value,
-                                    const std::string &cond_val_type,
-                                    const std::string &cond_op_string) {
-  check_xptr_tag<tiledb::QueryCondition>(query_cond);
-  tiledb_query_condition_op_t op =
-      _tiledb_query_string_to_condition_op(cond_op_string);
-  if (cond_val_type == "INT32" || cond_val_type == "UINT32") {
-    int v = as<int>(condition_value);
-    uint64_t cond_val_size = sizeof(int);
-    query_cond->init(attr_name, (void *)&v, cond_val_size, op);
-  } else if (cond_val_type == "FLOAT64") {
-    double v = as<double>(condition_value);
-    uint64_t cond_val_size = sizeof(double);
-    query_cond->init(attr_name, (void *)&v, cond_val_size, op);
-  } else if (cond_val_type == "INT64" || cond_val_type == "UINT64") {
-    int64_t v = fromInteger64(as<double>(condition_value));
-    uint64_t cond_val_size = sizeof(int64_t);
-    query_cond->init(attr_name, (void *)&v, cond_val_size, op);
-  } else if (cond_val_type == "INT8" || cond_val_type == "UINT8") {
-    int v = as<int>(condition_value);
-    uint64_t cond_val_size = sizeof(int8_t);
-    query_cond->init(attr_name, (void *)&v, cond_val_size, op);
-  } else if (cond_val_type == "INT16" || cond_val_type == "UINT16") {
-    int v = as<int>(condition_value);
-    uint64_t cond_val_size = sizeof(int16_t);
-    query_cond->init(attr_name, (void *)&v, cond_val_size, op);
-  } else if (cond_val_type == "FLOAT32") {
-    float v = static_cast<float>(as<double>(condition_value));
-    uint64_t cond_val_size = sizeof(float);
-    query_cond->init(attr_name, (void *)&v, cond_val_size, op);
-  } else if (cond_val_type == "ASCII" || cond_val_type == "UTF8") {
-    std::string v = as<std::string>(condition_value);
-    query_cond->init(attr_name, v, op);
-  } else if (cond_val_type == "BOOL") {
-    bool v = as<bool>(condition_value);
-    uint64_t cond_val_size = sizeof(bool);
-    query_cond->init(attr_name, (void *)&v, cond_val_size, op);
-  } else if (cond_val_type == "DATETIME_MS") {
-    int64_t v = static_cast<int64_t>(as<double>(condition_value) * 1000);
-    uint64_t cond_val_size = sizeof(int64_t);
-    query_cond->init(attr_name, (void *)&v, cond_val_size, op);
-  } else if (cond_val_type == "DATETIME_DAY") {
-    int64_t v = static_cast<int64_t>(as<double>(condition_value));
-    uint64_t cond_val_size = sizeof(int64_t);
-    query_cond->init(attr_name, (void *)&v, cond_val_size, op);
-  } else {
-    Rcpp::stop("Currently unsupported type: %s", cond_val_type);
-  }
-}
-
-// [[Rcpp::export]]
-XPtr<tiledb::QueryCondition>
-libtiledb_query_condition_combine(XPtr<tiledb::QueryCondition> lhs,
-                                  XPtr<tiledb::QueryCondition> rhs,
-                                  const std::string &str) {
-  check_xptr_tag<tiledb::QueryCondition>(lhs);
-  check_xptr_tag<tiledb::QueryCondition>(lhs);
-  tiledb_query_condition_combination_op_t op =
-      _tiledb_query_string_to_condition_combination_op(str);
-  tiledb::QueryCondition res = lhs->combine(*rhs.get(), op);
-  auto query_cond =
-      make_xptr<tiledb::QueryCondition>(new tiledb::QueryCondition(res));
-  return query_cond;
-}
-
-// [[Rcpp::export]]
-void libtiledb_query_condition_set_use_enumeration(
-    XPtr<tiledb::Context> ctx, XPtr<tiledb::QueryCondition> cond,
-    bool use_enumeration) {
-  check_xptr_tag<tiledb::Context>(ctx);
-  check_xptr_tag<tiledb::QueryCondition>(cond);
-#if TILEDB_VERSION >= TileDB_Version(2, 17, 0)
-  tiledb::QueryConditionExperimental::set_use_enumeration(
-      *ctx.get(), *cond.get(), use_enumeration);
-#endif
-}
-
-// [[Rcpp::export]]
-XPtr<tiledb::QueryCondition>
-libtiledb_query_condition_create(XPtr<tiledb::Context> ctx,
-                                 const std::string &name, SEXP vec,
-                                 const std::string &cond_op_string) {
-  check_xptr_tag<tiledb::Context>(ctx);
-#if TILEDB_VERSION >= TileDB_Version(2, 17, 0)
-  tiledb_query_condition_op_t op =
-      _tiledb_query_string_to_condition_op(cond_op_string);
-  // consider three cases of 'vec' based on R types:  int, double and
-  // int64-as-double
-  if (TYPEOF(vec) == INTSXP) {
-    std::vector<int32_t> iv = Rcpp::as<std::vector<int32_t>>(vec);
-    auto qc = tiledb::QueryConditionExperimental::create<int32_t>(*ctx.get(),
-                                                                  name, iv, op);
-    return make_xptr<tiledb::QueryCondition>(new tiledb::QueryCondition(qc));
-  } else if (TYPEOF(vec) == REALSXP) {
-    if (Rcpp::isInteger64(vec)) {
-      std::vector<int64_t> dv = Rcpp::fromInteger64(Rcpp::NumericVector(vec));
-      auto qc = tiledb::QueryConditionExperimental::create<int64_t>(
-          *ctx.get(), name, dv, op);
-      return make_xptr<tiledb::QueryCondition>(new tiledb::QueryCondition(qc));
+                                    const std::string& cond_val_type,
+                                    const std::string& cond_op_string) {
+    check_xptr_tag<tiledb::QueryCondition>(query_cond);
+    tiledb_query_condition_op_t op = _tiledb_query_string_to_condition_op(cond_op_string);
+    if (cond_val_type == "INT32"  || cond_val_type == "UINT32") {
+        int v = as<int>(condition_value);
+        uint64_t cond_val_size = sizeof(int);
+        query_cond->init(attr_name, (void*) &v, cond_val_size, op);
+    } else if (cond_val_type == "FLOAT64") {
+        double v = as<double>(condition_value);
+        uint64_t cond_val_size = sizeof(double);
+        query_cond->init(attr_name, (void*) &v, cond_val_size, op);
+    } else if (cond_val_type == "INT64" || cond_val_type == "UINT64") {
+        int64_t v = fromInteger64( as<double>(condition_value) );
+        uint64_t cond_val_size = sizeof(int64_t);
+        query_cond->init(attr_name, (void*) &v, cond_val_size, op);
+    } else if (cond_val_type == "INT8" || cond_val_type == "UINT8") {
+        int v = as<int>(condition_value);
+        uint64_t cond_val_size = sizeof(int8_t);
+        query_cond->init(attr_name, (void*) &v, cond_val_size, op);
+    } else if (cond_val_type == "INT16" || cond_val_type == "UINT16") {
+        int v = as<int>(condition_value);
+        uint64_t cond_val_size = sizeof(int16_t);
+        query_cond->init(attr_name, (void*) &v, cond_val_size, op);
+    } else if (cond_val_type == "FLOAT32") {
+        float v = static_cast<float>(as<double>(condition_value));
+        uint64_t cond_val_size = sizeof(float);
+        query_cond->init(attr_name, (void*) &v, cond_val_size, op);
+    } else if (cond_val_type == "ASCII" || cond_val_type == "UTF8") {
+        std::string v = as<std::string>(condition_value);
+        query_cond->init(attr_name, v, op);
+    } else if (cond_val_type == "BOOL") {
+        bool v = as<bool>(condition_value);
+        uint64_t cond_val_size = sizeof(bool);
+        query_cond->init(attr_name, (void*) &v, cond_val_size, op);
+    } else if (cond_val_type == "DATETIME_MS") {
+        int64_t v = static_cast<int64_t>(as<double>(condition_value) * 1000);
+        uint64_t cond_val_size = sizeof(int64_t);
+        query_cond->init(attr_name, (void*) &v, cond_val_size, op);
+    } else if (cond_val_type == "DATETIME_DAY") {
+        int64_t v = static_cast<int64_t>(as<double>(condition_value));
+        uint64_t cond_val_size = sizeof(int64_t);
+        query_cond->init(attr_name, (void*) &v, cond_val_size, op);
     } else {
-      std::vector<double> dv = Rcpp::as<std::vector<double>>(vec);
-      auto qc = tiledb::QueryConditionExperimental::create<double>(
-          *ctx.get(), name, dv, op);
-      return make_xptr<tiledb::QueryCondition>(new tiledb::QueryCondition(qc));
+        Rcpp::stop("Currently unsupported type: %s", cond_val_type);
     }
-  } else if (TYPEOF(vec) == STRSXP) {
-    std::vector<std::string> sv = Rcpp::as<std::vector<std::string>>(vec);
-    auto qc =
-        tiledb::QueryConditionExperimental::create(*ctx.get(), name, sv, op);
-    return make_xptr<tiledb::QueryCondition>(new tiledb::QueryCondition(qc));
-  } else {
-    Rcpp::stop("No support (yet) for type '%s'.", Rcpp::type2name(vec));
-  }
-#endif
-  return make_xptr<tiledb::QueryCondition>(R_NilValue);
 }
+
+// [[Rcpp::export]]
+XPtr<tiledb::QueryCondition> libtiledb_query_condition_combine(XPtr<tiledb::QueryCondition> lhs,
+                                                               XPtr<tiledb::QueryCondition> rhs,
+                                                               const std::string& str) {
+    check_xptr_tag<tiledb::QueryCondition>(lhs);
+    check_xptr_tag<tiledb::QueryCondition>(lhs);
+    tiledb_query_condition_combination_op_t op = _tiledb_query_string_to_condition_combination_op(str);
+    tiledb::QueryCondition res = lhs->combine(*rhs.get(), op);
+    auto query_cond = make_xptr<tiledb::QueryCondition>(new tiledb::QueryCondition(res));
+    return query_cond;
+}
+
+// [[Rcpp::export]]
+void libtiledb_query_condition_set_use_enumeration(XPtr<tiledb::Context> ctx,
+                                                   XPtr<tiledb::QueryCondition> cond,
+                                                   bool use_enumeration) {
+    check_xptr_tag<tiledb::Context>(ctx);
+    check_xptr_tag<tiledb::QueryCondition>(cond);
+#if TILEDB_VERSION >= TileDB_Version(2,17,0)
+    tiledb::QueryConditionExperimental::set_use_enumeration(*ctx.get(), *cond.get(), use_enumeration);
+#endif
+}
+
+// [[Rcpp::export]]
+XPtr<tiledb::QueryCondition>
+libtiledb_query_condition_create(XPtr<tiledb::Context> ctx, const std::string& name,
+                                 SEXP vec, const std::string& cond_op_string) {
+    check_xptr_tag<tiledb::Context>(ctx);
+#if TILEDB_VERSION >= TileDB_Version(2,17,0)
+    tiledb_query_condition_op_t op = _tiledb_query_string_to_condition_op(cond_op_string);
+    // consider three cases of 'vec' based on R types:  int, double and int64-as-double
+    if (TYPEOF(vec) == INTSXP) {
+        std::vector<int32_t> iv = Rcpp::as<std::vector<int32_t>>(vec);
+        auto qc = tiledb::QueryConditionExperimental::create<int32_t>(*ctx.get(), name, iv, op);
+        return make_xptr<tiledb::QueryCondition>(new tiledb::QueryCondition(qc));
+    } else if (TYPEOF(vec) == REALSXP) {
+        if (Rcpp::isInteger64(vec)) {
+            std::vector<int64_t> dv = Rcpp::fromInteger64(Rcpp::NumericVector(vec));
+            auto qc = tiledb::QueryConditionExperimental::create<int64_t>(*ctx.get(), name, dv, op);
+            return make_xptr<tiledb::QueryCondition>(new tiledb::QueryCondition(qc));
+        } else {
+            std::vector<double> dv = Rcpp::as<std::vector<double>>(vec);
+            auto qc = tiledb::QueryConditionExperimental::create<double>(*ctx.get(), name, dv, op);
+            return make_xptr<tiledb::QueryCondition>(new tiledb::QueryCondition(qc));
+        }
+    } else if (TYPEOF(vec) == STRSXP) {
+        std::vector<std::string> sv = Rcpp::as<std::vector<std::string>>(vec);
+        auto qc = tiledb::QueryConditionExperimental::create(*ctx.get(), name, sv, op);
+        return make_xptr<tiledb::QueryCondition>(new tiledb::QueryCondition(qc));
+    } else {
+        Rcpp::stop("No support (yet) for type '%s'.", Rcpp::type2name(vec));
+    }
+#endif
+    return make_xptr<tiledb::QueryCondition>(R_NilValue);
+}
+
 
 /**
  * Array helper functions
@@ -4643,6 +4333,7 @@ IntegerVector libtiledb_zip_coords_integer(List coords, R_xlen_t coord_length) {
   return result;
 }
 
+
 /**
  * Object functionality
  */
@@ -4655,13 +4346,13 @@ std::string libtiledb_create_group(XPtr<tiledb::Context> ctx, std::string uri) {
 
 std::string _object_type_to_string(tiledb::Object::Type otype) {
   switch (otype) {
-  case tiledb::Object::Type::Array:
-    return "ARRAY";
-  case tiledb::Object::Type::Group:
-    return "GROUP";
-  case tiledb::Object::Type::Invalid:
-  default:
-    return "INVALID";
+    case tiledb::Object::Type::Array:
+      return "ARRAY";
+    case tiledb::Object::Type::Group:
+      return "GROUP";
+    case tiledb::Object::Type::Invalid:
+    default:
+      return "INVALID";
   }
 }
 
@@ -4673,16 +4364,14 @@ std::string libtiledb_object_type(XPtr<tiledb::Context> ctx, std::string uri) {
 }
 
 // [[Rcpp::export]]
-std::string libtiledb_object_remove(XPtr<tiledb::Context> ctx,
-                                    std::string uri) {
+std::string libtiledb_object_remove(XPtr<tiledb::Context> ctx, std::string uri) {
   check_xptr_tag<tiledb::Context>(ctx);
   tiledb::Object::remove(*ctx.get(), uri);
   return uri;
 }
 
 // [[Rcpp::export]]
-std::string libtiledb_object_move(XPtr<tiledb::Context> ctx,
-                                  std::string old_uri, std::string new_uri) {
+std::string libtiledb_object_move(XPtr<tiledb::Context> ctx, std::string old_uri, std::string new_uri) {
   check_xptr_tag<tiledb::Context>(ctx);
   tiledb::Object::move(*ctx.get(), old_uri, new_uri);
   return new_uri;
@@ -4699,59 +4388,53 @@ tiledb::Object::Type _string_to_object_type(std::string otype) {
 }
 
 // [[Rcpp::export]]
-DataFrame libtiledb_object_walk(XPtr<tiledb::Context> ctx, std::string uri,
-                                std::string order, bool recursive = false) {
-  check_xptr_tag<tiledb::Context>(ctx);
-  std::vector<std::string> uris;
-  std::vector<std::string> types;
-  tiledb::ObjectIter obj_iter(*ctx.get(), uri);
-  if (recursive) {
-    if (!((order == "PREORDER") || (order == "POSTORDER"))) {
-      Rcpp::stop("invalid recursive walk order, must be \"PREORDER\" or "
-                 "\"POSTORDER\"");
+DataFrame libtiledb_object_walk(XPtr<tiledb::Context> ctx,
+                                std::string uri, std::string order, bool recursive = false) {
+    check_xptr_tag<tiledb::Context>(ctx);
+    std::vector<std::string> uris;
+    std::vector<std::string> types;
+    tiledb::ObjectIter obj_iter(*ctx.get(), uri);
+    if (recursive) {
+        if (! ((order == "PREORDER") || (order == "POSTORDER"))) {
+            Rcpp::stop("invalid recursive walk order, must be \"PREORDER\" or \"POSTORDER\"");
+        }
+        tiledb_walk_order_t walk_order = (order == "PREORDER") ? TILEDB_PREORDER : TILEDB_POSTORDER;
+        obj_iter.set_recursive(walk_order);
+    } else {
+        obj_iter.set_non_recursive();
     }
-    tiledb_walk_order_t walk_order =
-        (order == "PREORDER") ? TILEDB_PREORDER : TILEDB_POSTORDER;
-    obj_iter.set_recursive(walk_order);
-  } else {
-    obj_iter.set_non_recursive();
-  }
-  for (const auto &object : obj_iter) {
-    uris.push_back(object.uri());
-    types.push_back(_object_type_to_string(object.type()));
-  }
-  return Rcpp::DataFrame::create(Rcpp::Named("TYPE") = types,
-                                 Rcpp::Named("URI") = uris);
+    for (const auto& object : obj_iter) {
+        uris.push_back(object.uri());
+        types.push_back(_object_type_to_string(object.type()));
+    }
+    return Rcpp::DataFrame::create(Rcpp::Named("TYPE") = types,
+                                   Rcpp::Named("URI") = uris);
 }
 
 /**
  * VFS functionality
  */
 // [[Rcpp::export]]
-XPtr<tiledb::VFS>
-libtiledb_vfs(XPtr<tiledb::Context> ctx,
-              Nullable<XPtr<tiledb::Config>> config = R_NilValue) {
+XPtr<tiledb::VFS> libtiledb_vfs(XPtr<tiledb::Context> ctx,
+                                Nullable<XPtr<tiledb::Config>> config=R_NilValue) {
   check_xptr_tag<tiledb::Context>(ctx);
   if (config.isNull()) {
     return make_xptr<tiledb::VFS>(new tiledb::VFS(*ctx.get()));
   } else {
     XPtr<tiledb::Config> config_xptr(config);
-    return make_xptr<tiledb::VFS>(
-        new tiledb::VFS(*ctx.get(), *config_xptr.get()));
+    return make_xptr<tiledb::VFS>(new tiledb::VFS(*ctx.get(), *config_xptr.get()));
   }
 }
 
 // [[Rcpp::export]]
-std::string libtiledb_vfs_create_bucket(XPtr<tiledb::VFS> vfs,
-                                        std::string uri) {
+std::string libtiledb_vfs_create_bucket(XPtr<tiledb::VFS> vfs, std::string uri) {
   check_xptr_tag<tiledb::VFS>(vfs);
   vfs->create_bucket(uri);
   return uri;
 }
 
 // [[Rcpp::export]]
-std::string libtiledb_vfs_remove_bucket(XPtr<tiledb::VFS> vfs,
-                                        std::string uri) {
+std::string libtiledb_vfs_remove_bucket(XPtr<tiledb::VFS> vfs, std::string uri) {
   check_xptr_tag<tiledb::VFS>(vfs);
   vfs->remove_bucket(uri);
   return uri;
@@ -4785,8 +4468,8 @@ std::string libtiledb_vfs_create_dir(XPtr<tiledb::VFS> vfs, std::string uri) {
 
 // [[Rcpp::export]]
 bool libtiledb_vfs_is_dir(XPtr<tiledb::VFS> vfs, std::string uri) {
-  check_xptr_tag<tiledb::VFS>(vfs);
-  return vfs->is_dir(uri);
+    check_xptr_tag<tiledb::VFS>(vfs);
+    return vfs->is_dir(uri);
 }
 
 // [[Rcpp::export]]
@@ -4820,16 +4503,14 @@ R_xlen_t libtiledb_vfs_file_size(XPtr<tiledb::VFS> vfs, std::string uri) {
 }
 
 // [[Rcpp::export]]
-std::string libtiledb_vfs_move_file(XPtr<tiledb::VFS> vfs, std::string old_uri,
-                                    std::string new_uri) {
+std::string libtiledb_vfs_move_file(XPtr<tiledb::VFS> vfs, std::string old_uri, std::string new_uri) {
   check_xptr_tag<tiledb::VFS>(vfs);
   vfs->move_file(old_uri, new_uri);
   return new_uri;
 }
 
 // [[Rcpp::export]]
-std::string libtiledb_vfs_move_dir(XPtr<tiledb::VFS> vfs, std::string old_uri,
-                                   std::string new_uri) {
+std::string libtiledb_vfs_move_dir(XPtr<tiledb::VFS> vfs, std::string old_uri, std::string new_uri) {
   check_xptr_tag<tiledb::VFS>(vfs);
   vfs->move_dir(old_uri, new_uri);
   return new_uri;
@@ -4842,15 +4523,15 @@ std::string libtiledb_vfs_touch(XPtr<tiledb::VFS> vfs, std::string uri) {
   return uri;
 }
 
+
 // [[Rcpp::export]]
-XPtr<vfs_fh_t> libtiledb_vfs_open(XPtr<tiledb::Context> ctxxp,
-                                  XPtr<tiledb::VFS> vfsxp, std::string uri,
-                                  std::string mode) {
+XPtr<vfs_fh_t> libtiledb_vfs_open(XPtr<tiledb::Context> ctxxp, XPtr<tiledb::VFS> vfsxp,
+                                  std::string uri, std::string mode) {
   check_xptr_tag<tiledb::Context>(ctxxp);
   check_xptr_tag<tiledb::VFS>(vfsxp);
   std::shared_ptr<tiledb_ctx_t> ctx = ctxxp.get()->ptr();
   std::shared_ptr<tiledb_vfs_t> vfs = vfsxp.get()->ptr();
-#if TILEDB_VERSION >= TileDB_Version(2, 15, 0)
+#if TILEDB_VERSION >= TileDB_Version(2,15,0)
   tiledb_vfs_fh_handle_t *fh = nullptr;
 #else
   tiledb_vfs_fh_t *fh = nullptr;
@@ -4876,13 +4557,12 @@ void libtiledb_vfs_write(XPtr<tiledb::Context> ctxxp, XPtr<vfs_fh_t> fh,
   check_xptr_tag<tiledb::Context>(ctxxp);
   check_xptr_tag<vfs_fh_t>(fh);
   std::shared_ptr<tiledb_ctx_t> ctx = ctxxp.get()->ptr();
-  tiledb_vfs_write(ctx.get(), fh->fh, &(vec[0]), vec.size() * sizeof(int));
+  tiledb_vfs_write(ctx.get(), fh->fh, &(vec[0]), vec.size()*sizeof(int));
 }
 
 // [[Rcpp::export]]
-Rcpp::IntegerVector libtiledb_vfs_read(XPtr<tiledb::Context> ctxxp,
-                                       XPtr<vfs_fh_t> fh, double offset,
-                                       double nbytes) {
+Rcpp::IntegerVector libtiledb_vfs_read(XPtr<tiledb::Context> ctxxp, XPtr<vfs_fh_t> fh,
+                                       double offset, double nbytes) {
   check_xptr_tag<tiledb::Context>(ctxxp);
   check_xptr_tag<vfs_fh_t>(fh);
   std::shared_ptr<tiledb_ctx_t> ctx = ctxxp.get()->ptr();
@@ -4903,67 +4583,63 @@ void libtiledb_vfs_sync(XPtr<tiledb::Context> ctxxp, XPtr<vfs_fh_t> fh) {
 
 // [[Rcpp::export]]
 double libtiledb_vfs_dir_size(XPtr<tiledb::VFS> vfs, std::string uri) {
-  check_xptr_tag<tiledb::VFS>(vfs);
-  return static_cast<double>(vfs->dir_size(uri)); // uint64_t to double for R
+    check_xptr_tag<tiledb::VFS>(vfs);
+    return static_cast<double>(vfs->dir_size(uri)); // uint64_t to double for R
 }
 
 // [[Rcpp::export]]
-std::vector<std::string> libtiledb_vfs_ls(XPtr<tiledb::VFS> vfs,
-                                          std::string uri) {
-  check_xptr_tag<tiledb::VFS>(vfs);
-  return vfs->ls(uri);
+std::vector<std::string> libtiledb_vfs_ls(XPtr<tiledb::VFS> vfs, std::string uri) {
+    check_xptr_tag<tiledb::VFS>(vfs);
+    return vfs->ls(uri);
 }
 
 // [[Rcpp::export]]
-std::string libtiledb_vfs_copy_file(XPtr<tiledb::VFS> vfs, std::string old_uri,
-                                    std::string new_uri) {
-  check_xptr_tag<tiledb::VFS>(vfs);
-  vfs->copy_file(old_uri, new_uri);
-  return new_uri;
+std::string libtiledb_vfs_copy_file(XPtr<tiledb::VFS> vfs, std::string old_uri, std::string new_uri) {
+    check_xptr_tag<tiledb::VFS>(vfs);
+    vfs->copy_file(old_uri, new_uri);
+    return new_uri;
 }
 
 // [[Rcpp::export]]
 void libtiledb_vfs_fh_free(XPtr<vfs_fh_t> fhxp) {
-  check_xptr_tag<vfs_fh_t>(fhxp);
-  spdl::trace("[libtiledb_vfs_clear_handle] entered");
-  vfs_fh_t *strptr = fhxp.get();
-#if TILEDB_VERSION >= TileDB_Version(2, 15, 0)
-  tiledb_vfs_fh_handle_t *fh = strptr->fh;
-  tiledb_vfs_fh_free(&fh);
+    check_xptr_tag<vfs_fh_t>(fhxp);
+    spdl::trace("[libtiledb_vfs_clear_handle] entered");
+    vfs_fh_t* strptr = fhxp.get();
+#if TILEDB_VERSION >= TileDB_Version(2,15,0)
+    tiledb_vfs_fh_handle_t *fh = strptr->fh;
+    tiledb_vfs_fh_free(&fh);
 #endif
 }
 
 // [[Rcpp::export]]
 Rcpp::DataFrame libtiledb_vfs_ls_recursive(XPtr<tiledb::Context> ctx,
                                            XPtr<tiledb::VFS> vfs,
-                                           const std::string &uri) {
-  check_xptr_tag<tiledb::Context>(ctx);
-  check_xptr_tag<tiledb::VFS>(vfs);
+                                           const std::string& uri) {
+    check_xptr_tag<tiledb::Context>(ctx);
+    check_xptr_tag<tiledb::VFS>(vfs);
 
-#if TILEDB_VERSION >= TileDB_Version(2, 22, 0)
-  // standard / default list object (a vector of a pair<string, uint64_t?>) and
-  // callback
-  tiledb::VFSExperimental::LsObjects ls_objects;
-  tiledb::VFSExperimental::LsCallback cb = [&](const std::string_view &path,
-                                               uint64_t size) {
-    ls_objects.emplace_back(path, size);
-    return true; // Continue traversal to next entry.
-  };
-  tiledb::VFSExperimental::ls_recursive(*ctx.get(), *vfs.get(), uri, cb);
+#if TILEDB_VERSION >= TileDB_Version(2,22,0)
+    // standard / default list object (a vector of a pair<string, uint64_t?>) and callback
+    tiledb::VFSExperimental::LsObjects ls_objects;
+    tiledb::VFSExperimental::LsCallback cb = [&](const std::string_view& path, uint64_t size) {
+        ls_objects.emplace_back(path, size);
+        return true;  // Continue traversal to next entry.
+    };
+    tiledb::VFSExperimental::ls_recursive(*ctx.get(), *vfs.get(), uri, cb);
 
-  size_t n = ls_objects.size();
-  Rcpp::CharacterVector path(n);
-  std::vector<int64_t> size(n);
-  for (size_t i = 0; i < n; i++) {
-    auto obj = ls_objects[i];
-    path[i] = obj.first;
-    size[i] = static_cast<int64_t>(obj.second);
-  }
-  return Rcpp::DataFrame::create(Rcpp::Named("path") = path,
-                                 Rcpp::Named("size") = Rcpp::toInteger64(size));
+    size_t n = ls_objects.size();
+    Rcpp::CharacterVector path(n);
+    std::vector<int64_t> size(n);
+    for (size_t i=0; i<n; i++) {
+        auto obj = ls_objects[i];
+        path[i] = obj.first;
+        size[i] = static_cast<int64_t>(obj.second);
+    }
+    return Rcpp::DataFrame::create(Rcpp::Named("path") = path,
+                                   Rcpp::Named("size") = Rcpp::toInteger64(size));
 #else
-  return Rcpp::DataFrame::create(Rcpp::Named("path") = Rcpp::CharacterVector(),
-                                 Rcpp::Named("size") = Rcpp::NumericVector());
+    return Rcpp::DataFrame::create(Rcpp::Named("path") = Rcpp::CharacterVector(),
+                                   Rcpp::Named("size") = Rcpp::NumericVector());
 #endif
 }
 
@@ -4972,20 +4648,26 @@ Rcpp::DataFrame libtiledb_vfs_ls_recursive(XPtr<tiledb::Context> ctx,
  */
 
 // [[Rcpp::export]]
-void libtiledb_stats_enable() { tiledb::Stats::enable(); }
+void libtiledb_stats_enable() {
+  tiledb::Stats::enable();
+}
 
 // [[Rcpp::export]]
-void libtiledb_stats_disable() { tiledb::Stats::disable(); }
+void libtiledb_stats_disable() {
+  tiledb::Stats::disable();
+}
 
 // [[Rcpp::export]]
-void libtiledb_stats_reset() { tiledb::Stats::reset(); }
+void libtiledb_stats_reset() {
+  tiledb::Stats::reset();
+}
 
 // [[Rcpp::export]]
 void libtiledb_stats_dump(std::string path = "") {
   if (path == "") {
     tiledb::Stats::dump();
   } else {
-    FILE *fptr = nullptr;
+    FILE* fptr = nullptr;
     fptr = fopen(path.c_str(), "w");
     if (fptr == nullptr) {
       Rcpp::stop("error opening stats dump file for writing");
@@ -4997,16 +4679,15 @@ void libtiledb_stats_dump(std::string path = "") {
 
 // [[Rcpp::export]]
 std::string libtiledb_stats_raw_dump() {
-  std::string txt;
-  tiledb::Stats::raw_dump(&txt);
-  return txt;
+    std::string txt;
+    tiledb::Stats::raw_dump(&txt);
+    return txt;
 }
 
 // [[Rcpp::export]]
 std::string libtiledb_stats_raw_get() {
-  Rcpp::message(Rcpp::wrap(
-      "This function is deprecated, please use 'libtiledb_stats_raw_dump'."));
-  return libtiledb_stats_raw_dump();
+    Rcpp::message(Rcpp::wrap("This function is deprecated, please use 'libtiledb_stats_raw_dump'."));
+    return libtiledb_stats_raw_dump();
 }
 
 /**
@@ -5014,592 +4695,586 @@ std::string libtiledb_stats_raw_get() {
  */
 // [[Rcpp::export]]
 XPtr<tiledb::FragmentInfo> libtiledb_fragment_info(XPtr<tiledb::Context> ctx,
-                                                   const std::string &uri) {
-  auto ptr = make_xptr<tiledb::FragmentInfo>(
-      new tiledb::FragmentInfo(*ctx.get(), uri));
-  ptr->load(); // also load
-  return ptr;
+                                                   const std::string& uri) {
+    auto ptr = make_xptr<tiledb::FragmentInfo>(new tiledb::FragmentInfo(*ctx.get(), uri));
+    ptr->load();                // also load
+    return ptr;
 }
 
 // [[Rcpp::export]]
-std::string libtiledb_fragment_info_uri(XPtr<tiledb::FragmentInfo> fi,
-                                        int32_t fid) {
-  check_xptr_tag<tiledb::FragmentInfo>(fi);
-  return fi->fragment_uri(static_cast<uint32_t>(fid));
+std::string libtiledb_fragment_info_uri(XPtr<tiledb::FragmentInfo> fi, int32_t fid) {
+    check_xptr_tag<tiledb::FragmentInfo>(fi);
+    return fi->fragment_uri(static_cast<uint32_t>(fid));
 }
 
 // [[Rcpp::export]]
-Rcpp::NumericVector libtiledb_fragment_info_get_non_empty_domain_index(
-    XPtr<tiledb::FragmentInfo> fi, int32_t fid, int32_t did,
-    const std::string &typestr) {
-  check_xptr_tag<tiledb::FragmentInfo>(fi);
-  if (typestr == "INT64") {
-    std::vector<int64_t> non_empty_dom(2);
-    fi->get_non_empty_domain(fid, did, &non_empty_dom[0]);
-    return toInteger64(non_empty_dom);
-  } else if (typestr == "UINT64") {
-    std::vector<uint64_t> ned(2);
-    fi->get_non_empty_domain(fid, did, &ned[0]);
-    std::vector<int64_t> v{static_cast<int64_t>(ned[0]),
-                           static_cast<int64_t>(ned[1])};
-    return toInteger64(v);
-  } else if (typestr == "INT32") {
-    std::vector<int32_t> non_empty_dom(2);
-    fi->get_non_empty_domain(fid, did, &non_empty_dom[0]);
-    return NumericVector::create(non_empty_dom[0], non_empty_dom[1]);
-  } else if (typestr == "UINT32") {
-    std::vector<uint32_t> non_empty_dom(2);
-    fi->get_non_empty_domain(fid, did, &non_empty_dom[0]);
-    return NumericVector::create(non_empty_dom[0], non_empty_dom[1]);
-  } else if (typestr == "INT16") {
-    std::vector<int16_t> non_empty_dom(2);
-    fi->get_non_empty_domain(fid, did, &non_empty_dom[0]);
-    return NumericVector::create(non_empty_dom[0], non_empty_dom[1]);
-  } else if (typestr == "UINT16") {
-    std::vector<uint16_t> non_empty_dom(2);
-    fi->get_non_empty_domain(fid, did, &non_empty_dom[0]);
-    return NumericVector::create(non_empty_dom[0], non_empty_dom[1]);
+Rcpp::NumericVector libtiledb_fragment_info_get_non_empty_domain_index(XPtr<tiledb::FragmentInfo> fi,
+                                                                       int32_t fid, int32_t did,
+                                                                       const std::string& typestr) {
+    check_xptr_tag<tiledb::FragmentInfo>(fi);
+    if (typestr == "INT64") {
+        std::vector<int64_t> non_empty_dom(2);
+        fi->get_non_empty_domain(fid, did, &non_empty_dom[0]);
+        return toInteger64(non_empty_dom);
+    } else if (typestr == "UINT64") {
+        std::vector<uint64_t> ned(2);
+        fi->get_non_empty_domain(fid, did, &ned[0]);
+        std::vector<int64_t> v{ static_cast<int64_t>(ned[0]), static_cast<int64_t>(ned[1]) };
+        return toInteger64(v);
+    } else if (typestr == "INT32") {
+        std::vector<int32_t> non_empty_dom(2);
+        fi->get_non_empty_domain(fid, did, &non_empty_dom[0]);
+        return NumericVector::create(non_empty_dom[0], non_empty_dom[1]);
+    } else if (typestr == "UINT32") {
+        std::vector<uint32_t> non_empty_dom(2);
+        fi->get_non_empty_domain(fid, did, &non_empty_dom[0]);
+        return NumericVector::create(non_empty_dom[0], non_empty_dom[1]);
+    } else if (typestr == "INT16") {
+        std::vector<int16_t> non_empty_dom(2);
+        fi->get_non_empty_domain(fid, did, &non_empty_dom[0]);
+        return NumericVector::create(non_empty_dom[0], non_empty_dom[1]);
+    } else if (typestr == "UINT16") {
+        std::vector<uint16_t> non_empty_dom(2);
+        fi->get_non_empty_domain(fid, did, &non_empty_dom[0]);
+        return NumericVector::create(non_empty_dom[0], non_empty_dom[1]);
+    } else if (typestr == "INT8") {
+        std::vector<int8_t> non_empty_dom(2);
+        fi->get_non_empty_domain(fid, did, &non_empty_dom[0]);
+        return NumericVector::create(non_empty_dom[0], non_empty_dom[1]);
+    } else if (typestr == "UINT8") {
+        std::vector<uint8_t> non_empty_dom(2);
+        fi->get_non_empty_domain(fid, did, &non_empty_dom[0]);
+        return NumericVector::create(non_empty_dom[0], non_empty_dom[1]);
+    } else if (typestr == "FLOAT64") {
+        std::vector<double> non_empty_dom(2);
+        fi->get_non_empty_domain(fid, did, &non_empty_dom[0]);
+        return NumericVector::create(non_empty_dom[0], non_empty_dom[1]);
+    } else if (typestr == "FLOAT32") {
+        std::vector<float> non_empty_dom(2);
+        fi->get_non_empty_domain(fid, did, &non_empty_dom[0]);
+        return NumericVector::create(non_empty_dom[0], non_empty_dom[1]);
+    } else if (typestr == "DATETIME_YEAR" ||
+             typestr == "DATETIME_MONTH" ||
+             typestr == "DATETIME_WEEK" ||
+             typestr == "DATETIME_DAY" ||
+             typestr == "DATETIME_HR"  ||
+             typestr == "DATETIME_MIN" ||
+             typestr == "DATETIME_SEC" ||
+             typestr == "DATETIME_MS"  ||
+             typestr == "DATETIME_US"  ||
+             typestr == "DATETIME_PS"  ||
+             typestr == "DATETIME_FS"  ||
+             typestr == "DATETIME_AS"    ) {
+        // type_check() from exception.h gets invoked and wants an int64_t
+        std::vector<int64_t> non_empty_dom(2);
+        fi->get_non_empty_domain(fid, did, &non_empty_dom[0]);
+        return toInteger64(non_empty_dom);
+    } else if (typestr == "DATETIME_NS") {
+        std::vector<int64_t> non_empty_dom(2);
+        fi->get_non_empty_domain(fid, did, &non_empty_dom[0]);
+        return toNanotime(non_empty_dom);
+    } else {
+        Rcpp::stop("Currently unsupported tiledb domain type: '%s'", typestr.c_str());
+        return NumericVector::create(NA_REAL, NA_REAL); // not reached
+    }
+}
+
+// [[Rcpp::export]]
+Rcpp::NumericVector libtiledb_fragment_info_get_non_empty_domain_name(XPtr<tiledb::FragmentInfo> fi,
+                                                                      int32_t fid,
+                                                                      const std::string& dim_name,
+                                                                      const std::string& typestr) {
+    check_xptr_tag<tiledb::FragmentInfo>(fi);
+    if (typestr == "INT64") {
+        std::vector<int64_t> non_empty_dom(2);
+        fi->get_non_empty_domain(fid, dim_name, &non_empty_dom[0]);
+        return toInteger64(non_empty_dom);
+    } else if (typestr == "UINT64") {
+        std::vector<uint64_t> ned(2);
+        fi->get_non_empty_domain(fid, dim_name, &ned[0]);
+        std::vector<int64_t> v{ static_cast<int64_t>(ned[0]), static_cast<int64_t>(ned[1]) };
+        return toInteger64(v);
+    } else if (typestr == "INT32") {
+        std::vector<int32_t> non_empty_dom(2);
+        fi->get_non_empty_domain(fid, dim_name, &non_empty_dom[0]);
+        return NumericVector::create(non_empty_dom[0], non_empty_dom[1]);
+    } else if (typestr == "UINT32") {
+        std::vector<uint32_t> non_empty_dom(2);
+        fi->get_non_empty_domain(fid, dim_name, &non_empty_dom[0]);
+        return NumericVector::create(non_empty_dom[0], non_empty_dom[1]);
+    } else if (typestr == "INT16") {
+        std::vector<int16_t> non_empty_dom(2);
+        fi->get_non_empty_domain(fid, dim_name, &non_empty_dom[0]);
+        return NumericVector::create(non_empty_dom[0], non_empty_dom[1]);
+    } else if (typestr == "UINT16") {
+        std::vector<uint16_t> non_empty_dom(2);
+        fi->get_non_empty_domain(fid, dim_name, &non_empty_dom[0]);
+        return NumericVector::create(non_empty_dom[0], non_empty_dom[1]);
   } else if (typestr == "INT8") {
-    std::vector<int8_t> non_empty_dom(2);
-    fi->get_non_empty_domain(fid, did, &non_empty_dom[0]);
-    return NumericVector::create(non_empty_dom[0], non_empty_dom[1]);
+        std::vector<int8_t> non_empty_dom(2);
+        fi->get_non_empty_domain(fid, dim_name, &non_empty_dom[0]);
+        return NumericVector::create(non_empty_dom[0], non_empty_dom[1]);
   } else if (typestr == "UINT8") {
-    std::vector<uint8_t> non_empty_dom(2);
-    fi->get_non_empty_domain(fid, did, &non_empty_dom[0]);
-    return NumericVector::create(non_empty_dom[0], non_empty_dom[1]);
+        std::vector<uint8_t> non_empty_dom(2);
+        fi->get_non_empty_domain(fid, dim_name, &non_empty_dom[0]);
+        return NumericVector::create(non_empty_dom[0], non_empty_dom[1]);
   } else if (typestr == "FLOAT64") {
-    std::vector<double> non_empty_dom(2);
-    fi->get_non_empty_domain(fid, did, &non_empty_dom[0]);
-    return NumericVector::create(non_empty_dom[0], non_empty_dom[1]);
+        std::vector<double> non_empty_dom(2);
+        fi->get_non_empty_domain(fid, dim_name, &non_empty_dom[0]);
+        return NumericVector::create(non_empty_dom[0], non_empty_dom[1]);
   } else if (typestr == "FLOAT32") {
-    std::vector<float> non_empty_dom(2);
-    fi->get_non_empty_domain(fid, did, &non_empty_dom[0]);
-    return NumericVector::create(non_empty_dom[0], non_empty_dom[1]);
-  } else if (typestr == "DATETIME_YEAR" || typestr == "DATETIME_MONTH" ||
-             typestr == "DATETIME_WEEK" || typestr == "DATETIME_DAY" ||
-             typestr == "DATETIME_HR" || typestr == "DATETIME_MIN" ||
-             typestr == "DATETIME_SEC" || typestr == "DATETIME_MS" ||
-             typestr == "DATETIME_US" || typestr == "DATETIME_PS" ||
-             typestr == "DATETIME_FS" || typestr == "DATETIME_AS") {
-    // type_check() from exception.h gets invoked and wants an int64_t
-    std::vector<int64_t> non_empty_dom(2);
-    fi->get_non_empty_domain(fid, did, &non_empty_dom[0]);
-    return toInteger64(non_empty_dom);
-  } else if (typestr == "DATETIME_NS") {
-    std::vector<int64_t> non_empty_dom(2);
-    fi->get_non_empty_domain(fid, did, &non_empty_dom[0]);
-    return toNanotime(non_empty_dom);
-  } else {
-    Rcpp::stop("Currently unsupported tiledb domain type: '%s'",
-               typestr.c_str());
-    return NumericVector::create(NA_REAL, NA_REAL); // not reached
-  }
+        std::vector<float> non_empty_dom(2);
+        fi->get_non_empty_domain(fid, dim_name, &non_empty_dom[0]);
+        return NumericVector::create(non_empty_dom[0], non_empty_dom[1]);
+  } else if (typestr == "DATETIME_YEAR" ||
+             typestr == "DATETIME_MONTH" ||
+             typestr == "DATETIME_WEEK" ||
+             typestr == "DATETIME_DAY" ||
+             typestr == "DATETIME_HR"  ||
+             typestr == "DATETIME_MIN" ||
+             typestr == "DATETIME_SEC" ||
+             typestr == "DATETIME_MS"  ||
+             typestr == "DATETIME_US"  ||
+             typestr == "DATETIME_PS"  ||
+             typestr == "DATETIME_FS"  ||
+             typestr == "DATETIME_AS"    ) {
+        // type_check() from exception.h gets invoked and wants an int64_t
+        std::vector<int64_t> non_empty_dom(2);
+        fi->get_non_empty_domain(fid, dim_name, &non_empty_dom[0]);
+        return toInteger64(non_empty_dom);
+    } else if (typestr == "DATETIME_NS") {
+        std::vector<int64_t> non_empty_dom(2);
+        fi->get_non_empty_domain(fid, dim_name, &non_empty_dom[0]);
+        return toNanotime(non_empty_dom);
+    } else {
+        Rcpp::stop("Currently unsupported tiledb domain type: '%s'", typestr.c_str());
+        return NumericVector::create(NA_REAL, NA_REAL); // not reached
+    }
 }
 
 // [[Rcpp::export]]
-Rcpp::NumericVector libtiledb_fragment_info_get_non_empty_domain_name(
-    XPtr<tiledb::FragmentInfo> fi, int32_t fid, const std::string &dim_name,
-    const std::string &typestr) {
-  check_xptr_tag<tiledb::FragmentInfo>(fi);
-  if (typestr == "INT64") {
-    std::vector<int64_t> non_empty_dom(2);
-    fi->get_non_empty_domain(fid, dim_name, &non_empty_dom[0]);
-    return toInteger64(non_empty_dom);
-  } else if (typestr == "UINT64") {
-    std::vector<uint64_t> ned(2);
-    fi->get_non_empty_domain(fid, dim_name, &ned[0]);
-    std::vector<int64_t> v{static_cast<int64_t>(ned[0]),
-                           static_cast<int64_t>(ned[1])};
-    return toInteger64(v);
-  } else if (typestr == "INT32") {
-    std::vector<int32_t> non_empty_dom(2);
-    fi->get_non_empty_domain(fid, dim_name, &non_empty_dom[0]);
-    return NumericVector::create(non_empty_dom[0], non_empty_dom[1]);
-  } else if (typestr == "UINT32") {
-    std::vector<uint32_t> non_empty_dom(2);
-    fi->get_non_empty_domain(fid, dim_name, &non_empty_dom[0]);
-    return NumericVector::create(non_empty_dom[0], non_empty_dom[1]);
-  } else if (typestr == "INT16") {
-    std::vector<int16_t> non_empty_dom(2);
-    fi->get_non_empty_domain(fid, dim_name, &non_empty_dom[0]);
-    return NumericVector::create(non_empty_dom[0], non_empty_dom[1]);
-  } else if (typestr == "UINT16") {
-    std::vector<uint16_t> non_empty_dom(2);
-    fi->get_non_empty_domain(fid, dim_name, &non_empty_dom[0]);
-    return NumericVector::create(non_empty_dom[0], non_empty_dom[1]);
-  } else if (typestr == "INT8") {
-    std::vector<int8_t> non_empty_dom(2);
-    fi->get_non_empty_domain(fid, dim_name, &non_empty_dom[0]);
-    return NumericVector::create(non_empty_dom[0], non_empty_dom[1]);
-  } else if (typestr == "UINT8") {
-    std::vector<uint8_t> non_empty_dom(2);
-    fi->get_non_empty_domain(fid, dim_name, &non_empty_dom[0]);
-    return NumericVector::create(non_empty_dom[0], non_empty_dom[1]);
-  } else if (typestr == "FLOAT64") {
-    std::vector<double> non_empty_dom(2);
-    fi->get_non_empty_domain(fid, dim_name, &non_empty_dom[0]);
-    return NumericVector::create(non_empty_dom[0], non_empty_dom[1]);
-  } else if (typestr == "FLOAT32") {
-    std::vector<float> non_empty_dom(2);
-    fi->get_non_empty_domain(fid, dim_name, &non_empty_dom[0]);
-    return NumericVector::create(non_empty_dom[0], non_empty_dom[1]);
-  } else if (typestr == "DATETIME_YEAR" || typestr == "DATETIME_MONTH" ||
-             typestr == "DATETIME_WEEK" || typestr == "DATETIME_DAY" ||
-             typestr == "DATETIME_HR" || typestr == "DATETIME_MIN" ||
-             typestr == "DATETIME_SEC" || typestr == "DATETIME_MS" ||
-             typestr == "DATETIME_US" || typestr == "DATETIME_PS" ||
-             typestr == "DATETIME_FS" || typestr == "DATETIME_AS") {
-    // type_check() from exception.h gets invoked and wants an int64_t
-    std::vector<int64_t> non_empty_dom(2);
-    fi->get_non_empty_domain(fid, dim_name, &non_empty_dom[0]);
-    return toInteger64(non_empty_dom);
-  } else if (typestr == "DATETIME_NS") {
-    std::vector<int64_t> non_empty_dom(2);
-    fi->get_non_empty_domain(fid, dim_name, &non_empty_dom[0]);
-    return toNanotime(non_empty_dom);
-  } else {
-    Rcpp::stop("Currently unsupported tiledb domain type: '%s'",
-               typestr.c_str());
-    return NumericVector::create(NA_REAL, NA_REAL); // not reached
-  }
+Rcpp::CharacterVector
+libtiledb_fragment_info_get_non_empty_domain_var_index(XPtr<tiledb::FragmentInfo> fi,
+                                                       int32_t fid, int32_t did) {
+    check_xptr_tag<tiledb::FragmentInfo>(fi);
+    auto sp = fi->non_empty_domain_var(static_cast<uint32_t>(fid), static_cast<uint32_t>(did));
+    return CharacterVector::create(sp.first, sp.second);
 }
 
 // [[Rcpp::export]]
-Rcpp::CharacterVector libtiledb_fragment_info_get_non_empty_domain_var_index(
-    XPtr<tiledb::FragmentInfo> fi, int32_t fid, int32_t did) {
-  check_xptr_tag<tiledb::FragmentInfo>(fi);
-  auto sp = fi->non_empty_domain_var(static_cast<uint32_t>(fid),
-                                     static_cast<uint32_t>(did));
-  return CharacterVector::create(sp.first, sp.second);
-}
-
-// [[Rcpp::export]]
-Rcpp::CharacterVector libtiledb_fragment_info_get_non_empty_domain_var_name(
-    XPtr<tiledb::FragmentInfo> fi, int32_t fid, const std::string &dim_name) {
-  check_xptr_tag<tiledb::FragmentInfo>(fi);
-  auto sp = fi->non_empty_domain_var(static_cast<uint32_t>(fid), dim_name);
-  return CharacterVector::create(sp.first, sp.second);
+Rcpp::CharacterVector
+libtiledb_fragment_info_get_non_empty_domain_var_name(XPtr<tiledb::FragmentInfo> fi,
+                                                      int32_t fid,
+                                                      const std::string& dim_name) {
+    check_xptr_tag<tiledb::FragmentInfo>(fi);
+    auto sp = fi->non_empty_domain_var(static_cast<uint32_t>(fid), dim_name);
+    return CharacterVector::create(sp.first, sp.second);
 }
 
 // [[Rcpp::export]]
 double libtiledb_fragment_info_num(XPtr<tiledb::FragmentInfo> fi) {
-  check_xptr_tag<tiledb::FragmentInfo>(fi);
-  return static_cast<double>(fi->fragment_num());
+    check_xptr_tag<tiledb::FragmentInfo>(fi);
+    return static_cast<double>(fi->fragment_num());
 }
 
 // [[Rcpp::export]]
-double libtiledb_fragment_info_size(XPtr<tiledb::FragmentInfo> fi,
-                                    int32_t fid) {
-  check_xptr_tag<tiledb::FragmentInfo>(fi);
-  return static_cast<double>(fi->fragment_size(static_cast<uint32_t>(fid)));
+double libtiledb_fragment_info_size(XPtr<tiledb::FragmentInfo> fi, int32_t fid) {
+    check_xptr_tag<tiledb::FragmentInfo>(fi);
+    return static_cast<double>(fi->fragment_size(static_cast<uint32_t>(fid)));
 }
 
 // [[Rcpp::export]]
 bool libtiledb_fragment_info_dense(XPtr<tiledb::FragmentInfo> fi, int32_t fid) {
-  check_xptr_tag<tiledb::FragmentInfo>(fi);
-  return fi->dense(static_cast<uint32_t>(fid));
+    check_xptr_tag<tiledb::FragmentInfo>(fi);
+    return fi->dense(static_cast<uint32_t>(fid));
 }
 
 // [[Rcpp::export]]
-bool libtiledb_fragment_info_sparse(XPtr<tiledb::FragmentInfo> fi,
-                                    int32_t fid) {
-  check_xptr_tag<tiledb::FragmentInfo>(fi);
-  return fi->sparse(static_cast<uint32_t>(fid));
+bool libtiledb_fragment_info_sparse(XPtr<tiledb::FragmentInfo> fi, int32_t fid) {
+    check_xptr_tag<tiledb::FragmentInfo>(fi);
+    return fi->sparse(static_cast<uint32_t>(fid));
 }
 
 // [[Rcpp::export]]
 Rcpp::DatetimeVector
-libtiledb_fragment_info_timestamp_range(XPtr<tiledb::FragmentInfo> fi,
-                                        int32_t fid) {
-  check_xptr_tag<tiledb::FragmentInfo>(fi);
-  auto range = fi->timestamp_range(static_cast<uint32_t>(fid));
-  return Rcpp::DatetimeVector::create(range.first / 1000.0,
-                                      range.second / 1000.0);
+libtiledb_fragment_info_timestamp_range(XPtr<tiledb::FragmentInfo> fi, int32_t fid) {
+    check_xptr_tag<tiledb::FragmentInfo>(fi);
+    auto range = fi->timestamp_range(static_cast<uint32_t>(fid));
+    return Rcpp::DatetimeVector::create(range.first/1000.0, range.second/1000.0);
 }
 
 // [[Rcpp::export]]
-double libtiledb_fragment_info_cell_num(XPtr<tiledb::FragmentInfo> fi,
-                                        int32_t fid) {
-  check_xptr_tag<tiledb::FragmentInfo>(fi);
-  return static_cast<double>(fi->cell_num(static_cast<uint32_t>(fid)));
+double libtiledb_fragment_info_cell_num(XPtr<tiledb::FragmentInfo> fi, int32_t fid) {
+    check_xptr_tag<tiledb::FragmentInfo>(fi);
+    return static_cast<double>(fi->cell_num(static_cast<uint32_t>(fid)));
 }
 
 // [[Rcpp::export]]
-int libtiledb_fragment_info_version(XPtr<tiledb::FragmentInfo> fi,
-                                    int32_t fid) {
-  check_xptr_tag<tiledb::FragmentInfo>(fi);
-  return static_cast<int>(fi->version(static_cast<uint32_t>(fid)));
+int libtiledb_fragment_info_version(XPtr<tiledb::FragmentInfo> fi, int32_t fid) {
+    check_xptr_tag<tiledb::FragmentInfo>(fi);
+    return static_cast<int>(fi->version(static_cast<uint32_t>(fid)));
 }
 
 // [[Rcpp::export]]
-bool libtiledb_fragment_info_has_consolidated_metadata(
-    XPtr<tiledb::FragmentInfo> fi, int32_t fid) {
-  check_xptr_tag<tiledb::FragmentInfo>(fi);
-  return fi->has_consolidated_metadata(static_cast<uint32_t>(fid));
+bool libtiledb_fragment_info_has_consolidated_metadata(XPtr<tiledb::FragmentInfo> fi, int32_t fid) {
+    check_xptr_tag<tiledb::FragmentInfo>(fi);
+    return fi->has_consolidated_metadata(static_cast<uint32_t>(fid));
 }
 
 // [[Rcpp::export]]
-double libtiledb_fragment_info_unconsolidated_metadata_num(
-    XPtr<tiledb::FragmentInfo> fi) {
-  check_xptr_tag<tiledb::FragmentInfo>(fi);
-  return static_cast<double>(fi->unconsolidated_metadata_num());
+double libtiledb_fragment_info_unconsolidated_metadata_num(XPtr<tiledb::FragmentInfo> fi) {
+    check_xptr_tag<tiledb::FragmentInfo>(fi);
+    return static_cast<double>(fi->unconsolidated_metadata_num());
 }
 
 // [[Rcpp::export]]
 double libtiledb_fragment_info_to_vacuum_num(XPtr<tiledb::FragmentInfo> fi) {
-  check_xptr_tag<tiledb::FragmentInfo>(fi);
-  return static_cast<double>(fi->to_vacuum_num());
+    check_xptr_tag<tiledb::FragmentInfo>(fi);
+    return static_cast<double>(fi->to_vacuum_num());
 }
 
 // [[Rcpp::export]]
-std::string libtiledb_fragment_info_to_vacuum_uri(XPtr<tiledb::FragmentInfo> fi,
-                                                  int32_t fid) {
-  check_xptr_tag<tiledb::FragmentInfo>(fi);
-  return fi->to_vacuum_uri(static_cast<uint32_t>(fid));
+std::string libtiledb_fragment_info_to_vacuum_uri(XPtr<tiledb::FragmentInfo> fi, int32_t fid) {
+    check_xptr_tag<tiledb::FragmentInfo>(fi);
+    return fi->to_vacuum_uri(static_cast<uint32_t>(fid));
 }
 
 // [[Rcpp::export]]
 void libtiledb_fragment_info_dump(XPtr<tiledb::FragmentInfo> fi) {
-  check_xptr_tag<tiledb::FragmentInfo>(fi);
-#if TILEDB_VERSION >= TileDB_Version(2, 27, 0)
-  std::stringstream ss;
-  ss << *fi;
-  Rcpp::Rcout << ss.str();
+    check_xptr_tag<tiledb::FragmentInfo>(fi);
+#if TILEDB_VERSION >= TileDB_Version(2,27,0)
+    std::stringstream ss;
+    ss << *fi;
+    Rcpp::Rcout << ss.str();
 #else
-  fi->dump();
+    fi->dump();
 #endif
 }
 
 // [[Rcpp::export]]
 std::string libtiledb_error_message(XPtr<tiledb::Context> ctx) {
-  check_xptr_tag<tiledb::Context>(ctx);
-  tiledb::Error error(*ctx.get());
-  std::string txt(error.error_message());
-  return txt;
+    check_xptr_tag<tiledb::Context>(ctx);
+    tiledb::Error error(*ctx.get());
+    std::string txt(error.error_message());
+    return txt;
 }
+
+
 
 /**
  * Groups
  */
 // [[Rcpp::export]]
 XPtr<tiledb::Group> libtiledb_group(XPtr<tiledb::Context> ctx,
-                                    const std::string &uri,
-                                    const std::string &querytypestr) {
-  check_xptr_tag<tiledb::Context>(ctx);
-#if TILEDB_VERSION >= TileDB_Version(2, 8, 0)
-  tiledb_query_type_t querytype = _string_to_tiledb_query_type(querytypestr);
-  auto p = new tiledb::Group(*ctx.get(), uri, querytype);
-  XPtr<tiledb::Group> ptr = make_xptr<tiledb::Group>(p);
+                                    const std::string& uri,
+                                    const std::string& querytypestr) {
+    check_xptr_tag<tiledb::Context>(ctx);
+#if TILEDB_VERSION >= TileDB_Version(2,8,0)
+    tiledb_query_type_t querytype = _string_to_tiledb_query_type(querytypestr);
+    auto p = new tiledb::Group(*ctx.get(), uri, querytype);
+    XPtr<tiledb::Group> ptr = make_xptr<tiledb::Group>(p);
 #else
-  XPtr<tiledb::Group> ptr(new tiledb::Group()); // placeholder
+    XPtr<tiledb::Group> ptr(new tiledb::Group()); // placeholder
 #endif
-  return ptr;
+    return ptr;
 }
 
 // Interfaces to R are C-based so we cannot overload just on signature
 // [[Rcpp::export]]
 XPtr<tiledb::Group> libtiledb_group_with_config(XPtr<tiledb::Context> ctx,
-                                                const std::string &uri,
-                                                const std::string &querytypestr,
+                                                const std::string& uri,
+                                                const std::string& querytypestr,
                                                 XPtr<tiledb::Config> cfg) {
-  check_xptr_tag<tiledb::Context>(ctx);
-  check_xptr_tag<tiledb::Config>(cfg);
-  tiledb_query_type_t querytype = _string_to_tiledb_query_type(querytypestr);
-#if TILEDB_VERSION >= TileDB_Version(2, 15, 1)
-  auto p = new tiledb::Group(*ctx.get(), uri, querytype, *cfg.get());
-  XPtr<tiledb::Group> ptr = make_xptr<tiledb::Group>(p);
-#elif TILEDB_VERSION >= TileDB_Version(2, 8, 0)
-  Rcpp::warning("libtiledb_group_with_config should only called with TileDB "
-                "2.15.1 or later");
-  auto p = new tiledb::Group(*ctx.get(), uri, querytype); // placeholder
-  XPtr<tiledb::Group> ptr = make_xptr<tiledb::Group>(p);
+    check_xptr_tag<tiledb::Context>(ctx);
+    check_xptr_tag<tiledb::Config>(cfg);
+    tiledb_query_type_t querytype = _string_to_tiledb_query_type(querytypestr);
+#if TILEDB_VERSION >= TileDB_Version(2,15,1)
+    auto p = new tiledb::Group(*ctx.get(), uri, querytype, *cfg.get());
+    XPtr<tiledb::Group> ptr = make_xptr<tiledb::Group>(p);
+#elif TILEDB_VERSION >= TileDB_Version(2,8,0)
+    Rcpp::warning("libtiledb_group_with_config should only called with TileDB 2.15.1 or later");
+    auto p = new tiledb::Group(*ctx.get(), uri, querytype); // placeholder
+    XPtr<tiledb::Group> ptr = make_xptr<tiledb::Group>(p);
 #else
-  XPtr<tiledb::Group> ptr(new tiledb::Group()); // placeholder
+    XPtr<tiledb::Group> ptr(new tiledb::Group()); // placeholder
 #endif
-  return ptr;
+    return ptr;
 }
+
 
 // [[Rcpp::export]]
 XPtr<tiledb::Group> libtiledb_group_open(XPtr<tiledb::Group> grp,
-                                         const std::string &querytypestr) {
-  check_xptr_tag<tiledb::Group>(grp);
-#if TILEDB_VERSION >= TileDB_Version(2, 8, 0)
-  tiledb_query_type_t querytype = _string_to_tiledb_query_type(querytypestr);
-  grp->open(querytype);
+                                         const std::string& querytypestr) {
+    check_xptr_tag<tiledb::Group>(grp);
+#if TILEDB_VERSION >= TileDB_Version(2,8,0)
+    tiledb_query_type_t querytype = _string_to_tiledb_query_type(querytypestr);
+    grp->open(querytype);
 #endif
-  return grp;
+    return grp;
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::Group> libtiledb_group_set_config(XPtr<tiledb::Group> grp,
-                                               XPtr<tiledb::Config> cfg) {
-  check_xptr_tag<tiledb::Group>(grp);
-  check_xptr_tag<tiledb::Config>(cfg);
-#if TILEDB_VERSION >= TileDB_Version(2, 8, 0)
-  grp->set_config(*cfg.get());
+XPtr<tiledb::Group> libtiledb_group_set_config(XPtr<tiledb::Group> grp, XPtr<tiledb::Config> cfg) {
+    check_xptr_tag<tiledb::Group>(grp);
+    check_xptr_tag<tiledb::Config>(cfg);
+#if TILEDB_VERSION >= TileDB_Version(2,8,0)
+    grp->set_config(*cfg.get());
 #endif
-  return grp;
+    return grp;
 }
 
 // [[Rcpp::export]]
 XPtr<tiledb::Config> libtiledb_group_get_config(XPtr<tiledb::Group> grp) {
-  check_xptr_tag<tiledb::Group>(grp);
-#if TILEDB_VERSION >= TileDB_Version(2, 8, 0)
-  auto ptr = make_xptr<tiledb::Config>(new tiledb::Config(grp.get()->config()));
-  return ptr;
+    check_xptr_tag<tiledb::Group>(grp);
+#if TILEDB_VERSION >= TileDB_Version(2,8,0)
+    auto ptr = make_xptr<tiledb::Config>(new tiledb::Config(grp.get()->config()));
+    return ptr;
 #else
-  return make_xptr<tiledb::Config>(new tiledb::Config());
+    return make_xptr<tiledb::Config>(new tiledb::Config());
 #endif
 }
 
 // [[Rcpp::export]]
 XPtr<tiledb::Group> libtiledb_group_close(XPtr<tiledb::Group> grp) {
-  check_xptr_tag<tiledb::Group>(grp);
-#if TILEDB_VERSION >= TileDB_Version(2, 8, 0)
-  grp->close();
+    check_xptr_tag<tiledb::Group>(grp);
+#if TILEDB_VERSION >= TileDB_Version(2,8,0)
+    grp->close();
 #endif
-  return grp;
+    return grp;
 }
 
 // [[Rcpp::export]]
-std::string libtiledb_group_create(XPtr<tiledb::Context> ctx,
-                                   const std::string &uri) {
-  check_xptr_tag<tiledb::Context>(ctx);
-#if TILEDB_VERSION >= TileDB_Version(2, 8, 0)
-  tiledb::Group::create(*ctx.get(), uri);
+std::string libtiledb_group_create(XPtr<tiledb::Context> ctx, const std::string& uri) {
+    check_xptr_tag<tiledb::Context>(ctx);
+#if TILEDB_VERSION >= TileDB_Version(2,8,0)
+    tiledb::Group::create(*ctx.get(), uri);
 #endif
-  return uri;
+    return uri;
 }
 
 // [[Rcpp::export]]
 bool libtiledb_group_is_open(XPtr<tiledb::Group> grp) {
-  check_xptr_tag<tiledb::Group>(grp);
-#if TILEDB_VERSION >= TileDB_Version(2, 8, 0)
-  return grp->is_open();
+    check_xptr_tag<tiledb::Group>(grp);
+#if TILEDB_VERSION >= TileDB_Version(2,8,0)
+    return grp->is_open();
 #else
-  return FALSE;
+    return FALSE;
 #endif
 }
 
 // [[Rcpp::export]]
 std::string libtiledb_group_uri(XPtr<tiledb::Group> grp) {
-  check_xptr_tag<tiledb::Group>(grp);
-#if TILEDB_VERSION >= TileDB_Version(2, 8, 0)
-  return grp->uri();
+    check_xptr_tag<tiledb::Group>(grp);
+#if TILEDB_VERSION >= TileDB_Version(2,8,0)
+    return grp->uri();
 #else
-  return std::string("");
+    return std::string("");
 #endif
 }
 
 // [[Rcpp::export]]
 std::string libtiledb_group_query_type(XPtr<tiledb::Group> grp) {
-  check_xptr_tag<tiledb::Group>(grp);
-#if TILEDB_VERSION >= TileDB_Version(2, 8, 0)
-  return _tiledb_query_type_to_string(grp->query_type());
+    check_xptr_tag<tiledb::Group>(grp);
+#if TILEDB_VERSION >= TileDB_Version(2,8,0)
+    return _tiledb_query_type_to_string(grp->query_type());
 #else
-  return std::string("");
+    return std::string("");
 #endif
 }
 
 // [[Rcpp::export]]
-bool libtiledb_group_put_metadata(XPtr<tiledb::Group> grp, std::string key,
-                                  SEXP obj) {
-  check_xptr_tag<tiledb::Group>(grp);
-#if TILEDB_VERSION >= TileDB_Version(2, 8, 0)
-  // we implement a simpler interface here as the 'type' is given from
-  // the supplied SEXP, as is the extent
-  switch (TYPEOF(obj)) {
-  case VECSXP: {
-    Rcpp::stop("List objects are not supported.");
-    break; // not reached
-  }
-  case REALSXP: {
-    Rcpp::NumericVector v(obj);
-    grp->put_metadata(key, TILEDB_FLOAT64, v.size(), v.begin());
-    break;
-  }
-  case INTSXP: {
-    Rcpp::IntegerVector v(obj);
-    grp->put_metadata(key, TILEDB_INT32, v.size(), v.begin());
-    break;
-  }
-  case STRSXP: {
-    Rcpp::CharacterVector v(obj);
-    std::string s(v[0]);
-    // We use TILEDB_CHAR interchangeably with TILEDB_STRING_ASCII is this best
-    // string type?
-    grp->put_metadata(key, TILEDB_STRING_ASCII, s.length(), s.c_str());
-    break;
-  }
-  case LGLSXP: { // experimental: map R logical (ie TRUE, FALSE, NA) to int8
-    Rcpp::stop("Logical vector objects are not supported.");
-    break; // not reached
-  }
-  default: {
-    Rcpp::stop("No support (yet) for type '%s'.", Rf_type2char(TYPEOF(obj)));
-    break; // not reached
-  }
-  }
+bool libtiledb_group_put_metadata(XPtr<tiledb::Group> grp, std::string key, SEXP obj) {
+    check_xptr_tag<tiledb::Group>(grp);
+#if TILEDB_VERSION >= TileDB_Version(2,8,0)
+    // we implement a simpler interface here as the 'type' is given from
+    // the supplied SEXP, as is the extent
+    switch(TYPEOF(obj)) {
+    case VECSXP: {
+        Rcpp::stop("List objects are not supported.");
+        break;// not reached
+        }
+    case REALSXP: {
+        Rcpp::NumericVector v(obj);
+        grp->put_metadata(key, TILEDB_FLOAT64, v.size(), v.begin());
+        break;
+    }
+    case INTSXP: {
+        Rcpp::IntegerVector v(obj);
+        grp->put_metadata(key, TILEDB_INT32, v.size(), v.begin());
+        break;
+    }
+    case STRSXP: {
+        Rcpp::CharacterVector v(obj);
+        std::string s(v[0]);
+        // We use TILEDB_CHAR interchangeably with TILEDB_STRING_ASCII is this best string type?
+        grp->put_metadata(key, TILEDB_STRING_ASCII, s.length(), s.c_str());
+        break;
+    }
+    case LGLSXP: {              // experimental: map R logical (ie TRUE, FALSE, NA) to int8
+        Rcpp::stop("Logical vector objects are not supported.");
+        break;// not reached
+    }
+    default: {
+        Rcpp::stop("No support (yet) for type '%s'.", Rf_type2char(TYPEOF(obj)));
+        break; // not reached
+    }
+    }
 #endif
-  return true;
+    return true;
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::Group> libtiledb_group_delete_metadata(XPtr<tiledb::Group> grp,
-                                                    std::string key) {
-  check_xptr_tag<tiledb::Group>(grp);
-#if TILEDB_VERSION >= TileDB_Version(2, 8, 0)
-  grp->delete_metadata(key);
+XPtr<tiledb::Group> libtiledb_group_delete_metadata(XPtr<tiledb::Group> grp, std::string key) {
+    check_xptr_tag<tiledb::Group>(grp);
+#if TILEDB_VERSION >= TileDB_Version(2,8,0)
+    grp->delete_metadata(key);
 #endif
-  return grp;
+    return grp;
 }
 
 // [[Rcpp::export]]
 SEXP libtiledb_group_get_metadata(XPtr<tiledb::Group> grp, std::string key) {
-  check_xptr_tag<tiledb::Group>(grp);
-#if TILEDB_VERSION >= TileDB_Version(2, 8, 0)
-  tiledb_datatype_t v_type;
-  uint32_t v_num;
-  const void *v;
-  grp->get_metadata(key, &v_type, &v_num, &v);
-  if (v == NULL) {
-    return R_NilValue;
-  }
-  RObject vec = _metadata_to_sexp(v_type, v_num, v);
-  vec.attr("key") = Rcpp::CharacterVector::create(key);
-  return vec;
+    check_xptr_tag<tiledb::Group>(grp);
+#if TILEDB_VERSION >= TileDB_Version(2,8,0)
+    tiledb_datatype_t v_type;
+    uint32_t v_num;
+    const void* v;
+    grp->get_metadata(key, &v_type, &v_num, &v);
+    if (v == NULL) {
+        return R_NilValue;
+    }
+    RObject vec = _metadata_to_sexp(v_type, v_num, v);
+    vec.attr("key") = Rcpp::CharacterVector::create(key);
+    return vec;
 #else
-  return R_NilValue;
+    return R_NilValue;
 #endif
 }
 
 // [[Rcpp::export]]
 bool libtiledb_group_has_metadata(XPtr<tiledb::Group> grp, std::string key) {
-  check_xptr_tag<tiledb::Group>(grp);
-#if TILEDB_VERSION >= TileDB_Version(2, 8, 0)
-  tiledb_datatype_t value_type; // set by C++ API on return, not returned to R
-  return grp->has_metadata(key, &value_type);
+    check_xptr_tag<tiledb::Group>(grp);
+#if TILEDB_VERSION >= TileDB_Version(2,8,0)
+    tiledb_datatype_t value_type; // set by C++ API on return, not returned to R
+    return grp->has_metadata(key, &value_type);
 #else
-  return false;
+    return false;
 #endif
 }
 
 // [[Rcpp::export]]
 double libtiledb_group_metadata_num(XPtr<tiledb::Group> grp) {
-  check_xptr_tag<tiledb::Group>(grp);
-#if TILEDB_VERSION >= TileDB_Version(2, 8, 0)
-  return grp->metadata_num();
+    check_xptr_tag<tiledb::Group>(grp);
+#if TILEDB_VERSION >= TileDB_Version(2,8,0)
+    return grp->metadata_num();
 #else
-  return 0;
+    return 0;
 #endif
 }
 
 // [[Rcpp::export]]
 SEXP libtiledb_group_get_metadata_from_index(XPtr<tiledb::Group> grp, int idx) {
-  check_xptr_tag<tiledb::Group>(grp);
-#if TILEDB_VERSION >= TileDB_Version(2, 8, 0)
-  std::string key;
-  tiledb_datatype_t v_type;
-  uint32_t v_num;
-  const void *v;
-  grp->get_metadata_from_index(static_cast<uint64_t>(idx), &key, &v_type,
-                               &v_num, &v);
-  if (v == NULL) {
-    return R_NilValue;
-  }
-  RObject vec = _metadata_to_sexp(v_type, v_num, v);
-  vec.attr("key") = Rcpp::CharacterVector::create(key);
-  return vec;
+    check_xptr_tag<tiledb::Group>(grp);
+#if TILEDB_VERSION >= TileDB_Version(2,8,0)
+    std::string key;
+    tiledb_datatype_t v_type;
+    uint32_t v_num;
+    const void* v;
+    grp->get_metadata_from_index(static_cast<uint64_t>(idx), &key, &v_type, &v_num, &v);
+    if (v == NULL) {
+        return R_NilValue;
+    }
+    RObject vec = _metadata_to_sexp(v_type, v_num, v);
+    vec.attr("key") = Rcpp::CharacterVector::create(key);
+    return vec;
 #else
-  return R_NilValue;
+    return R_NilValue;
 #endif
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::Group>
-libtiledb_group_add_member(XPtr<tiledb::Group> grp, std::string uri,
-                           bool relative,
-                           Nullable<Rcpp::String> optional_name = R_NilValue) {
-  check_xptr_tag<tiledb::Group>(grp);
-#if TILEDB_VERSION >= TileDB_Version(2, 8, 0)
-  if (optional_name.isNotNull()) {
-    Rcpp::String string_name(optional_name);
-    std::string name(string_name);
-    grp->add_member(uri, relative, name);
-  } else {
-    grp->add_member(uri, relative);
-  }
+XPtr<tiledb::Group> libtiledb_group_add_member(XPtr<tiledb::Group> grp,
+                                               std::string uri, bool relative,
+                                               Nullable<Rcpp::String> optional_name = R_NilValue) {
+    check_xptr_tag<tiledb::Group>(grp);
+#if TILEDB_VERSION >= TileDB_Version(2,8,0)
+    if (optional_name.isNotNull()) {
+        Rcpp::String string_name(optional_name);
+        std::string name(string_name);
+        grp->add_member(uri, relative, name);
+    } else {
+        grp->add_member(uri, relative);
+    }
 #endif
-  return grp;
+    return grp;
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::Group> libtiledb_group_remove_member(XPtr<tiledb::Group> grp,
-                                                  std::string uri) {
-  check_xptr_tag<tiledb::Group>(grp);
-#if TILEDB_VERSION >= TileDB_Version(2, 8, 0)
-  grp->remove_member(uri);
+XPtr<tiledb::Group> libtiledb_group_remove_member(XPtr<tiledb::Group> grp, std::string uri) {
+    check_xptr_tag<tiledb::Group>(grp);
+#if TILEDB_VERSION >= TileDB_Version(2,8,0)
+    grp->remove_member(uri);
 #endif
-  return grp;
+    return grp;
 }
 
 // [[Rcpp::export]]
 double libtiledb_group_member_count(XPtr<tiledb::Group> grp) {
-  check_xptr_tag<tiledb::Group>(grp);
-#if TILEDB_VERSION >= TileDB_Version(2, 8, 0)
-  return grp->member_count();
+    check_xptr_tag<tiledb::Group>(grp);
+#if TILEDB_VERSION >= TileDB_Version(2,8,0)
+    return grp->member_count();
 #else
-  return 0;
+    return 0;
 #endif
 }
 
 // [[Rcpp::export]]
 CharacterVector libtiledb_group_member(XPtr<tiledb::Group> grp, int idx) {
-  check_xptr_tag<tiledb::Group>(grp);
-#if TILEDB_VERSION >= TileDB_Version(2, 8, 0)
-  tiledb::Object obj = grp->member(idx);
-  CharacterVector v = CharacterVector::create(
-      _object_type_to_string(obj.type()), obj.uri(), obj.name().value_or(""));
+    check_xptr_tag<tiledb::Group>(grp);
+#if TILEDB_VERSION >= TileDB_Version(2,8,0)
+    tiledb::Object obj = grp->member(idx);
+    CharacterVector v = CharacterVector::create(_object_type_to_string(obj.type()), obj.uri(), obj.name().value_or(""));
 #else
-  CharacterVector v = CharacterVector::create("", "", "");
+    CharacterVector v = CharacterVector::create("", "", "");
 #endif
-  return v;
+    return v;
 }
 
 // [[Rcpp::export]]
 std::string libtiledb_group_dump(XPtr<tiledb::Group> grp, bool recursive) {
-  check_xptr_tag<tiledb::Group>(grp);
-#if TILEDB_VERSION >= TileDB_Version(2, 8, 0)
-  return grp->dump(recursive);
+    check_xptr_tag<tiledb::Group>(grp);
+#if TILEDB_VERSION >= TileDB_Version(2,8,0)
+    return grp->dump(recursive);
 #else
-  return std::string("");
+    return std::string("");
 #endif
 }
 
 // [[Rcpp::export]]
-bool libtiledb_group_is_relative(XPtr<tiledb::Group> grp,
-                                 const std::string &name) {
-  check_xptr_tag<tiledb::Group>(grp);
-#if TILEDB_VERSION >= TileDB_Version(2, 12, 0)
-  return grp->is_relative(name);
+bool libtiledb_group_is_relative(XPtr<tiledb::Group> grp, const std::string &name) {
+    check_xptr_tag<tiledb::Group>(grp);
+#if TILEDB_VERSION >= TileDB_Version(2,12,0)
+    return grp->is_relative(name);
 #else
-  return false;
+    return false;
 #endif
 }
 
 // See comments in group.h: the group has to be opened in MODIFY_EXCLUSIVE mode
 // The function throws (creating an R error) is that condition is not met
 // [[Rcpp::export]]
-void libtiledb_group_delete(XPtr<tiledb::Group> grp, const std::string &uri,
+void libtiledb_group_delete(XPtr<tiledb::Group> grp,
+                            const std::string& uri,
                             const bool recursive = false) {
-  check_xptr_tag<tiledb::Group>(grp);
-#if TILEDB_VERSION >= TileDB_Version(2, 14, 0)
-  grp->delete_group(uri, recursive);
+    check_xptr_tag<tiledb::Group>(grp);
+#if TILEDB_VERSION >= TileDB_Version(2,14,0)
+    grp->delete_group(uri, recursive);
 #else
-  Rcpp::message(Rcpp::wrap(
-      "This function is only available with TileDB Core 2.14.0 or later"));
+    Rcpp::message(Rcpp::wrap("This function is only available with TileDB Core 2.14.0 or later"));
 #endif
 }
+
+
 
 /**
  * Filestore (via tiledb_experimental.h)
@@ -5607,23 +5282,23 @@ void libtiledb_group_delete(XPtr<tiledb::Group> grp, const std::string &uri,
 
 // Creates array schema based on URL, or default schema if no URI provided
 // [[Rcpp::export]]
-XPtr<tiledb::ArraySchema>
-libtiledb_filestore_schema_create(XPtr<tiledb::Context> ctx, std::string uri) {
-#if TILEDB_VERSION >= TileDB_Version(2, 9, 0)
-  tiledb_ctx_t *ctx_ptr = ctx->ptr().get();
-  tiledb_array_schema_t *schema_type_ptr;
-  if (tiledb_filestore_schema_create(ctx_ptr,
-                                     (uri == "" ? nullptr : uri.c_str()),
-                                     &schema_type_ptr) == TILEDB_ERR) {
-    Rcpp::stop("Error creating array schema from defaults");
-  }
-  auto schptr = new tiledb::ArraySchema(*ctx.get(), schema_type_ptr);
-  auto schema = make_xptr<tiledb::ArraySchema>(schptr);
-  return schema;
+XPtr<tiledb::ArraySchema> libtiledb_filestore_schema_create(XPtr<tiledb::Context> ctx,
+                                                            std::string uri) {
+#if TILEDB_VERSION >= TileDB_Version(2,9,0)
+    tiledb_ctx_t* ctx_ptr = ctx->ptr().get();
+    tiledb_array_schema_t* schema_type_ptr;
+    if (tiledb_filestore_schema_create(ctx_ptr,
+                                       (uri == "" ? nullptr : uri.c_str()),
+                                       &schema_type_ptr) == TILEDB_ERR) {
+        Rcpp::stop("Error creating array schema from defaults");
+    }
+    auto schptr = new tiledb::ArraySchema(*ctx.get(), schema_type_ptr);
+    auto schema = make_xptr<tiledb::ArraySchema>(schptr);
+    return schema;
 #else
-  auto schptr = new tiledb::ArraySchema(*ctx.get(), TILEDB_SPARSE);
-  auto schema = make_xptr<tiledb::ArraySchema>(schptr);
-  return schema;
+    auto schptr = new tiledb::ArraySchema(*ctx.get(), TILEDB_SPARSE);
+    auto schema = make_xptr<tiledb::ArraySchema>(schptr);
+    return schema;
 #endif
 }
 
@@ -5632,18 +5307,18 @@ libtiledb_filestore_schema_create(XPtr<tiledb::Context> ctx, std::string uri) {
 bool libtiledb_filestore_uri_import(XPtr<tiledb::Context> ctx,
                                     std::string filestore_uri,
                                     std::string file_uri) {
-#if TILEDB_VERSION >= TileDB_Version(2, 9, 0)
-  tiledb_ctx_t *ctx_ptr = ctx->ptr().get();
-  if (tiledb_filestore_uri_import(ctx_ptr, filestore_uri.c_str(),
-                                  file_uri.c_str(),
-                                  TILEDB_MIME_AUTODETECT) == TILEDB_ERR) {
-    Rcpp::stop("Error importing file into filestore");
-    return false; // not reached
-  }
-  return true;
+#if TILEDB_VERSION >= TileDB_Version(2,9,0)
+    tiledb_ctx_t* ctx_ptr = ctx->ptr().get();
+    if (tiledb_filestore_uri_import(ctx_ptr, filestore_uri.c_str(),
+                                    file_uri.c_str(), TILEDB_MIME_AUTODETECT) == TILEDB_ERR) {
+        Rcpp::stop("Error importing file into filestore");
+        return false;           // not reached
+    }
+    return true;
 #else
-  return false;
+    return false;
 #endif
+
 }
 
 // Export from a TileDB filestore array into a file uri
@@ -5651,16 +5326,15 @@ bool libtiledb_filestore_uri_import(XPtr<tiledb::Context> ctx,
 bool libtiledb_filestore_uri_export(XPtr<tiledb::Context> ctx,
                                     std::string file_uri,
                                     std::string filestore_uri) {
-#if TILEDB_VERSION >= TileDB_Version(2, 9, 0)
-  tiledb_ctx_t *ctx_ptr = ctx->ptr().get();
-  if (tiledb_filestore_uri_export(ctx_ptr, file_uri.c_str(),
-                                  filestore_uri.c_str()) == TILEDB_ERR) {
-    Rcpp::stop("Error exporting file from filestore");
-    return false; // not reached
-  }
-  return true;
+#if TILEDB_VERSION >= TileDB_Version(2,9,0)
+    tiledb_ctx_t* ctx_ptr = ctx->ptr().get();
+    if (tiledb_filestore_uri_export(ctx_ptr, file_uri.c_str(), filestore_uri.c_str())  == TILEDB_ERR) {
+        Rcpp::stop("Error exporting file from filestore");
+        return false;           // not reached
+    }
+    return true;
 #else
-  return false;
+    return false;
 #endif
 }
 
@@ -5669,17 +5343,17 @@ bool libtiledb_filestore_uri_export(XPtr<tiledb::Context> ctx,
 bool libtiledb_filestore_buffer_import(XPtr<tiledb::Context> ctx,
                                        std::string filestore_uri,
                                        std::string buf, size_t size) {
-#if TILEDB_VERSION >= TileDB_Version(2, 9, 0)
-  tiledb_ctx_t *ctx_ptr = ctx->ptr().get();
-  if (tiledb_filestore_buffer_import(ctx_ptr, filestore_uri.c_str(),
-                                     static_cast<void *>(buf.data()), size,
-                                     TILEDB_MIME_AUTODETECT) == TILEDB_ERR) {
-    Rcpp::stop("Error importing file into filestore");
-    return false; // not reached
-  }
-  return true;
+#if TILEDB_VERSION >= TileDB_Version(2,9,0)
+    tiledb_ctx_t* ctx_ptr = ctx->ptr().get();
+    if (tiledb_filestore_buffer_import(ctx_ptr, filestore_uri.c_str(),
+                                       static_cast<void*>(buf.data()), size,
+                                       TILEDB_MIME_AUTODETECT) == TILEDB_ERR) {
+        Rcpp::stop("Error importing file into filestore");
+        return false;           // not reached
+    }
+    return true;
 #else
-  return false;
+    return false;
 #endif
 }
 
@@ -5688,290 +5362,281 @@ bool libtiledb_filestore_buffer_import(XPtr<tiledb::Context> ctx,
 std::string libtiledb_filestore_buffer_export(XPtr<tiledb::Context> ctx,
                                               std::string filestore_uri,
                                               size_t offset, size_t size) {
-  std::string buf("");
-#if TILEDB_VERSION >= TileDB_Version(2, 9, 0)
-  tiledb_ctx_t *ctx_ptr = ctx->ptr().get();
-  buf.resize(size);
-  if (tiledb_filestore_buffer_export(ctx_ptr, filestore_uri.c_str(), offset,
-                                     static_cast<void *>(buf.data()),
-                                     size) == TILEDB_ERR) {
-    Rcpp::stop("Error exporting file from filestore");
-  }
+    std::string buf("");
+#if TILEDB_VERSION >= TileDB_Version(2,9,0)
+    tiledb_ctx_t* ctx_ptr = ctx->ptr().get();
+    buf.resize(size);
+    if (tiledb_filestore_buffer_export(ctx_ptr, filestore_uri.c_str(), offset,
+                                       static_cast<void*>(buf.data()), size) == TILEDB_ERR) {
+        Rcpp::stop("Error exporting file from filestore");
+    }
 #endif
-  return buf;
+    return buf;
+
 }
 
 // Get size of uncompressed TileDB filestore array
 // [[Rcpp::export]]
-size_t libtiledb_filestore_size(XPtr<tiledb::Context> ctx,
-                                std::string filestore_uri) {
-  size_t sz = 0;
-#if TILEDB_VERSION >= TileDB_Version(2, 9, 0)
-  tiledb_ctx_t *ctx_ptr = ctx->ptr().get();
-  if (tiledb_filestore_size(ctx_ptr, filestore_uri.c_str(), &sz) ==
-      TILEDB_ERR) {
-    Rcpp::stop("Error accessize filestore uri size");
-  }
+size_t libtiledb_filestore_size(XPtr<tiledb::Context> ctx, std::string filestore_uri) {
+    size_t sz = 0;
+#if TILEDB_VERSION >= TileDB_Version(2,9,0)
+    tiledb_ctx_t* ctx_ptr = ctx->ptr().get();
+    if (tiledb_filestore_size(ctx_ptr, filestore_uri.c_str(), &sz) == TILEDB_ERR) {
+        Rcpp::stop("Error accessize filestore uri size");
+    }
 #endif
-  return sz;
+    return sz;
 }
 
 // Get MIME type of TileDB filestore as string
 // [[Rcpp::export]]
 std::string libtiledb_mime_type_to_str(int32_t mime_type) {
-#if TILEDB_VERSION >= TileDB_Version(2, 9, 0)
-  const char *ptr;
-  if (tiledb_mime_type_to_str(static_cast<tiledb_mime_type_t>(mime_type),
-                              &ptr) == TILEDB_ERR) {
-    Rcpp::stop("Error converting mime type to string");
-  }
-  return std::string(ptr);
+#if TILEDB_VERSION >= TileDB_Version(2,9,0)
+    const char* ptr;
+    if (tiledb_mime_type_to_str(static_cast<tiledb_mime_type_t>(mime_type),
+                                &ptr) == TILEDB_ERR) {
+        Rcpp::stop("Error converting mime type to string");
+    }
+    return std::string(ptr);
 #else
-  return std::string("");
+    return std::string("");
 #endif
 }
 
 // Create MIME type of TileDB filestore from string
 // [[Rcpp::export]]
 int32_t libtiledb_mime_type_from_str(std::string mime_type) {
-#if TILEDB_VERSION >= TileDB_Version(2, 9, 0)
-  tiledb_mime_type_t mt;
-  if (tiledb_mime_type_from_str(mime_type.c_str(), &mt) == TILEDB_ERR) {
-    Rcpp::stop("Error converting mime type from string");
-  }
-  return static_cast<int32_t>(mt);
+#if TILEDB_VERSION >= TileDB_Version(2,9,0)
+    tiledb_mime_type_t mt;
+    if (tiledb_mime_type_from_str(mime_type.c_str(), &mt) == TILEDB_ERR) {
+        Rcpp::stop("Error converting mime type from string");
+    }
+    return static_cast<int32_t>(mt);
 #else
-  return -1;
+    return -1;
 #endif
 }
+
 
 /**
  * NDRectangle (2.25.0 or later)
  */
 
 // [[Rcpp::export]]
-XPtr<tiledb::NDRectangle>
-libtiledb_ndrectangle_create(XPtr<tiledb::Context> ctx,
-                             XPtr<tiledb::Domain> dom) {
-  check_xptr_tag<tiledb::Context>(ctx);
-  check_xptr_tag<tiledb::Domain>(dom);
-#if TILEDB_VERSION >= TileDB_Version(2, 25, 0)
-  auto ndr = new tiledb::NDRectangle(*ctx.get(), *dom.get());
+XPtr<tiledb::NDRectangle> libtiledb_ndrectangle_create(XPtr<tiledb::Context> ctx,
+                                                       XPtr<tiledb::Domain> dom) {
+    check_xptr_tag<tiledb::Context>(ctx);
+    check_xptr_tag<tiledb::Domain>(dom);
+#if TILEDB_VERSION >= TileDB_Version(2,25,0)
+    auto ndr = new tiledb::NDRectangle(*ctx.get(), *dom.get());
 #else
-  auto ndr = new tiledb::NDRectangle();
+    auto ndr = new tiledb::NDRectangle();
 #endif
-  auto ptr = make_xptr<tiledb::NDRectangle>(ndr);
-  return ptr;
+    auto ptr = make_xptr<tiledb::NDRectangle>(ndr);
+    return ptr;
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::NDRectangle>
-libtiledb_ndrectangle_set_range(XPtr<tiledb::NDRectangle> ndr,
-                                std::string &datatype, std::string &dimname,
-                                SEXP start, SEXP end) {
-  check_xptr_tag<tiledb::NDRectangle>(ndr);
-#if TILEDB_VERSION >= TileDB_Version(2, 25, 0)
-  auto dtype = _string_to_tiledb_datatype(datatype);
-  if (dtype == TILEDB_CHAR || // branch for 'string'
-      dtype == TILEDB_STRING_ASCII || dtype == TILEDB_STRING_UTF8) {
-    ndr->set_range(dimname, Rcpp::as<std::string>(start),
-                   Rcpp::as<std::string>(end));
-  } else if (dtype == TILEDB_INT64) {
-    ndr->set_range<int64_t>(dimname, Rcpp::fromInteger64(start),
-                            Rcpp::fromInteger64(end));
-  } else if (dtype == TILEDB_UINT64) {
-    ndr->set_range<int64_t>(
-        dimname,
-        static_cast<uint64_t>(Rcpp::fromInteger64(Rcpp::as<double>(start))),
-        static_cast<uint64_t>(Rcpp::fromInteger64(Rcpp::as<double>(end))));
-  } else if (dtype == TILEDB_INT32) {
-    ndr->set_range<int32_t>(dimname, Rcpp::as<int32_t>(start),
-                            Rcpp::as<int32_t>(end));
-  } else if (dtype == TILEDB_UINT32) {
-    ndr->set_range<uint32_t>(dimname,
-                             static_cast<uint32_t>(Rcpp::as<int32_t>(start)),
-                             static_cast<uint32_t>(Rcpp::as<int32_t>(end)));
-  } else if (dtype == TILEDB_INT16) {
-    ndr->set_range<int16_t>(dimname,
-                            static_cast<int16_t>(Rcpp::as<int32_t>(start)),
-                            static_cast<int16_t>(Rcpp::as<int32_t>(end)));
-  } else if (dtype == TILEDB_UINT16) {
-    ndr->set_range<uint16_t>(dimname,
-                             static_cast<uint16_t>(Rcpp::as<int32_t>(start)),
-                             static_cast<uint16_t>(Rcpp::as<int32_t>(end)));
-  } else if (dtype == TILEDB_INT8) {
-    ndr->set_range<int8_t>(dimname,
-                           static_cast<int8_t>(Rcpp::as<int32_t>(start)),
-                           static_cast<int8_t>(Rcpp::as<int32_t>(end)));
-  } else if (dtype == TILEDB_UINT8) {
-    ndr->set_range<uint8_t>(dimname,
-                            static_cast<uint8_t>(Rcpp::as<int32_t>(start)),
-                            static_cast<uint8_t>(Rcpp::as<int32_t>(end)));
-  } else if (dtype == TILEDB_FLOAT64) {
-    ndr->set_range<double>(dimname, Rcpp::as<double>(start),
-                           Rcpp::as<double>(end));
-  } else if (dtype == TILEDB_FLOAT32) {
-    ndr->set_range<float>(dimname, static_cast<float>(Rcpp::as<double>(start)),
-                          static_cast<float>(Rcpp::as<double>(end)));
-  } else {
-    Rcpp::stop(
-        "Domain datatype '%s' of dimname '%s' is not currently supported",
-        _tiledb_datatype_to_string(dtype), dimname);
-  }
+XPtr<tiledb::NDRectangle> libtiledb_ndrectangle_set_range(XPtr<tiledb::NDRectangle> ndr,
+                                                          std::string& datatype,
+                                                          std::string& dimname,
+                                                          SEXP start, SEXP end) {
+    check_xptr_tag<tiledb::NDRectangle>(ndr);
+#if TILEDB_VERSION >= TileDB_Version(2,25,0)
+    auto dtype = _string_to_tiledb_datatype(datatype);
+    if (dtype == TILEDB_CHAR ||         // branch for 'string'
+        dtype == TILEDB_STRING_ASCII ||
+        dtype == TILEDB_STRING_UTF8) {
+        ndr->set_range(dimname, Rcpp::as<std::string>(start), Rcpp::as<std::string>(end));
+    } else if (dtype == TILEDB_INT64) {
+        ndr->set_range<int64_t>(dimname, Rcpp::fromInteger64(start), Rcpp::fromInteger64(end));
+    } else if (dtype == TILEDB_UINT64) {
+        ndr->set_range<int64_t>(dimname,
+                                static_cast<uint64_t>(Rcpp::fromInteger64(Rcpp::as<double>(start))),
+                                static_cast<uint64_t>(Rcpp::fromInteger64(Rcpp::as<double>(end))));
+    } else if (dtype == TILEDB_INT32) {
+        ndr->set_range<int32_t>(dimname, Rcpp::as<int32_t>(start), Rcpp::as<int32_t>(end));
+    } else if (dtype == TILEDB_UINT32) {
+        ndr->set_range<uint32_t>(dimname,
+                                 static_cast<uint32_t>(Rcpp::as<int32_t>(start)),
+                                 static_cast<uint32_t>(Rcpp::as<int32_t>(end)));
+    } else if (dtype == TILEDB_INT16) {
+        ndr->set_range<int16_t>(dimname,
+                                static_cast<int16_t>(Rcpp::as<int32_t>(start)),
+                                static_cast<int16_t>(Rcpp::as<int32_t>(end)));
+    } else if (dtype == TILEDB_UINT16) {
+        ndr->set_range<uint16_t>(dimname,
+                                 static_cast<uint16_t>(Rcpp::as<int32_t>(start)),
+                                 static_cast<uint16_t>(Rcpp::as<int32_t>(end)));
+    } else if (dtype == TILEDB_INT8) {
+        ndr->set_range<int8_t>(dimname,
+                               static_cast<int8_t>(Rcpp::as<int32_t>(start)),
+                               static_cast<int8_t>(Rcpp::as<int32_t>(end)));
+    } else if (dtype == TILEDB_UINT8) {
+        ndr->set_range<uint8_t>(dimname,
+                                static_cast<uint8_t>(Rcpp::as<int32_t>(start)),
+                                static_cast<uint8_t>(Rcpp::as<int32_t>(end)));
+    } else if (dtype == TILEDB_FLOAT64) {
+        ndr->set_range<double>(dimname, Rcpp::as<double>(start), Rcpp::as<double>(end));
+    } else if (dtype == TILEDB_FLOAT32) {
+        ndr->set_range<float>(dimname,
+                              static_cast<float>(Rcpp::as<double>(start)),
+                              static_cast<float>(Rcpp::as<double>(end)));
+    } else {
+        Rcpp::stop("Domain datatype '%s' of dimname '%s' is not currently supported",
+                   _tiledb_datatype_to_string(dtype), dimname);
+    }
 #endif
-  return ndr;
+    return ndr;
 }
 
 // NB maybe not exporting as we need a type which we get from current domain
 // [[Rcpp::export]]
 SEXP libtiledb_ndrectangle_get_range(XPtr<tiledb::NDRectangle> ndr,
-                                     std::string &dimname, std::string &dtype) {
-  check_xptr_tag<tiledb::NDRectangle>(ndr);
-#if TILEDB_VERSION >= TileDB_Version(2, 25, 0)
-  if (dtype == "CHAR" || dtype == "ASCII" || dtype == "UTF8") {
-    auto range = ndr->range<std::string>(dimname);
-    return Rcpp::CharacterVector::create(range[0], range[1]);
-  } else if (dtype == "INT64") {
-    auto range = ndr->range<int64_t>(dimname);
-    return Rcpp::toInteger64(std::vector<int64_t>{range[0], range[1]});
-  } else if (dtype == "UINT64") {
-    auto range = ndr->range<uint64_t>(dimname);
-    return Rcpp::toInteger64(std::vector<int64_t>{
-        static_cast<int64_t>(range[0]), static_cast<int64_t>(range[1])});
-  } else if (dtype == "INT32") {
-    auto range = ndr->range<int32_t>(dimname);
-    return Rcpp::IntegerVector::create(range[0], range[1]);
-  } else if (dtype == "UINT32") {
-    auto range = ndr->range<uint32_t>(dimname);
-    return Rcpp::IntegerVector::create(static_cast<int32_t>(range[0]),
-                                       static_cast<int32_t>(range[1]));
-  } else if (dtype == "INT16") {
-    auto range = ndr->range<int16_t>(dimname);
-    return Rcpp::IntegerVector::create(static_cast<int32_t>(range[0]),
-                                       static_cast<int32_t>(range[1]));
-  } else if (dtype == "UINT16") {
-    auto range = ndr->range<uint16_t>(dimname);
-    return Rcpp::IntegerVector::create(static_cast<int32_t>(range[0]),
-                                       static_cast<int32_t>(range[1]));
-  } else if (dtype == "INT8") {
-    auto range = ndr->range<int8_t>(dimname);
-    return Rcpp::IntegerVector::create(static_cast<int32_t>(range[0]),
-                                       static_cast<int32_t>(range[1]));
-  } else if (dtype == "UINT8") {
-    auto range = ndr->range<uint8_t>(dimname);
-    return Rcpp::IntegerVector::create(static_cast<int32_t>(range[0]),
-                                       static_cast<int32_t>(range[1]));
-  } else if (dtype == "FLOAT64") {
-    auto range = ndr->range<double>(dimname);
-    return Rcpp::NumericVector::create(range[0], range[1]);
-  } else if (dtype == "FLOAT32") {
-    auto range = ndr->range<float>(dimname);
-    return Rcpp::NumericVector::create(static_cast<double>(range[0]),
-                                       static_cast<double>(range[1]));
-  } else {
-    Rcpp::stop(
-        "Domain datatype '%s' of dimname '%s' is not currently supported",
-        dtype, dimname);
-  }
+                                     std::string& dimname, std::string& dtype) {
+    check_xptr_tag<tiledb::NDRectangle>(ndr);
+#if TILEDB_VERSION >= TileDB_Version(2,25,0)
+    if (dtype == "CHAR" || dtype == "ASCII" || dtype == "UTF8") {
+        auto range = ndr->range<std::string>(dimname);
+        return Rcpp::CharacterVector::create(range[0], range[1]);
+    } else if (dtype == "INT64") {
+        auto range = ndr->range<int64_t>(dimname);
+        return Rcpp::toInteger64( std::vector<int64_t>{range[0], range[1] } );
+    } else if (dtype == "UINT64") {
+        auto range = ndr->range<uint64_t>(dimname);
+        return Rcpp::toInteger64( std::vector<int64_t>{ static_cast<int64_t>(range[0]),
+                                                        static_cast<int64_t>(range[1]) } );
+    } else if (dtype == "INT32") {
+        auto range = ndr->range<int32_t>(dimname);
+        return Rcpp::IntegerVector::create(range[0], range[1]);
+    } else if (dtype == "UINT32") {
+        auto range = ndr->range<uint32_t>(dimname);
+        return Rcpp::IntegerVector::create( static_cast<int32_t>(range[0]),
+                                            static_cast<int32_t>(range[1]) );
+    } else if (dtype == "INT16") {
+        auto range = ndr->range<int16_t>(dimname);
+        return Rcpp::IntegerVector::create( static_cast<int32_t>(range[0]),
+                                            static_cast<int32_t>(range[1]) );
+    } else if (dtype == "UINT16") {
+        auto range = ndr->range<uint16_t>(dimname);
+        return Rcpp::IntegerVector::create( static_cast<int32_t>(range[0]),
+                                            static_cast<int32_t>(range[1]) );
+    } else if (dtype == "INT8") {
+        auto range = ndr->range<int8_t>(dimname);
+        return Rcpp::IntegerVector::create( static_cast<int32_t>(range[0]),
+                                            static_cast<int32_t>(range[1]) );
+    } else if (dtype == "UINT8") {
+        auto range = ndr->range<uint8_t>(dimname);
+        return Rcpp::IntegerVector::create( static_cast<int32_t>(range[0]),
+                                            static_cast<int32_t>(range[1]) );
+    } else if (dtype == "FLOAT64") {
+        auto range = ndr->range<double>(dimname);
+        return Rcpp::NumericVector::create(range[0], range[1]);
+    } else if (dtype == "FLOAT32") {
+        auto range = ndr->range<float>(dimname);
+        return Rcpp::NumericVector::create( static_cast<double>(range[0]),
+                                            static_cast<double>(range[1]));
+    } else {
+        Rcpp::stop("Domain datatype '%s' of dimname '%s' is not currently supported", dtype, dimname);
+    }
 #endif
-  return R_NilValue; // not reached
+    return R_NilValue;          // not reached
 }
 
 // [[Rcpp::export]]
 int libtiledb_ndrectangle_dim_num(XPtr<tiledb::NDRectangle> ndr) {
-  check_xptr_tag<tiledb::NDRectangle>(ndr);
-#if TILEDB_VERSION >= TileDB_Version(2, 26, 0)
-  return static_cast<int32_t>(ndr->dim_num());
+    check_xptr_tag<tiledb::NDRectangle>(ndr);
+#if TILEDB_VERSION >= TileDB_Version(2,26,0)
+    return static_cast<int32_t>(ndr->dim_num());
 #else
-  return R_NaInt;
+    return R_NaInt;
 #endif
 }
 
 // [[Rcpp::export]]
-std::string libtiledb_ndrectangle_datatype(XPtr<tiledb::NDRectangle> ndr,
-                                           const std::string &name) {
-  check_xptr_tag<tiledb::NDRectangle>(ndr);
-#if TILEDB_VERSION >= TileDB_Version(2, 26, 0)
-  return _tiledb_datatype_to_string(ndr->range_dtype(name));
+std::string libtiledb_ndrectangle_datatype(XPtr<tiledb::NDRectangle> ndr, const std::string& name) {
+    check_xptr_tag<tiledb::NDRectangle>(ndr);
+#if TILEDB_VERSION >= TileDB_Version(2,26,0)
+    return _tiledb_datatype_to_string(ndr->range_dtype(name));
 #else
-  Rcpp::stop("This function requires TileDB 2.26.0 or later.");
-  return std::string{Rcpp::as<std::string>(R_NaString)}; // not reached
+    Rcpp::stop("This function requires TileDB 2.26.0 or later.");
+    return std::string{Rcpp::as<std::string>(R_NaString)}; // not reached
 #endif
 }
 
 // [[Rcpp::export]]
-std::string libtiledb_ndrectangle_datatype_by_ind(XPtr<tiledb::NDRectangle> ndr,
-                                                  int dim) {
-  check_xptr_tag<tiledb::NDRectangle>(ndr);
-#if TILEDB_VERSION >= TileDB_Version(2, 26, 0)
-  return _tiledb_datatype_to_string(
-      ndr->range_dtype(static_cast<uint32_t>(dim)));
+std::string libtiledb_ndrectangle_datatype_by_ind(XPtr<tiledb::NDRectangle> ndr, int dim) {
+    check_xptr_tag<tiledb::NDRectangle>(ndr);
+#if TILEDB_VERSION >= TileDB_Version(2,26,0)
+    return _tiledb_datatype_to_string(ndr->range_dtype(static_cast<uint32_t>(dim)));
 #else
-  Rcpp::stop("This function requires TileDB 2.26.0 or later.");
-  return std::string{Rcpp::as<std::string>(R_NaString)}; // not reached
+    Rcpp::stop("This function requires TileDB 2.26.0 or later.");
+    return std::string{Rcpp::as<std::string>(R_NaString)}; // not reached
 #endif
 }
+
+
+
+
 
 /**
  * Current Domain (2.25.0 or later)
  */
 
 // [[Rcpp::export]]
-XPtr<tiledb::CurrentDomain>
-libtiledb_current_domain_create(XPtr<tiledb::Context> ctx) {
-  check_xptr_tag<tiledb::Context>(ctx);
-#if TILEDB_VERSION >= TileDB_Version(2, 25, 0)
-  auto cd = new tiledb::CurrentDomain(*ctx.get());
+XPtr<tiledb::CurrentDomain> libtiledb_current_domain_create(XPtr<tiledb::Context> ctx) {
+    check_xptr_tag<tiledb::Context>(ctx);
+#if TILEDB_VERSION >= TileDB_Version(2,25,0)
+    auto cd = new tiledb::CurrentDomain(*ctx.get());
 #else
-  auto cd = new tiledb::CurrentDomain();
+    auto cd = new tiledb::CurrentDomain();
 #endif
-  auto ptr = make_xptr<tiledb::CurrentDomain>(cd);
-  return ptr;
+    auto ptr = make_xptr<tiledb::CurrentDomain>(cd);
+    return ptr;
 }
 
 // [[Rcpp::export]]
 std::string libtiledb_current_domain_type(XPtr<tiledb::CurrentDomain> cd) {
-  check_xptr_tag<tiledb::CurrentDomain>(cd);
-#if TILEDB_VERSION >= TileDB_Version(2, 25, 0)
-  auto tp = cd->type();
-  auto str = std::string(_tiledb_current_domain_type_to_string(tp));
-  return str;
+    check_xptr_tag<tiledb::CurrentDomain>(cd);
+#if TILEDB_VERSION >= TileDB_Version(2,25,0)
+    auto tp = cd->type();
+    auto str = std::string(_tiledb_current_domain_type_to_string(tp));
+    return str;
 #else
-  return std::string();
+    return std::string();
 #endif
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::CurrentDomain>
-libtiledb_current_domain_set_ndrectangle(XPtr<tiledb::CurrentDomain> cd,
-                                         XPtr<tiledb::NDRectangle> ndr) {
-  check_xptr_tag<tiledb::CurrentDomain>(cd);
-  check_xptr_tag<tiledb::NDRectangle>(ndr);
-#if TILEDB_VERSION >= TileDB_Version(2, 25, 0)
-  cd->set_ndrectangle(*ndr.get());
+XPtr<tiledb::CurrentDomain> libtiledb_current_domain_set_ndrectangle(XPtr<tiledb::CurrentDomain> cd,
+                                                                     XPtr<tiledb::NDRectangle> ndr) {
+    check_xptr_tag<tiledb::CurrentDomain>(cd);
+    check_xptr_tag<tiledb::NDRectangle>(ndr);
+#if TILEDB_VERSION >= TileDB_Version(2,25,0)
+    cd->set_ndrectangle(*ndr.get());
 #endif
-  return cd;
+    return cd;
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::NDRectangle>
-libtiledb_current_domain_get_ndrectangle(XPtr<tiledb::CurrentDomain> cd) {
-  check_xptr_tag<tiledb::CurrentDomain>(cd);
-#if TILEDB_VERSION >= TileDB_Version(2, 25, 0)
-  auto nd = new tiledb::NDRectangle(cd->ndrectangle());
+XPtr<tiledb::NDRectangle> libtiledb_current_domain_get_ndrectangle(XPtr<tiledb::CurrentDomain> cd) {
+    check_xptr_tag<tiledb::CurrentDomain>(cd);
+#if TILEDB_VERSION >= TileDB_Version(2,25,0)
+    auto nd = new tiledb::NDRectangle(cd->ndrectangle());
 #else
-  auto nd = new tiledb::NDRectangle;
+    auto nd = new tiledb::NDRectangle;
 #endif
-  auto ptr = make_xptr<tiledb::NDRectangle>(nd);
-  return ptr;
+    auto ptr = make_xptr<tiledb::NDRectangle>(nd);
+    return ptr;
+
 }
 
 // [[Rcpp::export]]
 bool libtiledb_current_domain_is_empty(XPtr<tiledb::CurrentDomain> cd) {
-  check_xptr_tag<tiledb::CurrentDomain>(cd);
-#if TILEDB_VERSION >= TileDB_Version(2, 25, 0)
-  return cd->is_empty();
+    check_xptr_tag<tiledb::CurrentDomain>(cd);
+#if TILEDB_VERSION >= TileDB_Version(2,25,0)
+    return cd->is_empty();
 #else
-  return false;
+    return false;
 #endif
 }

--- a/src/libtiledb.cpp
+++ b/src/libtiledb.cpp
@@ -3,22 +3,22 @@
 //  Copyright (c) 2017-2024 TileDB Inc.
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
-//  of this software and associated documentation files (the "Software"), to deal
-//  in the Software without restriction, including without limitation the rights
-//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-//  copies of the Software, and to permit persons to whom the Software is
+//  of this software and associated documentation files (the "Software"), to
+//  deal in the Software without restriction, including without limitation the
+//  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the Software is
 //  furnished to do so, subject to the following conditions:
 //
-//  The above copyright notice and this permission notice shall be included in all
-//  copies or substantial portions of the Software.
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
 //
 //  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 //  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 //  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 //  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-//  SOFTWARE.
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+//  IN THE SOFTWARE.
 
 #include "libtiledb.h"
 #include "tiledb_version.h"
@@ -28,89 +28,89 @@
 
 using namespace Rcpp;
 
-const char* _tiledb_datatype_to_string(tiledb_datatype_t dtype) {
+const char *_tiledb_datatype_to_string(tiledb_datatype_t dtype) {
   switch (dtype) {
-    case TILEDB_INT8:
-      return "INT8";
-    case TILEDB_UINT8:
-      return "UINT8";
-    case TILEDB_INT16:
-      return "INT16";
-    case TILEDB_UINT16:
-      return "UINT16";
-    case TILEDB_INT32:
-      return "INT32";
-    case TILEDB_UINT32:
-      return "UINT32";
-    case TILEDB_INT64:
-      return "INT64";
-    case TILEDB_UINT64:
-      return "UINT64";
-    case TILEDB_FLOAT32:
-      return "FLOAT32";
-    case TILEDB_FLOAT64:
-      return "FLOAT64";
-    case TILEDB_CHAR:
-      return "CHAR";
-    case TILEDB_STRING_ASCII:
-      return "ASCII";
-    case TILEDB_STRING_UTF8:
-      return "UTF8";
-    case TILEDB_STRING_UTF16:
-      return "UTF16";
-    case TILEDB_STRING_UTF32:
-      return "UTF32";
-    case TILEDB_STRING_UCS2:
-      return "UCS2";
-    case TILEDB_STRING_UCS4:
-      return "UCS4";
-    case TILEDB_ANY:
-      return "ANY";
-    case TILEDB_DATETIME_YEAR:
-      return "DATETIME_YEAR";
-    case TILEDB_DATETIME_MONTH:
-      return "DATETIME_MONTH";
-    case TILEDB_DATETIME_WEEK:
-      return "DATETIME_WEEK";
-    case TILEDB_DATETIME_DAY:
-      return "DATETIME_DAY";
-    case TILEDB_DATETIME_HR:
-      return "DATETIME_HR";
-    case TILEDB_DATETIME_MIN:
-      return "DATETIME_MIN";
-    case TILEDB_DATETIME_SEC:
-      return "DATETIME_SEC";
-    case TILEDB_DATETIME_MS:
-      return "DATETIME_MS";
-    case TILEDB_DATETIME_US:
-      return "DATETIME_US";
-    case TILEDB_DATETIME_NS:
-      return "DATETIME_NS";
-    case TILEDB_DATETIME_PS:
-      return "DATETIME_PS";
-    case TILEDB_DATETIME_FS:
-      return "DATETIME_FS";
-    case TILEDB_DATETIME_AS:
-      return "DATETIME_AS";
-    case TILEDB_BLOB:
-      return "BLOB";
-#if TILEDB_VERSION >= TileDB_Version(2,10,0)
-    case TILEDB_BOOL:
-      return "BOOL";
+  case TILEDB_INT8:
+    return "INT8";
+  case TILEDB_UINT8:
+    return "UINT8";
+  case TILEDB_INT16:
+    return "INT16";
+  case TILEDB_UINT16:
+    return "UINT16";
+  case TILEDB_INT32:
+    return "INT32";
+  case TILEDB_UINT32:
+    return "UINT32";
+  case TILEDB_INT64:
+    return "INT64";
+  case TILEDB_UINT64:
+    return "UINT64";
+  case TILEDB_FLOAT32:
+    return "FLOAT32";
+  case TILEDB_FLOAT64:
+    return "FLOAT64";
+  case TILEDB_CHAR:
+    return "CHAR";
+  case TILEDB_STRING_ASCII:
+    return "ASCII";
+  case TILEDB_STRING_UTF8:
+    return "UTF8";
+  case TILEDB_STRING_UTF16:
+    return "UTF16";
+  case TILEDB_STRING_UTF32:
+    return "UTF32";
+  case TILEDB_STRING_UCS2:
+    return "UCS2";
+  case TILEDB_STRING_UCS4:
+    return "UCS4";
+  case TILEDB_ANY:
+    return "ANY";
+  case TILEDB_DATETIME_YEAR:
+    return "DATETIME_YEAR";
+  case TILEDB_DATETIME_MONTH:
+    return "DATETIME_MONTH";
+  case TILEDB_DATETIME_WEEK:
+    return "DATETIME_WEEK";
+  case TILEDB_DATETIME_DAY:
+    return "DATETIME_DAY";
+  case TILEDB_DATETIME_HR:
+    return "DATETIME_HR";
+  case TILEDB_DATETIME_MIN:
+    return "DATETIME_MIN";
+  case TILEDB_DATETIME_SEC:
+    return "DATETIME_SEC";
+  case TILEDB_DATETIME_MS:
+    return "DATETIME_MS";
+  case TILEDB_DATETIME_US:
+    return "DATETIME_US";
+  case TILEDB_DATETIME_NS:
+    return "DATETIME_NS";
+  case TILEDB_DATETIME_PS:
+    return "DATETIME_PS";
+  case TILEDB_DATETIME_FS:
+    return "DATETIME_FS";
+  case TILEDB_DATETIME_AS:
+    return "DATETIME_AS";
+  case TILEDB_BLOB:
+    return "BLOB";
+#if TILEDB_VERSION >= TileDB_Version(2, 10, 0)
+  case TILEDB_BOOL:
+    return "BOOL";
 #endif
-#if TILEDB_VERSION >= TileDB_Version(2,21,0)
-    case TILEDB_GEOM_WKB:
-      return "GEOM_WKB";
-    case TILEDB_GEOM_WKT:
-      return "GEOM_WKT";
+#if TILEDB_VERSION >= TileDB_Version(2, 21, 0)
+  case TILEDB_GEOM_WKB:
+    return "GEOM_WKB";
+  case TILEDB_GEOM_WKT:
+    return "GEOM_WKT";
 #endif
-    default:
-      Rcpp::stop("unknown tiledb_datatype_t (%d)", dtype);
+  default:
+    Rcpp::stop("unknown tiledb_datatype_t (%d)", dtype);
   }
 }
 
 tiledb_datatype_t _string_to_tiledb_datatype(std::string typestr) {
-  if (typestr == "FLOAT32")  {
+  if (typestr == "FLOAT32") {
     return TILEDB_FLOAT32;
   } else if (typestr == "FLOAT64") {
     return TILEDB_FLOAT64;
@@ -123,7 +123,7 @@ tiledb_datatype_t _string_to_tiledb_datatype(std::string typestr) {
   } else if (typestr == "UINT8") {
     return TILEDB_UINT8;
   } else if (typestr == "INT16") {
-    return  TILEDB_INT16;
+    return TILEDB_INT16;
   } else if (typestr == "UINT16") {
     return TILEDB_UINT16;
   } else if (typestr == "INT32") {
@@ -164,11 +164,11 @@ tiledb_datatype_t _string_to_tiledb_datatype(std::string typestr) {
     return TILEDB_STRING_UTF8;
   } else if (typestr == "BLOB") {
     return TILEDB_BLOB;
-#if TILEDB_VERSION >= TileDB_Version(2,10,0)
+#if TILEDB_VERSION >= TileDB_Version(2, 10, 0)
   } else if (typestr == "BOOL") {
     return TILEDB_BOOL;
 #endif
-#if TILEDB_VERSION >= TileDB_Version(2,21,0)
+#if TILEDB_VERSION >= TileDB_Version(2, 21, 0)
   } else if (typestr == "GEOM_WKB") {
     return TILEDB_GEOM_WKB;
   } else if (typestr == "GEOM_WKT") {
@@ -181,85 +181,88 @@ tiledb_datatype_t _string_to_tiledb_datatype(std::string typestr) {
 
 // [[Rcpp::export]]
 int32_t tiledb_datatype_string_to_sizeof(const std::string str) {
-    return static_cast<int32_t>(tiledb_datatype_size(_string_to_tiledb_datatype(str)));
+  return static_cast<int32_t>(
+      tiledb_datatype_size(_string_to_tiledb_datatype(str)));
 }
 
 //' Map from TileDB type to R datatype
 //'
-//' This function maps from the TileDB types to the (fewer) key datatypes in R. This
-//' can be lossy as TileDB integers range from (signed and unsigned) 8 to 64 bit whereas
-//' R only has (signed) 32 bit values. Similarly, R only has 64 bit doubles whereas TileDB
-//' has 32 and 64 bit floating point types. TileDB also has more character encodings, and the
-//' full range of (NumPy) date and time types.
+//' This function maps from the TileDB types to the (fewer) key datatypes in R.
+//' This can be lossy as TileDB integers range from (signed and unsigned) 8 to
+//' 64 bit whereas R only has (signed) 32 bit values. Similarly, R only has 64
+//' bit doubles whereas TileDB has 32 and 64 bit floating point types. TileDB
+//' also has more character encodings, and the full range of (NumPy) date and
+//' time types.
 //'
 //' @param datatype A string describing one TileDB datatype
 //' @return A string describing the closest match for an R datatype
 //' @export
 // [[Rcpp::export]]
+
 std::string tiledb_datatype_R_type(std::string datatype) {
   tiledb_datatype_t dtype = _string_to_tiledb_datatype(datatype);
   switch (dtype) {
-    case TILEDB_INT8:
-    case TILEDB_UINT8:
-    case TILEDB_INT16:
-    case TILEDB_UINT16:
-    case TILEDB_INT32:
-    case TILEDB_UINT32:
-    case TILEDB_INT64:
-    case TILEDB_UINT64:
-      return "integer";
-    case TILEDB_FLOAT32:
-    case TILEDB_FLOAT64:
-      return "double";
-    case TILEDB_CHAR:
-      return "raw";
-    case TILEDB_STRING_ASCII:
-    case TILEDB_STRING_UTF8:
-    case TILEDB_STRING_UTF16:
-    case TILEDB_STRING_UTF32:
-    case TILEDB_STRING_UCS2:
-    case TILEDB_STRING_UCS4:
-      return "character";
-    case TILEDB_ANY:
-      return "any";
-    case TILEDB_DATETIME_DAY:
-      return "DATETIME_DAY";
-    case TILEDB_DATETIME_SEC:
-      return "DATETIME_SEC";
-    case TILEDB_DATETIME_MS:
-      return "DATETIME_MS";
-    case TILEDB_DATETIME_US:
-      return "DATETIME_US";
-    case TILEDB_DATETIME_NS:
-      return "DATETIME_NS";
-#if TILEDB_VERSION >= TileDB_Version(2,10,0)
-    case TILEDB_BOOL:
-      return "BOOL";
+  case TILEDB_INT8:
+  case TILEDB_UINT8:
+  case TILEDB_INT16:
+  case TILEDB_UINT16:
+  case TILEDB_INT32:
+  case TILEDB_UINT32:
+  case TILEDB_INT64:
+  case TILEDB_UINT64:
+    return "integer";
+  case TILEDB_FLOAT32:
+  case TILEDB_FLOAT64:
+    return "double";
+  case TILEDB_CHAR:
+    return "raw";
+  case TILEDB_STRING_ASCII:
+  case TILEDB_STRING_UTF8:
+  case TILEDB_STRING_UTF16:
+  case TILEDB_STRING_UTF32:
+  case TILEDB_STRING_UCS2:
+  case TILEDB_STRING_UCS4:
+    return "character";
+  case TILEDB_ANY:
+    return "any";
+  case TILEDB_DATETIME_DAY:
+    return "DATETIME_DAY";
+  case TILEDB_DATETIME_SEC:
+    return "DATETIME_SEC";
+  case TILEDB_DATETIME_MS:
+    return "DATETIME_MS";
+  case TILEDB_DATETIME_US:
+    return "DATETIME_US";
+  case TILEDB_DATETIME_NS:
+    return "DATETIME_NS";
+#if TILEDB_VERSION >= TileDB_Version(2, 10, 0)
+  case TILEDB_BOOL:
+    return "BOOL";
 #endif
-    default:
-      Rcpp::stop("unknown tiledb_datatype_t (%d)", dtype);
+  default:
+    Rcpp::stop("unknown tiledb_datatype_t (%d)", dtype);
   }
 }
 
-const char* _tiledb_layout_to_string(tiledb_layout_t layout) {
-  switch(layout) {
-    case TILEDB_ROW_MAJOR:
-      return "ROW_MAJOR";
-    case TILEDB_COL_MAJOR:
-      return "COL_MAJOR";
-    case TILEDB_GLOBAL_ORDER:
-      return "GLOBAL_ORDER";
-    case TILEDB_UNORDERED:
-      return "UNORDERED";
-    case TILEDB_HILBERT:
-      return "HILBERT";
-    default:
-      Rcpp::stop("unknown tiledb_layout_t (%d)", layout);
+const char *_tiledb_layout_to_string(tiledb_layout_t layout) {
+  switch (layout) {
+  case TILEDB_ROW_MAJOR:
+    return "ROW_MAJOR";
+  case TILEDB_COL_MAJOR:
+    return "COL_MAJOR";
+  case TILEDB_GLOBAL_ORDER:
+    return "GLOBAL_ORDER";
+  case TILEDB_UNORDERED:
+    return "UNORDERED";
+  case TILEDB_HILBERT:
+    return "HILBERT";
+  default:
+    Rcpp::stop("unknown tiledb_layout_t (%d)", layout);
   }
 }
 
 tiledb_layout_t _string_to_tiledb_layout(std::string lstr) {
-  if (lstr == "ROW_MAJOR")  {
+  if (lstr == "ROW_MAJOR") {
     return TILEDB_ROW_MAJOR;
   } else if (lstr == "COL_MAJOR") {
     return TILEDB_COL_MAJOR;
@@ -301,15 +304,15 @@ tiledb_filter_type_t _string_to_tiledb_filter(std::string filter) {
     return TILEDB_FILTER_CHECKSUM_MD5;
   } else if (filter == "CHECKSUM_SHA256") {
     return TILEDB_FILTER_CHECKSUM_SHA256;
-#if TILEDB_VERSION >= TileDB_Version(2,9,0)
+#if TILEDB_VERSION >= TileDB_Version(2, 9, 0)
   } else if (filter == "DICTIONARY_ENCODING") {
     return TILEDB_FILTER_DICTIONARY;
 #endif
-#if TILEDB_VERSION >= TileDB_Version(2,11,0)
+#if TILEDB_VERSION >= TileDB_Version(2, 11, 0)
   } else if (filter == "SCALE_FLOAT") {
     return TILEDB_FILTER_SCALE_FLOAT;
 #endif
-#if TILEDB_VERSION >= TileDB_Version(2,12,0)
+#if TILEDB_VERSION >= TileDB_Version(2, 12, 0)
   } else if (filter == "FILTER_XOR") {
     return TILEDB_FILTER_XOR;
 #endif
@@ -318,60 +321,61 @@ tiledb_filter_type_t _string_to_tiledb_filter(std::string filter) {
   }
 }
 
-const char* _tiledb_filter_to_string(tiledb_filter_type_t filter) {
-  switch(filter) {
-    case TILEDB_FILTER_NONE:
-     return "NONE";
-    case TILEDB_FILTER_GZIP:
-      return "GZIP";
-    case TILEDB_FILTER_ZSTD:
-      return "ZSTD";
-    case TILEDB_FILTER_LZ4:
-      return "LZ4";
-    case TILEDB_FILTER_RLE:
-      return "RLE";
-    case TILEDB_FILTER_BZIP2:
-      return "BZIP2";
-    case TILEDB_FILTER_DOUBLE_DELTA:
-      return "DOUBLE_DELTA";
-    case TILEDB_FILTER_BIT_WIDTH_REDUCTION:
-      return "BIT_WIDTH_REDUCTION";
-    case TILEDB_FILTER_BITSHUFFLE:
-      return "BITSHUFFLE";
-    case TILEDB_FILTER_BYTESHUFFLE:
-      return "BYTESHUFFLE";
-    case TILEDB_FILTER_POSITIVE_DELTA:
-      return "POSITIVE_DELTA";
-    case TILEDB_FILTER_CHECKSUM_MD5:
-      return "CHECKSUM_MD5";
-    case TILEDB_FILTER_CHECKSUM_SHA256:
-      return "CHECKSUM_SHA256";
-#if TILEDB_VERSION >= TileDB_Version(2,9,0)
-    case TILEDB_FILTER_DICTIONARY:
-      return "DICTIONARY_ENCODING";
+const char *_tiledb_filter_to_string(tiledb_filter_type_t filter) {
+  switch (filter) {
+  case TILEDB_FILTER_NONE:
+    return "NONE";
+  case TILEDB_FILTER_GZIP:
+    return "GZIP";
+  case TILEDB_FILTER_ZSTD:
+    return "ZSTD";
+  case TILEDB_FILTER_LZ4:
+    return "LZ4";
+  case TILEDB_FILTER_RLE:
+    return "RLE";
+  case TILEDB_FILTER_BZIP2:
+    return "BZIP2";
+  case TILEDB_FILTER_DOUBLE_DELTA:
+    return "DOUBLE_DELTA";
+  case TILEDB_FILTER_BIT_WIDTH_REDUCTION:
+    return "BIT_WIDTH_REDUCTION";
+  case TILEDB_FILTER_BITSHUFFLE:
+    return "BITSHUFFLE";
+  case TILEDB_FILTER_BYTESHUFFLE:
+    return "BYTESHUFFLE";
+  case TILEDB_FILTER_POSITIVE_DELTA:
+    return "POSITIVE_DELTA";
+  case TILEDB_FILTER_CHECKSUM_MD5:
+    return "CHECKSUM_MD5";
+  case TILEDB_FILTER_CHECKSUM_SHA256:
+    return "CHECKSUM_SHA256";
+#if TILEDB_VERSION >= TileDB_Version(2, 9, 0)
+  case TILEDB_FILTER_DICTIONARY:
+    return "DICTIONARY_ENCODING";
 #endif
-#if TILEDB_VERSION >= TileDB_Version(2,11,0)
-    case TILEDB_FILTER_SCALE_FLOAT:
-      return "SCALE_FLOAT";
+#if TILEDB_VERSION >= TileDB_Version(2, 11, 0)
+  case TILEDB_FILTER_SCALE_FLOAT:
+    return "SCALE_FLOAT";
 #endif
-#if TILEDB_VERSION >= TileDB_Version(2,12,0)
+#if TILEDB_VERSION >= TileDB_Version(2, 12, 0)
   case TILEDB_FILTER_XOR:
     return "FILTER_XOR";
 #endif
   default: {
-      Rcpp::stop("unknown tiledb_filter_t (%d)", filter);
-    }
+    Rcpp::stop("unknown tiledb_filter_t (%d)", filter);
+  }
   }
 }
 
-tiledb_filter_option_t _string_to_tiledb_filter_option(std::string filter_option) {
+tiledb_filter_option_t
+_string_to_tiledb_filter_option(std::string filter_option) {
   if (filter_option == "COMPRESSION_LEVEL") {
     return TILEDB_COMPRESSION_LEVEL;
   } else if (filter_option == "BIT_WIDTH_MAX_WINDOW") {
     return TILEDB_BIT_WIDTH_MAX_WINDOW;
   } else if (filter_option == "POSITIVE_DELTA_MAX_WINDOW") {
     return TILEDB_POSITIVE_DELTA_MAX_WINDOW;
-#if TILEDB_VERSION >= TileDB_Version(2,11,0)
+#if TILEDB_VERSION >= TileDB_Version(2, 11, 0)
   } else if (filter_option == "SCALE_FLOAT_BYTEWIDTH") {
     return TILEDB_SCALE_FLOAT_BYTEWIDTH;
   } else if (filter_option == "SCALE_FLOAT_FACTOR") {
@@ -384,15 +388,16 @@ tiledb_filter_option_t _string_to_tiledb_filter_option(std::string filter_option
   }
 }
 
-const char* _tiledb_filter_option_to_string(tiledb_filter_option_t filter_option) {
-  switch(filter_option) {
+const char *
+_tiledb_filter_option_to_string(tiledb_filter_option_t filter_option) {
+  switch (filter_option) {
   case TILEDB_COMPRESSION_LEVEL:
     return "COMPRESSION_LEVEL";
   case TILEDB_BIT_WIDTH_MAX_WINDOW:
     return "BIT_WIDTH_MAX_WINDOW";
   case TILEDB_POSITIVE_DELTA_MAX_WINDOW:
     return "POSITIVE_DELTA_MAX_WINDOW";
-#if TILEDB_VERSION >= TileDB_Version(2,11,0)
+#if TILEDB_VERSION >= TileDB_Version(2, 11, 0)
   case TILEDB_SCALE_FLOAT_BYTEWIDTH:
     return "SCALE_FLOAT_BYTEWIDTH";
   case TILEDB_SCALE_FLOAT_FACTOR:
@@ -410,7 +415,7 @@ tiledb_query_type_t _string_to_tiledb_query_type(std::string qtstr) {
     return TILEDB_READ;
   } else if (qtstr == "WRITE") {
     return TILEDB_WRITE;
-#if TILEDB_VERSION >= TileDB_Version(2,12,0)
+#if TILEDB_VERSION >= TileDB_Version(2, 12, 0)
   } else if (qtstr == "MODIFY_EXCLUSIVE") {
     return TILEDB_MODIFY_EXCLUSIVE;
   } else if (qtstr == "DELETE") {
@@ -423,29 +428,29 @@ tiledb_query_type_t _string_to_tiledb_query_type(std::string qtstr) {
 
 std::string _tiledb_query_type_to_string(tiledb_query_type_t qtype) {
   switch (qtype) {
-    case TILEDB_READ:
-      return "READ";
-    case TILEDB_WRITE:
-      return "WRITE";
-#if TILEDB_VERSION >= TileDB_Version(2,12,0)
-    case TILEDB_DELETE:
-      return "DELETE";
-    case TILEDB_MODIFY_EXCLUSIVE:
-      return "MODIFY_EXCLUSIVE";
+  case TILEDB_READ:
+    return "READ";
+  case TILEDB_WRITE:
+    return "WRITE";
+#if TILEDB_VERSION >= TileDB_Version(2, 12, 0)
+  case TILEDB_DELETE:
+    return "DELETE";
+  case TILEDB_MODIFY_EXCLUSIVE:
+    return "MODIFY_EXCLUSIVE";
 #endif
-    default:
-      Rcpp::stop("unknown tiledb_query_type_t (%d)", qtype);
+  default:
+    Rcpp::stop("unknown tiledb_query_type_t (%d)", qtype);
   }
 }
 
-const char* _tiledb_array_type_to_string(tiledb_array_type_t atype) {
+const char *_tiledb_array_type_to_string(tiledb_array_type_t atype) {
   switch (atype) {
-    case TILEDB_DENSE:
-      return "dense";
-    case TILEDB_SPARSE:
-      return "sparse";
-    default:
-      Rcpp::stop("Unknown tiledb_array_type_t");
+  case TILEDB_DENSE:
+    return "dense";
+  case TILEDB_SPARSE:
+    return "sparse";
+  default:
+    Rcpp::stop("Unknown tiledb_array_type_t");
   }
 }
 
@@ -471,39 +476,43 @@ tiledb_vfs_mode_t _string_to_tiledb_vfs_mode_t(std::string modestr) {
   }
 }
 
-#if TILEDB_VERSION >= TileDB_Version(2,25,0)
-std::string _tiledb_current_domain_type_to_string(tiledb_current_domain_type_t type) {
-    if (type == TILEDB_NDRECTANGLE) {
-        return std::string{"NDRECTANGLE"};
-    } else {
-        Rcpp::stop("Unknown TileDB CurrentDomain type (%d)", (int32_t) type);
-    }
-    return std::string();
+#if TILEDB_VERSION >= TileDB_Version(2, 25, 0)
+std::string
+_tiledb_current_domain_type_to_string(tiledb_current_domain_type_t type) {
+  if (type == TILEDB_NDRECTANGLE) {
+    return std::string{"NDRECTANGLE"};
+  } else {
+    Rcpp::stop("Unknown TileDB CurrentDomain type (%d)", (int32_t)type);
+  }
+  return std::string();
 }
 #endif
 
-#if TILEDB_VERSION >= TileDB_Version(2,25,0)
-tiledb_current_domain_type_t _string_to_tiledb_current_domain_type(std::string typestr) {
-    if (typestr == "NDRECTANGLE") {
-        return TILEDB_NDRECTANGLE;
-    } else {
-        Rcpp::stop("Unknown TileDB CurrentDomain type '%s'", typestr.c_str());
-    }
+#if TILEDB_VERSION >= TileDB_Version(2, 25, 0)
+tiledb_current_domain_type_t
+_string_to_tiledb_current_domain_type(std::string typestr) {
+  if (typestr == "NDRECTANGLE") {
+    return TILEDB_NDRECTANGLE;
+  } else {
+    Rcpp::stop("Unknown TileDB CurrentDomain type '%s'", typestr.c_str());
+  }
 }
 #endif
 
-// NB Limited type coverage here as aimed to sizing R allocations of either int, double or char
-// Also note that there is 'inline size_t type_size(tiledb_datatype_t type)' in core_interface.h
+// NB Limited type coverage here as aimed to sizing R allocations of either int,
+// double or char Also note that there is 'inline size_t
+// type_size(tiledb_datatype_t type)' in core_interface.h
 const size_t _tiledb_datatype_sizeof(const tiledb_datatype_t dtype) {
-  switch(dtype) {
-    case TILEDB_FLOAT64:
-      return sizeof(double);
-    case TILEDB_INT32:
-      return sizeof(int32_t);
-    case TILEDB_CHAR:
-      return sizeof(char);
-    default:
-      Rcpp::stop("Unsupported tiledb_datatype_t '%s'", _tiledb_datatype_to_string(dtype));
+  switch (dtype) {
+  case TILEDB_FLOAT64:
+    return sizeof(double);
+  case TILEDB_INT32:
+    return sizeof(int32_t);
+  case TILEDB_CHAR:
+    return sizeof(char);
+  default:
+    Rcpp::stop("Unsupported tiledb_datatype_t '%s'",
+               _tiledb_datatype_to_string(dtype));
   }
 }
 
@@ -516,19 +525,28 @@ NumericVector libtiledb_version() {
 }
 
 // [[Rcpp::export]]
-size_t tiledb_datatype_max_value(const std::string& datatype) {
-    tiledb_datatype_t dtype = _string_to_tiledb_datatype(datatype);
-    switch (dtype) {
-    case TILEDB_INT8:    return std::numeric_limits<int8_t>::max();
-    case TILEDB_UINT8:   return std::numeric_limits<uint8_t>::max();
-    case TILEDB_INT16:   return std::numeric_limits<int16_t>::max();
-    case TILEDB_UINT16:  return std::numeric_limits<uint16_t>::max();
-    case TILEDB_INT32:   return std::numeric_limits<int32_t>::max();
-    case TILEDB_UINT32:  return std::numeric_limits<uint32_t>::max();
-    case TILEDB_INT64:   return std::numeric_limits<int64_t>::max();
-    case TILEDB_UINT64:  return std::numeric_limits<uint64_t>::max();
-    default: Rcpp::stop("currently unsupported datatype (%s)", datatype);
-    }
+size_t tiledb_datatype_max_value(const std::string &datatype) {
+  tiledb_datatype_t dtype = _string_to_tiledb_datatype(datatype);
+  switch (dtype) {
+  case TILEDB_INT8:
+    return std::numeric_limits<int8_t>::max();
+  case TILEDB_UINT8:
+    return std::numeric_limits<uint8_t>::max();
+  case TILEDB_INT16:
+    return std::numeric_limits<int16_t>::max();
+  case TILEDB_UINT16:
+    return std::numeric_limits<uint16_t>::max();
+  case TILEDB_INT32:
+    return std::numeric_limits<int32_t>::max();
+  case TILEDB_UINT32:
+    return std::numeric_limits<uint32_t>::max();
+  case TILEDB_INT64:
+    return std::numeric_limits<int64_t>::max();
+  case TILEDB_UINT64:
+    return std::numeric_limits<uint64_t>::max();
+  default:
+    Rcpp::stop("currently unsupported datatype (%s)", datatype);
+  }
 }
 
 /**
@@ -536,27 +554,29 @@ size_t tiledb_datatype_max_value(const std::string& datatype) {
  */
 
 // [[Rcpp::export]]
-XPtr<tiledb::Context> libtiledb_ctx(Nullable<XPtr<tiledb::Config>> config = R_NilValue) {
-    if (config.isNull()) {
-        return make_xptr<tiledb::Context>(new tiledb::Context());
-    } else {
-        XPtr<tiledb::Config> config_xptr(config);
-        return make_xptr<tiledb::Context>(new tiledb::Context(*config_xptr.get()));
-    }
+XPtr<tiledb::Context>
+libtiledb_ctx(Nullable<XPtr<tiledb::Config>> config = R_NilValue) {
+  if (config.isNull()) {
+    return make_xptr<tiledb::Context>(new tiledb::Context());
+  } else {
+    XPtr<tiledb::Config> config_xptr(config);
+    return make_xptr<tiledb::Context>(new tiledb::Context(*config_xptr.get()));
+  }
 }
 
 // [[Rcpp::export]]
 XPtr<tiledb::Config> libtiledb_ctx_config(XPtr<tiledb::Context> ctx) {
-    check_xptr_tag<tiledb::Context>(ctx);
-    return make_xptr<tiledb::Config>(new tiledb::Config(ctx.get()->config()));
+  check_xptr_tag<tiledb::Context>(ctx);
+  return make_xptr<tiledb::Config>(new tiledb::Config(ctx.get()->config()));
 }
 
 // [[Rcpp::export]]
-bool libtiledb_ctx_is_supported_fs(XPtr<tiledb::Context> ctx, std::string scheme) {
+bool libtiledb_ctx_is_supported_fs(XPtr<tiledb::Context> ctx,
+                                   std::string scheme) {
   check_xptr_tag<tiledb::Context>(ctx);
   if (scheme == "file") {
     return true;
-  } else if  (scheme == "s3") {
+  } else if (scheme == "s3") {
     return ctx->is_supported_fs(TILEDB_S3);
   } else if (scheme == "hdfs") {
     return ctx->is_supported_fs(TILEDB_HDFS);
@@ -572,15 +592,16 @@ bool libtiledb_ctx_is_supported_fs(XPtr<tiledb::Context> ctx, std::string scheme
 }
 
 // [[Rcpp::export]]
-void libtiledb_ctx_set_tag(XPtr<tiledb::Context> ctx, std::string key, std::string value) {
+void libtiledb_ctx_set_tag(XPtr<tiledb::Context> ctx, std::string key,
+                           std::string value) {
   check_xptr_tag<tiledb::Context>(ctx);
   ctx->set_tag(key, value);
 }
 
 // [[Rcpp::export]]
 std::string libtiledb_ctx_stats(XPtr<tiledb::Context> ctx) {
-    check_xptr_tag<tiledb::Context>(ctx);
-    return ctx->stats();
+  check_xptr_tag<tiledb::Context>(ctx);
+  return ctx->stats();
 }
 
 /**
@@ -588,7 +609,8 @@ std::string libtiledb_ctx_stats(XPtr<tiledb::Context> ctx) {
  */
 
 // [[Rcpp::export]]
-XPtr<tiledb::Config> libtiledb_config(Nullable<CharacterVector> config = R_NilValue) {
+XPtr<tiledb::Config>
+libtiledb_config(Nullable<CharacterVector> config = R_NilValue) {
   XPtr<tiledb::Config> ptr = make_xptr<tiledb::Config>(new tiledb::Config());
   if (config.isNotNull()) {
     auto config_vec = config.as();
@@ -603,7 +625,8 @@ XPtr<tiledb::Config> libtiledb_config(Nullable<CharacterVector> config = R_NilVa
 }
 
 // [[Rcpp::export]]
-std::string libtiledb_config_save_to_file(XPtr<tiledb::Config> config, std::string filename) {
+std::string libtiledb_config_save_to_file(XPtr<tiledb::Config> config,
+                                          std::string filename) {
   check_xptr_tag<tiledb::Config>(config);
   config->save_to_file(filename);
   return filename;
@@ -611,7 +634,8 @@ std::string libtiledb_config_save_to_file(XPtr<tiledb::Config> config, std::stri
 
 // [[Rcpp::export]]
 XPtr<tiledb::Config> libtiledb_config_load_from_file(std::string filename) {
-  XPtr<tiledb::Config> ptr = make_xptr<tiledb::Config>(new tiledb::Config(filename));
+  XPtr<tiledb::Config> ptr =
+      make_xptr<tiledb::Config>(new tiledb::Config(filename));
   return ptr;
 }
 
@@ -619,29 +643,31 @@ XPtr<tiledb::Config> libtiledb_config_load_from_file(std::string filename) {
 CharacterVector libtiledb_config_vector(XPtr<tiledb::Config> config) {
   check_xptr_tag<tiledb::Config>(config);
   CharacterVector config_vec;
-  for (auto& p : *config) {
-    config_vec[p.first]  = p.second;
+  for (auto &p : *config) {
+    config_vec[p.first] = p.second;
   }
   return config_vec;
 }
 
 // [[Rcpp::export]]
 XPtr<tiledb::Config> libtiledb_config_set(XPtr<tiledb::Config> config,
-                                          std::string param, std::string value) {
+                                          std::string param,
+                                          std::string value) {
   check_xptr_tag<tiledb::Config>(config);
   (*config)[param] = value;
   return config;
 }
 
 // [[Rcpp::export]]
-CharacterVector libtiledb_config_get(XPtr<tiledb::Config> config, CharacterVector params) {
+CharacterVector libtiledb_config_get(XPtr<tiledb::Config> config,
+                                     CharacterVector params) {
   check_xptr_tag<tiledb::Config>(config);
   CharacterVector result;
-  for (auto const& p : params) {
+  for (auto const &p : params) {
     auto param = as<std::string>(p);
     try {
       result.push_back(config->get(param), param);
-    } catch (std::exception& err) {
+    } catch (std::exception &err) {
       result.push_back(NA_STRING, as<std::string>(NA_STRING));
     }
   }
@@ -649,7 +675,8 @@ CharacterVector libtiledb_config_get(XPtr<tiledb::Config> config, CharacterVecto
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::Config> libtiledb_config_unset(XPtr<tiledb::Config> config, std::string param) {
+XPtr<tiledb::Config> libtiledb_config_unset(XPtr<tiledb::Config> config,
+                                            std::string param) {
   check_xptr_tag<tiledb::Config>(config);
   config->unset(param);
   return config;
@@ -659,19 +686,20 @@ XPtr<tiledb::Config> libtiledb_config_unset(XPtr<tiledb::Config> config, std::st
 void libtiledb_config_dump(XPtr<tiledb::Config> config) {
   check_xptr_tag<tiledb::Config>(config);
   Rcout << "Config settings:\n";
-  for (auto& p : *config) {
+  for (auto &p : *config) {
     Rcout << "\"" << p.first << "\" : \"" << p.second << "\"\n";
   }
 }
 
-// Placed here as it relates to config. (New as of 2.17, uses experimental header)
+// Placed here as it relates to config. (New as of 2.17, uses experimental
+// header)
 // [[Rcpp::export]]
 std::string libtiledb_as_built_dump() {
-    std::string str = "";
-#if TILEDB_VERSION >= TileDB_Version(2,17,0)
-    str = tiledb::AsBuilt::dump();
+  std::string str = "";
+#if TILEDB_VERSION >= TileDB_Version(2, 17, 0)
+  str = tiledb::AsBuilt::dump();
 #endif
-    return str;
+  return str;
 }
 
 /**
@@ -679,209 +707,228 @@ std::string libtiledb_as_built_dump() {
  */
 // [[Rcpp::export]]
 XPtr<tiledb::Dimension> libtiledb_dim(XPtr<tiledb::Context> ctx,
-                                      std::string name,
-                                      std::string type,
-                                      SEXP domain,
-                                      SEXP tile_extent) {
-    check_xptr_tag<tiledb::Context>(ctx);
-    // check that the dimension type is supported
-    const tiledb_datatype_t dtype = _string_to_tiledb_datatype(type);
-    if (dtype != TILEDB_INT8 &&
-        dtype != TILEDB_INT16 &&
-        dtype != TILEDB_INT32 &&
-        dtype != TILEDB_INT64 &&
-        dtype != TILEDB_UINT8 &&
-        dtype != TILEDB_UINT16 &&
-        dtype != TILEDB_UINT32 &&
-        dtype != TILEDB_UINT64 &&
-        dtype != TILEDB_FLOAT32 &&
-        dtype != TILEDB_FLOAT64 &&
-        dtype != TILEDB_DATETIME_YEAR &&
-        dtype != TILEDB_DATETIME_MONTH &&
-        dtype != TILEDB_DATETIME_WEEK &&
-        dtype != TILEDB_DATETIME_DAY &&
-        dtype != TILEDB_DATETIME_HR &&
-        dtype != TILEDB_DATETIME_MIN &&
-        dtype != TILEDB_DATETIME_SEC &&
-        dtype != TILEDB_DATETIME_MS &&
-        dtype != TILEDB_DATETIME_US &&
-        dtype != TILEDB_DATETIME_NS &&
-        dtype != TILEDB_DATETIME_PS &&
-        dtype != TILEDB_DATETIME_FS &&
-        dtype != TILEDB_DATETIME_AS &&
-        dtype != TILEDB_STRING_ASCII) {
-        Rcpp::stop("only integer ((U)INT{8,16,32,64}), real (FLOAT{32,64}), DATETIME_{YEAR,MONTH,WEEK,DAY,HR,MIN,SEC,MS,US,NS,PS,FS,AS}, STRING_ASCII domains supported");
+                                      std::string name, std::string type,
+                                      SEXP domain, SEXP tile_extent) {
+  check_xptr_tag<tiledb::Context>(ctx);
+  // check that the dimension type is supported
+  const tiledb_datatype_t dtype = _string_to_tiledb_datatype(type);
+  if (dtype != TILEDB_INT8 && dtype != TILEDB_INT16 && dtype != TILEDB_INT32 &&
+      dtype != TILEDB_INT64 && dtype != TILEDB_UINT8 &&
+      dtype != TILEDB_UINT16 && dtype != TILEDB_UINT32 &&
+      dtype != TILEDB_UINT64 && dtype != TILEDB_FLOAT32 &&
+      dtype != TILEDB_FLOAT64 && dtype != TILEDB_DATETIME_YEAR &&
+      dtype != TILEDB_DATETIME_MONTH && dtype != TILEDB_DATETIME_WEEK &&
+      dtype != TILEDB_DATETIME_DAY && dtype != TILEDB_DATETIME_HR &&
+      dtype != TILEDB_DATETIME_MIN && dtype != TILEDB_DATETIME_SEC &&
+      dtype != TILEDB_DATETIME_MS && dtype != TILEDB_DATETIME_US &&
+      dtype != TILEDB_DATETIME_NS && dtype != TILEDB_DATETIME_PS &&
+      dtype != TILEDB_DATETIME_FS && dtype != TILEDB_DATETIME_AS &&
+      dtype != TILEDB_STRING_ASCII) {
+    Rcpp::stop("only integer ((U)INT{8,16,32,64}), real (FLOAT{32,64}), "
+               "DATETIME_{YEAR,MONTH,WEEK,DAY,HR,MIN,SEC,MS,US,NS,PS,FS,AS}, "
+               "STRING_ASCII domains supported");
+  }
+  // check that the dimension type aligns with the domain and tiledb_extent type
+  if (dtype == TILEDB_INT32 &&
+      (TYPEOF(domain) != INTSXP || TYPEOF(tile_extent) != INTSXP)) {
+    Rcpp::stop("domain or tile_extent does not match dimension type");
+  } else if (dtype == TILEDB_FLOAT64 &&
+             (TYPEOF(domain) != REALSXP || TYPEOF(tile_extent) != REALSXP)) {
+    Rcpp::stop("domain or tile_extent does not match dimension type");
+  }
+  if (dtype == TILEDB_INT32) {
+    Rcpp::IntegerVector domain_vec = Rcpp::IntegerVector(domain);
+    if (domain_vec.length() != 2) {
+      Rcpp::stop("dimension domain must be a c(lower bound, upper bound) pair");
     }
-    // check that the dimension type aligns with the domain and tiledb_extent type
-    if (dtype == TILEDB_INT32 && (TYPEOF(domain) != INTSXP || TYPEOF(tile_extent) != INTSXP)) {
-        Rcpp::stop("domain or tile_extent does not match dimension type");
-    } else if (dtype == TILEDB_FLOAT64 && (TYPEOF(domain) != REALSXP || TYPEOF(tile_extent) != REALSXP)) {
-        Rcpp::stop("domain or tile_extent does not match dimension type");
+    std::array<int32_t, 2> _domain = {domain_vec[0], domain_vec[1]};
+    int32_t _tile_extent = Rcpp::as<int32_t>(tile_extent);
+    auto dim = new tiledb::Dimension(tiledb::Dimension::create<int32_t>(
+        *ctx.get(), name, _domain, _tile_extent));
+    auto ptr = make_xptr<tiledb::Dimension>(dim);
+    return ptr;
+
+  } else if (dtype == TILEDB_UINT32) {
+    Rcpp::IntegerVector domain_vec = Rcpp::IntegerVector(domain);
+    if (domain_vec.length() != 2) {
+      Rcpp::stop("dimension domain must be a c(lower bound, upper bound) pair");
     }
-    if (dtype == TILEDB_INT32) {
-        Rcpp::IntegerVector domain_vec = Rcpp::IntegerVector(domain);
-        if (domain_vec.length() != 2) {
-            Rcpp::stop("dimension domain must be a c(lower bound, upper bound) pair");
-        }
-        std::array<int32_t, 2> _domain = {domain_vec[0], domain_vec[1]};
-        int32_t _tile_extent = Rcpp::as<int32_t>(tile_extent);
-        auto dim = new tiledb::Dimension(tiledb::Dimension::create<int32_t>(*ctx.get(), name, _domain, _tile_extent));
-        auto ptr = make_xptr<tiledb::Dimension>(dim);
-        return ptr;
+    std::array<uint32_t, 2> _domain = {static_cast<uint32_t>(domain_vec[0]),
+                                       static_cast<uint32_t>(domain_vec[1])};
+    uint32_t _tile_extent = Rcpp::as<uint32_t>(tile_extent);
+    auto dim = new tiledb::Dimension(tiledb::Dimension::create<uint32_t>(
+        *ctx.get(), name, _domain, _tile_extent));
+    auto ptr = make_xptr<tiledb::Dimension>(dim);
+    return ptr;
 
-    } else if (dtype == TILEDB_UINT32) {
-        Rcpp::IntegerVector domain_vec = Rcpp::IntegerVector(domain);
-        if (domain_vec.length() != 2) {
-            Rcpp::stop("dimension domain must be a c(lower bound, upper bound) pair");
-        }
-        std::array<uint32_t, 2> _domain = {static_cast<uint32_t>(domain_vec[0]), static_cast<uint32_t>(domain_vec[1])};
-        uint32_t _tile_extent = Rcpp::as<uint32_t>(tile_extent);
-        auto dim = new tiledb::Dimension(tiledb::Dimension::create<uint32_t>(*ctx.get(), name, _domain, _tile_extent));
-        auto ptr = make_xptr<tiledb::Dimension>(dim);
-        return ptr;
+  } else if (dtype == TILEDB_INT16) {
+    Rcpp::IntegerVector domain_vec = Rcpp::IntegerVector(domain);
+    if (domain_vec.length() != 2) {
+      Rcpp::stop("dimension domain must be a c(lower bound, upper bound) pair");
+    }
+    std::array<int16_t, 2> _domain = {static_cast<int16_t>(domain_vec[0]),
+                                      static_cast<int16_t>(domain_vec[1])};
+    int16_t _tile_extent = Rcpp::as<int16_t>(tile_extent);
+    auto dim = new tiledb::Dimension(tiledb::Dimension::create<int16_t>(
+        *ctx.get(), name, _domain, _tile_extent));
+    auto ptr = make_xptr<tiledb::Dimension>(dim);
+    return ptr;
 
-    } else if (dtype == TILEDB_INT16) {
-        Rcpp::IntegerVector domain_vec = Rcpp::IntegerVector(domain);
-        if (domain_vec.length() != 2) {
-            Rcpp::stop("dimension domain must be a c(lower bound, upper bound) pair");
-        }
-        std::array<int16_t, 2> _domain = {static_cast<int16_t>(domain_vec[0]), static_cast<int16_t>(domain_vec[1])};
-        int16_t _tile_extent = Rcpp::as<int16_t>(tile_extent);
-        auto dim = new tiledb::Dimension(tiledb::Dimension::create<int16_t>(*ctx.get(), name, _domain, _tile_extent));
-        auto ptr = make_xptr<tiledb::Dimension>(dim);
-        return ptr;
+  } else if (dtype == TILEDB_UINT16) {
+    Rcpp::IntegerVector domain_vec = Rcpp::IntegerVector(domain);
+    if (domain_vec.length() != 2) {
+      Rcpp::stop("dimension domain must be a c(lower bound, upper bound) pair");
+    }
+    std::array<uint16_t, 2> _domain = {static_cast<uint16_t>(domain_vec[0]),
+                                       static_cast<uint16_t>(domain_vec[1])};
+    int16_t _tile_extent = Rcpp::as<int16_t>(tile_extent);
+    auto dim = new tiledb::Dimension(tiledb::Dimension::create<uint16_t>(
+        *ctx.get(), name, _domain, _tile_extent));
+    auto ptr = make_xptr<tiledb::Dimension>(dim);
+    return ptr;
 
-    } else if (dtype == TILEDB_UINT16) {
-        Rcpp::IntegerVector domain_vec = Rcpp::IntegerVector(domain);
-        if (domain_vec.length() != 2) {
-            Rcpp::stop("dimension domain must be a c(lower bound, upper bound) pair");
-        }
-        std::array<uint16_t, 2> _domain = {static_cast<uint16_t>(domain_vec[0]), static_cast<uint16_t>(domain_vec[1])};
-        uint16_t _tile_extent = Rcpp::as<uint16_t>(tile_extent);
-        auto dim = new tiledb::Dimension(tiledb::Dimension::create<uint16_t>(*ctx.get(), name, _domain, _tile_extent));
-        auto ptr = make_xptr<tiledb::Dimension>(dim);
-        return ptr;
+  } else if (dtype == TILEDB_UINT16) {
+    Rcpp::IntegerVector domain_vec = Rcpp::IntegerVector(domain);
+    if (domain_vec.length() != 2) {
+      Rcpp::stop("dimension domain must be a c(lower bound, upper bound) pair");
+    }
+    std::array<uint16_t, 2> _domain = {static_cast<uint16_t>(domain_vec[0]),
+                                       static_cast<uint16_t>(domain_vec[1])};
+    uint16_t _tile_extent = Rcpp::as<uint16_t>(tile_extent);
+    auto dim = new tiledb::Dimension(tiledb::Dimension::create<uint16_t>(
+        *ctx.get(), name, _domain, _tile_extent));
+    auto ptr = make_xptr<tiledb::Dimension>(dim);
+    return ptr;
 
-    } else if (dtype == TILEDB_INT8) {
-        Rcpp::IntegerVector domain_vec = Rcpp::IntegerVector(domain);
-        if (domain_vec.length() != 2) {
-            Rcpp::stop("dimension domain must be a c(lower bound, upper bound) pair");
-        }
-        std::array<int8_t, 2> _domain = {static_cast<int8_t>(domain_vec[0]), static_cast<int8_t>(domain_vec[1])};
-        int8_t _tile_extent = static_cast<int8_t>(Rcpp::as<int16_t>(tile_extent));
-        auto dim = new tiledb::Dimension(tiledb::Dimension::create<int8_t>(*ctx.get(), name, _domain, _tile_extent));
-        auto ptr = make_xptr<tiledb::Dimension>(dim);
-        return ptr;
+  } else if (dtype == TILEDB_INT8) {
+    Rcpp::IntegerVector domain_vec = Rcpp::IntegerVector(domain);
+    if (domain_vec.length() != 2) {
+      Rcpp::stop("dimension domain must be a c(lower bound, upper bound) pair");
+    }
+    std::array<int8_t, 2> _domain = {static_cast<int8_t>(domain_vec[0]),
+                                     static_cast<int8_t>(domain_vec[1])};
+    int8_t _tile_extent = static_cast<int8_t>(Rcpp::as<int16_t>(tile_extent));
+    auto dim = new tiledb::Dimension(tiledb::Dimension::create<int8_t>(
+        *ctx.get(), name, _domain, _tile_extent));
+    auto ptr = make_xptr<tiledb::Dimension>(dim);
+    return ptr;
 
   } else if (dtype == TILEDB_UINT8) {
-        Rcpp::IntegerVector domain_vec = Rcpp::IntegerVector(domain);
-        if (domain_vec.length() != 2) {
-            Rcpp::stop("dimension domain must be a c(lower bound, upper bound) pair");
-        }
-        std::array<uint8_t, 2> _domain = {static_cast<uint8_t>(domain_vec[0]), static_cast<uint8_t>(domain_vec[1])};
-        uint8_t _tile_extent = Rcpp::as<uint8_t>(tile_extent);
-        auto dim = new tiledb::Dimension(tiledb::Dimension::create<uint8_t>(*ctx.get(), name, _domain, _tile_extent));
-        auto ptr = make_xptr<tiledb::Dimension>(dim);
-        return ptr;
+    Rcpp::IntegerVector domain_vec = Rcpp::IntegerVector(domain);
+    if (domain_vec.length() != 2) {
+      Rcpp::stop("dimension domain must be a c(lower bound, upper bound) pair");
+    }
+    std::array<uint8_t, 2> _domain = {static_cast<uint8_t>(domain_vec[0]),
+                                      static_cast<uint8_t>(domain_vec[1])};
+    uint8_t _tile_extent = Rcpp::as<uint8_t>(tile_extent);
+    auto dim = new tiledb::Dimension(tiledb::Dimension::create<uint8_t>(
+        *ctx.get(), name, _domain, _tile_extent));
+    auto ptr = make_xptr<tiledb::Dimension>(dim);
+    return ptr;
 
   } else if (dtype == TILEDB_INT64) {
-        // for int64 domains and extents we require integer64 types which are internally memmap'ed from double
-        Rcpp::NumericVector dv(domain);
-        if (!isInteger64(dv)) {
-            Rcpp::stop("dimension domain for INT64 must be an integer64 type in R");
-        }
-        if (dv.size() != 2) {
-            Rcpp::stop("dimension domain must be a c(lower bound, upper bound) pair");
-        }
-        std::vector<int64_t> domain_vec = fromInteger64(Rcpp::NumericVector(dv));
-        std::array<int64_t, 2> _domain = {domain_vec[0], domain_vec[1]};
-        Rcpp::NumericVector ext(tile_extent);
-        if (!isInteger64(ext)) {
-            Rcpp::stop("tile exent for INT64 domain must be an integer64 type in R");
-        }
-        int64_t _tile_extent = fromInteger64(ext[0]);
-        auto dim = new tiledb::Dimension(tiledb::Dimension::create<int64_t>(*ctx.get(), name, _domain, _tile_extent));
-        auto ptr = make_xptr<tiledb::Dimension>(dim);
-        return ptr;
-
-    } else if (dtype == TILEDB_UINT64) {
-        // for uint64 domains and extents we require integer64 types which are internally memmap'ed from double
-        Rcpp::NumericVector dv(domain);
-        if (!isInteger64(dv)) {
-            Rcpp::stop("dimension domain for UINT64 must be an integer64 type in R");
-        }
-        if (dv.size() != 2) {
-            Rcpp::stop("dimension domain must be a c(lower bound, upper bound) pair");
-        }
-        std::vector<int64_t> domain_vec = fromInteger64(Rcpp::NumericVector(dv));
-        std::array<uint64_t, 2> _domain = { static_cast<uint64_t>(domain_vec[0]), static_cast<uint64_t>(domain_vec[1])};
-        Rcpp::NumericVector ext(tile_extent);
-        if (!isInteger64(ext)) {
-            Rcpp::stop("tile exent for UINT64 domain must be an integer64 type in R");
-        }
-        uint64_t _tile_extent = static_cast<uint64_t>(fromInteger64(ext[0]));
-        auto dim = new tiledb::Dimension(tiledb::Dimension::create<uint64_t>(*ctx.get(), name, _domain, _tile_extent));
-        auto ptr = make_xptr<tiledb::Dimension>(dim);
-        return ptr;
-
-    } else if (dtype == TILEDB_FLOAT32) {
-        Rcpp::NumericVector domain_vec = Rcpp::NumericVector(domain);
-        if (domain_vec.length() != 2) {
-            Rcpp::stop("dimension domain must be a c(lower bound, upper bound) pair");
-        }
-        std::array<float, 2> _domain = {static_cast<float>(domain_vec[0]), static_cast<float>(domain_vec[1])};
-        float_t _tile_extent = Rcpp::as<float>(tile_extent);
-        auto d = new tiledb::Dimension(tiledb::Dimension::create<float>(*ctx.get(), name, _domain, _tile_extent));
-        auto ptr = make_xptr<tiledb::Dimension>(d);
-        return ptr;
-
-    } else if (dtype == TILEDB_FLOAT64) {
-        Rcpp::NumericVector domain_vec = Rcpp::NumericVector(domain);
-        if (domain_vec.length() != 2) {
-            Rcpp::stop("dimension domain must be a c(lower bound, upper bound) pair");
-        }
-        std::array<double, 2> _domain = {static_cast<double>(domain_vec[0]), static_cast<double>(domain_vec[1])};
-        double_t _tile_extent = Rcpp::as<double>(tile_extent);
-        auto d = new tiledb::Dimension(tiledb::Dimension::create<double>(*ctx.get(), name, _domain, _tile_extent));
-        auto ptr = make_xptr<tiledb::Dimension>(d);
-        return ptr;
-
-    } else if (dtype == TILEDB_DATETIME_YEAR ||
-               dtype == TILEDB_DATETIME_MONTH ||
-               dtype == TILEDB_DATETIME_WEEK ||
-               dtype == TILEDB_DATETIME_DAY ||
-               dtype == TILEDB_DATETIME_HR  ||
-               dtype == TILEDB_DATETIME_MIN ||
-               dtype == TILEDB_DATETIME_SEC ||
-               dtype == TILEDB_DATETIME_MS  ||
-               dtype == TILEDB_DATETIME_US  ||
-               dtype == TILEDB_DATETIME_NS  ||
-               dtype == TILEDB_DATETIME_PS  ||
-               dtype == TILEDB_DATETIME_FS  ||
-               dtype == TILEDB_DATETIME_AS    ) {
-        auto domain_vec = as<std::vector<int64_t>>(domain);
-        if (domain_vec.size() != 2) {
-            Rcpp::stop("dimension domain must be a c(lower bound, upper bound) pair");
-        }
-        int64_t domain[] = {domain_vec[0], domain_vec[1]};
-        int64_t extent = Rcpp::as<int64_t>(tile_extent);
-        auto dim = new tiledb::Dimension(tiledb::Dimension::create(*ctx.get(), name, dtype, domain, &extent));
-        auto ptr = make_xptr<tiledb::Dimension>(dim);
-        return ptr;
-
-    } else if (dtype == TILEDB_STRING_ASCII) {
-        if (Rf_isNull(domain) && Rf_isNull(tile_extent)) {
-            auto d = tiledb::Dimension::create(*ctx.get(), name, dtype, nullptr, nullptr);
-            auto dim = new tiledb::Dimension(d);
-            auto ptr = make_xptr<tiledb::Dimension>(dim);
-            return ptr;
-
-        } else {
-            Rcpp::stop("Non-null domain or extent to be added.");
-        }
-    } else {
-        Rcpp::stop("Unsupported tiledb type (%d) this should not happen!", dtype);
+    // for int64 domains and extents we require integer64 types which are
+    // internally memmap'ed from double
+    Rcpp::NumericVector dv(domain);
+    if (!isInteger64(dv)) {
+      Rcpp::stop("dimension domain for INT64 must be an integer64 type in R");
     }
+    if (dv.size() != 2) {
+      Rcpp::stop("dimension domain must be a c(lower bound, upper bound) pair");
+    }
+    std::vector<int64_t> domain_vec = fromInteger64(Rcpp::NumericVector(dv));
+    std::array<int64_t, 2> _domain = {domain_vec[0], domain_vec[1]};
+    Rcpp::NumericVector ext(tile_extent);
+    if (!isInteger64(ext)) {
+      Rcpp::stop("tile exent for INT64 domain must be an integer64 type in R");
+    }
+    int64_t _tile_extent = fromInteger64(ext[0]);
+    auto dim = new tiledb::Dimension(tiledb::Dimension::create<int64_t>(
+        *ctx.get(), name, _domain, _tile_extent));
+    auto ptr = make_xptr<tiledb::Dimension>(dim);
+    return ptr;
+
+  } else if (dtype == TILEDB_UINT64) {
+    // for uint64 domains and extents we require integer64 types which are
+    // internally memmap'ed from double
+    Rcpp::NumericVector dv(domain);
+    if (!isInteger64(dv)) {
+      Rcpp::stop("dimension domain for UINT64 must be an integer64 type in R");
+    }
+    if (dv.size() != 2) {
+      Rcpp::stop("dimension domain must be a c(lower bound, upper bound) pair");
+    }
+    std::vector<int64_t> domain_vec = fromInteger64(Rcpp::NumericVector(dv));
+    std::array<uint64_t, 2> _domain = {static_cast<uint64_t>(domain_vec[0]),
+                                       static_cast<uint64_t>(domain_vec[1])};
+    Rcpp::NumericVector ext(tile_extent);
+    if (!isInteger64(ext)) {
+      Rcpp::stop("tile exent for UINT64 domain must be an integer64 type in R");
+    }
+    uint64_t _tile_extent = static_cast<uint64_t>(fromInteger64(ext[0]));
+    auto dim = new tiledb::Dimension(tiledb::Dimension::create<uint64_t>(
+        *ctx.get(), name, _domain, _tile_extent));
+    auto ptr = make_xptr<tiledb::Dimension>(dim);
+    return ptr;
+
+  } else if (dtype == TILEDB_FLOAT32) {
+    Rcpp::NumericVector domain_vec = Rcpp::NumericVector(domain);
+    if (domain_vec.length() != 2) {
+      Rcpp::stop("dimension domain must be a c(lower bound, upper bound) pair");
+    }
+    std::array<float, 2> _domain = {static_cast<float>(domain_vec[0]),
+                                    static_cast<float>(domain_vec[1])};
+    float_t _tile_extent = Rcpp::as<float>(tile_extent);
+    auto d = new tiledb::Dimension(tiledb::Dimension::create<float>(
+        *ctx.get(), name, _domain, _tile_extent));
+    auto ptr = make_xptr<tiledb::Dimension>(d);
+    return ptr;
+
+  } else if (dtype == TILEDB_FLOAT64) {
+    Rcpp::NumericVector domain_vec = Rcpp::NumericVector(domain);
+    if (domain_vec.length() != 2) {
+      Rcpp::stop("dimension domain must be a c(lower bound, upper bound) pair");
+    }
+    std::array<double, 2> _domain = {static_cast<double>(domain_vec[0]),
+                                     static_cast<double>(domain_vec[1])};
+    double_t _tile_extent = Rcpp::as<double>(tile_extent);
+    auto d = new tiledb::Dimension(tiledb::Dimension::create<double>(
+        *ctx.get(), name, _domain, _tile_extent));
+    auto ptr = make_xptr<tiledb::Dimension>(d);
+    return ptr;
+
+  } else if (dtype == TILEDB_DATETIME_YEAR || dtype == TILEDB_DATETIME_MONTH ||
+             dtype == TILEDB_DATETIME_WEEK || dtype == TILEDB_DATETIME_DAY ||
+             dtype == TILEDB_DATETIME_HR || dtype == TILEDB_DATETIME_MIN ||
+             dtype == TILEDB_DATETIME_SEC || dtype == TILEDB_DATETIME_MS ||
+             dtype == TILEDB_DATETIME_US || dtype == TILEDB_DATETIME_NS ||
+             dtype == TILEDB_DATETIME_PS || dtype == TILEDB_DATETIME_FS ||
+             dtype == TILEDB_DATETIME_AS) {
+    auto domain_vec = as<std::vector<int64_t>>(domain);
+    if (domain_vec.size() != 2) {
+      Rcpp::stop("dimension domain must be a c(lower bound, upper bound) pair");
+    }
+    int64_t domain[] = {domain_vec[0], domain_vec[1]};
+    int64_t extent = Rcpp::as<int64_t>(tile_extent);
+    auto dim = new tiledb::Dimension(
+        tiledb::Dimension::create(*ctx.get(), name, dtype, domain, &extent));
+    auto ptr = make_xptr<tiledb::Dimension>(dim);
+    return ptr;
+
+  } else if (dtype == TILEDB_STRING_ASCII) {
+    if (Rf_isNull(domain) && Rf_isNull(tile_extent)) {
+      auto d =
+          tiledb::Dimension::create(*ctx.get(), name, dtype, nullptr, nullptr);
+      auto dim = new tiledb::Dimension(d);
+      auto ptr = make_xptr<tiledb::Dimension>(dim);
+      return ptr;
+
+    } else {
+      Rcpp::stop("Non-null domain or extent to be added.");
+    }
+  } else {
+    Rcpp::stop("Unsupported tiledb type (%d) this should not happen!", dtype);
+  }
 }
 
 // [[Rcpp::export]]
@@ -895,105 +942,125 @@ SEXP libtiledb_dim_get_domain(XPtr<tiledb::Dimension> dim) {
   check_xptr_tag<tiledb::Dimension>(dim);
   auto dim_type = dim->type();
   switch (dim_type) {
-    case TILEDB_FLOAT32: {
-      using DataType = tiledb::impl::tiledb_to_type<TILEDB_FLOAT32>::type;
-      return NumericVector({dim->domain<DataType>().first,
-                            dim->domain<DataType>().second});
+  case TILEDB_FLOAT32: {
+    using DataType = tiledb::impl::tiledb_to_type<TILEDB_FLOAT32>::type;
+    return NumericVector(
+        {dim->domain<DataType>().first, dim->domain<DataType>().second});
+  }
+  case TILEDB_FLOAT64: {
+    using DataType = tiledb::impl::tiledb_to_type<TILEDB_FLOAT64>::type;
+    auto d1 = dim->domain<DataType>().first;
+    auto d2 = dim->domain<DataType>().second;
+    if (d1 == R_NaReal || d2 == R_NaReal) {
+      Rcpp::stop(
+          "tiledb_dim domain FLOAT64 value not representable as an R double");
     }
-    case TILEDB_FLOAT64: {
-      using DataType = tiledb::impl::tiledb_to_type<TILEDB_FLOAT64>::type;
-      auto d1 = dim->domain<DataType>().first;
-      auto d2 = dim->domain<DataType>().second;
-      if (d1 == R_NaReal || d2 == R_NaReal) {
-        Rcpp::stop("tiledb_dim domain FLOAT64 value not representable as an R double");
-      }
-      return NumericVector({d1, d2});
+    return NumericVector({d1, d2});
+  }
+  case TILEDB_INT8: {
+    using DataType = tiledb::impl::tiledb_to_type<TILEDB_INT8>::type;
+    return IntegerVector(
+        {dim->domain<DataType>().first, dim->domain<DataType>().second});
+  }
+  case TILEDB_UINT8: {
+    using DataType = tiledb::impl::tiledb_to_type<TILEDB_UINT8>::type;
+    return IntegerVector(
+        {dim->domain<DataType>().first, dim->domain<DataType>().second});
+  }
+  case TILEDB_INT16: {
+    using DataType = tiledb::impl::tiledb_to_type<TILEDB_INT16>::type;
+    return IntegerVector(
+        {dim->domain<DataType>().first, dim->domain<DataType>().second});
+  }
+  case TILEDB_UINT16: {
+    using DataType = tiledb::impl::tiledb_to_type<TILEDB_INT16>::type;
+    return IntegerVector(
+        {dim->domain<DataType>().first, dim->domain<DataType>().second});
+  }
+  case TILEDB_INT32: {
+    using DataType = tiledb::impl::tiledb_to_type<TILEDB_INT32>::type;
+    auto d1 = dim->domain<DataType>().first;
+    auto d2 = dim->domain<DataType>().second;
+    if (d1 == R_NaInt || d2 == R_NaInt) {
+      Rcpp::stop(
+          "tiledb_dim domain INT32 value not representable as an R integer");
     }
-    case TILEDB_INT8: {
-      using DataType = tiledb::impl::tiledb_to_type<TILEDB_INT8>::type;
-      return IntegerVector({dim->domain<DataType>().first,
-                            dim->domain<DataType>().second});
+    return IntegerVector({d1, d2});
+  }
+  case TILEDB_UINT32: {
+    using DataType = tiledb::impl::tiledb_to_type<TILEDB_UINT32>::type;
+    auto d1 = dim->domain<DataType>().first;
+    auto d2 = dim->domain<DataType>().second;
+    if (d1 > std::numeric_limits<uint32_t>::max() ||
+        d2 > std::numeric_limits<uint32_t>::max()) {
+      Rcpp::stop("tiledb_dim domain UINT32 value not representable as an R "
+                 "integer64 type");
     }
-    case TILEDB_UINT8: {
-      using DataType = tiledb::impl::tiledb_to_type<TILEDB_UINT8>::type;
-      return IntegerVector({dim->domain<DataType>().first,
-                            dim->domain<DataType>().second});
+    std::vector<int64_t> v = {static_cast<int64_t>(d1),
+                              static_cast<int64_t>(d2)};
+    return toInteger64(v);
+  }
+  case TILEDB_INT64: {
+    using DataType = tiledb::impl::tiledb_to_type<TILEDB_INT64>::type;
+    auto d1 = dim->domain<DataType>().first;
+    auto d2 = dim->domain<DataType>().second;
+    if (d1 > std::numeric_limits<int64_t>::max() ||
+        d2 > std::numeric_limits<int64_t>::max()) {
+      return NumericVector({static_cast<double>(d1), static_cast<double>(d2)});
     }
-    case TILEDB_INT16: {
-      using DataType = tiledb::impl::tiledb_to_type<TILEDB_INT16>::type;
-      return IntegerVector({dim->domain<DataType>().first,
-                            dim->domain<DataType>().second});
+    std::vector<int64_t> v = {d1, d2};
+    return toInteger64(v);
+  }
+  case TILEDB_UINT64: {
+    using DataType = tiledb::impl::tiledb_to_type<TILEDB_UINT64>::type;
+    auto d1 = dim->domain<DataType>().first;
+    auto d2 = dim->domain<DataType>().second;
+    if (d1 > std::numeric_limits<int64_t>::max() ||
+        d2 > std::numeric_limits<int64_t>::max()) {
+      return NumericVector({static_cast<double>(d1), static_cast<double>(d2)});
     }
-    case TILEDB_UINT16: {
-      using DataType = tiledb::impl::tiledb_to_type<TILEDB_UINT16>::type;
-      return IntegerVector({dim->domain<DataType>().first,
-                            dim->domain<DataType>().second});
-    }
-    case TILEDB_INT32: {
-      using DataType = tiledb::impl::tiledb_to_type<TILEDB_INT32>::type;
-      auto d1 = dim->domain<DataType>().first;
-      auto d2 = dim->domain<DataType>().second;
-      if (d1 == R_NaInt || d2 == R_NaInt) {
-        Rcpp::stop("tiledb_dim domain INT32 value not representable as an R integer");
-      }
-      return IntegerVector({d1, d2});
-    }
-    case TILEDB_UINT32: {
-      using DataType = tiledb::impl::tiledb_to_type<TILEDB_UINT32>::type;
-      auto d1 = dim->domain<DataType>().first;
-      auto d2 = dim->domain<DataType>().second;
-      if (d1 > std::numeric_limits<uint32_t>::max() ||
-          d2 > std::numeric_limits<uint32_t>::max()) {
-        Rcpp::stop("tiledb_dim domain UINT32 value not representable as an R integer64 type");
-      }
-      std::vector<int64_t> v = { static_cast<int64_t>(d1), static_cast<int64_t>(d2) };
-      return toInteger64(v);
-    }
-    case TILEDB_INT64: {
-      using DataType = tiledb::impl::tiledb_to_type<TILEDB_INT64>::type;
-      auto d1 = dim->domain<DataType>().first;
-      auto d2 = dim->domain<DataType>().second;
-      if (d1 > std::numeric_limits<int64_t>::max() || d2 > std::numeric_limits<int64_t>::max()) {
-          return NumericVector({static_cast<double>(d1), static_cast<double>(d2)});
-      }
-      std::vector<int64_t> v = { d1, d2 };
-      return toInteger64(v);
-    }
-    case TILEDB_UINT64: {
-      using DataType = tiledb::impl::tiledb_to_type<TILEDB_UINT64>::type;
-      auto d1 = dim->domain<DataType>().first;
-      auto d2 = dim->domain<DataType>().second;
-      if (d1 > std::numeric_limits<int64_t>::max() || d2 > std::numeric_limits<int64_t>::max()) {
-          return NumericVector({static_cast<double>(d1), static_cast<double>(d2)});
-      }
-      std::vector<int64_t> v = { static_cast<int64_t>(d1), static_cast<int64_t>(d2) };
-      return toInteger64(v);
-    }
-    case TILEDB_DATETIME_YEAR:
-    case TILEDB_DATETIME_MONTH:
-    case TILEDB_DATETIME_WEEK:
-    case TILEDB_DATETIME_DAY:
-    case TILEDB_DATETIME_HR:
-    case TILEDB_DATETIME_MIN:
-    case TILEDB_DATETIME_SEC:
-    case TILEDB_DATETIME_MS:
-    case TILEDB_DATETIME_US:
-    case TILEDB_DATETIME_NS:
-    case TILEDB_DATETIME_PS:
-    case TILEDB_DATETIME_FS:
-    case TILEDB_DATETIME_AS: {
-      using DataType = tiledb::impl::tiledb_to_type<TILEDB_INT64>::type;
-      auto d1 = dim->domain<DataType>().first;
-      auto d2 = dim->domain<DataType>().second;
-      if (d1 <= R_NaInt || d1 > std::numeric_limits<int32_t>::max() ||
-          d2 <= R_NaInt || d2 > std::numeric_limits<int32_t>::max()) {
-          std::vector<int64_t> v{d1, d2};     // return as int64
-          return toInteger64(v);              // which 'travels' as a double
-      }
-      return IntegerVector({static_cast<int32_t>(d1), static_cast<int32_t>(d2)});
-    }
-    default:
-      Rcpp::stop("invalid tiledb_dim domain type (%s)", _tiledb_datatype_to_string(dim_type));
+<<<<<<< HEAD
+  case TILEDB_UINT16: {
+    using DataType = tiledb::impl::tiledb_to_type<TILEDB_UINT16>::type;
+    return IntegerVector(
+        {dim->domain<DataType>().first, dim->domain<DataType>().second});
+||||||| parent of 11968568 (clang-format src/libtiledb.cpp)
+  case TILEDB_UINT16: {
+    using DataType = tiledb::impl::tiledb_to_type<TILEDB_INT16>::type;
+    return IntegerVector(
+        {dim->domain<DataType>().first, dim->domain<DataType>().second});
+=======
+    std::vector<int64_t> v = {static_cast<int64_t>(d1),
+                              static_cast<int64_t>(d2)};
+    return toInteger64(v);
+  }
+  case TILEDB_DATETIME_YEAR:
+  case TILEDB_DATETIME_MONTH:
+  case TILEDB_DATETIME_WEEK:
+  case TILEDB_DATETIME_DAY:
+  case TILEDB_DATETIME_HR:
+  case TILEDB_DATETIME_MIN:
+  case TILEDB_DATETIME_SEC:
+  case TILEDB_DATETIME_MS:
+  case TILEDB_DATETIME_US:
+  case TILEDB_DATETIME_NS:
+  case TILEDB_DATETIME_PS:
+  case TILEDB_DATETIME_FS:
+  case TILEDB_DATETIME_AS: {
+    using DataType = tiledb::impl::tiledb_to_type<TILEDB_INT64>::type;
+    auto d1 = dim->domain<DataType>().first;
+    auto d2 = dim->domain<DataType>().second;
+    if (d1 <= R_NaInt || d1 > std::numeric_limits<int32_t>::max() ||
+        d2 <= R_NaInt || d2 > std::numeric_limits<int32_t>::max()) {
+      std::vector<int64_t> v{d1, d2}; // return as int64
+      return toInteger64(v);          // which 'travels' as a double
+>>>>>>> 11968568 (clang-format src/libtiledb.cpp)
+  }
+    return IntegerVector({static_cast<int32_t>(d1), static_cast<int32_t>(d2)});
+  }
+  default:
+    Rcpp::stop("invalid tiledb_dim domain type (%s)",
+               _tiledb_datatype_to_string(dim_type));
   }
 }
 
@@ -1002,91 +1069,146 @@ SEXP libtiledb_dim_get_tile_extent(XPtr<tiledb::Dimension> dim) {
   check_xptr_tag<tiledb::Dimension>(dim);
   auto dim_type = dim->type();
   switch (dim_type) {
-    case TILEDB_FLOAT32: {
-      using DataType = tiledb::impl::tiledb_to_type<TILEDB_FLOAT32>::type;
-      return Rcpp::wrap(static_cast<double>(dim->tile_extent<DataType>()));
+  case TILEDB_FLOAT32: {
+    using DataType = tiledb::impl::tiledb_to_type<TILEDB_FLOAT32>::type;
+    return Rcpp::wrap(static_cast<double>(dim->tile_extent<DataType>()));
+  }
+  case TILEDB_FLOAT64: {
+    using DataType = tiledb::impl::tiledb_to_type<TILEDB_FLOAT64>::type;
+    auto t = dim->tile_extent<DataType>();
+    if (t == R_NaReal) {
+      Rcpp::stop(
+          "tiledb_dim tile FLOAT64 value not representable as an R double");
     }
-    case TILEDB_FLOAT64: {
-      using DataType = tiledb::impl::tiledb_to_type<TILEDB_FLOAT64>::type;
-      auto t = dim->tile_extent<DataType>();
-      if (t == R_NaReal) {
-        Rcpp::stop("tiledb_dim tile FLOAT64 value not representable as an R double");
-      }
-      return Rcpp::wrap(static_cast<double>(dim->tile_extent<DataType>()));
+    return Rcpp::wrap(static_cast<double>(dim->tile_extent<DataType>()));
+  }
+  case TILEDB_INT8: {
+    using DataType = tiledb::impl::tiledb_to_type<TILEDB_INT8>::type;
+    return Rcpp::wrap(static_cast<int32_t>(dim->tile_extent<DataType>()));
+  }
+  case TILEDB_UINT8: {
+    using DataType = tiledb::impl::tiledb_to_type<TILEDB_UINT8>::type;
+    return Rcpp::wrap(static_cast<int32_t>(dim->tile_extent<DataType>()));
+  }
+  case TILEDB_INT16: {
+    using DataType = tiledb::impl::tiledb_to_type<TILEDB_INT16>::type;
+    return Rcpp::wrap(static_cast<int32_t>(dim->tile_extent<DataType>()));
+  }
+  case TILEDB_UINT16: {
+    using DataType = tiledb::impl::tiledb_to_type<TILEDB_INT16>::type;
+    return Rcpp::wrap(static_cast<int32_t>(dim->tile_extent<DataType>()));
+  }
+  case TILEDB_INT32: {
+    using DataType = tiledb::impl::tiledb_to_type<TILEDB_INT32>::type;
+    auto t = dim->tile_extent<DataType>();
+    if (t == R_NaInt) {
+      Rcpp::stop(
+          "tiledb_dim tile INT32 value not representable as an R integer");
     }
-    case TILEDB_INT8: {
-      using DataType = tiledb::impl::tiledb_to_type<TILEDB_INT8>::type;
-      return Rcpp::wrap(static_cast<int32_t>(dim->tile_extent<DataType>()));
+<<<<<<< HEAD
+  case TILEDB_INT8: {
+    using DataType = tiledb::impl::tiledb_to_type<TILEDB_INT8>::type;
+    return Rcpp::wrap(static_cast<int32_t>(dim->tile_extent<DataType>()));
+  }
+  case TILEDB_UINT8: {
+    using DataType = tiledb::impl::tiledb_to_type<TILEDB_UINT8>::type;
+    return Rcpp::wrap(static_cast<int32_t>(dim->tile_extent<DataType>()));
+  }
+  case TILEDB_INT16: {
+    using DataType = tiledb::impl::tiledb_to_type<TILEDB_INT16>::type;
+    return Rcpp::wrap(static_cast<int32_t>(dim->tile_extent<DataType>()));
+  }
+  case TILEDB_UINT16: {
+    using DataType = tiledb::impl::tiledb_to_type<TILEDB_UINT16>::type;
+    return Rcpp::wrap(static_cast<int32_t>(dim->tile_extent<DataType>()));
+  }
+  case TILEDB_INT32: {
+    using DataType = tiledb::impl::tiledb_to_type<TILEDB_INT32>::type;
+    auto t = dim->tile_extent<DataType>();
+    if (t == R_NaInt) {
+      Rcpp::stop(
+          "tiledb_dim tile INT32 value not representable as an R integer");
     }
-    case TILEDB_UINT8: {
-      using DataType = tiledb::impl::tiledb_to_type<TILEDB_UINT8>::type;
-      return Rcpp::wrap(static_cast<int32_t>(dim->tile_extent<DataType>()));
+||||||| parent of 11968568 (clang-format src/libtiledb.cpp)
+  case TILEDB_INT8: {
+    using DataType = tiledb::impl::tiledb_to_type<TILEDB_INT8>::type;
+    return Rcpp::wrap(static_cast<int32_t>(dim->tile_extent<DataType>()));
+  }
+  case TILEDB_UINT8: {
+    using DataType = tiledb::impl::tiledb_to_type<TILEDB_UINT8>::type;
+    return Rcpp::wrap(static_cast<int32_t>(dim->tile_extent<DataType>()));
+  }
+  case TILEDB_INT16: {
+    using DataType = tiledb::impl::tiledb_to_type<TILEDB_INT16>::type;
+    return Rcpp::wrap(static_cast<int32_t>(dim->tile_extent<DataType>()));
+  }
+  case TILEDB_UINT16: {
+    using DataType = tiledb::impl::tiledb_to_type<TILEDB_INT16>::type;
+    return Rcpp::wrap(static_cast<int32_t>(dim->tile_extent<DataType>()));
+  }
+  case TILEDB_INT32: {
+    using DataType = tiledb::impl::tiledb_to_type<TILEDB_INT32>::type;
+    auto t = dim->tile_extent<DataType>();
+    if (t == R_NaInt) {
+      Rcpp::stop(
+          "tiledb_dim tile INT32 value not representable as an R integer");
     }
-    case TILEDB_INT16: {
-      using DataType = tiledb::impl::tiledb_to_type<TILEDB_INT16>::type;
-      return Rcpp::wrap(static_cast<int32_t>(dim->tile_extent<DataType>()));
+=======
+    return Rcpp::wrap(static_cast<int32_t>(t));
+  }
+  case TILEDB_UINT32: {
+    using DataType = tiledb::impl::tiledb_to_type<TILEDB_UINT32>::type;
+    auto t = dim->tile_extent<DataType>();
+    if (t > std::numeric_limits<int32_t>::max()) {
+      Rcpp::warning("tiledb_dim tile UINT32 value not representable as an R "
+                    "integer, returning double");
+      return Rcpp::wrap(static_cast<double>(t));
+    } else {
+>>>>>>> 11968568 (clang-format src/libtiledb.cpp)
+    return Rcpp::wrap(static_cast<int32_t>(t));
+  }
+  }
+  case TILEDB_DATETIME_YEAR:
+  case TILEDB_DATETIME_MONTH:
+  case TILEDB_DATETIME_WEEK:
+  case TILEDB_DATETIME_DAY:
+  case TILEDB_DATETIME_HR:
+  case TILEDB_DATETIME_MIN:
+  case TILEDB_DATETIME_SEC:
+  case TILEDB_DATETIME_MS:
+  case TILEDB_DATETIME_US:
+  case TILEDB_DATETIME_NS:
+  case TILEDB_DATETIME_PS:
+  case TILEDB_DATETIME_FS:
+  case TILEDB_DATETIME_AS:
+  case TILEDB_INT64: {
+    using DataType = tiledb::impl::tiledb_to_type<TILEDB_INT64>::type;
+    auto t = dim->tile_extent<DataType>();
+    if (t <= R_NaInt || t > std::numeric_limits<int32_t>::max()) {
+      std::vector<int64_t> v{t}; // return as int64
+      return toInteger64(v);     // which 'travels' as a double
     }
-    case TILEDB_UINT16: {
-      using DataType = tiledb::impl::tiledb_to_type<TILEDB_UINT16>::type;
-      return Rcpp::wrap(static_cast<int32_t>(dim->tile_extent<DataType>()));
+    // 'else' i.e. default cast to int32
+    return Rcpp::wrap(static_cast<int32_t>(t));
+  }
+  case TILEDB_UINT64: {
+    using DataType = tiledb::impl::tiledb_to_type<TILEDB_UINT64>::type;
+    auto t = dim->tile_extent<DataType>();
+    if (t > std::numeric_limits<int64_t>::max()) {
+      Rcpp::warning("tiledb_dim tile UINT32 value not representable as an "
+                    "INT64, returning double");
+      return Rcpp::wrap(static_cast<double>(t));
     }
-    case TILEDB_INT32: {
-      using DataType = tiledb::impl::tiledb_to_type<TILEDB_INT32>::type;
-      auto t = dim->tile_extent<DataType>();
-      if (t == R_NaInt) {
-        Rcpp::stop("tiledb_dim tile INT32 value not representable as an R integer");
-      }
-      return Rcpp::wrap(static_cast<int32_t>(t));
+    if (t > std::numeric_limits<int32_t>::max()) {
+      auto tt = static_cast<int64_t>(t); // avoids a 'narrowing' watnings
+      std::vector<int64_t> v{tt};        // return as int64
+      return toInteger64(v);             // which 'travels' as a double
     }
-    case TILEDB_UINT32: {
-      using DataType = tiledb::impl::tiledb_to_type<TILEDB_UINT32>::type;
-      auto t = dim->tile_extent<DataType>();
-      if (t > std::numeric_limits<int32_t>::max()) {
-        Rcpp::warning("tiledb_dim tile UINT32 value not representable as an R integer, returning double");
-        return Rcpp::wrap(static_cast<double>(t));
-      } else {
-        return Rcpp::wrap(static_cast<int32_t>(t));
-      }
-    }
-    case TILEDB_DATETIME_YEAR:
-    case TILEDB_DATETIME_MONTH:
-    case TILEDB_DATETIME_WEEK:
-    case TILEDB_DATETIME_DAY:
-    case TILEDB_DATETIME_HR:
-    case TILEDB_DATETIME_MIN:
-    case TILEDB_DATETIME_SEC:
-    case TILEDB_DATETIME_MS:
-    case TILEDB_DATETIME_US:
-    case TILEDB_DATETIME_NS:
-    case TILEDB_DATETIME_PS:
-    case TILEDB_DATETIME_FS:
-    case TILEDB_DATETIME_AS:
-    case TILEDB_INT64: {
-      using DataType = tiledb::impl::tiledb_to_type<TILEDB_INT64>::type;
-      auto t = dim->tile_extent<DataType>();
-      if (t <= R_NaInt || t > std::numeric_limits<int32_t>::max()) {
-          std::vector<int64_t> v{t};         // return as int64
-          return toInteger64(v);             // which 'travels' as a double
-      }
-      // 'else' i.e. default cast to int32
-      return Rcpp::wrap(static_cast<int32_t>(t));
-    }
-    case TILEDB_UINT64: {
-      using DataType = tiledb::impl::tiledb_to_type<TILEDB_UINT64>::type;
-      auto t = dim->tile_extent<DataType>();
-      if (t > std::numeric_limits<int64_t>::max()) {
-          Rcpp::warning("tiledb_dim tile UINT32 value not representable as an INT64, returning double");
-          return Rcpp::wrap(static_cast<double>(t));
-      }
-      if (t > std::numeric_limits<int32_t>::max()) {
-          auto tt = static_cast<int64_t>(t); // avoids a 'narrowing' watnings
-          std::vector<int64_t> v{ tt };      // return as int64
-          return toInteger64(v);             // which 'travels' as a double
-      }
-      return Rcpp::wrap(static_cast<int32_t>(t));
-    }
-    default:
-      Rcpp::stop("invalid tiledb_dim domain type (%s)", _tiledb_datatype_to_string(dim_type));
+    return Rcpp::wrap(static_cast<int32_t>(t));
+  }
+  default:
+    Rcpp::stop("invalid tiledb_dim domain type (%s)",
+               _tiledb_datatype_to_string(dim_type));
   }
 }
 
@@ -1098,7 +1220,8 @@ std::string libtiledb_dim_get_datatype(XPtr<tiledb::Dimension> dim) {
 
 // Computes the TileDB subarray for a given dimension domain
 // [[Rcpp::export]]
-NumericVector dim_domain_subarray(NumericVector domain, NumericVector subscript) {
+NumericVector dim_domain_subarray(NumericVector domain,
+                                  NumericVector subscript) {
   if (domain.length() != 2) {
     Rcpp::stop("invalid tiledb_dim domain");
   }
@@ -1125,8 +1248,8 @@ NumericVector dim_domain_subarray(NumericVector domain, NumericVector subscript)
       Rcpp::stop("NA subscripting not supported");
     }
     if (high < domain_lb || high > domain_ub) {
-      Rcpp::stop("subscript out of domain bounds: (at index: [%d] %f < %f",
-                 i, high, domain_lb);
+      Rcpp::stop("subscript out of domain bounds: (at index: [%d] %f < %f", i,
+                 high, domain_lb);
     }
     double diff = high - low;
     if (diff > 1.0 || diff < 1.0) {
@@ -1147,7 +1270,7 @@ int libtiledb_dim_get_cell_val_num(XPtr<tiledb::Dimension> dim) {
   check_xptr_tag<tiledb::Dimension>(dim);
   unsigned int ncells = dim->cell_val_num();
   if (ncells == TILEDB_VAR_NUM) {
-    return R_NaInt;          // set to R's NA for integer
+    return R_NaInt; // set to R's NA for integer
   } else if (ncells > std::numeric_limits<int32_t>::max()) {
     Rcpp::stop("tiledb_attr ncells value not representable as an R integer");
   }
@@ -1155,20 +1278,22 @@ int libtiledb_dim_get_cell_val_num(XPtr<tiledb::Dimension> dim) {
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::FilterList> libtiledb_dimension_get_filter_list(XPtr<tiledb::Dimension> dim) {
+XPtr<tiledb::FilterList>
+libtiledb_dimension_get_filter_list(XPtr<tiledb::Dimension> dim) {
   check_xptr_tag<tiledb::Dimension>(dim);
-  return make_xptr<tiledb::FilterList>(new tiledb::FilterList(dim->filter_list()));
+  return make_xptr<tiledb::FilterList>(
+      new tiledb::FilterList(dim->filter_list()));
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::Dimension> libtiledb_dimension_set_filter_list(XPtr<tiledb::Dimension> dim,
-                                                            XPtr<tiledb::FilterList> fltrlst) {
+XPtr<tiledb::Dimension>
+libtiledb_dimension_set_filter_list(XPtr<tiledb::Dimension> dim,
+                                    XPtr<tiledb::FilterList> fltrlst) {
   check_xptr_tag<tiledb::Dimension>(dim);
   check_xptr_tag<tiledb::FilterList>(fltrlst);
   dim->set_filter_list(*fltrlst);
   return dim;
 }
-
 
 /**
  * TileDB Domain
@@ -1180,15 +1305,18 @@ XPtr<tiledb::Domain> libtiledb_domain(XPtr<tiledb::Context> ctx, List dims) {
   if (ndims == 0) {
     Rcpp::stop("domain must have one or more dimensions");
   }
-  for (R_xlen_t i=0; i < ndims; i++) {
+  for (R_xlen_t i = 0; i < ndims; i++) {
     SEXP d = dims[i];
     if (TYPEOF(d) != EXTPTRSXP) {
-      Rcpp::stop("Invalid tiledb_dim object at index %d (type %s)", i, Rcpp::type2name(d));
+      Rcpp::stop("Invalid tiledb_dim object at index %d (type %s)", i,
+                 Rcpp::type2name(d));
     }
   }
-  XPtr<tiledb::Domain> domain = make_xptr<tiledb::Domain>(new tiledb::Domain(*ctx.get()));
-  for (auto& val : dims) {
-    // TODO: we can't do much type checking for the cast here until we wrap EXTPTRSXP in S4 classes
+  XPtr<tiledb::Domain> domain =
+      make_xptr<tiledb::Domain>(new tiledb::Domain(*ctx.get()));
+  for (auto &val : dims) {
+    // TODO: we can't do much type checking for the cast here until we wrap
+    // EXTPTRSXP in S4 classes
     auto dim = as<XPtr<tiledb::Dimension>>(val);
     check_xptr_tag<tiledb::Dimension>(dim);
     domain->add_dimension(*dim.get());
@@ -1214,7 +1342,8 @@ int libtiledb_domain_get_ndim(XPtr<tiledb::Domain> domain) {
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::Dimension> libtiledb_domain_get_dimension_from_index(XPtr<tiledb::Domain> dom, int idx) {
+XPtr<tiledb::Dimension>
+libtiledb_domain_get_dimension_from_index(XPtr<tiledb::Domain> dom, int idx) {
   check_xptr_tag<tiledb::Domain>(dom);
   auto dim = dom->dimension(idx);
   auto ptr = make_xptr<tiledb::Dimension>(new tiledb::Dimension(dim));
@@ -1222,8 +1351,9 @@ XPtr<tiledb::Dimension> libtiledb_domain_get_dimension_from_index(XPtr<tiledb::D
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::Dimension> libtiledb_domain_get_dimension_from_name(XPtr<tiledb::Domain> dom,
-                                                                 std::string name) {
+XPtr<tiledb::Dimension>
+libtiledb_domain_get_dimension_from_name(XPtr<tiledb::Domain> dom,
+                                         std::string name) {
   check_xptr_tag<tiledb::Domain>(dom);
   auto dim = dom->dimension(name.c_str());
   auto ptr = make_xptr<tiledb::Dimension>(new tiledb::Dimension(dim));
@@ -1234,14 +1364,16 @@ XPtr<tiledb::Dimension> libtiledb_domain_get_dimension_from_name(XPtr<tiledb::Do
 List libtiledb_domain_get_dimensions(XPtr<tiledb::Domain> domain) {
   check_xptr_tag<tiledb::Domain>(domain);
   List dimensions;
-  for (auto& dim : domain->dimensions()) {
-    dimensions.push_back(make_xptr<tiledb::Dimension>(new tiledb::Dimension(dim)));
+  for (auto &dim : domain->dimensions()) {
+    dimensions.push_back(
+        make_xptr<tiledb::Dimension>(new tiledb::Dimension(dim)));
   }
   return dimensions;
 }
 
 // [[Rcpp::export]]
-bool libtiledb_domain_has_dimension(XPtr<tiledb::Domain> domain, std::string name) {
+bool libtiledb_domain_has_dimension(XPtr<tiledb::Domain> domain,
+                                    std::string name) {
   check_xptr_tag<tiledb::Domain>(domain);
   return domain->has_dimension(name.c_str());
 }
@@ -1249,7 +1381,7 @@ bool libtiledb_domain_has_dimension(XPtr<tiledb::Domain> domain, std::string nam
 // [[Rcpp::export]]
 void libtiledb_domain_dump(XPtr<tiledb::Domain> domain) {
   check_xptr_tag<tiledb::Domain>(domain);
-#if TILEDB_VERSION >= TileDB_Version(2,25,0)
+#if TILEDB_VERSION >= TileDB_Version(2, 25, 0)
   std::stringstream ss;
   ss << *domain;
   Rcpp::Rcout << ss.str();
@@ -1259,7 +1391,8 @@ void libtiledb_domain_dump(XPtr<tiledb::Domain> domain) {
 }
 
 double _domain_datatype_time_scale_factor(tiledb_datatype_t dtype) {
-  //Rcpp::Rcout << "In _domain_datatype_time_scale_factor " << dtype << std::endl;
+  // Rcpp::Rcout << "In _domain_datatype_time_scale_factor " << dtype <<
+  // std::endl;
   switch (dtype) {
   case TILEDB_INT8:
   case TILEDB_UINT8:
@@ -1279,11 +1412,11 @@ double _domain_datatype_time_scale_factor(tiledb_datatype_t dtype) {
   case TILEDB_STRING_UCS2:
   case TILEDB_STRING_UCS4:
   case TILEDB_ANY:
-    return 1.0;               // fallback, could also error here
+    return 1.0; // fallback, could also error here
   case TILEDB_DATETIME_YEAR:
   case TILEDB_DATETIME_MONTH:
   case TILEDB_DATETIME_WEEK:
-    return 1.0;                 // also fallback
+    return 1.0; // also fallback
   case TILEDB_DATETIME_DAY:
     return 24 * 60 * 60 * 1e9;
   case TILEDB_DATETIME_HR:
@@ -1310,12 +1443,12 @@ double _domain_datatype_time_scale_factor(tiledb_datatype_t dtype) {
   return R_NaReal; // not reached
 }
 
-
 /**
  * TileDB Filter
  */
 //[[Rcpp::export]]
-XPtr<tiledb::Filter> libtiledb_filter(XPtr<tiledb::Context> ctx, std::string filter) {
+XPtr<tiledb::Filter> libtiledb_filter(XPtr<tiledb::Context> ctx,
+                                      std::string filter) {
   check_xptr_tag<tiledb::Context>(ctx);
   tiledb_filter_type_t fltr = _string_to_tiledb_filter(filter);
   return make_xptr<tiledb::Filter>(new tiledb::Filter(*ctx.get(), fltr));
@@ -1328,10 +1461,13 @@ std::string libtiledb_filter_get_type(XPtr<tiledb::Filter> filter) {
 }
 
 //[[Rcpp::export]]
-R_xlen_t libtiledb_filter_get_option(XPtr<tiledb::Filter> filter, std::string filter_option_str) {
+R_xlen_t libtiledb_filter_get_option(XPtr<tiledb::Filter> filter,
+                                     std::string filter_option_str) {
   check_xptr_tag<tiledb::Filter>(filter);
-  tiledb_filter_option_t filter_option = _string_to_tiledb_filter_option(filter_option_str);
-  if (filter_option == TILEDB_BIT_WIDTH_MAX_WINDOW || filter_option == TILEDB_POSITIVE_DELTA_MAX_WINDOW) {
+  tiledb_filter_option_t filter_option =
+      _string_to_tiledb_filter_option(filter_option_str);
+  if (filter_option == TILEDB_BIT_WIDTH_MAX_WINDOW ||
+      filter_option == TILEDB_POSITIVE_DELTA_MAX_WINDOW) {
     uint32_t value;
     filter->get_option(filter_option, &value);
     return static_cast<R_xlen_t>(value);
@@ -1342,39 +1478,46 @@ R_xlen_t libtiledb_filter_get_option(XPtr<tiledb::Filter> filter, std::string fi
 }
 
 //[[Rcpp::export]]
-XPtr<tiledb::Filter> libtiledb_filter_set_option(XPtr<tiledb::Filter> filter, std::string filter_option_str, SEXP valuesxp) {
-    check_xptr_tag<tiledb::Filter>(filter);
-    tiledb_filter_option_t filter_option = _string_to_tiledb_filter_option(filter_option_str);
-#if TILEDB_VERSION >= TileDB_Version(2,11,0)
-    // For scale_float filters we need either a double, or an
-    if (filter_option == TILEDB_SCALE_FLOAT_FACTOR || filter_option == TILEDB_SCALE_FLOAT_OFFSET) {
-        double value = Rcpp::as<double>(valuesxp);
-        spdl::debug(tfm::format("[libtiledb_filter_set_option] setting %s to %f", filter_option_str, value));
-        filter->set_option(filter_option, &value);
-        return filter;
-    } else if (filter_option == TILEDB_SCALE_FLOAT_BYTEWIDTH) {
-        double dblval = Rcpp::as<double>(valuesxp);
-        int64_t int64val = fromInteger64(dblval);
-        uint64_t value = static_cast<uint64_t>(int64val);
-        spdl::debug(tfm::format("[libtiledb_filter_set_option] setting %s to %ld", filter_option_str, value));
-        filter->set_option(filter_option, &value);
-        return filter;
-    }
-#endif
-    // all others set an int value
-    int32_t value = Rcpp::as<int32_t>(valuesxp);
+XPtr<tiledb::Filter> libtiledb_filter_set_option(XPtr<tiledb::Filter> filter,
+                                                 std::string filter_option_str,
+                                                 SEXP valuesxp) {
+  check_xptr_tag<tiledb::Filter>(filter);
+  tiledb_filter_option_t filter_option =
+      _string_to_tiledb_filter_option(filter_option_str);
+#if TILEDB_VERSION >= TileDB_Version(2, 11, 0)
+  // For scale_float filters we need either a double, or an
+  if (filter_option == TILEDB_SCALE_FLOAT_FACTOR ||
+      filter_option == TILEDB_SCALE_FLOAT_OFFSET) {
+    double value = Rcpp::as<double>(valuesxp);
+    spdl::debug(tfm::format("[libtiledb_filter_set_option] setting %s to %f",
+                            filter_option_str, value));
     filter->set_option(filter_option, &value);
     return filter;
+  } else if (filter_option == TILEDB_SCALE_FLOAT_BYTEWIDTH) {
+    double dblval = Rcpp::as<double>(valuesxp);
+    int64_t int64val = fromInteger64(dblval);
+    uint64_t value = static_cast<uint64_t>(int64val);
+    spdl::debug(tfm::format("[libtiledb_filter_set_option] setting %s to %ld",
+                            filter_option_str, value));
+    filter->set_option(filter_option, &value);
+    return filter;
+  }
+#endif
+  // all others set an int value
+  int32_t value = Rcpp::as<int32_t>(valuesxp);
+  filter->set_option(filter_option, &value);
+  return filter;
 }
-
 
 /**
  * TileDB Filter List
  */
 //[[Rcpp::export]]
-XPtr<tiledb::FilterList> libtiledb_filter_list(XPtr<tiledb::Context> ctx, List filters) {
+XPtr<tiledb::FilterList> libtiledb_filter_list(XPtr<tiledb::Context> ctx,
+                                               List filters) {
   check_xptr_tag<tiledb::Context>(ctx);
-  XPtr<tiledb::FilterList> fltrlst = make_xptr<tiledb::FilterList>(new tiledb::FilterList(*ctx.get()));
+  XPtr<tiledb::FilterList> fltrlst =
+      make_xptr<tiledb::FilterList>(new tiledb::FilterList(*ctx.get()));
   // check that external pointers are supported
   R_xlen_t nfilters = filters.length();
   if (nfilters > 0) {
@@ -1388,13 +1531,15 @@ XPtr<tiledb::FilterList> libtiledb_filter_list(XPtr<tiledb::Context> ctx, List f
 }
 
 //[[Rcpp::export]]
-void libtiledb_filter_list_set_max_chunk_size(XPtr<tiledb::FilterList> filterList, uint32_t max_chunk_size) {
+void libtiledb_filter_list_set_max_chunk_size(
+    XPtr<tiledb::FilterList> filterList, uint32_t max_chunk_size) {
   check_xptr_tag<tiledb::FilterList>(filterList);
   filterList->set_max_chunk_size(max_chunk_size);
 }
 
 //[[Rcpp::export]]
-int libtiledb_filter_list_get_max_chunk_size(XPtr<tiledb::FilterList> filterList) {
+int libtiledb_filter_list_get_max_chunk_size(
+    XPtr<tiledb::FilterList> filterList) {
   check_xptr_tag<tiledb::FilterList>(filterList);
   return filterList->max_chunk_size();
 }
@@ -1406,82 +1551,78 @@ int libtiledb_filter_list_get_nfilters(XPtr<tiledb::FilterList> filterList) {
 }
 
 //[[Rcpp::export]]
-XPtr<tiledb::Filter> libtiledb_filter_list_get_filter_from_index(XPtr<tiledb::FilterList> filterList, uint32_t filter_index) {
+XPtr<tiledb::Filter>
+libtiledb_filter_list_get_filter_from_index(XPtr<tiledb::FilterList> filterList,
+                                            uint32_t filter_index) {
   check_xptr_tag<tiledb::FilterList>(filterList);
-  return make_xptr<tiledb::Filter>(new tiledb::Filter(filterList->filter(filter_index)));
+  return make_xptr<tiledb::Filter>(
+      new tiledb::Filter(filterList->filter(filter_index)));
 }
-
-
 
 /**
  * TileDB Attribute
  */
 //[[Rcpp::export]]
 XPtr<tiledb::Attribute> libtiledb_attribute(XPtr<tiledb::Context> ctx,
-                                            std::string name,
-                                            std::string type,
+                                            std::string name, std::string type,
                                             XPtr<tiledb::FilterList> fltrlst,
-                                            int ncells,
-                                            bool nullable) {
-    check_xptr_tag<tiledb::Context>(ctx);
-    spdl::debug(tfm::format("[libtiledb_attribute] Attr name %s type %s ncells %d nullable %s",
-                            name, type, ncells, nullable ? "true" : "false"));
-    tiledb_datatype_t attr_dtype = _string_to_tiledb_datatype(type);
-    if (ncells < 1 && ncells != R_NaInt) {
-        Rcpp::stop("ncells must be >= 1 (or NA for variable cells)");
-    }
-    // placeholder, overwritten in all branches below
-    XPtr<tiledb::Attribute> attr = XPtr<tiledb::Attribute>(static_cast<tiledb::Attribute*>(nullptr));
+                                            int ncells, bool nullable) {
+  check_xptr_tag<tiledb::Context>(ctx);
+  spdl::debug(tfm::format(
+      "[libtiledb_attribute] Attr name %s type %s ncells %d nullable %s", name,
+      type, ncells, nullable ? "true" : "false"));
+  tiledb_datatype_t attr_dtype = _string_to_tiledb_datatype(type);
+  if (ncells < 1 && ncells != R_NaInt) {
+    Rcpp::stop("ncells must be >= 1 (or NA for variable cells)");
+  }
+  // placeholder, overwritten in all branches below
+  XPtr<tiledb::Attribute> attr =
+      XPtr<tiledb::Attribute>(static_cast<tiledb::Attribute *>(nullptr));
 
-    if (attr_dtype == TILEDB_INT32 ||
-        attr_dtype == TILEDB_UINT32 ||
-        attr_dtype == TILEDB_FLOAT64 ||
-        attr_dtype == TILEDB_FLOAT32 ||
-        attr_dtype == TILEDB_INT64  ||
-        attr_dtype == TILEDB_UINT64 ||
-        attr_dtype == TILEDB_UINT32 ||
-        attr_dtype == TILEDB_INT16  ||
-        attr_dtype == TILEDB_UINT16 ||
-        attr_dtype == TILEDB_INT8   ||
-        attr_dtype == TILEDB_UINT8  ||
-        attr_dtype == TILEDB_DATETIME_YEAR ||
-        attr_dtype == TILEDB_DATETIME_MONTH ||
-        attr_dtype == TILEDB_DATETIME_WEEK ||
-        attr_dtype == TILEDB_DATETIME_DAY ||
-        attr_dtype == TILEDB_DATETIME_HR ||
-        attr_dtype == TILEDB_DATETIME_MIN ||
-        attr_dtype == TILEDB_DATETIME_SEC ||
-        attr_dtype == TILEDB_DATETIME_MS  ||
-        attr_dtype == TILEDB_DATETIME_US  ||
-        attr_dtype == TILEDB_DATETIME_NS  ||
-        attr_dtype == TILEDB_DATETIME_PS  ||
-        attr_dtype == TILEDB_DATETIME_FS  ||
-        attr_dtype == TILEDB_DATETIME_AS) {
-        attr = make_xptr<tiledb::Attribute>(new tiledb::Attribute(*ctx.get(), name, attr_dtype));
-        attr->set_cell_val_num(static_cast<uint64_t>(ncells));
-    } else if (attr_dtype == TILEDB_CHAR ||
-               attr_dtype == TILEDB_STRING_ASCII ||
-               attr_dtype == TILEDB_STRING_UTF8) {
-        attr = make_xptr<tiledb::Attribute>(new tiledb::Attribute(*ctx.get(), name, attr_dtype));
-#if TILEDB_VERSION >= TileDB_Version(2,10,0)
-    } else if (attr_dtype == TILEDB_BOOL) {
-        attr = make_xptr<tiledb::Attribute>(new tiledb::Attribute(*ctx.get(), name, attr_dtype));
+  if (attr_dtype == TILEDB_INT32 || attr_dtype == TILEDB_UINT32 ||
+      attr_dtype == TILEDB_FLOAT64 || attr_dtype == TILEDB_FLOAT32 ||
+      attr_dtype == TILEDB_INT64 || attr_dtype == TILEDB_UINT64 ||
+      attr_dtype == TILEDB_UINT32 || attr_dtype == TILEDB_INT16 ||
+      attr_dtype == TILEDB_UINT16 || attr_dtype == TILEDB_INT8 ||
+      attr_dtype == TILEDB_UINT8 || attr_dtype == TILEDB_DATETIME_YEAR ||
+      attr_dtype == TILEDB_DATETIME_MONTH ||
+      attr_dtype == TILEDB_DATETIME_WEEK || attr_dtype == TILEDB_DATETIME_DAY ||
+      attr_dtype == TILEDB_DATETIME_HR || attr_dtype == TILEDB_DATETIME_MIN ||
+      attr_dtype == TILEDB_DATETIME_SEC || attr_dtype == TILEDB_DATETIME_MS ||
+      attr_dtype == TILEDB_DATETIME_US || attr_dtype == TILEDB_DATETIME_NS ||
+      attr_dtype == TILEDB_DATETIME_PS || attr_dtype == TILEDB_DATETIME_FS ||
+      attr_dtype == TILEDB_DATETIME_AS) {
+    attr = make_xptr<tiledb::Attribute>(
+        new tiledb::Attribute(*ctx.get(), name, attr_dtype));
+    attr->set_cell_val_num(static_cast<uint64_t>(ncells));
+  } else if (attr_dtype == TILEDB_CHAR || attr_dtype == TILEDB_STRING_ASCII ||
+             attr_dtype == TILEDB_STRING_UTF8) {
+    attr = make_xptr<tiledb::Attribute>(
+        new tiledb::Attribute(*ctx.get(), name, attr_dtype));
+#if TILEDB_VERSION >= TileDB_Version(2, 10, 0)
+  } else if (attr_dtype == TILEDB_BOOL) {
+    attr = make_xptr<tiledb::Attribute>(
+        new tiledb::Attribute(*ctx.get(), name, attr_dtype));
 #endif
-    } else {
-        Rcpp::stop("Only integer ((U)INT{8,16,32,64}), logical (INT32), real (FLOAT{32,64}), "
-                   "Date (DATEIME_DAY), Datetime (DATETIME_{SEC,MS,US}), nanotime (DATETIME_NS), "
-#if TILEDB_VERSION >= TileDB_Version(2,10,0)
-                   "logical (BOOL), "
+  } else {
+    Rcpp::stop("Only integer ((U)INT{8,16,32,64}), logical (INT32), real "
+               "(FLOAT{32,64}), "
+               "Date (DATEIME_DAY), Datetime (DATETIME_{SEC,MS,US}), nanotime "
+               "(DATETIME_NS), "
+#if TILEDB_VERSION >= TileDB_Version(2, 10, 0)
+               "logical (BOOL), "
 #endif
-                   "and character (CHAR,ASCII,UTF8) attributes are supported "
-                   "-- seeing %s which is not", type.c_str());
-    }
-    // R's NA is different from TileDB's NA so test for NA_integer_, else cast
-    uint64_t num = (ncells == R_NaInt) ? TILEDB_VAR_NUM : static_cast<uint64_t>(ncells);
-    attr->set_cell_val_num(num);
-    attr->set_filter_list(*fltrlst);
-    attr->set_nullable(nullable);
-    return attr;
+               "and character (CHAR,ASCII,UTF8) attributes are supported "
+               "-- seeing %s which is not",
+               type.c_str());
+  }
+  // R's NA is different from TileDB's NA so test for NA_integer_, else cast
+  uint64_t num =
+      (ncells == R_NaInt) ? TILEDB_VAR_NUM : static_cast<uint64_t>(ncells);
+  attr->set_cell_val_num(num);
+  attr->set_filter_list(*fltrlst);
+  attr->set_nullable(nullable);
+  return attr;
 }
 
 // [[Rcpp::export]]
@@ -1504,13 +1645,17 @@ double libtiledb_attribute_get_cell_size(XPtr<tiledb::Attribute> attr) {
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::FilterList> libtiledb_attribute_get_filter_list(XPtr<tiledb::Attribute> attr) {
+XPtr<tiledb::FilterList>
+libtiledb_attribute_get_filter_list(XPtr<tiledb::Attribute> attr) {
   check_xptr_tag<tiledb::Attribute>(attr);
-  return make_xptr<tiledb::FilterList>(new tiledb::FilterList(attr->filter_list()));
+  return make_xptr<tiledb::FilterList>(
+      new tiledb::FilterList(attr->filter_list()));
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::Attribute> libtiledb_attribute_set_filter_list(XPtr<tiledb::Attribute> attr, XPtr<tiledb::FilterList> fltrlst) {
+XPtr<tiledb::Attribute>
+libtiledb_attribute_set_filter_list(XPtr<tiledb::Attribute> attr,
+                                    XPtr<tiledb::FilterList> fltrlst) {
   check_xptr_tag<tiledb::Attribute>(attr);
   check_xptr_tag<tiledb::FilterList>(fltrlst);
   attr->set_filter_list(*fltrlst);
@@ -1522,7 +1667,7 @@ int libtiledb_attribute_get_cell_val_num(XPtr<tiledb::Attribute> attr) {
   check_xptr_tag<tiledb::Attribute>(attr);
   unsigned int ncells = attr->cell_val_num();
   if (ncells == TILEDB_VAR_NUM) {
-    return R_NaInt;          // set to R's NA for integer
+    return R_NaInt; // set to R's NA for integer
   } else if (ncells > std::numeric_limits<int32_t>::max()) {
     Rcpp::stop("tiledb_attr ncells value not representable as an R integer");
   }
@@ -1530,15 +1675,17 @@ int libtiledb_attribute_get_cell_val_num(XPtr<tiledb::Attribute> attr) {
 }
 
 // [[Rcpp::export]]
-void libtiledb_attribute_set_cell_val_num(XPtr<tiledb::Attribute> attr, int num) {
+void libtiledb_attribute_set_cell_val_num(XPtr<tiledb::Attribute> attr,
+                                          int num) {
   check_xptr_tag<tiledb::Attribute>(attr);
   uint64_t ncells = static_cast<uint64_t>(num);
   if (num == R_NaInt) {
-    ncells = TILEDB_VAR_NUM;             // R's NA is different from TileDB's NA
+    ncells = TILEDB_VAR_NUM; // R's NA is different from TileDB's NA
   } else if (num <= 0) {
     Rcpp::stop("Variable cell number of '%d' not sensible", num);
   }
-  attr->set_cell_val_num(ncells);        // returns reference to self so nothing for us to return
+  attr->set_cell_val_num(
+      ncells); // returns reference to self so nothing for us to return
 }
 
 // [[Rcpp::export]]
@@ -1550,7 +1697,7 @@ bool libtiledb_attribute_is_variable_sized(XPtr<tiledb::Attribute> attr) {
 // [[Rcpp::export]]
 void libtiledb_attribute_dump(XPtr<tiledb::Attribute> attr) {
   check_xptr_tag<tiledb::Attribute>(attr);
-#if TILEDB_VERSION >= TileDB_Version(2,25,0)
+#if TILEDB_VERSION >= TileDB_Version(2, 25, 0)
   std::stringstream ss;
   ss << *attr;
   Rcpp::Rcout << ss.str();
@@ -1560,26 +1707,34 @@ void libtiledb_attribute_dump(XPtr<tiledb::Attribute> attr) {
 }
 
 // [[Rcpp::export]]
-void libtiledb_attribute_set_fill_value(XPtr<tiledb::Attribute> attr, SEXP val) {
+void libtiledb_attribute_set_fill_value(XPtr<tiledb::Attribute> attr,
+                                        SEXP val) {
   tiledb_datatype_t dtype = attr->type();
   check_xptr_tag<tiledb::Attribute>(attr);
   if (dtype == TILEDB_INT32) {
     IntegerVector v(val);
-    if (v.size() > 1) Rcpp::stop("Setting fill values only supports scalar values for now.");
-    attr->set_fill_value((void*) &(v[0]), static_cast<uint64_t>(sizeof(int32_t)));
+    if (v.size() > 1)
+      Rcpp::stop("Setting fill values only supports scalar values for now.");
+    attr->set_fill_value((void *)&(v[0]),
+                         static_cast<uint64_t>(sizeof(int32_t)));
   } else if (dtype == TILEDB_UINT32) {
     IntegerVector v(val);
-    if (v.size() > 1) Rcpp::stop("Setting fill values only supports scalar values for now.");
-    attr->set_fill_value((void*) &(v[0]), static_cast<uint64_t>(sizeof(uint32_t)));
+    if (v.size() > 1)
+      Rcpp::stop("Setting fill values only supports scalar values for now.");
+    attr->set_fill_value((void *)&(v[0]),
+                         static_cast<uint64_t>(sizeof(uint32_t)));
   } else if (dtype == TILEDB_FLOAT64) {
     NumericVector v(val);
-    if (v.size() > 1) Rcpp::stop("Setting fill values only supports scalar values for now.");
-    attr->set_fill_value((void*) &(v[0]), static_cast<uint64_t>(sizeof(double)));
+    if (v.size() > 1)
+      Rcpp::stop("Setting fill values only supports scalar values for now.");
+    attr->set_fill_value((void *)&(v[0]),
+                         static_cast<uint64_t>(sizeof(double)));
   } else if (dtype == TILEDB_STRING_ASCII || dtype == TILEDB_CHAR) {
     CharacterVector v(val);
-    if (v.size() > 1) Rcpp::stop("Setting fill values only supports scalar values for now.");
+    if (v.size() > 1)
+      Rcpp::stop("Setting fill values only supports scalar values for now.");
     std::string s(v[0]);
-    attr->set_fill_value((void*) s.c_str(), static_cast<uint64_t>(s.size()));
+    attr->set_fill_value((void *)s.c_str(), static_cast<uint64_t>(s.size()));
   } else {
     std::string typestr = _tiledb_datatype_to_string(dtype);
     Rcpp::stop("Type '%s' is not currently supported.", typestr.c_str());
@@ -1590,20 +1745,20 @@ void libtiledb_attribute_set_fill_value(XPtr<tiledb::Attribute> attr, SEXP val) 
 SEXP libtiledb_attribute_get_fill_value(XPtr<tiledb::Attribute> attr) {
   check_xptr_tag<tiledb::Attribute>(attr);
   tiledb_datatype_t dtype = attr->type();
-  const void* valptr;
+  const void *valptr;
   uint64_t size = sizeof(dtype);
   attr->get_fill_value(&valptr, &size);
   if (dtype == TILEDB_INT32) {
-    int32_t v = *(const int32_t*)valptr;
+    int32_t v = *(const int32_t *)valptr;
     return wrap(v);
   } else if (dtype == TILEDB_UINT32) {
-    uint32_t v = *(const uint32_t*)valptr;
+    uint32_t v = *(const uint32_t *)valptr;
     return wrap(v);
   } else if (dtype == TILEDB_FLOAT64) {
-    double v = *(const double*)valptr;
+    double v = *(const double *)valptr;
     return wrap(v);
   } else if (dtype == TILEDB_STRING_ASCII || dtype == TILEDB_CHAR) {
-    std::string s(static_cast<const char*>(valptr), static_cast<size_t>(size));
+    std::string s(static_cast<const char *>(valptr), static_cast<size_t>(size));
     return wrap(s);
   } else {
     std::string typestr = _tiledb_datatype_to_string(dtype);
@@ -1612,243 +1767,257 @@ SEXP libtiledb_attribute_get_fill_value(XPtr<tiledb::Attribute> attr) {
 }
 
 // [[Rcpp::export]]
-void libtiledb_attribute_set_nullable(XPtr<tiledb::Attribute> attr, const bool flag) {
-    check_xptr_tag<tiledb::Attribute>(attr);
-    attr->set_nullable(flag);
+void libtiledb_attribute_set_nullable(XPtr<tiledb::Attribute> attr,
+                                      const bool flag) {
+  check_xptr_tag<tiledb::Attribute>(attr);
+  attr->set_nullable(flag);
 }
 
 // [[Rcpp::export]]
 bool libtiledb_attribute_get_nullable(XPtr<tiledb::Attribute> attr) {
-    check_xptr_tag<tiledb::Attribute>(attr);
-    return attr->nullable();
+  check_xptr_tag<tiledb::Attribute>(attr);
+  return attr->nullable();
 }
 
 // [[Rcpp::export]]
 bool libtiledb_attribute_has_enumeration(XPtr<tiledb::Context> ctx,
                                          XPtr<tiledb::Attribute> attr) {
-    check_xptr_tag<tiledb::Context>(ctx);
-    check_xptr_tag<tiledb::Attribute>(attr);
-    bool res = false;
-#if TILEDB_VERSION >= TileDB_Version(2,17,0)
-    auto enmr = tiledb::AttributeExperimental::get_enumeration_name(*ctx.get(), *attr.get());
-    if (enmr != std::nullopt) {
-        res = true;
-    }
+  check_xptr_tag<tiledb::Context>(ctx);
+  check_xptr_tag<tiledb::Attribute>(attr);
+  bool res = false;
+#if TILEDB_VERSION >= TileDB_Version(2, 17, 0)
+  auto enmr = tiledb::AttributeExperimental::get_enumeration_name(*ctx.get(),
+                                                                  *attr.get());
+  if (enmr != std::nullopt) {
+    res = true;
+  }
 #endif
-    return res;
+  return res;
 }
 
 // [[Rcpp::export]]
-Rcpp::String libtiledb_attribute_get_enumeration_type(XPtr<tiledb::Context> ctx,
-                                                      XPtr<tiledb::Attribute> attr,
-                                                      XPtr<tiledb::Array> arr) {
+Rcpp::String
+libtiledb_attribute_get_enumeration_type(XPtr<tiledb::Context> ctx,
+                                         XPtr<tiledb::Attribute> attr,
+                                         XPtr<tiledb::Array> arr) {
 
-    check_xptr_tag<tiledb::Context>(ctx);
-    check_xptr_tag<tiledb::Attribute>(attr);
-    check_xptr_tag<tiledb::Array>(arr);
-#if TILEDB_VERSION >= TileDB_Version(2,17,0)
-    auto enmrname = tiledb::AttributeExperimental::get_enumeration_name(*ctx.get(), *attr.get());
-    if (enmrname == std::nullopt) {
-        Rcpp::stop("No enumeration name for attribute");
-    }
-    auto enmr = tiledb::ArrayExperimental::get_enumeration(*ctx.get(), *arr.get(), enmrname.value());
-    if (enmr.ptr() == nullptr) {
-        Rcpp::stop("No enumeration for given attribute.");
-    }
-    Rcpp::String res = Rcpp::as<Rcpp::String>(Rcpp::wrap(_tiledb_datatype_to_string(enmr.type())));
+  check_xptr_tag<tiledb::Context>(ctx);
+  check_xptr_tag<tiledb::Attribute>(attr);
+  check_xptr_tag<tiledb::Array>(arr);
+#if TILEDB_VERSION >= TileDB_Version(2, 17, 0)
+  auto enmrname = tiledb::AttributeExperimental::get_enumeration_name(
+      *ctx.get(), *attr.get());
+  if (enmrname == std::nullopt) {
+    Rcpp::stop("No enumeration name for attribute");
+  }
+  auto enmr = tiledb::ArrayExperimental::get_enumeration(*ctx.get(), *arr.get(),
+                                                         enmrname.value());
+  if (enmr.ptr() == nullptr) {
+    Rcpp::stop("No enumeration for given attribute.");
+  }
+  Rcpp::String res = Rcpp::as<Rcpp::String>(
+      Rcpp::wrap(_tiledb_datatype_to_string(enmr.type())));
 #else
-    Rcpp::String res = Rcpp::as<Rcpp::String>(NA_STRING);
+  Rcpp::String res = Rcpp::as<Rcpp::String>(NA_STRING);
 #endif
-    return res;
+  return res;
 }
 
 // [[Rcpp::export]]
 SEXP libtiledb_attribute_get_enumeration_vector(XPtr<tiledb::Context> ctx,
                                                 XPtr<tiledb::Attribute> attr,
                                                 XPtr<tiledb::Array> arr) {
-    check_xptr_tag<tiledb::Context>(ctx);
-    check_xptr_tag<tiledb::Attribute>(attr);
-    check_xptr_tag<tiledb::Array>(arr);
-    SEXP res = R_NilValue;
-#if TILEDB_VERSION >= TileDB_Version(2,17,0)
-    auto enmrname = tiledb::AttributeExperimental::get_enumeration_name(*ctx.get(), *attr.get());
-    if (enmrname == std::nullopt) {
-        Rcpp::stop("No enumeration name for attribute");
-    }
-    auto enmr = tiledb::ArrayExperimental::get_enumeration(*ctx.get(), *arr.get(), enmrname.value());
-    if (enmr.ptr() == nullptr) {
-        Rcpp::stop("No enumeration for given attribute.");
-    }
-    auto dtype = enmr.type();
-    if (dtype == TILEDB_FLOAT32 || dtype == TILEDB_FLOAT64) {
-        auto v = enmr.as_vector<double>();
-        res = Rcpp::wrap(v);
-    } else if (dtype == TILEDB_INT8 || dtype == TILEDB_INT16 || dtype == TILEDB_INT32 ||
-               dtype == TILEDB_UINT8 || dtype == TILEDB_UINT16 || dtype == TILEDB_UINT32) {
-        auto v = enmr.as_vector<int32_t>();
-        res = Rcpp::wrap(v);
-    } else if (dtype == TILEDB_INT64 || dtype == TILEDB_UINT64) {
-        auto v = enmr.as_vector<int64_t>();
-        res = Rcpp::toInteger64(v);
-    } else if (dtype == TILEDB_BOOL) {
-        auto v = enmr.as_vector<bool>();
-        res = Rcpp::wrap(v);
-    } else {
-        Rcpp::stop("Unsupported non-string type '%s'", _tiledb_datatype_to_string(dtype));
-    }
+  check_xptr_tag<tiledb::Context>(ctx);
+  check_xptr_tag<tiledb::Attribute>(attr);
+  check_xptr_tag<tiledb::Array>(arr);
+  SEXP res = R_NilValue;
+#if TILEDB_VERSION >= TileDB_Version(2, 17, 0)
+  auto enmrname = tiledb::AttributeExperimental::get_enumeration_name(
+      *ctx.get(), *attr.get());
+  if (enmrname == std::nullopt) {
+    Rcpp::stop("No enumeration name for attribute");
+  }
+  auto enmr = tiledb::ArrayExperimental::get_enumeration(*ctx.get(), *arr.get(),
+                                                         enmrname.value());
+  if (enmr.ptr() == nullptr) {
+    Rcpp::stop("No enumeration for given attribute.");
+  }
+  auto dtype = enmr.type();
+  if (dtype == TILEDB_FLOAT32 || dtype == TILEDB_FLOAT64) {
+    auto v = enmr.as_vector<double>();
+    res = Rcpp::wrap(v);
+  } else if (dtype == TILEDB_INT8 || dtype == TILEDB_INT16 ||
+             dtype == TILEDB_INT32 || dtype == TILEDB_UINT8 ||
+             dtype == TILEDB_UINT16 || dtype == TILEDB_UINT32) {
+    auto v = enmr.as_vector<int32_t>();
+    res = Rcpp::wrap(v);
+  } else if (dtype == TILEDB_INT64 || dtype == TILEDB_UINT64) {
+    auto v = enmr.as_vector<int64_t>();
+    res = Rcpp::toInteger64(v);
+  } else if (dtype == TILEDB_BOOL) {
+    auto v = enmr.as_vector<bool>();
+    res = Rcpp::wrap(v);
+  } else {
+    Rcpp::stop("Unsupported non-string type '%s'",
+               _tiledb_datatype_to_string(dtype));
+  }
 #endif
-    return res;
+  return res;
 }
 
 // [[Rcpp::export]]
-std::vector<std::string> libtiledb_attribute_get_enumeration(XPtr<tiledb::Context> ctx,
-                                                             XPtr<tiledb::Attribute> attr,
-                                                             XPtr<tiledb::Array> arr) {
-    check_xptr_tag<tiledb::Context>(ctx);
-    check_xptr_tag<tiledb::Attribute>(attr);
-    check_xptr_tag<tiledb::Array>(arr);
-    std::vector<std::string> res;
-#if TILEDB_VERSION >= TileDB_Version(2,17,0)
-    auto enmrname = tiledb::AttributeExperimental::get_enumeration_name(*ctx.get(), *attr.get());
-    if (enmrname == std::nullopt) {
-        Rcpp::stop("No enumeration name for attribute");
-    }
-    auto enmr = tiledb::ArrayExperimental::get_enumeration(*ctx.get(), *arr.get(), enmrname.value());
-    if (enmr.ptr() == nullptr) {
-        Rcpp::stop("No enumeration for given attribute.");
-    }
-    res = enmr.as_vector<std::string>();
+std::vector<std::string>
+libtiledb_attribute_get_enumeration(XPtr<tiledb::Context> ctx,
+                                    XPtr<tiledb::Attribute> attr,
+                                    XPtr<tiledb::Array> arr) {
+  check_xptr_tag<tiledb::Context>(ctx);
+  check_xptr_tag<tiledb::Attribute>(attr);
+  check_xptr_tag<tiledb::Array>(arr);
+  std::vector<std::string> res;
+#if TILEDB_VERSION >= TileDB_Version(2, 17, 0)
+  auto enmrname = tiledb::AttributeExperimental::get_enumeration_name(
+      *ctx.get(), *attr.get());
+  if (enmrname == std::nullopt) {
+    Rcpp::stop("No enumeration name for attribute");
+  }
+  auto enmr = tiledb::ArrayExperimental::get_enumeration(*ctx.get(), *arr.get(),
+                                                         enmrname.value());
+  if (enmr.ptr() == nullptr) {
+    Rcpp::stop("No enumeration for given attribute.");
+  }
+  res = enmr.as_vector<std::string>();
 #endif
-    return res;
+  return res;
 }
 
-
 // [[Rcpp::export]]
-XPtr<tiledb::Attribute> libtiledb_attribute_set_enumeration(XPtr<tiledb::Context> ctx,
-                                                            XPtr<tiledb::Attribute> attr,
-                                                            const std::string &enum_name) {
-    check_xptr_tag<tiledb::Context>(ctx);
-    check_xptr_tag<tiledb::Attribute>(attr);
-#if TILEDB_VERSION >= TileDB_Version(2,17,0)
-    tiledb::AttributeExperimental::set_enumeration_name(*ctx.get(), *attr.get(), enum_name);
+XPtr<tiledb::Attribute>
+libtiledb_attribute_set_enumeration(XPtr<tiledb::Context> ctx,
+                                    XPtr<tiledb::Attribute> attr,
+                                    const std::string &enum_name) {
+  check_xptr_tag<tiledb::Context>(ctx);
+  check_xptr_tag<tiledb::Attribute>(attr);
+#if TILEDB_VERSION >= TileDB_Version(2, 17, 0)
+  tiledb::AttributeExperimental::set_enumeration_name(*ctx.get(), *attr.get(),
+                                                      enum_name);
 #endif
-    return attr;
+  return attr;
 }
 
 // [[Rcpp::export]]
 bool libtiledb_attribute_is_ordered_enumeration(XPtr<tiledb::Context> ctx,
                                                 XPtr<tiledb::Attribute> attr,
                                                 XPtr<tiledb::Array> arr) {
-    check_xptr_tag<tiledb::Context>(ctx);
-    check_xptr_tag<tiledb::Attribute>(attr);
-    check_xptr_tag<tiledb::Array>(arr);
-    bool res = false;
-#if TILEDB_VERSION >= TileDB_Version(2,17,0)
-    auto enmrname = tiledb::AttributeExperimental::get_enumeration_name(*ctx.get(), *attr.get());
-    if (enmrname == std::nullopt) {
-        Rcpp::stop("No enumeration name for attribute");
-    }
-    auto enmr = tiledb::ArrayExperimental::get_enumeration(*ctx.get(), *arr.get(), enmrname.value());
-    if (enmr.ptr() != nullptr) {
-        res = enmr.ordered();
-    }
+  check_xptr_tag<tiledb::Context>(ctx);
+  check_xptr_tag<tiledb::Attribute>(attr);
+  check_xptr_tag<tiledb::Array>(arr);
+  bool res = false;
+#if TILEDB_VERSION >= TileDB_Version(2, 17, 0)
+  auto enmrname = tiledb::AttributeExperimental::get_enumeration_name(
+      *ctx.get(), *attr.get());
+  if (enmrname == std::nullopt) {
+    Rcpp::stop("No enumeration name for attribute");
+  }
+  auto enmr = tiledb::ArrayExperimental::get_enumeration(*ctx.get(), *arr.get(),
+                                                         enmrname.value());
+  if (enmr.ptr() != nullptr) {
+    res = enmr.ordered();
+  }
 #endif
-    return res;
+  return res;
 }
-
 
 /**
  * TileDB Array Schema
  */
 
 // forward declaration
-XPtr<tiledb::ArraySchema> libtiledb_array_schema_set_enumeration(XPtr<tiledb::Context> ctx,
-                                                                 XPtr<tiledb::ArraySchema> schema,
-                                                                 XPtr<tiledb::Attribute> attr,
-                                                                 const std::string enum_name,
-                                                                 std::vector<std::string> values,
-                                                                 bool nullable,
-                                                                 bool ordered);
+XPtr<tiledb::ArraySchema> libtiledb_array_schema_set_enumeration(
+    XPtr<tiledb::Context> ctx, XPtr<tiledb::ArraySchema> schema,
+    XPtr<tiledb::Attribute> attr, const std::string enum_name,
+    std::vector<std::string> values, bool nullable, bool ordered);
 
 //[[Rcpp::export]]
-XPtr<tiledb::ArraySchema>
-libtiledb_array_schema(XPtr<tiledb::Context> ctx,
-                       XPtr<tiledb::Domain> domain,
-                       List attributes,
-                       std::string cell_order,
-                       std::string tile_order,
-                       Nullable<XPtr<tiledb::FilterList>> coords_filter_list = R_NilValue,
-                       Nullable<XPtr<tiledb::FilterList>> offsets_filter_list = R_NilValue,
-                       Nullable<XPtr<tiledb::FilterList>> validity_filter_list = R_NilValue,
-                       bool sparse = false,
-                       Nullable<List> enumerations_list = R_NilValue) {
-    // check that external pointers are supported
-    check_xptr_tag<tiledb::Context>(ctx);
-    check_xptr_tag<tiledb::Domain>(domain);
-    R_xlen_t nattr = attributes.length();
-    if (nattr > 0) {
-        for (R_xlen_t i=0; i < nattr; i++)  {
-            XPtr<tiledb::Attribute> attr = as<XPtr<tiledb::Attribute>>(attributes[i]);
-            check_xptr_tag<tiledb::Attribute>(attr);
-        }
+XPtr<tiledb::ArraySchema> libtiledb_array_schema(
+    XPtr<tiledb::Context> ctx, XPtr<tiledb::Domain> domain, List attributes,
+    std::string cell_order, std::string tile_order,
+    Nullable<XPtr<tiledb::FilterList>> coords_filter_list = R_NilValue,
+    Nullable<XPtr<tiledb::FilterList>> offsets_filter_list = R_NilValue,
+    Nullable<XPtr<tiledb::FilterList>> validity_filter_list = R_NilValue,
+    bool sparse = false, Nullable<List> enumerations_list = R_NilValue) {
+  // check that external pointers are supported
+  check_xptr_tag<tiledb::Context>(ctx);
+  check_xptr_tag<tiledb::Domain>(domain);
+  R_xlen_t nattr = attributes.length();
+  if (nattr > 0) {
+    for (R_xlen_t i = 0; i < nattr; i++) {
+      XPtr<tiledb::Attribute> attr = as<XPtr<tiledb::Attribute>>(attributes[i]);
+      check_xptr_tag<tiledb::Attribute>(attr);
     }
-    auto _cell_order = _string_to_tiledb_layout(cell_order);
-    auto _tile_order = _string_to_tiledb_layout(tile_order);
-    auto schptr = new tiledb::ArraySchema(tiledb::ArraySchema(*ctx.get(), sparse ? TILEDB_SPARSE : TILEDB_DENSE));
-    auto schema = make_xptr<tiledb::ArraySchema>(schptr);
-    schema->set_domain(*domain.get());
+  }
+  auto _cell_order = _string_to_tiledb_layout(cell_order);
+  auto _tile_order = _string_to_tiledb_layout(tile_order);
+  auto schptr = new tiledb::ArraySchema(
+      tiledb::ArraySchema(*ctx.get(), sparse ? TILEDB_SPARSE : TILEDB_DENSE));
+  auto schema = make_xptr<tiledb::ArraySchema>(schptr);
+  schema->set_domain(*domain.get());
 
-    // Deal with enumerations before attributes (that use them) are added
-    if (enumerations_list.isNotNull()) {
-        List enumerations(enumerations_list); // instantiate from now known non-null Nullable<List> wrapper
-        CharacterVector enumnames = enumerations.names();
-        R_xlen_t nenum = enumerations.length();
-        for (R_xlen_t i=0; i < nenum; i++)  {
-            bool nn = enumerations[i] == R_NilValue;
-            if (nn == false) {
-                XPtr<tiledb::Attribute> attr = as<XPtr<tiledb::Attribute>>(attributes[i]);
-                std::vector<std::string> enums = as<std::vector<std::string>>(enumerations[i]);
-                std::string enum_name = std::string(enumnames[i]);
-                bool is_ordered = false; // default
-                // 'ordered' is an attribute off the CharacterVector
-                CharacterVector enumvect = enumerations[i];
-                if (enumvect.hasAttribute("ordered")) {
-                    is_ordered = (as<bool>(enumvect.attr("ordered")) == true);
-                }
-                libtiledb_array_schema_set_enumeration(ctx, schema, attr, enum_name, enums,
-                                                       false, is_ordered);
-            }
+  // Deal with enumerations before attributes (that use them) are added
+  if (enumerations_list.isNotNull()) {
+    List enumerations(enumerations_list); // instantiate from now known non-null
+                                          // Nullable<List> wrapper
+    CharacterVector enumnames = enumerations.names();
+    R_xlen_t nenum = enumerations.length();
+    for (R_xlen_t i = 0; i < nenum; i++) {
+      bool nn = enumerations[i] == R_NilValue;
+      if (nn == false) {
+        XPtr<tiledb::Attribute> attr =
+            as<XPtr<tiledb::Attribute>>(attributes[i]);
+        std::vector<std::string> enums =
+            as<std::vector<std::string>>(enumerations[i]);
+        std::string enum_name = std::string(enumnames[i]);
+        bool is_ordered = false; // default
+        // 'ordered' is an attribute off the CharacterVector
+        CharacterVector enumvect = enumerations[i];
+        if (enumvect.hasAttribute("ordered")) {
+          is_ordered = (as<bool>(enumvect.attr("ordered")) == true);
         }
+        libtiledb_array_schema_set_enumeration(ctx, schema, attr, enum_name,
+                                               enums, false, is_ordered);
+      }
     }
+  }
 
-    // Now add attributes
-    if (nattr > 0) {
-        for (SEXP a : attributes) {
-            auto attr = as<XPtr<tiledb::Attribute>>(a);
-            spdl::debug(tfm::format("[libtiledb_array_schema] About to attr %s", libtiledb_attribute_get_name(attr)));
-            schema->add_attribute(*attr.get());
-        }
+  // Now add attributes
+  if (nattr > 0) {
+    for (SEXP a : attributes) {
+      auto attr = as<XPtr<tiledb::Attribute>>(a);
+      spdl::debug(tfm::format("[libtiledb_array_schema] About to attr %s",
+                              libtiledb_attribute_get_name(attr)));
+      schema->add_attribute(*attr.get());
     }
-    schema->set_cell_order(_cell_order);
-    schema->set_tile_order(_tile_order);
-    if (coords_filter_list.isNotNull()) {
-        XPtr<tiledb::FilterList> xptr_coords(coords_filter_list);
-        schema->set_coords_filter_list(*xptr_coords);
-    }
-    if (offsets_filter_list.isNotNull()) {
-        XPtr<tiledb::FilterList> xptr_offsets(offsets_filter_list);
-        schema->set_offsets_filter_list(*xptr_offsets);
-    }
-    if (validity_filter_list.isNotNull()) {
-        XPtr<tiledb::FilterList> xptr_validity(validity_filter_list);
-        schema->set_validity_filter_list(*xptr_validity);
-    }
-    schema->check();
-    return schema;
+  }
+  schema->set_cell_order(_cell_order);
+  schema->set_tile_order(_tile_order);
+  if (coords_filter_list.isNotNull()) {
+    XPtr<tiledb::FilterList> xptr_coords(coords_filter_list);
+    schema->set_coords_filter_list(*xptr_coords);
+  }
+  if (offsets_filter_list.isNotNull()) {
+    XPtr<tiledb::FilterList> xptr_offsets(offsets_filter_list);
+    schema->set_offsets_filter_list(*xptr_offsets);
+  }
+  if (validity_filter_list.isNotNull()) {
+    XPtr<tiledb::FilterList> xptr_validity(validity_filter_list);
+    schema->set_validity_filter_list(*xptr_validity);
+  }
+  schema->check();
+  return schema;
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::ArraySchema> libtiledb_array_schema_create(XPtr<tiledb::Context> ctx, std::string atstr) {
+XPtr<tiledb::ArraySchema>
+libtiledb_array_schema_create(XPtr<tiledb::Context> ctx, std::string atstr) {
   check_xptr_tag<tiledb::Context>(ctx);
   auto at = _string_to_tiledb_array_type(atstr);
   auto ptr = new tiledb::ArraySchema(*ctx.get(), at);
@@ -1856,23 +2025,24 @@ XPtr<tiledb::ArraySchema> libtiledb_array_schema_create(XPtr<tiledb::Context> ct
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::ArraySchema> libtiledb_array_schema_load(XPtr<tiledb::Context> ctx, std::string uri) {
-    check_xptr_tag<tiledb::Context>(ctx);
-    auto ptr = new tiledb::ArraySchema(*ctx.get(), uri);
-    return make_xptr<tiledb::ArraySchema>(ptr);
+XPtr<tiledb::ArraySchema> libtiledb_array_schema_load(XPtr<tiledb::Context> ctx,
+                                                      std::string uri) {
+  check_xptr_tag<tiledb::Context>(ctx);
+  auto ptr = new tiledb::ArraySchema(*ctx.get(), uri);
+  return make_xptr<tiledb::ArraySchema>(ptr);
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::ArraySchema> libtiledb_array_schema_load_with_key(XPtr<tiledb::Context> ctx,
-                                                               std::string uri,
-                                                               std::string key) {
-    check_xptr_tag<tiledb::Context>(ctx);
-    spdl::debug("[libtiledb_array_schema_load_with_key] function is deprecated");
-    XPtr<tiledb::Config> cfg = libtiledb_ctx_config(ctx);
-    cfg = libtiledb_config_set(cfg, "sm.encryption_key", key);
-    cfg = libtiledb_config_set(cfg, "sm.encryption_type", "AES_256_GCM");
-    XPtr<tiledb::Context> newctx = libtiledb_ctx(cfg);
-    return libtiledb_array_schema_load(newctx, uri);
+XPtr<tiledb::ArraySchema>
+libtiledb_array_schema_load_with_key(XPtr<tiledb::Context> ctx, std::string uri,
+                                     std::string key) {
+  check_xptr_tag<tiledb::Context>(ctx);
+  spdl::debug("[libtiledb_array_schema_load_with_key] function is deprecated");
+  XPtr<tiledb::Config> cfg = libtiledb_ctx_config(ctx);
+  cfg = libtiledb_config_set(cfg, "sm.encryption_key", key);
+  cfg = libtiledb_config_set(cfg, "sm.encryption_type", "AES_256_GCM");
+  XPtr<tiledb::Context> newctx = libtiledb_ctx(cfg);
+  return libtiledb_array_schema_load(newctx, uri);
 }
 
 // [[Rcpp::export]]
@@ -1883,7 +2053,8 @@ void libtiledb_array_schema_set_domain(XPtr<tiledb::ArraySchema> schema,
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::Domain> libtiledb_array_schema_get_domain(XPtr<tiledb::ArraySchema> schema) {
+XPtr<tiledb::Domain>
+libtiledb_array_schema_get_domain(XPtr<tiledb::ArraySchema> schema) {
   check_xptr_tag<tiledb::ArraySchema>(schema);
   auto ptr = make_xptr<tiledb::Domain>(new tiledb::Domain(schema->domain()));
   return ptr;
@@ -1902,50 +2073,57 @@ List libtiledb_array_schema_attributes(XPtr<tiledb::ArraySchema> schema) {
   check_xptr_tag<tiledb::ArraySchema>(schema);
   List result;
   int nattr = schema->attribute_num();
-  for (auto i=0; i < nattr; i++) {
-    auto attr = make_xptr<tiledb::Attribute>(new tiledb::Attribute(schema->attribute(i)));
+  for (auto i = 0; i < nattr; i++) {
+    auto attr = make_xptr<tiledb::Attribute>(
+        new tiledb::Attribute(schema->attribute(i)));
     result[attr->name()] = attr;
   }
   return result;
 }
 
 // [[Rcpp::export]]
-std::string libtiledb_array_schema_get_array_type(XPtr<tiledb::ArraySchema> schema) {
+std::string
+libtiledb_array_schema_get_array_type(XPtr<tiledb::ArraySchema> schema) {
   check_xptr_tag<tiledb::ArraySchema>(schema);
   auto type = schema->array_type();
   return _tiledb_array_type_to_string(type);
 }
 
 // [[Rcpp::export]]
-void libtiledb_array_schema_set_cell_order(XPtr<tiledb::ArraySchema> schema, std::string ord) {
+void libtiledb_array_schema_set_cell_order(XPtr<tiledb::ArraySchema> schema,
+                                           std::string ord) {
   check_xptr_tag<tiledb::ArraySchema>(schema);
   tiledb_layout_t cellorder = _string_to_tiledb_layout(ord);
   schema->set_cell_order(cellorder);
 }
 
 // [[Rcpp::export]]
-std::string libtiledb_array_schema_get_cell_order(XPtr<tiledb::ArraySchema> schema) {
+std::string
+libtiledb_array_schema_get_cell_order(XPtr<tiledb::ArraySchema> schema) {
   check_xptr_tag<tiledb::ArraySchema>(schema);
   auto order = schema->cell_order();
   return _tiledb_layout_to_string(order);
 }
 
 // [[Rcpp::export]]
-void libtiledb_array_schema_set_tile_order(XPtr<tiledb::ArraySchema> schema, std::string ord) {
+void libtiledb_array_schema_set_tile_order(XPtr<tiledb::ArraySchema> schema,
+                                           std::string ord) {
   check_xptr_tag<tiledb::ArraySchema>(schema);
   tiledb_layout_t tileorder = _string_to_tiledb_layout(ord);
   schema->set_cell_order(tileorder);
 }
 
 // [[Rcpp::export]]
-std::string libtiledb_array_schema_get_tile_order(XPtr<tiledb::ArraySchema> schema) {
+std::string
+libtiledb_array_schema_get_tile_order(XPtr<tiledb::ArraySchema> schema) {
   check_xptr_tag<tiledb::ArraySchema>(schema);
   auto order = schema->tile_order();
   return _tiledb_layout_to_string(order);
 }
 
 // [[Rcpp::export]]
-void libtiledb_array_schema_set_capacity(XPtr<tiledb::ArraySchema> schema, int cap) {
+void libtiledb_array_schema_set_capacity(XPtr<tiledb::ArraySchema> schema,
+                                         int cap) {
   check_xptr_tag<tiledb::ArraySchema>(schema);
   if (cap <= 0) {
     Rcpp::stop("Tile capacity of '%d' not sensible", cap);
@@ -1972,23 +2150,24 @@ bool libtiledb_array_schema_get_allows_dups(XPtr<tiledb::ArraySchema> schema) {
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::ArraySchema> libtiledb_array_schema_set_allows_dups(XPtr<tiledb::ArraySchema> schema,
-                                                                 bool allows_dups) {
+XPtr<tiledb::ArraySchema>
+libtiledb_array_schema_set_allows_dups(XPtr<tiledb::ArraySchema> schema,
+                                       bool allows_dups) {
   check_xptr_tag<tiledb::ArraySchema>(schema);
   schema->set_allows_dups(allows_dups);
   return schema;
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::FilterList>
-libtiledb_array_schema_get_coords_filter_list(XPtr<tiledb::ArraySchema> schema) {
-  return make_xptr<tiledb::FilterList>(new tiledb::FilterList(schema->coords_filter_list()));
+XPtr<tiledb::FilterList> libtiledb_array_schema_get_coords_filter_list(
+    XPtr<tiledb::ArraySchema> schema) {
+  return make_xptr<tiledb::FilterList>(
+      new tiledb::FilterList(schema->coords_filter_list()));
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::ArraySchema>
-libtiledb_array_schema_set_coords_filter_list(XPtr<tiledb::ArraySchema> schema,
-                                              XPtr<tiledb::FilterList> fltrlst) {
+XPtr<tiledb::ArraySchema> libtiledb_array_schema_set_coords_filter_list(
+    XPtr<tiledb::ArraySchema> schema, XPtr<tiledb::FilterList> fltrlst) {
   check_xptr_tag<tiledb::ArraySchema>(schema);
   check_xptr_tag<tiledb::FilterList>(fltrlst);
   schema->set_coords_filter_list(*fltrlst);
@@ -1996,16 +2175,16 @@ libtiledb_array_schema_set_coords_filter_list(XPtr<tiledb::ArraySchema> schema,
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::FilterList>
-libtiledb_array_schema_get_offsets_filter_list(XPtr<tiledb::ArraySchema> schema) {
+XPtr<tiledb::FilterList> libtiledb_array_schema_get_offsets_filter_list(
+    XPtr<tiledb::ArraySchema> schema) {
   check_xptr_tag<tiledb::ArraySchema>(schema);
-  return make_xptr<tiledb::FilterList>(new tiledb::FilterList(schema->offsets_filter_list()));
+  return make_xptr<tiledb::FilterList>(
+      new tiledb::FilterList(schema->offsets_filter_list()));
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::ArraySchema>
-libtiledb_array_schema_set_offsets_filter_list(XPtr<tiledb::ArraySchema> schema,
-                                               XPtr<tiledb::FilterList> fltrlst) {
+XPtr<tiledb::ArraySchema> libtiledb_array_schema_set_offsets_filter_list(
+    XPtr<tiledb::ArraySchema> schema, XPtr<tiledb::FilterList> fltrlst) {
   check_xptr_tag<tiledb::ArraySchema>(schema);
   check_xptr_tag<tiledb::FilterList>(fltrlst);
   schema->set_offsets_filter_list(*fltrlst);
@@ -2013,22 +2192,21 @@ libtiledb_array_schema_set_offsets_filter_list(XPtr<tiledb::ArraySchema> schema,
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::FilterList>
-libtiledb_array_schema_get_validity_filter_list(XPtr<tiledb::ArraySchema> schema) {
-    check_xptr_tag<tiledb::ArraySchema>(schema);
-    return make_xptr<tiledb::FilterList>(new tiledb::FilterList(schema->validity_filter_list()));
+XPtr<tiledb::FilterList> libtiledb_array_schema_get_validity_filter_list(
+    XPtr<tiledb::ArraySchema> schema) {
+  check_xptr_tag<tiledb::ArraySchema>(schema);
+  return make_xptr<tiledb::FilterList>(
+      new tiledb::FilterList(schema->validity_filter_list()));
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::ArraySchema>
-libtiledb_array_schema_set_validity_filter_list(XPtr<tiledb::ArraySchema> schema,
-                                                XPtr<tiledb::FilterList> fltrlst) {
-    check_xptr_tag<tiledb::ArraySchema>(schema);
-    check_xptr_tag<tiledb::FilterList>(fltrlst);
-    schema->set_validity_filter_list(*fltrlst);
-    return schema;
+XPtr<tiledb::ArraySchema> libtiledb_array_schema_set_validity_filter_list(
+    XPtr<tiledb::ArraySchema> schema, XPtr<tiledb::FilterList> fltrlst) {
+  check_xptr_tag<tiledb::ArraySchema>(schema);
+  check_xptr_tag<tiledb::FilterList>(fltrlst);
+  schema->set_validity_filter_list(*fltrlst);
+  return schema;
 }
-
 
 // [[Rcpp::export]]
 int libtiledb_array_schema_get_attribute_num(XPtr<tiledb::ArraySchema> schema) {
@@ -2041,25 +2219,29 @@ int libtiledb_array_schema_get_attribute_num(XPtr<tiledb::ArraySchema> schema) {
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::Attribute> libtiledb_array_schema_get_attribute_from_index(XPtr<tiledb::ArraySchema> schema,
-                                                                        int ind) {
+XPtr<tiledb::Attribute> libtiledb_array_schema_get_attribute_from_index(
+    XPtr<tiledb::ArraySchema> schema, int ind) {
   check_xptr_tag<tiledb::ArraySchema>(schema);
   if (ind < 0) {
     Rcpp::stop("Index must be non-negative.");
   }
   uint32_t idx = static_cast<uint32_t>(ind);
-  return make_xptr<tiledb::Attribute>(new tiledb::Attribute(schema->attribute(idx)));
+  return make_xptr<tiledb::Attribute>(
+      new tiledb::Attribute(schema->attribute(idx)));
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::Attribute> libtiledb_array_schema_get_attribute_from_name(XPtr<tiledb::ArraySchema> schema,
-                                                                       std::string name) {
+XPtr<tiledb::Attribute>
+libtiledb_array_schema_get_attribute_from_name(XPtr<tiledb::ArraySchema> schema,
+                                               std::string name) {
   check_xptr_tag<tiledb::ArraySchema>(schema);
-  return make_xptr<tiledb::Attribute>(new tiledb::Attribute(schema->attribute(name)));
+  return make_xptr<tiledb::Attribute>(
+      new tiledb::Attribute(schema->attribute(name)));
 }
 
 // [[Rcpp::export]]
-bool libtiledb_array_schema_has_attribute(XPtr<tiledb::ArraySchema> schema, std::string name) {
+bool libtiledb_array_schema_has_attribute(XPtr<tiledb::ArraySchema> schema,
+                                          std::string name) {
   check_xptr_tag<tiledb::ArraySchema>(schema);
   return schema->has_attribute(name);
 }
@@ -2073,7 +2255,7 @@ bool libtiledb_array_schema_sparse(XPtr<tiledb::ArraySchema> schema) {
 // [[Rcpp::export]]
 void libtiledb_array_schema_dump(XPtr<tiledb::ArraySchema> schema) {
   check_xptr_tag<tiledb::ArraySchema>(schema);
-#if TILEDB_VERSION >= TileDB_Version(2,25,0)
+#if TILEDB_VERSION >= TileDB_Version(2, 25, 0)
   std::stringstream ss;
   ss << *schema;
   Rcpp::Rcout << ss.str();
@@ -2085,7 +2267,7 @@ void libtiledb_array_schema_dump(XPtr<tiledb::ArraySchema> schema) {
 // [[Rcpp::export]]
 bool libtiledb_array_schema_check(XPtr<tiledb::ArraySchema> schema) {
   check_xptr_tag<tiledb::ArraySchema>(schema);
-  schema->check();   // throws, rather than returning bool
+  schema->check(); // throws, rather than returning bool
   return true;
 }
 
@@ -2096,75 +2278,77 @@ int libtiledb_array_schema_version(XPtr<tiledb::ArraySchema> schema) {
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::ArraySchema> libtiledb_array_schema_set_enumeration(XPtr<tiledb::Context> ctx,
-                                                                 XPtr<tiledb::ArraySchema> schema,
-                                                                 XPtr<tiledb::Attribute> attr,
-                                                                 const std::string enum_name,
-                                                                 std::vector<std::string> values,
-                                                                 bool nullable = false,
-                                                                 bool ordered = false) {
-    check_xptr_tag<tiledb::Context>(ctx);
-    check_xptr_tag<tiledb::ArraySchema>(schema);
-    check_xptr_tag<tiledb::Attribute>(attr);
-#if TILEDB_VERSION >= TileDB_Version(2,17,0)
-    auto enumeration = tiledb::Enumeration::create(*ctx.get(), enum_name, values, ordered);
-    tiledb::ArraySchemaExperimental::add_enumeration(*ctx.get(), *schema.get(), enumeration);
-    tiledb::AttributeExperimental::set_enumeration_name(*ctx.get(), *attr.get(), enum_name);
+XPtr<tiledb::ArraySchema> libtiledb_array_schema_set_enumeration(
+    XPtr<tiledb::Context> ctx, XPtr<tiledb::ArraySchema> schema,
+    XPtr<tiledb::Attribute> attr, const std::string enum_name,
+    std::vector<std::string> values, bool nullable = false,
+    bool ordered = false) {
+  check_xptr_tag<tiledb::Context>(ctx);
+  check_xptr_tag<tiledb::ArraySchema>(schema);
+  check_xptr_tag<tiledb::Attribute>(attr);
+#if TILEDB_VERSION >= TileDB_Version(2, 17, 0)
+  auto enumeration =
+      tiledb::Enumeration::create(*ctx.get(), enum_name, values, ordered);
+  tiledb::ArraySchemaExperimental::add_enumeration(*ctx.get(), *schema.get(),
+                                                   enumeration);
+  tiledb::AttributeExperimental::set_enumeration_name(*ctx.get(), *attr.get(),
+                                                      enum_name);
 #endif
-    return schema;
+  return schema;
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::ArraySchema>
-libtiledb_array_schema_set_enumeration_empty(XPtr<tiledb::Context> ctx,
-                                             XPtr<tiledb::ArraySchema> schema,
-                                             XPtr<tiledb::Attribute> attr,
-                                             const std::string enum_name,
-                                             const std::string type_str,
-                                             int cell_val_num,
-                                             bool ordered) {
-    check_xptr_tag<tiledb::Context>(ctx);
-    check_xptr_tag<tiledb::ArraySchema>(schema);
-    check_xptr_tag<tiledb::Attribute>(attr);
-#if TILEDB_VERSION >= TileDB_Version(2,17,3)
-    tiledb_datatype_t type = _string_to_tiledb_datatype(type_str);
-    uint32_t num = static_cast<uint64_t>(cell_val_num);
-    if (cell_val_num == R_NaInt) {
-        num = TILEDB_VAR_NUM;           // R's NA is different from TileDB's NA
-    }
-    auto enumeration = tiledb::Enumeration::create_empty(*ctx.get(), enum_name, type, num, ordered);
-    tiledb::ArraySchemaExperimental::add_enumeration(*ctx.get(), *schema.get(), enumeration);
-    tiledb::AttributeExperimental::set_enumeration_name(*ctx.get(), *attr.get(), enum_name);
+XPtr<tiledb::ArraySchema> libtiledb_array_schema_set_enumeration_empty(
+    XPtr<tiledb::Context> ctx, XPtr<tiledb::ArraySchema> schema,
+    XPtr<tiledb::Attribute> attr, const std::string enum_name,
+    const std::string type_str, int cell_val_num, bool ordered) {
+  check_xptr_tag<tiledb::Context>(ctx);
+  check_xptr_tag<tiledb::ArraySchema>(schema);
+  check_xptr_tag<tiledb::Attribute>(attr);
+#if TILEDB_VERSION >= TileDB_Version(2, 17, 3)
+  tiledb_datatype_t type = _string_to_tiledb_datatype(type_str);
+  uint32_t num = static_cast<uint64_t>(cell_val_num);
+  if (cell_val_num == R_NaInt) {
+    num = TILEDB_VAR_NUM; // R's NA is different from TileDB's NA
+  }
+  auto enumeration = tiledb::Enumeration::create_empty(*ctx.get(), enum_name,
+                                                       type, num, ordered);
+  tiledb::ArraySchemaExperimental::add_enumeration(*ctx.get(), *schema.get(),
+                                                   enumeration);
+  tiledb::AttributeExperimental::set_enumeration_name(*ctx.get(), *attr.get(),
+                                                      enum_name);
 #endif
-    return schema;
+  return schema;
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::CurrentDomain> libtiledb_array_schema_get_current_domain(XPtr<tiledb::Context> ctx,
-                                                                      XPtr<tiledb::ArraySchema> sch) {
-    check_xptr_tag<tiledb::Context>(ctx);
-    check_xptr_tag<tiledb::ArraySchema>(sch);
-#if TILEDB_VERSION >= TileDB_Version(2,25,0)
-    auto cd = tiledb::ArraySchemaExperimental::current_domain(*ctx.get(), *sch.get());
+XPtr<tiledb::CurrentDomain>
+libtiledb_array_schema_get_current_domain(XPtr<tiledb::Context> ctx,
+                                          XPtr<tiledb::ArraySchema> sch) {
+  check_xptr_tag<tiledb::Context>(ctx);
+  check_xptr_tag<tiledb::ArraySchema>(sch);
+#if TILEDB_VERSION >= TileDB_Version(2, 25, 0)
+  auto cd =
+      tiledb::ArraySchemaExperimental::current_domain(*ctx.get(), *sch.get());
 #else
-    auto cd = tiledb::CurrentDomain();
+  auto cd = tiledb::CurrentDomain();
 #endif
-    auto ptr = make_xptr<tiledb::CurrentDomain>(new tiledb::CurrentDomain(cd));
-    return ptr;
+  auto ptr = make_xptr<tiledb::CurrentDomain>(new tiledb::CurrentDomain(cd));
+  return ptr;
 }
 
 // [[Rcpp::export]]
 void libtiledb_array_schema_set_current_domain(XPtr<tiledb::Context> ctx,
                                                XPtr<tiledb::ArraySchema> sch,
                                                XPtr<tiledb::CurrentDomain> cd) {
-    check_xptr_tag<tiledb::Context>(ctx);
-    check_xptr_tag<tiledb::ArraySchema>(sch);
-    check_xptr_tag<tiledb::CurrentDomain>(cd);
-#if TILEDB_VERSION >= TileDB_Version(2,25,0)
-    tiledb::ArraySchemaExperimental::set_current_domain(*ctx.get(), *sch.get(), *cd.get());
+  check_xptr_tag<tiledb::Context>(ctx);
+  check_xptr_tag<tiledb::ArraySchema>(sch);
+  check_xptr_tag<tiledb::CurrentDomain>(cd);
+#if TILEDB_VERSION >= TileDB_Version(2, 25, 0)
+  tiledb::ArraySchemaExperimental::set_current_domain(*ctx.get(), *sch.get(),
+                                                      *cd.get());
 #endif
 }
-
 
 /**
  * TileDB Array Schema Evolution
@@ -2172,196 +2356,204 @@ void libtiledb_array_schema_set_current_domain(XPtr<tiledb::Context> ctx,
 //[[Rcpp::export]]
 XPtr<tiledb::ArraySchemaEvolution>
 libtiledb_array_schema_evolution(XPtr<tiledb::Context> ctx) {
-    check_xptr_tag<tiledb::Context>(ctx);
-    auto p = new tiledb::ArraySchemaEvolution(*ctx.get());
-    auto ptr = make_xptr<tiledb::ArraySchemaEvolution>(p);
-    return ptr;
+  check_xptr_tag<tiledb::Context>(ctx);
+  auto p = new tiledb::ArraySchemaEvolution(*ctx.get());
+  auto ptr = make_xptr<tiledb::ArraySchemaEvolution>(p);
+  return ptr;
 }
 
 //[[Rcpp::export]]
 XPtr<tiledb::ArraySchemaEvolution>
-libtiledb_array_schema_evolution_add_attribute(XPtr<tiledb::ArraySchemaEvolution> ase,
-                                               XPtr<tiledb::Attribute> attr) {
-    check_xptr_tag<tiledb::ArraySchemaEvolution>(ase);
-    check_xptr_tag<tiledb::Attribute>(attr);
-    tiledb::ArraySchemaEvolution res = ase->add_attribute(*attr.get());
-    auto ptr = new tiledb::ArraySchemaEvolution(res);
-    return make_xptr<tiledb::ArraySchemaEvolution>(ptr);
+libtiledb_array_schema_evolution_add_attribute(
+    XPtr<tiledb::ArraySchemaEvolution> ase, XPtr<tiledb::Attribute> attr) {
+  check_xptr_tag<tiledb::ArraySchemaEvolution>(ase);
+  check_xptr_tag<tiledb::Attribute>(attr);
+  tiledb::ArraySchemaEvolution res = ase->add_attribute(*attr.get());
+  auto ptr = new tiledb::ArraySchemaEvolution(res);
+  return make_xptr<tiledb::ArraySchemaEvolution>(ptr);
 }
 
 //[[Rcpp::export]]
 XPtr<tiledb::ArraySchemaEvolution>
-libtiledb_array_schema_evolution_drop_attribute(XPtr<tiledb::ArraySchemaEvolution> ase,
-                                                const std::string & attrname) {
-    check_xptr_tag<tiledb::ArraySchemaEvolution>(ase);
-    tiledb::ArraySchemaEvolution res = ase->drop_attribute(attrname);
-    auto ptr = new tiledb::ArraySchemaEvolution(res);
-    return make_xptr<tiledb::ArraySchemaEvolution>(ptr);
+libtiledb_array_schema_evolution_drop_attribute(
+    XPtr<tiledb::ArraySchemaEvolution> ase, const std::string &attrname) {
+  check_xptr_tag<tiledb::ArraySchemaEvolution>(ase);
+  tiledb::ArraySchemaEvolution res = ase->drop_attribute(attrname);
+  auto ptr = new tiledb::ArraySchemaEvolution(res);
+  return make_xptr<tiledb::ArraySchemaEvolution>(ptr);
 }
 
 //[[Rcpp::export]]
 XPtr<tiledb::ArraySchemaEvolution>
-libtiledb_array_schema_evolution_array_evolve(XPtr<tiledb::ArraySchemaEvolution> ase,
-                                              const std::string & uri) {
-    check_xptr_tag<tiledb::ArraySchemaEvolution>(ase);
-    tiledb::ArraySchemaEvolution res = ase->array_evolve(uri);
-    auto ptr = new tiledb::ArraySchemaEvolution(res);
-    return make_xptr<tiledb::ArraySchemaEvolution>(ptr);
+libtiledb_array_schema_evolution_array_evolve(
+    XPtr<tiledb::ArraySchemaEvolution> ase, const std::string &uri) {
+  check_xptr_tag<tiledb::ArraySchemaEvolution>(ase);
+  tiledb::ArraySchemaEvolution res = ase->array_evolve(uri);
+  auto ptr = new tiledb::ArraySchemaEvolution(res);
+  return make_xptr<tiledb::ArraySchemaEvolution>(ptr);
 }
 
 //[[Rcpp::export]]
 XPtr<tiledb::ArraySchemaEvolution>
-libtiledb_array_schema_evolution_add_enumeration(XPtr<tiledb::Context> ctx,
-                                                 XPtr<tiledb::ArraySchemaEvolution> ase,
-                                                 const std::string & enum_name,
-                                                 std::vector<std::string> values,
-                                                 bool nullable = false,
-                                                 bool ordered = false) {
-    check_xptr_tag<tiledb::Context>(ctx);
-    check_xptr_tag<tiledb::ArraySchemaEvolution>(ase);
-#if TILEDB_VERSION >= TileDB_Version(2,17,0)
-    auto enumeration = tiledb::Enumeration::create(*ctx.get(), enum_name, values, ordered);
-    tiledb::ArraySchemaEvolution res = ase->add_enumeration(enumeration);
-    auto ptr = new tiledb::ArraySchemaEvolution(res);
-    return make_xptr<tiledb::ArraySchemaEvolution>(ptr);
+libtiledb_array_schema_evolution_add_enumeration(
+    XPtr<tiledb::Context> ctx, XPtr<tiledb::ArraySchemaEvolution> ase,
+    const std::string &enum_name, std::vector<std::string> values,
+    bool nullable = false, bool ordered = false) {
+  check_xptr_tag<tiledb::Context>(ctx);
+  check_xptr_tag<tiledb::ArraySchemaEvolution>(ase);
+#if TILEDB_VERSION >= TileDB_Version(2, 17, 0)
+  auto enumeration =
+      tiledb::Enumeration::create(*ctx.get(), enum_name, values, ordered);
+  tiledb::ArraySchemaEvolution res = ase->add_enumeration(enumeration);
+  auto ptr = new tiledb::ArraySchemaEvolution(res);
+  return make_xptr<tiledb::ArraySchemaEvolution>(ptr);
 #endif
-    return ase;
+  return ase;
 }
 
 //[[Rcpp::export]]
 XPtr<tiledb::ArraySchemaEvolution>
-libtiledb_array_schema_evolution_add_enumeration_empty(XPtr<tiledb::Context> ctx,
-                                                       XPtr<tiledb::ArraySchemaEvolution> ase,
-                                                       const std::string & enum_name,
-                                                       const std::string type_str,
-                                                       int cell_val_num,
-                                                       bool ordered = false) {
-    check_xptr_tag<tiledb::Context>(ctx);
-    check_xptr_tag<tiledb::ArraySchemaEvolution>(ase);
-#if TILEDB_VERSION >= TileDB_Version(2,17,3)
-    tiledb_datatype_t type = _string_to_tiledb_datatype(type_str);
-    uint32_t num = static_cast<uint32_t>(cell_val_num);
-    auto enumeration = tiledb::Enumeration::create_empty(*ctx.get(), enum_name, type, num, ordered);
-    tiledb::ArraySchemaEvolution res = ase->add_enumeration(enumeration);
-    auto ptr = new tiledb::ArraySchemaEvolution(res);
-    return make_xptr<tiledb::ArraySchemaEvolution>(ptr);
+libtiledb_array_schema_evolution_add_enumeration_empty(
+    XPtr<tiledb::Context> ctx, XPtr<tiledb::ArraySchemaEvolution> ase,
+    const std::string &enum_name, const std::string type_str, int cell_val_num,
+    bool ordered = false) {
+  check_xptr_tag<tiledb::Context>(ctx);
+  check_xptr_tag<tiledb::ArraySchemaEvolution>(ase);
+#if TILEDB_VERSION >= TileDB_Version(2, 17, 3)
+  tiledb_datatype_t type = _string_to_tiledb_datatype(type_str);
+  uint32_t num = static_cast<uint32_t>(cell_val_num);
+  auto enumeration = tiledb::Enumeration::create_empty(*ctx.get(), enum_name,
+                                                       type, num, ordered);
+  tiledb::ArraySchemaEvolution res = ase->add_enumeration(enumeration);
+  auto ptr = new tiledb::ArraySchemaEvolution(res);
+  return make_xptr<tiledb::ArraySchemaEvolution>(ptr);
 #endif
-    return ase;
-}
-
-
-//[[Rcpp::export]]
-XPtr<tiledb::ArraySchemaEvolution>
-libtiledb_array_schema_evolution_drop_enumeration(XPtr<tiledb::ArraySchemaEvolution> ase,
-                                                  const std::string & attrname) {
-    check_xptr_tag<tiledb::ArraySchemaEvolution>(ase);
-#if TILEDB_VERSION >= TileDB_Version(2,17,0)
-    tiledb::ArraySchemaEvolution res = ase->drop_attribute(attrname);
-    auto ptr = new tiledb::ArraySchemaEvolution(res);
-    return make_xptr<tiledb::ArraySchemaEvolution>(ptr);
-#endif
-    return ase;
+  return ase;
 }
 
 //[[Rcpp::export]]
 XPtr<tiledb::ArraySchemaEvolution>
-libtiledb_array_schema_evolution_extend_enumeration(XPtr<tiledb::Context> ctx,
-                                                    XPtr<tiledb::ArraySchemaEvolution> ase,
-                                                    XPtr<tiledb::Array> array,
-                                                    const std::string & enum_name,
-                                                    std::vector<std::string> new_values,
-                                                    bool nullable = false,
-                                                    bool ordered = false) {
-    check_xptr_tag<tiledb::Context>(ctx);
-    check_xptr_tag<tiledb::ArraySchemaEvolution>(ase);
-    check_xptr_tag<tiledb::Array>(array);
-#if TILEDB_VERSION >= TileDB_Version(2,17,3)
-    auto old_enumeration = tiledb::ArrayExperimental::get_enumeration(*ctx.get(), *array.get(), enum_name);
-    auto new_enumeration = old_enumeration.extend(new_values);
-    tiledb::ArraySchemaEvolution res = ase->extend_enumeration(new_enumeration);
-    auto ptr = new tiledb::ArraySchemaEvolution(res);
-    return make_xptr<tiledb::ArraySchemaEvolution>(ptr);
+libtiledb_array_schema_evolution_drop_enumeration(
+    XPtr<tiledb::ArraySchemaEvolution> ase, const std::string &attrname) {
+  check_xptr_tag<tiledb::ArraySchemaEvolution>(ase);
+#if TILEDB_VERSION >= TileDB_Version(2, 17, 0)
+  tiledb::ArraySchemaEvolution res = ase->drop_attribute(attrname);
+  auto ptr = new tiledb::ArraySchemaEvolution(res);
+  return make_xptr<tiledb::ArraySchemaEvolution>(ptr);
 #endif
-    return ase;
+  return ase;
 }
 
 //[[Rcpp::export]]
 XPtr<tiledb::ArraySchemaEvolution>
-libtiledb_array_schema_evolution_expand_current_domain(XPtr<tiledb::ArraySchemaEvolution> ase,
-                                                       XPtr<tiledb::CurrentDomain> cd) {
-    check_xptr_tag<tiledb::ArraySchemaEvolution>(ase);
-    check_xptr_tag<tiledb::CurrentDomain>(cd);
-#if TILEDB_VERSION >= TileDB_Version(2,25,0)
-    ase->expand_current_domain(*cd.get());
+libtiledb_array_schema_evolution_extend_enumeration(
+    XPtr<tiledb::Context> ctx, XPtr<tiledb::ArraySchemaEvolution> ase,
+    XPtr<tiledb::Array> array, const std::string &enum_name,
+    std::vector<std::string> new_values, bool nullable = false,
+    bool ordered = false) {
+  check_xptr_tag<tiledb::Context>(ctx);
+  check_xptr_tag<tiledb::ArraySchemaEvolution>(ase);
+  check_xptr_tag<tiledb::Array>(array);
+#if TILEDB_VERSION >= TileDB_Version(2, 17, 3)
+  auto old_enumeration = tiledb::ArrayExperimental::get_enumeration(
+      *ctx.get(), *array.get(), enum_name);
+  auto new_enumeration = old_enumeration.extend(new_values);
+  tiledb::ArraySchemaEvolution res = ase->extend_enumeration(new_enumeration);
+  auto ptr = new tiledb::ArraySchemaEvolution(res);
+  return make_xptr<tiledb::ArraySchemaEvolution>(ptr);
 #endif
-    return ase;
+  return ase;
 }
 
+//[[Rcpp::export]]
+XPtr<tiledb::ArraySchemaEvolution>
+libtiledb_array_schema_evolution_expand_current_domain(
+    XPtr<tiledb::ArraySchemaEvolution> ase, XPtr<tiledb::CurrentDomain> cd) {
+  check_xptr_tag<tiledb::ArraySchemaEvolution>(ase);
+  check_xptr_tag<tiledb::CurrentDomain>(cd);
+#if TILEDB_VERSION >= TileDB_Version(2, 25, 0)
+  ase->expand_current_domain(*cd.get());
+#endif
+  return ase;
+}
 
 /**
  * TileDB Array
  */
 // [[Rcpp::export]]
-std::string libtiledb_array_create(std::string uri, XPtr<tiledb::ArraySchema> schema) {
+std::string libtiledb_array_create(std::string uri,
+                                   XPtr<tiledb::ArraySchema> schema) {
   check_xptr_tag<tiledb::ArraySchema>(schema);
   tiledb::Array::create(uri, *schema.get());
   return uri;
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::Array> libtiledb_array_open(XPtr<tiledb::Context> ctx, std::string uri,
-                                         std::string type) {
+XPtr<tiledb::Array> libtiledb_array_open(XPtr<tiledb::Context> ctx,
+                                         std::string uri, std::string type) {
   check_xptr_tag<tiledb::Context>(ctx);
   auto query_type = _string_to_tiledb_query_type(type);
-  return make_xptr<tiledb::Array>(new tiledb::Array(*ctx.get(), uri, query_type));
+  return make_xptr<tiledb::Array>(
+      new tiledb::Array(*ctx.get(), uri, query_type));
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::Array> libtiledb_array_open_at(XPtr<tiledb::Context> ctx, std::string uri,
-                                            std::string type, Datetime tstamp) {
-    check_xptr_tag<tiledb::Context>(ctx);
-    auto query_type = _string_to_tiledb_query_type(type);
-    // get timestamp as seconds since epoch (plus fractional seconds, returns double), scale to millisec
-    uint64_t ts_ms = static_cast<uint64_t>(std::round(tstamp.getFractionalTimestamp() * 1000));
-#if TILEDB_VERSION >= TileDB_Version(2,15,0)
-    auto ptr = new tiledb::Array(*ctx.get(), uri, query_type, tiledb::TemporalPolicy(tiledb::TimeTravel, ts_ms));
-    ptr->set_open_timestamp_end(ts_ms);
+XPtr<tiledb::Array> libtiledb_array_open_at(XPtr<tiledb::Context> ctx,
+                                            std::string uri, std::string type,
+                                            Datetime tstamp) {
+  check_xptr_tag<tiledb::Context>(ctx);
+  auto query_type = _string_to_tiledb_query_type(type);
+  // get timestamp as seconds since epoch (plus fractional seconds, returns
+  // double), scale to millisec
+  uint64_t ts_ms =
+      static_cast<uint64_t>(std::round(tstamp.getFractionalTimestamp() * 1000));
+#if TILEDB_VERSION >= TileDB_Version(2, 15, 0)
+  auto ptr =
+      new tiledb::Array(*ctx.get(), uri, query_type,
+                        tiledb::TemporalPolicy(tiledb::TimeTravel, ts_ms));
+  ptr->set_open_timestamp_end(ts_ms);
 #else
-    auto ptr = new tiledb::Array(*ctx.get(), uri, query_type);
-    ptr->set_open_timestamp_end(ts_ms);
+  auto ptr = new tiledb::Array(*ctx.get(), uri, query_type);
+  ptr->set_open_timestamp_end(ts_ms);
 #endif
-    return make_xptr<tiledb::Array>(ptr);
+  return make_xptr<tiledb::Array>(ptr);
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::Array> libtiledb_array_open_with_key(XPtr<tiledb::Context> ctx, std::string uri,
+XPtr<tiledb::Array> libtiledb_array_open_with_key(XPtr<tiledb::Context> ctx,
+                                                  std::string uri,
                                                   std::string type,
                                                   std::string enc_key) {
-    check_xptr_tag<tiledb::Context>(ctx);
-    spdl::debug("[libtiledb_array_open_with_key] function is deprecated");
-    XPtr<tiledb::Config> cfg = libtiledb_ctx_config(ctx);
-    cfg = libtiledb_config_set(cfg, "sm.encryption_key", enc_key);
-    cfg = libtiledb_config_set(cfg, "sm.encryption_type", "AES_256_GCM");
-    XPtr<tiledb::Context> newctx = libtiledb_ctx(cfg);
-    return libtiledb_array_open(newctx, uri, type);
+  check_xptr_tag<tiledb::Context>(ctx);
+  spdl::debug("[libtiledb_array_open_with_key] function is deprecated");
+  XPtr<tiledb::Config> cfg = libtiledb_ctx_config(ctx);
+  cfg = libtiledb_config_set(cfg, "sm.encryption_key", enc_key);
+  cfg = libtiledb_config_set(cfg, "sm.encryption_type", "AES_256_GCM");
+  XPtr<tiledb::Context> newctx = libtiledb_ctx(cfg);
+  return libtiledb_array_open(newctx, uri, type);
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::Array> libtiledb_array_open_at_with_key(XPtr<tiledb::Context> ctx, std::string uri,
-                                                     std::string type, std::string enc_key,
+XPtr<tiledb::Array> libtiledb_array_open_at_with_key(XPtr<tiledb::Context> ctx,
+                                                     std::string uri,
+                                                     std::string type,
+                                                     std::string enc_key,
                                                      Datetime tstamp) {
-    check_xptr_tag<tiledb::Context>(ctx);
-    spdl::debug("[libtiledb_array_open_at_with_key] function is deprecated");
-    auto query_type = _string_to_tiledb_query_type(type);
-    uint64_t ts_ms = static_cast<uint64_t>(std::round(tstamp.getFractionalTimestamp() * 1000));
-    XPtr<tiledb::Array> ptr = libtiledb_array_open_with_key(ctx, uri, type, enc_key);
-    ptr->close();               // close to reopen at timestamp, this should be revisited
-    ptr->open(query_type, TILEDB_AES_256_GCM, enc_key, ts_ms);
-    return ptr;
+  check_xptr_tag<tiledb::Context>(ctx);
+  spdl::debug("[libtiledb_array_open_at_with_key] function is deprecated");
+  auto query_type = _string_to_tiledb_query_type(type);
+  uint64_t ts_ms =
+      static_cast<uint64_t>(std::round(tstamp.getFractionalTimestamp() * 1000));
+  XPtr<tiledb::Array> ptr =
+      libtiledb_array_open_with_key(ctx, uri, type, enc_key);
+  ptr->close(); // close to reopen at timestamp, this should be revisited
+  ptr->open(query_type, TILEDB_AES_256_GCM, enc_key, ts_ms);
+  return ptr;
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::Array> libtiledb_array_open_with_ptr(XPtr<tiledb::Array> array, std::string query_type) {
+XPtr<tiledb::Array> libtiledb_array_open_with_ptr(XPtr<tiledb::Array> array,
+                                                  std::string query_type) {
   check_xptr_tag<tiledb::Array>(array);
   tiledb_query_type_t qtype = _string_to_tiledb_query_type(query_type);
   array->open(qtype);
@@ -2391,9 +2583,11 @@ std::string libtiledb_array_get_uri(XPtr<tiledb::Array> array) {
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::ArraySchema> libtiledb_array_get_schema(XPtr<tiledb::Array> array) {
+XPtr<tiledb::ArraySchema>
+libtiledb_array_get_schema(XPtr<tiledb::Array> array) {
   check_xptr_tag<tiledb::Array>(array);
-  return make_xptr<tiledb::ArraySchema>(new tiledb::ArraySchema(array->schema()));
+  return make_xptr<tiledb::ArraySchema>(
+      new tiledb::ArraySchema(array->schema()));
 }
 
 // [[Rcpp::export]]
@@ -2425,39 +2619,40 @@ List libtiledb_array_get_non_empty_domain(XPtr<tiledb::Array> array) {
   if (domain.type() == TILEDB_INT32) {
     using DType = tiledb::impl::tiledb_to_type<TILEDB_INT32>::type;
     auto res = array->non_empty_domain<DType>();
-    for (auto& d: res) {
+    for (auto &d : res) {
       auto dim_name = d.first;
       auto dim_domain = d.second;
-      nonempty_domain[dim_name] = IntegerVector::create(dim_domain.first,
-                                                        dim_domain.second);
+      nonempty_domain[dim_name] =
+          IntegerVector::create(dim_domain.first, dim_domain.second);
     }
   } else if (domain.type() == TILEDB_FLOAT64) {
     using DType = tiledb::impl::tiledb_to_type<TILEDB_FLOAT64>::type;
     auto res = array->non_empty_domain<DType>();
-    for (auto& d: res) {
+    for (auto &d : res) {
       auto dim_name = d.first;
       auto dim_domain = d.second;
-      nonempty_domain[dim_name] = NumericVector::create(dim_domain.first,
-                                                        dim_domain.second);
+      nonempty_domain[dim_name] =
+          NumericVector::create(dim_domain.first, dim_domain.second);
     }
   } else {
-    Rcpp::stop("Invalid tiledb_schema domain type: '%s'", _tiledb_datatype_to_string(domain.type()));
+    Rcpp::stop("Invalid tiledb_schema domain type: '%s'",
+               _tiledb_datatype_to_string(domain.type()));
   }
   return nonempty_domain;
 }
 
 // [[Rcpp::export]]
-CharacterVector libtiledb_array_get_non_empty_domain_var_from_name(XPtr<tiledb::Array> array,
-                                                                   std::string name) {
+CharacterVector
+libtiledb_array_get_non_empty_domain_var_from_name(XPtr<tiledb::Array> array,
+                                                   std::string name) {
   check_xptr_tag<tiledb::Array>(array);
   auto res = array->non_empty_domain_var(name);
   return CharacterVector::create(res.first, res.second);
 }
 
 // [[Rcpp::export]]
-CharacterVector libtiledb_array_get_non_empty_domain_var_from_index(XPtr<tiledb::Array> array,
-                                                                    int32_t idx,
-                                                                    std::string typestr = "ASCII") {
+CharacterVector libtiledb_array_get_non_empty_domain_var_from_index(
+    XPtr<tiledb::Array> array, int32_t idx, std::string typestr = "ASCII") {
   check_xptr_tag<tiledb::Array>(array);
   if (typestr == "ASCII") {
     auto res = array->non_empty_domain_var(idx);
@@ -2470,9 +2665,8 @@ CharacterVector libtiledb_array_get_non_empty_domain_var_from_index(XPtr<tiledb:
 }
 
 // [[Rcpp::export]]
-NumericVector libtiledb_array_get_non_empty_domain_from_name(XPtr<tiledb::Array> array,
-                                                             std::string name,
-                                                             std::string typestr) {
+NumericVector libtiledb_array_get_non_empty_domain_from_name(
+    XPtr<tiledb::Array> array, std::string name, std::string typestr) {
   check_xptr_tag<tiledb::Array>(array);
   if (typestr == "INT64") {
     auto p = array->non_empty_domain<int64_t>(name);
@@ -2480,7 +2674,8 @@ NumericVector libtiledb_array_get_non_empty_domain_from_name(XPtr<tiledb::Array>
     return toInteger64(v);
   } else if (typestr == "UINT64") {
     auto p = array->non_empty_domain<uint64_t>(name);
-    std::vector<int64_t> v{ static_cast<int64_t>(p.first), static_cast<int64_t>(p.second) };
+    std::vector<int64_t> v{static_cast<int64_t>(p.first),
+                           static_cast<int64_t>(p.second)};
     return toInteger64(v);
   } else if (typestr == "INT32") {
     auto p = array->non_empty_domain<int32_t>(name);
@@ -2506,18 +2701,12 @@ NumericVector libtiledb_array_get_non_empty_domain_from_name(XPtr<tiledb::Array>
   } else if (typestr == "FLOAT32") {
     auto p = array->non_empty_domain<float>(name);
     return NumericVector::create(p.first, p.second);
-  } else if (typestr == "DATETIME_YEAR" ||
-             typestr == "DATETIME_MONTH" ||
-             typestr == "DATETIME_WEEK" ||
-             typestr == "DATETIME_DAY" ||
-             typestr == "DATETIME_HR"  ||
-             typestr == "DATETIME_MIN" ||
-             typestr == "DATETIME_SEC" ||
-             typestr == "DATETIME_MS"  ||
-             typestr == "DATETIME_US"  ||
-             typestr == "DATETIME_PS"  ||
-             typestr == "DATETIME_FS"  ||
-             typestr == "DATETIME_AS"    ) {
+  } else if (typestr == "DATETIME_YEAR" || typestr == "DATETIME_MONTH" ||
+             typestr == "DATETIME_WEEK" || typestr == "DATETIME_DAY" ||
+             typestr == "DATETIME_HR" || typestr == "DATETIME_MIN" ||
+             typestr == "DATETIME_SEC" || typestr == "DATETIME_MS" ||
+             typestr == "DATETIME_US" || typestr == "DATETIME_PS" ||
+             typestr == "DATETIME_FS" || typestr == "DATETIME_AS") {
     // type_check() from exception.h gets invoked and wants an int64_t
     auto p = array->non_empty_domain<int64_t>(name);
     std::vector<int64_t> v{p.first, p.second};
@@ -2527,16 +2716,15 @@ NumericVector libtiledb_array_get_non_empty_domain_from_name(XPtr<tiledb::Array>
     std::vector<int64_t> v{p.first, p.second};
     return toNanotime(v);
   } else {
-    Rcpp::stop("Currently unsupported tiledb domain type: '%s'", typestr.c_str());
+    Rcpp::stop("Currently unsupported tiledb domain type: '%s'",
+               typestr.c_str());
     return NumericVector::create(NA_REAL, NA_REAL); // not reached
   }
 }
 
-
 // [[Rcpp::export]]
-NumericVector libtiledb_array_get_non_empty_domain_from_index(XPtr<tiledb::Array> array,
-                                                              int32_t idx,
-                                                              std::string typestr) {
+NumericVector libtiledb_array_get_non_empty_domain_from_index(
+    XPtr<tiledb::Array> array, int32_t idx, std::string typestr) {
   check_xptr_tag<tiledb::Array>(array);
   if (typestr == "INT64") {
     auto p = array->non_empty_domain<int64_t>(idx);
@@ -2544,7 +2732,8 @@ NumericVector libtiledb_array_get_non_empty_domain_from_index(XPtr<tiledb::Array
     return toInteger64(v);
   } else if (typestr == "UINT64") {
     auto p = array->non_empty_domain<uint64_t>(idx);
-    std::vector<int64_t> v{ static_cast<int64_t>(p.first), static_cast<int64_t>(p.second) };
+    std::vector<int64_t> v{static_cast<int64_t>(p.first),
+                           static_cast<int64_t>(p.second)};
     return toInteger64(v);
   } else if (typestr == "INT32") {
     auto p = array->non_empty_domain<int32_t>(idx);
@@ -2570,18 +2759,12 @@ NumericVector libtiledb_array_get_non_empty_domain_from_index(XPtr<tiledb::Array
   } else if (typestr == "FLOAT32") {
     auto p = array->non_empty_domain<float>(idx);
     return NumericVector::create(p.first, p.second);
-  } else if (typestr == "DATETIME_YEAR" ||
-             typestr == "DATETIME_MONTH" ||
-             typestr == "DATETIME_WEEK" ||
-             typestr == "DATETIME_DAY" ||
-             typestr == "DATETIME_HR"  ||
-             typestr == "DATETIME_MIN" ||
-             typestr == "DATETIME_SEC" ||
-             typestr == "DATETIME_MS"  ||
-             typestr == "DATETIME_US"  ||
-             typestr == "DATETIME_PS"  ||
-             typestr == "DATETIME_FS"  ||
-             typestr == "DATETIME_AS"    ) {
+  } else if (typestr == "DATETIME_YEAR" || typestr == "DATETIME_MONTH" ||
+             typestr == "DATETIME_WEEK" || typestr == "DATETIME_DAY" ||
+             typestr == "DATETIME_HR" || typestr == "DATETIME_MIN" ||
+             typestr == "DATETIME_SEC" || typestr == "DATETIME_MS" ||
+             typestr == "DATETIME_US" || typestr == "DATETIME_PS" ||
+             typestr == "DATETIME_FS" || typestr == "DATETIME_AS") {
     // type_check() from exception.h gets invoked and wants an int64_t
     auto p = array->non_empty_domain<int64_t>(idx);
     std::vector<int64_t> v{p.first, p.second};
@@ -2591,16 +2774,16 @@ NumericVector libtiledb_array_get_non_empty_domain_from_index(XPtr<tiledb::Array
     std::vector<int64_t> v{p.first, p.second};
     return toNanotime(v);
   } else {
-    Rcpp::stop("Currently unsupported tiledb domain type: '%s'", typestr.c_str());
+    Rcpp::stop("Currently unsupported tiledb domain type: '%s'",
+               typestr.c_str());
     return NumericVector::create(NA_REAL, NA_REAL); // not reached
   }
 }
 
-
 // [[Rcpp::export]]
-void libtiledb_array_consolidate(XPtr<tiledb::Context> ctx,
-                                 std::string uri,
-                                 Nullable<XPtr<tiledb::Config>> cfgptr = R_NilValue) {
+void libtiledb_array_consolidate(
+    XPtr<tiledb::Context> ctx, std::string uri,
+    Nullable<XPtr<tiledb::Config>> cfgptr = R_NilValue) {
   check_xptr_tag<tiledb::Context>(ctx);
   if (cfgptr.isNotNull()) {
     XPtr<tiledb::Config> cfg(cfgptr);
@@ -2612,9 +2795,9 @@ void libtiledb_array_consolidate(XPtr<tiledb::Context> ctx,
 }
 
 // [[Rcpp::export]]
-void libtiledb_array_vacuum(XPtr<tiledb::Context> ctx,
-                            std::string uri,
-                            Nullable<XPtr<tiledb::Config>> cfgptr = R_NilValue) {
+void libtiledb_array_vacuum(
+    XPtr<tiledb::Context> ctx, std::string uri,
+    Nullable<XPtr<tiledb::Config>> cfgptr = R_NilValue) {
   check_xptr_tag<tiledb::Context>(ctx);
   if (cfgptr.isNotNull()) {
     XPtr<tiledb::Config> cfg(cfgptr);
@@ -2625,55 +2808,58 @@ void libtiledb_array_vacuum(XPtr<tiledb::Context> ctx,
   }
 }
 
-
 // [[Rcpp::export]]
-bool libtiledb_array_put_metadata(XPtr<tiledb::Array> array,
-                                  std::string key, SEXP obj) {
+bool libtiledb_array_put_metadata(XPtr<tiledb::Array> array, std::string key,
+                                  SEXP obj) {
   check_xptr_tag<tiledb::Array>(array);
   // we implement a simpler interface here as the 'type' is given from
   // the supplied SEXP, as is the extent
-  switch(TYPEOF(obj)) {
-    case VECSXP: {
-      Rcpp::stop("List objects are not supported.");
-      break;// not reached
+  switch (TYPEOF(obj)) {
+  case VECSXP: {
+    Rcpp::stop("List objects are not supported.");
+    break; // not reached
+  }
+  case REALSXP: {
+    Rcpp::NumericVector v(obj);
+    if (isInteger64(v)) {
+      std::vector<int64_t> iv = fromInteger64(v);
+      array->put_metadata(key.c_str(), TILEDB_INT64, iv.size(), (void *)&iv[0]);
+    } else {
+      array->put_metadata(key.c_str(), TILEDB_FLOAT64, v.size(), v.begin());
     }
-    case REALSXP: {
-      Rcpp::NumericVector v(obj);
-      if (isInteger64(v)) {
-          std::vector<int64_t> iv = fromInteger64(v);
-          array->put_metadata(key.c_str(), TILEDB_INT64, iv.size(), (void*) &iv[0]);
-      } else {
-          array->put_metadata(key.c_str(), TILEDB_FLOAT64, v.size(), v.begin());
-      }
-      break;
-    }
-    case INTSXP: {
-      Rcpp::IntegerVector v(obj);
-      array->put_metadata(key.c_str(), TILEDB_INT32, v.size(), v.begin());
-      break;
-    }
-    case STRSXP: {
-      Rcpp::CharacterVector v(obj);
-      std::string s(v[0]);
-      // We use TILEDB_CHAR interchangeably with TILEDB_STRING_ASCII is this best string type?
-      array->put_metadata(key.c_str(), TILEDB_STRING_ASCII, s.length(), s.c_str());
-      break;
-    }
-    case LGLSXP: {              // experimental: map R logical (ie TRUE, FALSE, NA) to int8
-      Rcpp::LogicalVector v(obj);
-      size_t n = static_cast<size_t>(v.size());
-      std::vector<int8_t> ints(n);
-      for (size_t i=0; i<n; i++) ints[i] = static_cast<int8_t>(v[i]);
-      array->put_metadata(key.c_str(), TILEDB_INT8, ints.size(), ints.data());
-      break;
-    }
-    default: {
-      Rcpp::stop("No support (yet) for type '%s'.", Rf_type2char(TYPEOF(obj)));
-      break; // not reached
-    }
+    break;
+  }
+  case INTSXP: {
+    Rcpp::IntegerVector v(obj);
+    array->put_metadata(key.c_str(), TILEDB_INT32, v.size(), v.begin());
+    break;
+  }
+  case STRSXP: {
+    Rcpp::CharacterVector v(obj);
+    std::string s(v[0]);
+    // We use TILEDB_CHAR interchangeably with TILEDB_STRING_ASCII is this best
+    // string type?
+    array->put_metadata(key.c_str(), TILEDB_STRING_ASCII, s.length(),
+                        s.c_str());
+    break;
+  }
+  case LGLSXP: { // experimental: map R logical (ie TRUE, FALSE, NA) to int8
+    Rcpp::LogicalVector v(obj);
+    size_t n = static_cast<size_t>(v.size());
+    std::vector<int8_t> ints(n);
+    for (size_t i = 0; i < n; i++)
+      ints[i] = static_cast<int8_t>(v[i]);
+    array->put_metadata(key.c_str(), TILEDB_INT8, ints.size(), ints.data());
+    break;
+  }
+  default: {
+    Rcpp::stop("No support (yet) for type '%s'.", Rf_type2char(TYPEOF(obj)));
+    break; // not reached
+  }
   }
   // Close array - Important so that the metadata get flushed
-  // not here, array opening and closing responsibility of caller:  array.close();
+  // not here, array opening and closing responsibility of caller:
+  // array.close();
   return true;
 }
 
@@ -2686,46 +2872,53 @@ R_xlen_t libtiledb_array_get_metadata_num(XPtr<tiledb::Array> array) {
 
 // helper function to copy int vector
 template <typename T>
-Rcpp::IntegerVector copy_int_vector(const uint32_t v_num, const void* v) {
-  // Strictly speaking a check for under/overflow would be needed here yet this for
-  // metadata annotation (and not data payload) so extreme ranges are less likely
+Rcpp::IntegerVector copy_int_vector(const uint32_t v_num, const void *v) {
+  // Strictly speaking a check for under/overflow would be needed here yet this
+  // for metadata annotation (and not data payload) so extreme ranges are less
+  // likely
   Rcpp::IntegerVector vec(v_num);
-  const T *ivec = static_cast<const T*>(v);
+  const T *ivec = static_cast<const T *>(v);
   size_t n = static_cast<size_t>(v_num);
-  for (size_t i=0; i<n; i++) vec[i] = static_cast<int32_t>(ivec[i]);
-  return(vec);
+  for (size_t i = 0; i < n; i++)
+    vec[i] = static_cast<int32_t>(ivec[i]);
+  return (vec);
 }
 
 // helper function to convert_metadata
-SEXP _metadata_to_sexp(const tiledb_datatype_t v_type, const uint32_t v_num, const void* v) {
+SEXP _metadata_to_sexp(const tiledb_datatype_t v_type, const uint32_t v_num,
+                       const void *v) {
   // This supports a limited set of basic types as the metadata
   // annotation is not meant to support complete serialization
   if (v_type == TILEDB_INT32) {
     Rcpp::IntegerVector vec(v_num);
-    std::memcpy(vec.begin(), v, v_num*sizeof(int32_t));
-    return(vec);
+    std::memcpy(vec.begin(), v, v_num * sizeof(int32_t));
+    return (vec);
   } else if (v_type == TILEDB_FLOAT64) {
     Rcpp::NumericVector vec(v_num);
-    std::memcpy(vec.begin(), v, v_num*sizeof(double));
-    return(vec);
+    std::memcpy(vec.begin(), v, v_num * sizeof(double));
+    return (vec);
   } else if (v_type == TILEDB_FLOAT32) {
     Rcpp::NumericVector vec(v_num);
-    const float *fvec = static_cast<const float*>(v);
+    const float *fvec = static_cast<const float *>(v);
     size_t n = static_cast<size_t>(v_num);
-    for (size_t i=0; i<n; i++) vec[i] = static_cast<double>(fvec[i]);
-    return(vec);
-  } else if (v_type == TILEDB_CHAR || v_type == TILEDB_STRING_ASCII || v_type == TILEDB_STRING_UTF8) {
-    std::string s(static_cast<const char*>(v), v_num);
-    return(Rcpp::wrap(s));
+    for (size_t i = 0; i < n; i++)
+      vec[i] = static_cast<double>(fvec[i]);
+    return (vec);
+  } else if (v_type == TILEDB_CHAR || v_type == TILEDB_STRING_ASCII ||
+             v_type == TILEDB_STRING_UTF8) {
+    std::string s(static_cast<const char *>(v), v_num);
+    return (Rcpp::wrap(s));
   } else if (v_type == TILEDB_INT8) {
     Rcpp::LogicalVector vec(v_num);
-    const int8_t *ivec = static_cast<const int8_t*>(v);
+    const int8_t *ivec = static_cast<const int8_t *>(v);
     size_t n = static_cast<size_t>(v_num);
-    for (size_t i=0; i<n; i++) vec[i] = static_cast<bool>(ivec[i]);
-    return(vec);
+    for (size_t i = 0; i < n; i++)
+      vec[i] = static_cast<bool>(ivec[i]);
+    return (vec);
   } else if (v_type == TILEDB_UINT8) {
-    // Strictly speaking a check for under/overflow would be needed here (and below) yet this
-    // is for metadata annotation (and not data payload) so extreme ranges are less likely
+    // Strictly speaking a check for under/overflow would be needed here (and
+    // below) yet this is for metadata annotation (and not data payload) so
+    // extreme ranges are less likely
     return copy_int_vector<uint8_t>(v_num, v);
   } else if (v_type == TILEDB_INT16) {
     return copy_int_vector<int16_t>(v_num, v);
@@ -2735,7 +2928,7 @@ SEXP _metadata_to_sexp(const tiledb_datatype_t v_type, const uint32_t v_num, con
     return copy_int_vector<uint32_t>(v_num, v);
   } else if (v_type == TILEDB_INT64) {
     std::vector<int64_t> iv(v_num);
-    std::memcpy(&(iv[0]), v, v_num*sizeof(int64_t));
+    std::memcpy(&(iv[0]), v, v_num * sizeof(int64_t));
     return toInteger64(iv);
   } else if (v_type == TILEDB_UINT64) {
     return copy_int_vector<uint64_t>(v_num, v);
@@ -2745,13 +2938,15 @@ SEXP _metadata_to_sexp(const tiledb_datatype_t v_type, const uint32_t v_num, con
 }
 
 // [[Rcpp::export]]
-SEXP libtiledb_array_get_metadata_from_index(XPtr<tiledb::Array> array, int idx) {
+SEXP libtiledb_array_get_metadata_from_index(XPtr<tiledb::Array> array,
+                                             int idx) {
   check_xptr_tag<tiledb::Array>(array);
   std::string key;
   tiledb_datatype_t v_type;
   uint32_t v_num;
-  const void* v;
-  array->get_metadata_from_index(static_cast<uint64_t>(idx), &key, &v_type, &v_num, &v);
+  const void *v;
+  array->get_metadata_from_index(static_cast<uint64_t>(idx), &key, &v_type,
+                                 &v_num, &v);
   if (v == NULL) {
     return R_NilValue;
   }
@@ -2768,9 +2963,10 @@ SEXP libtiledb_array_get_metadata_list(XPtr<tiledb::Array> array) {
   int n = static_cast<int>(num);
   Rcpp::List lst(n);
   Rcpp::CharacterVector names(n);
-  for (auto i=0; i<n; i++) {
-    // we trick this a little by having the returned object also carry an attribute
-    // cleaner way (in a C++ pure sense) would be to return a pair of string and SEXP
+  for (auto i = 0; i < n; i++) {
+    // we trick this a little by having the returned object also carry an
+    // attribute cleaner way (in a C++ pure sense) would be to return a pair of
+    // string and SEXP
     SEXP v = libtiledb_array_get_metadata_from_index(array, i);
     Rcpp::RObject obj(v);
     Rcpp::CharacterVector objnms = obj.attr("names");
@@ -2783,73 +2979,85 @@ SEXP libtiledb_array_get_metadata_list(XPtr<tiledb::Array> array) {
 }
 
 // [[Rcpp::export]]
-void libtiledb_array_delete_metadata(XPtr<tiledb::Array> array, std::string key) {
+void libtiledb_array_delete_metadata(XPtr<tiledb::Array> array,
+                                     std::string key) {
   check_xptr_tag<tiledb::Array>(array);
   array->delete_metadata(key.c_str());
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::Array> libtiledb_array_set_open_timestamp_start(XPtr<tiledb::Array> array, Rcpp::Datetime tstamp) {
-    check_xptr_tag<tiledb::Array>(array);
-    uint64_t ts_ms = static_cast<uint64_t>(std::round(tstamp.getFractionalTimestamp() * 1000));
-    array->set_open_timestamp_start(ts_ms);
-    return array;
+XPtr<tiledb::Array>
+libtiledb_array_set_open_timestamp_start(XPtr<tiledb::Array> array,
+                                         Rcpp::Datetime tstamp) {
+  check_xptr_tag<tiledb::Array>(array);
+  uint64_t ts_ms =
+      static_cast<uint64_t>(std::round(tstamp.getFractionalTimestamp() * 1000));
+  array->set_open_timestamp_start(ts_ms);
+  return array;
 }
 
 // [[Rcpp::export]]
 Rcpp::Datetime libtiledb_array_open_timestamp_start(XPtr<tiledb::Array> array) {
-    check_xptr_tag<tiledb::Array>(array);
-    uint64_t ts_ms = array->open_timestamp_start();
-    double ts = ts_ms / 1000.0;
-    return(Rcpp::Datetime(ts));
+  check_xptr_tag<tiledb::Array>(array);
+  uint64_t ts_ms = array->open_timestamp_start();
+  double ts = ts_ms / 1000.0;
+  return (Rcpp::Datetime(ts));
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::Array> libtiledb_array_set_open_timestamp_end(XPtr<tiledb::Array> array, Rcpp::Datetime tstamp) {
-    check_xptr_tag<tiledb::Array>(array);
-    uint64_t ts_ms = static_cast<uint64_t>(std::round(tstamp.getFractionalTimestamp() * 1000));
-    array->set_open_timestamp_end(ts_ms);
-    return array;
+XPtr<tiledb::Array>
+libtiledb_array_set_open_timestamp_end(XPtr<tiledb::Array> array,
+                                       Rcpp::Datetime tstamp) {
+  check_xptr_tag<tiledb::Array>(array);
+  uint64_t ts_ms =
+      static_cast<uint64_t>(std::round(tstamp.getFractionalTimestamp() * 1000));
+  array->set_open_timestamp_end(ts_ms);
+  return array;
 }
 
 // [[Rcpp::export]]
 Rcpp::Datetime libtiledb_array_open_timestamp_end(XPtr<tiledb::Array> array) {
-    check_xptr_tag<tiledb::Array>(array);
-    uint64_t ts_ms = array->open_timestamp_end();
-    double ts = ts_ms / 1000.0;
-    return(Rcpp::Datetime(ts));
+  check_xptr_tag<tiledb::Array>(array);
+  uint64_t ts_ms = array->open_timestamp_end();
+  double ts = ts_ms / 1000.0;
+  return (Rcpp::Datetime(ts));
 }
 
 // [[Rcpp::export]]
-void libtiledb_array_delete_fragments(XPtr<tiledb::Context> ctx, XPtr<tiledb::Array> array,
-                                      Rcpp::Datetime tstamp_start, Rcpp::Datetime tstamp_end) {
-#if TILEDB_VERSION >= TileDB_Version(2,12,0)
-    check_xptr_tag<tiledb::Context>(ctx);
-    check_xptr_tag<tiledb::Array>(array);
-    const std::string uri = array->uri();
-    uint64_t ts_ms_st = static_cast<uint64_t>(std::round(tstamp_start.getFractionalTimestamp() * 1000));
-    uint64_t ts_ms_en = static_cast<uint64_t>(std::round(tstamp_end.getFractionalTimestamp() * 1000));
-#if TILEDB_VERSION >= TileDB_Version(2,18,0)
-    tiledb::Array::delete_fragments(*ctx.get(), uri, ts_ms_st, ts_ms_en);
+void libtiledb_array_delete_fragments(XPtr<tiledb::Context> ctx,
+                                      XPtr<tiledb::Array> array,
+                                      Rcpp::Datetime tstamp_start,
+                                      Rcpp::Datetime tstamp_end) {
+#if TILEDB_VERSION >= TileDB_Version(2, 12, 0)
+  check_xptr_tag<tiledb::Context>(ctx);
+  check_xptr_tag<tiledb::Array>(array);
+  const std::string uri = array->uri();
+  uint64_t ts_ms_st = static_cast<uint64_t>(
+      std::round(tstamp_start.getFractionalTimestamp() * 1000));
+  uint64_t ts_ms_en = static_cast<uint64_t>(
+      std::round(tstamp_end.getFractionalTimestamp() * 1000));
+#if TILEDB_VERSION >= TileDB_Version(2, 18, 0)
+  tiledb::Array::delete_fragments(*ctx.get(), uri, ts_ms_st, ts_ms_en);
 #else
-    array->delete_fragments(uri, ts_ms_st, ts_ms_en);
+  array->delete_fragments(uri, ts_ms_st, ts_ms_en);
 #endif
 #endif
 }
 
 // [[Rcpp::export]]
-void libtiledb_array_delete_fragments_list(XPtr<tiledb::Context> ctx, XPtr<tiledb::Array> array,
+void libtiledb_array_delete_fragments_list(XPtr<tiledb::Context> ctx,
+                                           XPtr<tiledb::Array> array,
                                            std::vector<std::string> fragments) {
-    check_xptr_tag<tiledb::Context>(ctx);
-    check_xptr_tag<tiledb::Array>(array);
-    const std::string uri = array->uri();
-    size_t n = fragments.size();
-    std::vector<const char*> frags(n);
-    for (size_t i = 0; i < n; i++) {
-        frags[i] = fragments[i].c_str();
-    }
-#if TILEDB_VERSION >= TileDB_Version(2,18,0)
-    tiledb::Array::delete_fragments_list(*ctx.get(), uri, &frags[0], n);
+  check_xptr_tag<tiledb::Context>(ctx);
+  check_xptr_tag<tiledb::Array>(array);
+  const std::string uri = array->uri();
+  size_t n = fragments.size();
+  std::vector<const char *> frags(n);
+  for (size_t i = 0; i < n; i++) {
+    frags[i] = fragments[i].c_str();
+  }
+#if TILEDB_VERSION >= TileDB_Version(2, 18, 0)
+  tiledb::Array::delete_fragments_list(*ctx.get(), uri, &frags[0], n);
 #endif
 }
 
@@ -2857,68 +3065,71 @@ void libtiledb_array_delete_fragments_list(XPtr<tiledb::Context> ctx, XPtr<tiled
 bool libtiledb_array_has_enumeration(XPtr<tiledb::Context> ctx,
                                      XPtr<tiledb::Array> arr,
                                      const std::string name) {
-    check_xptr_tag<tiledb::Context>(ctx);
-    check_xptr_tag<tiledb::Array>(arr);
-    bool res = false;
-#if TILEDB_VERSION >= TileDB_Version(2,17,0)
-    auto enmr = tiledb::ArrayExperimental::get_enumeration(*ctx.get(), *arr.get(), name);
-    if (enmr.ptr() != nullptr) {
-        res = true;
-    }
+  check_xptr_tag<tiledb::Context>(ctx);
+  check_xptr_tag<tiledb::Array>(arr);
+  bool res = false;
+#if TILEDB_VERSION >= TileDB_Version(2, 17, 0)
+  auto enmr =
+      tiledb::ArrayExperimental::get_enumeration(*ctx.get(), *arr.get(), name);
+  if (enmr.ptr() != nullptr) {
+    res = true;
+  }
 #endif
-    return res;
+  return res;
 }
 
 // [[Rcpp::export]]
-std::vector<std::string> libtiledb_array_get_enumeration(XPtr<tiledb::Context> ctx,
-                                                         XPtr<tiledb::Array> arr,
-                                                         const std::string name) {
-    check_xptr_tag<tiledb::Context>(ctx);
-    check_xptr_tag<tiledb::Array>(arr);
-    std::vector<std::string> res;
-#if TILEDB_VERSION >= TileDB_Version(2,17,0)
-    auto enmr = tiledb::ArrayExperimental::get_enumeration(*ctx.get(), *arr.get(), name);
-    if (enmr.ptr() == nullptr) {
-        Rcpp::stop("No enumeration named '%s' in array.");
-    }
-    res = enmr.as_vector<std::string>();
+std::vector<std::string>
+libtiledb_array_get_enumeration(XPtr<tiledb::Context> ctx,
+                                XPtr<tiledb::Array> arr,
+                                const std::string name) {
+  check_xptr_tag<tiledb::Context>(ctx);
+  check_xptr_tag<tiledb::Array>(arr);
+  std::vector<std::string> res;
+#if TILEDB_VERSION >= TileDB_Version(2, 17, 0)
+  auto enmr =
+      tiledb::ArrayExperimental::get_enumeration(*ctx.get(), *arr.get(), name);
+  if (enmr.ptr() == nullptr) {
+    Rcpp::stop("No enumeration named '%s' in array.");
+  }
+  res = enmr.as_vector<std::string>();
 #endif
-    return res;
+  return res;
 }
 
 // quick and dirty checker for an entire array
 // [[Rcpp::export]]
-Rcpp::LogicalVector libtiledb_array_has_enumeration_vector(XPtr<tiledb::Context> ctx, XPtr<tiledb::Array> array) {
-    check_xptr_tag<tiledb::Context>(ctx);
-    check_xptr_tag<tiledb::Array>(array);
-    Rcpp::XPtr<tiledb::ArraySchema> arrsch = libtiledb_array_get_schema(array);
-    Rcpp::List attrs = libtiledb_array_schema_attributes(arrsch);
-    size_t n = attrs.size();
-    Rcpp::LogicalVector has_enum = Rcpp::LogicalVector(n);
-    Rcpp::CharacterVector attr_names(n);
-    for (size_t i = 0; i < n; i++) {
-        has_enum[i] = libtiledb_attribute_has_enumeration(ctx, attrs[i]);
-        attr_names[i] = libtiledb_attribute_get_name(attrs[i]);
-    }
-    has_enum.attr("names") = attr_names;
-    return has_enum;
+Rcpp::LogicalVector
+libtiledb_array_has_enumeration_vector(XPtr<tiledb::Context> ctx,
+                                       XPtr<tiledb::Array> array) {
+  check_xptr_tag<tiledb::Context>(ctx);
+  check_xptr_tag<tiledb::Array>(array);
+  Rcpp::XPtr<tiledb::ArraySchema> arrsch = libtiledb_array_get_schema(array);
+  Rcpp::List attrs = libtiledb_array_schema_attributes(arrsch);
+  size_t n = attrs.size();
+  Rcpp::LogicalVector has_enum = Rcpp::LogicalVector(n);
+  Rcpp::CharacterVector attr_names(n);
+  for (size_t i = 0; i < n; i++) {
+    has_enum[i] = libtiledb_attribute_has_enumeration(ctx, attrs[i]);
+    attr_names[i] = libtiledb_attribute_get_name(attrs[i]);
+  }
+  has_enum.attr("names") = attr_names;
+  return has_enum;
 }
 
 // [[Rcpp::export]]
-void libtiledb_array_upgrade_version(XPtr<tiledb::Context> ctx,
-                                     XPtr<tiledb::Array> array,
-                                     std::string& uri,
-                                     Rcpp::Nullable<XPtr<tiledb::Config>> cfg = R_NilValue) {
-    check_xptr_tag<tiledb::Context>(ctx);
-    check_xptr_tag<tiledb::Array>(array);
-    if (cfg.isNull()) {
-        array->upgrade_version(*ctx.get(), uri);
-    } else {
-        XPtr<tiledb::Config> config(cfg);
-        array->upgrade_version(*ctx.get(), uri, config.get());
-    }
+void libtiledb_array_upgrade_version(
+    XPtr<tiledb::Context> ctx, XPtr<tiledb::Array> array, std::string &uri,
+    Rcpp::Nullable<XPtr<tiledb::Config>> cfg = R_NilValue) {
+  check_xptr_tag<tiledb::Context>(ctx);
+  check_xptr_tag<tiledb::Array>(array);
+  if (cfg.isNull()) {
+    array->upgrade_version(*ctx.get(), uri);
+  } else {
+    XPtr<tiledb::Config> config(cfg);
+    array->upgrade_version(*ctx.get(), uri, config.get());
+  }
 }
-
 
 /**
  * Query
@@ -2956,83 +3167,85 @@ std::string libtiledb_query_layout(XPtr<tiledb::Query> query) {
   return _tiledb_layout_to_string(layout);
 }
 
-// NB Function XPtr<tiledb::Array> libtiledb_query_get_array(XPtr<tiledb::Query> query,
-//                                                           XPtr<tiledb::Context> ctx) {
+// NB Function XPtr<tiledb::Array> libtiledb_query_get_array(XPtr<tiledb::Query>
+// query,
+//                                                           XPtr<tiledb::Context>
+//                                                           ctx) {
 // is below along with schema getter
-
 
 // generalized version which switches
 // [[Rcpp::export]]
-XPtr<tiledb::Query> libtiledb_query_set_subarray_with_type(XPtr<tiledb::Query> query,
-                                                           SEXP subarray, std::string typestr) {
-    check_xptr_tag<tiledb::Query>(query);
-    spdl::debug(tfm::format("libtiledb_query_set_subarray_with_type] setting subarray for type %s", typestr));
-    tiledb::Subarray subarr(query->ctx(), query->array());
-    if (typestr == "INT32") {
-        IntegerVector vec(subarray);
-        subarr.set_subarray(vec.begin(), vec.length());
-    } else if (typestr == "FLOAT64") {
-        NumericVector sub(subarray);
-        subarr.set_subarray(sub.begin(), sub.length());
-    } else if (typestr == "INT64" ||
-               typestr == "UINT32" ||
-               typestr == "DATETIME_NS") {
-        NumericVector sub(subarray);
-        std::vector<int64_t> v(sub.length());
-        for (int i=0; i<sub.length(); i++)
-            v[i] = static_cast<int64_t>(sub[i]);
-        subarr.set_subarray(v);
-    } else if (typestr == "DATETIME_YEAR"  ||
-               typestr == "DATETIME_MONTH" ||
-               typestr == "DATETIME_WEEK"  ||
-               typestr == "DATETIME_DAY") {
-        DateVector sub(subarray);
-        std::vector<int64_t> v = dates_to_int64(sub, _string_to_tiledb_datatype(typestr));
-        subarr.set_subarray(v);
-    } else if (typestr == "DATETIME_HR"  ||
-               typestr == "DATETIME_MIN" ||
-               typestr == "DATETIME_SEC" ||
-               typestr == "DATETIME_MS"  ||
-               typestr == "DATETIME_US") {
-        DatetimeVector sub(subarray);
-        std::vector<int64_t> v = datetimes_to_int64(sub, _string_to_tiledb_datatype(typestr));
-        subarr.set_subarray(v);
-    } else if (typestr == "UINT64") {
-        NumericVector sub(subarray);
-        std::vector<uint64_t> v(sub.length());
-        for (int i=0; i<sub.length(); i++)
-            v[i] = static_cast<uint64_t>(sub[i]);
-        subarr.set_subarray(v);
-    } else {
-        Rcpp::stop("currently unsupported subarray datatype '%s'", typestr.c_str());
-    }
-    query->set_subarray(subarr);
-    return query;
+XPtr<tiledb::Query>
+libtiledb_query_set_subarray_with_type(XPtr<tiledb::Query> query, SEXP subarray,
+                                       std::string typestr) {
+  check_xptr_tag<tiledb::Query>(query);
+  spdl::debug(tfm::format(
+      "libtiledb_query_set_subarray_with_type] setting subarray for type %s",
+      typestr));
+  tiledb::Subarray subarr(query->ctx(), query->array());
+  if (typestr == "INT32") {
+    IntegerVector vec(subarray);
+    subarr.set_subarray(vec.begin(), vec.length());
+  } else if (typestr == "FLOAT64") {
+    NumericVector sub(subarray);
+    subarr.set_subarray(sub.begin(), sub.length());
+  } else if (typestr == "INT64" || typestr == "UINT32" ||
+             typestr == "DATETIME_NS") {
+    NumericVector sub(subarray);
+    std::vector<int64_t> v(sub.length());
+    for (int i = 0; i < sub.length(); i++)
+      v[i] = static_cast<int64_t>(sub[i]);
+    subarr.set_subarray(v);
+  } else if (typestr == "DATETIME_YEAR" || typestr == "DATETIME_MONTH" ||
+             typestr == "DATETIME_WEEK" || typestr == "DATETIME_DAY") {
+    DateVector sub(subarray);
+    std::vector<int64_t> v =
+        dates_to_int64(sub, _string_to_tiledb_datatype(typestr));
+    subarr.set_subarray(v);
+  } else if (typestr == "DATETIME_HR" || typestr == "DATETIME_MIN" ||
+             typestr == "DATETIME_SEC" || typestr == "DATETIME_MS" ||
+             typestr == "DATETIME_US") {
+    DatetimeVector sub(subarray);
+    std::vector<int64_t> v =
+        datetimes_to_int64(sub, _string_to_tiledb_datatype(typestr));
+    subarr.set_subarray(v);
+  } else if (typestr == "UINT64") {
+    NumericVector sub(subarray);
+    std::vector<uint64_t> v(sub.length());
+    for (int i = 0; i < sub.length(); i++)
+      v[i] = static_cast<uint64_t>(sub[i]);
+    subarr.set_subarray(v);
+  } else {
+    Rcpp::stop("currently unsupported subarray datatype '%s'", typestr.c_str());
+  }
+  query->set_subarray(subarr);
+  return query;
 }
 
 // [[Rcpp::export]]
 XPtr<tiledb::Query> libtiledb_query_set_subarray(XPtr<tiledb::Query> query,
                                                  SEXP subarray) {
-    check_xptr_tag<tiledb::Query>(query);
-    spdl::debug(tfm::format("libtiledb_query_set_subarray] setting subarray for type %s", Rf_type2char(TYPEOF(subarray))));
-    tiledb::Subarray subarr(query->ctx(), query->array());
-    if (TYPEOF(subarray) == INTSXP) {
-        IntegerVector vec(subarray);
-        subarr.set_subarray(vec.begin(), vec.length());
-    } else if (TYPEOF(subarray) == REALSXP) {
-        NumericVector vec(subarray);
-        subarr.set_subarray(vec.begin(), vec.length());
-    } else {
-        Rcpp::stop("currently unsupported subarray datatype");
-    }
-    query->set_subarray(subarr);
-    return query;
+  check_xptr_tag<tiledb::Query>(query);
+  spdl::debug(
+      tfm::format("libtiledb_query_set_subarray] setting subarray for type %s",
+                  Rf_type2char(TYPEOF(subarray))));
+  tiledb::Subarray subarr(query->ctx(), query->array());
+  if (TYPEOF(subarray) == INTSXP) {
+    IntegerVector vec(subarray);
+    subarr.set_subarray(vec.begin(), vec.length());
+  } else if (TYPEOF(subarray) == REALSXP) {
+    NumericVector vec(subarray);
+    subarr.set_subarray(vec.begin(), vec.length());
+  } else {
+    Rcpp::stop("currently unsupported subarray datatype");
+  }
+  query->set_subarray(subarr);
+  return query;
 }
 
 // [[Rcpp::export]]
 XPtr<tiledb::Query> libtiledb_query_set_buffer(XPtr<tiledb::Query> query,
-                                               std::string attr,
-                                               SEXP buffer) {
+                                               std::string attr, SEXP buffer) {
   check_xptr_tag<tiledb::Query>(query);
   if (TYPEOF(buffer) == INTSXP) {
     IntegerVector vec(buffer);
@@ -3043,7 +3256,8 @@ XPtr<tiledb::Query> libtiledb_query_set_buffer(XPtr<tiledb::Query> query,
     query->set_data_buffer(attr, vec.begin(), vec.length());
     return query;
   } else if (TYPEOF(buffer) == LGLSXP) {
-    LogicalVector vec(buffer);  // note that it is really an int at the element storage
+    LogicalVector vec(
+        buffer); // note that it is really an int at the element storage
     query->set_data_buffer(attr, vec.begin(), vec.length());
     return query;
   } else {
@@ -3055,137 +3269,151 @@ XPtr<tiledb::Query> libtiledb_query_set_buffer(XPtr<tiledb::Query> query,
 // -- vlc_buf_t functions below
 
 // [[Rcpp::export]]
-XPtr<vlc_buf_t> libtiledb_query_buffer_var_char_alloc_direct(double szoffsets, double szdata,
-                                                             bool nullable, int cols=1) {
-    XPtr<vlc_buf_t> buf = make_xptr<vlc_buf_t>(new vlc_buf_t);
-    buf->offsets.resize(static_cast<size_t>(szoffsets));
-    buf->str.resize(static_cast<size_t>(szdata));
-    buf->rows = std::round(szoffsets/cols);           // guess for number of elements
-    buf->cols = cols;
-    buf->nullable = nullable;
-    buf->validity_map.resize(static_cast<size_t>(szdata));
-    buf->legacy_validity = false; 		              // for legacy validity mode
-    return buf;
+XPtr<vlc_buf_t> libtiledb_query_buffer_var_char_alloc_direct(double szoffsets,
+                                                             double szdata,
+                                                             bool nullable,
+                                                             int cols = 1) {
+  XPtr<vlc_buf_t> buf = make_xptr<vlc_buf_t>(new vlc_buf_t);
+  buf->offsets.resize(static_cast<size_t>(szoffsets));
+  buf->str.resize(static_cast<size_t>(szdata));
+  buf->rows = std::round(szoffsets / cols); // guess for number of elements
+  buf->cols = cols;
+  buf->nullable = nullable;
+  buf->validity_map.resize(static_cast<size_t>(szdata));
+  buf->legacy_validity = false; // for legacy validity mode
+  return buf;
 }
 
 // [[Rcpp::export]]
-bool libtiledb_query_buffer_var_char_get_legacy_validity_value(XPtr<tiledb::Context> ctx,
-                                                               bool validity_override = false) {
-    check_xptr_tag<tiledb::Context>(ctx);
-    XPtr<tiledb::Config> cfg = libtiledb_ctx_config(ctx);
-    Rcpp::CharacterVector vec = libtiledb_config_get(cfg, "r.legacy_validity_mode");
-    bool legacy_validity = std::string("true") == std::string(vec[0]) || validity_override;
-    return legacy_validity;
+bool libtiledb_query_buffer_var_char_get_legacy_validity_value(
+    XPtr<tiledb::Context> ctx, bool validity_override = false) {
+  check_xptr_tag<tiledb::Context>(ctx);
+  XPtr<tiledb::Config> cfg = libtiledb_ctx_config(ctx);
+  Rcpp::CharacterVector vec =
+      libtiledb_config_get(cfg, "r.legacy_validity_mode");
+  bool legacy_validity =
+      std::string("true") == std::string(vec[0]) || validity_override;
+  return legacy_validity;
 }
 
 // [[Rcpp::export]]
-XPtr<vlc_buf_t> libtiledb_query_buffer_var_char_legacy_validity_mode(XPtr<tiledb::Context> ctx,
-                                                                     XPtr<vlc_buf_t> buf,
-                                                                     bool validity_override = false) {
-    buf->legacy_validity = libtiledb_query_buffer_var_char_get_legacy_validity_value(ctx,
-                                                                                     validity_override);
-    spdl::debug(tfm::format("[libtiledb_query_buffer_var_char_legacy_validity_mode] "
-                            "legacy_validity set to %s", buf->legacy_validity ? "true" : "false"));
-    return buf;
+XPtr<vlc_buf_t> libtiledb_query_buffer_var_char_legacy_validity_mode(
+    XPtr<tiledb::Context> ctx, XPtr<vlc_buf_t> buf,
+    bool validity_override = false) {
+  buf->legacy_validity =
+      libtiledb_query_buffer_var_char_get_legacy_validity_value(
+          ctx, validity_override);
+  spdl::debug(
+      tfm::format("[libtiledb_query_buffer_var_char_legacy_validity_mode] "
+                  "legacy_validity set to %s",
+                  buf->legacy_validity ? "true" : "false"));
+  return buf;
 }
 
 // assigning (for a write) allocates
 // [[Rcpp::export]]
-XPtr<vlc_buf_t> libtiledb_query_buffer_var_char_create(CharacterVector vec, bool nullable,
-                                                       bool legacy_validity = false) {
-    size_t n = vec.size();
-    XPtr<vlc_buf_t> bufptr = make_xptr<vlc_buf_t>(new vlc_buf_t);
-    bufptr->offsets.resize(n);
-    bufptr->validity_map.resize(n);
-    bufptr->nullable = nullable;
-    bufptr->legacy_validity = legacy_validity;
-    bufptr->str = "";
-    uint64_t cumlen = 0;
-    for (size_t i=0; i<n; i++) {
-        std::string s(vec[i]);
-        bufptr->offsets[i] = cumlen;
-        bufptr->str += s;
-        cumlen += s.length();
-        if (nullable) {
-            if (legacy_validity) {
-                bufptr->validity_map[i] = vec[i] == R_NaString;
-            } else {
-                bufptr->validity_map[i] = vec[i] != R_NaString;
-            }
-        }
+XPtr<vlc_buf_t>
+libtiledb_query_buffer_var_char_create(CharacterVector vec, bool nullable,
+                                       bool legacy_validity = false) {
+  size_t n = vec.size();
+  XPtr<vlc_buf_t> bufptr = make_xptr<vlc_buf_t>(new vlc_buf_t);
+  bufptr->offsets.resize(n);
+  bufptr->validity_map.resize(n);
+  bufptr->nullable = nullable;
+  bufptr->legacy_validity = legacy_validity;
+  bufptr->str = "";
+  uint64_t cumlen = 0;
+  for (size_t i = 0; i < n; i++) {
+    std::string s(vec[i]);
+    bufptr->offsets[i] = cumlen;
+    bufptr->str += s;
+    cumlen += s.length();
+    if (nullable) {
+      if (legacy_validity) {
+        bufptr->validity_map[i] = vec[i] == R_NaString;
+      } else {
+        bufptr->validity_map[i] = vec[i] != R_NaString;
+      }
     }
-    bufptr->rows = bufptr->cols = 0; // signal unassigned for the write case
-    return(bufptr);
+  }
+  bufptr->rows = bufptr->cols = 0; // signal unassigned for the write case
+  return (bufptr);
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::Query> libtiledb_query_set_buffer_var_char(XPtr<tiledb::Query> query,
-                                                        std::string attr,
-                                                        XPtr<vlc_buf_t> bufptr) {
-    check_xptr_tag<tiledb::Query>(query);
-    check_xptr_tag<vlc_buf_t>(bufptr);
-    if (bufptr->nullable) {
-        query->set_validity_buffer(attr, bufptr->validity_map);
-    }
-    query->set_data_buffer(attr, bufptr->str);
-    query->set_offsets_buffer(attr, bufptr->offsets);
-    return query;
+XPtr<tiledb::Query>
+libtiledb_query_set_buffer_var_char(XPtr<tiledb::Query> query, std::string attr,
+                                    XPtr<vlc_buf_t> bufptr) {
+  check_xptr_tag<tiledb::Query>(query);
+  check_xptr_tag<vlc_buf_t>(bufptr);
+  if (bufptr->nullable) {
+    query->set_validity_buffer(attr, bufptr->validity_map);
+  }
+  query->set_data_buffer(attr, bufptr->str);
+  query->set_offsets_buffer(attr, bufptr->offsets);
+  return query;
 }
 
-// 'len' is the length of the query result set, i.e. buffer elements for standard columns
-// 'nchar' is the length of the result set for the particular column, i.e. actual (ex-post)
+// 'len' is the length of the query result set, i.e. buffer elements for
+// standard columns 'nchar' is the length of the result set for the particular
+// column, i.e. actual (ex-post)
 //    string length in bufptr (as opposed to ex-ante guess)
 // [[Rcpp::export]]
 CharacterMatrix libtiledb_query_get_buffer_var_char(XPtr<vlc_buf_t> bufptr,
-                                                    int32_t len=0, int32_t nchar=0) {
+                                                    int32_t len = 0,
+                                                    int32_t nchar = 0) {
   check_xptr_tag<vlc_buf_t>(bufptr);
-  size_t n = (len==0 ? bufptr->offsets.size() : len);
-  //Rprintf("n=%d, strsize=%d, row %d col %d, nchar %d, nullable %d len=%d nchar=%d\n",
-  //        n, bufptr->str.size(), bufptr->rows, bufptr->cols, nchar, bufptr->nullable, len, nchar);
+  size_t n = (len == 0 ? bufptr->offsets.size() : len);
+  // Rprintf("n=%d, strsize=%d, row %d col %d, nchar %d, nullable %d len=%d
+  // nchar=%d\n",
+  //         n, bufptr->str.size(), bufptr->rows, bufptr->cols, nchar,
+  //         bufptr->nullable, len, nchar);
   std::vector<uint64_t> str_sizes(n);
-  for (size_t i = 0; i < n - 1; i++) {                          // all but last
-      //  Rprintf("%d %d %d\n", i, bufptr->offsets[i + 1] , bufptr->offsets[i]);
-      str_sizes[i] = bufptr->offsets[i + 1] - bufptr->offsets[i];
-  }                                                             // last is total size minus last start
-  str_sizes[n-1] = (nchar==0 ? bufptr->str.size() * sizeof(char) : nchar) - bufptr->offsets[n-1];
+  for (size_t i = 0; i < n - 1; i++) { // all but last
+    //  Rprintf("%d %d %d\n", i, bufptr->offsets[i + 1] , bufptr->offsets[i]);
+    str_sizes[i] = bufptr->offsets[i + 1] - bufptr->offsets[i];
+  } // last is total size minus last start
+  str_sizes[n - 1] = (nchar == 0 ? bufptr->str.size() * sizeof(char) : nchar) -
+                     bufptr->offsets[n - 1];
   // Get the strings
   CharacterMatrix mat(bufptr->rows, bufptr->cols);
   for (size_t i = 0; i < n; i++) {
-      if (bufptr->nullable) {
-          if (bufptr->legacy_validity) {
-              if (bufptr->validity_map[i] == 0)
-                  mat[i] = std::string(&bufptr->str[bufptr->offsets[i]], str_sizes[i]);
-              else
-                  mat[i] = R_NaString;
-          } else {
-              if (bufptr->validity_map[i] != 0)
-                  mat[i] = std::string(&bufptr->str[bufptr->offsets[i]], str_sizes[i]);
-              else
-                  mat[i] = R_NaString;
-          }
-      } else {
+    if (bufptr->nullable) {
+      if (bufptr->legacy_validity) {
+        if (bufptr->validity_map[i] == 0)
           mat[i] = std::string(&bufptr->str[bufptr->offsets[i]], str_sizes[i]);
+        else
+          mat[i] = R_NaString;
+      } else {
+        if (bufptr->validity_map[i] != 0)
+          mat[i] = std::string(&bufptr->str[bufptr->offsets[i]], str_sizes[i]);
+        else
+          mat[i] = R_NaString;
       }
+    } else {
+      mat[i] = std::string(&bufptr->str[bufptr->offsets[i]], str_sizes[i]);
+    }
   }
-  return(mat);
+  return (mat);
 }
 
 // more of a debugging helper
 // [[Rcpp::export]]
 std::string libtiledb_query_get_buffer_var_char_simple(XPtr<vlc_buf_t> bufptr) {
   check_xptr_tag<vlc_buf_t>(bufptr);
-  return(bufptr->str);
+  return (bufptr->str);
 }
 
 // -- vlv_buf_t functions below
 
 // assigning (for a write) allocates
 // [[Rcpp::export]]
-XPtr<vlv_buf_t> libtiledb_query_buffer_var_vec_create(IntegerVector intoffsets, SEXP data) {
+XPtr<vlv_buf_t> libtiledb_query_buffer_var_vec_create(IntegerVector intoffsets,
+                                                      SEXP data) {
   int n = intoffsets.size();
   XPtr<vlv_buf_t> bufptr = make_xptr<vlv_buf_t>(new vlv_buf_t);
   bufptr->offsets.resize(n);
-  for (int i=0; i<n; i++) {
+  for (int i = 0; i < n; i++) {
     bufptr->offsets[i] = static_cast<uint64_t>(intoffsets[i]);
   }
   if (TYPEOF(data) == INTSXP) {
@@ -3196,255 +3424,251 @@ XPtr<vlv_buf_t> libtiledb_query_buffer_var_vec_create(IntegerVector intoffsets, 
     bufptr->ddata = Rcpp::as<std::vector<double>>(data);
     bufptr->idata.clear();
     bufptr->dtype = TILEDB_FLOAT64;
-    return(bufptr);
+    return (bufptr);
   } else {
     Rcpp::stop("Invalid data type for buffer: '%s'", Rcpp::type2name(data));
   }
-  return(bufptr);
+  return (bufptr);
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::Query> libtiledb_query_set_buffer_var_vec(XPtr<tiledb::Query> query,
-                                                       std::string attr, XPtr<vlv_buf_t> buf) {
+XPtr<tiledb::Query>
+libtiledb_query_set_buffer_var_vec(XPtr<tiledb::Query> query, std::string attr,
+                                   XPtr<vlv_buf_t> buf) {
   check_xptr_tag<vlv_buf_t>(buf);
   if (buf->dtype == TILEDB_INT32) {
-      query->set_data_buffer(attr, buf->idata);
-      query->set_offsets_buffer(attr, buf->offsets);
+    query->set_data_buffer(attr, buf->idata);
+    query->set_offsets_buffer(attr, buf->offsets);
   } else if (buf->dtype == TILEDB_FLOAT64) {
-      query->set_data_buffer(attr, buf->ddata);
-      query->set_offsets_buffer(attr, buf->offsets);
+    query->set_data_buffer(attr, buf->ddata);
+    query->set_offsets_buffer(attr, buf->offsets);
   } else {
-      Rcpp::stop("Unsupported type '%s' for buffer", _tiledb_datatype_to_string(buf->dtype));
+    Rcpp::stop("Unsupported type '%s' for buffer",
+               _tiledb_datatype_to_string(buf->dtype));
   }
   return query;
 }
 
 // [[Rcpp::export]]
-List libtiledb_query_get_buffer_var_vec(XPtr<tiledb::Query> query, std::string attr,
-                                        XPtr<vlv_buf_t> buf) {
+List libtiledb_query_get_buffer_var_vec(XPtr<tiledb::Query> query,
+                                        std::string attr, XPtr<vlv_buf_t> buf) {
 
   check_xptr_tag<tiledb::Query>(query);
   check_xptr_tag<vlv_buf_t>(buf);
   int n = buf->offsets.size();
   IntegerVector ivec(n);
-  for (int i=0; i<n; i++) {
+  for (int i = 0; i < n; i++) {
     ivec[i] = static_cast<int32_t>(buf->offsets[i]);
   }
-  auto dims = query->result_buffer_elements()[attr]; // actual result dims post query
-  n = dims.second;            // actual size, not allocated size
+  auto dims =
+      query->result_buffer_elements()[attr]; // actual result dims post query
+  n = dims.second;                           // actual size, not allocated size
   if (buf->dtype == TILEDB_INT32) {
     IntegerVector dvec(n);
-    for (int i=0; i<n; i++) {
+    for (int i = 0; i < n; i++) {
       dvec[i] = static_cast<int32_t>(buf->idata[i]);
     }
-    List rl = List::create(Rcpp::Named("offsets") = ivec,
-                           Rcpp::Named("data")    = dvec);
-    return(rl);
+    List rl =
+        List::create(Rcpp::Named("offsets") = ivec, Rcpp::Named("data") = dvec);
+    return (rl);
   } else if (buf->dtype == TILEDB_FLOAT64) {
     NumericVector dvec(n);
-    for (int i=0; i<n; i++) {
+    for (int i = 0; i < n; i++) {
       dvec[i] = static_cast<double>(buf->ddata[i]);
     }
-    List rl = List::create(Rcpp::Named("offsets") = ivec,
-                           Rcpp::Named("data")    = dvec);
-    return(rl);
+    List rl =
+        List::create(Rcpp::Named("offsets") = ivec, Rcpp::Named("data") = dvec);
+    return (rl);
   } else {
-    Rcpp::stop("Unsupported type '%s' for buffer", _tiledb_datatype_to_string(buf->dtype));
+    Rcpp::stop("Unsupported type '%s' for buffer",
+               _tiledb_datatype_to_string(buf->dtype));
   }
   return Rcpp::as<Rcpp::List>(R_NilValue); // not reached
 }
 
 // -- query_buf_t aka sparse_coords_buf_t
 
-// In the following signature we cannot have a templated type as the return type so we have
-// to bring the switch between types 'inside' and make it run-time dependent on the subarray
-// type we already had
+// In the following signature we cannot have a templated type as the return type
+// so we have to bring the switch between types 'inside' and make it run-time
+// dependent on the subarray type we already had
 // [[Rcpp::export]]
 XPtr<query_buf_t> libtiledb_query_buffer_alloc_ptr(std::string domaintype,
                                                    R_xlen_t ncells,
                                                    bool nullable = false,
                                                    int32_t numvar = 1) {
   XPtr<query_buf_t> buf = make_xptr<query_buf_t>(new query_buf_t);
-  if (domaintype == "INT32"  || domaintype == "UINT32") {
-     buf->size = sizeof(int32_t);
+  if (domaintype == "INT32" || domaintype == "UINT32") {
+    buf->size = sizeof(int32_t);
   } else if (domaintype == "INT16" || domaintype == "UINT16") {
-     buf->size = sizeof(int16_t);
+    buf->size = sizeof(int16_t);
   } else if (domaintype == "INT8" || domaintype == "UINT8") {
-     buf->size = sizeof(int8_t);
+    buf->size = sizeof(int8_t);
   } else if (domaintype == "BLOB"
-#if TILEDB_VERSION >= TileDB_Version(2,21,0)
-             || domaintype == "GEOM_WKB"
-             || domaintype == "GEOM_WKT"
+#if TILEDB_VERSION >= TileDB_Version(2, 21, 0)
+             || domaintype == "GEOM_WKB" || domaintype == "GEOM_WKT"
 #endif
-             ) {
-     buf->size = sizeof(int8_t);
-#if TILEDB_VERSION >= TileDB_Version(2,10,0)
+  ) {
+    buf->size = sizeof(int8_t);
+#if TILEDB_VERSION >= TileDB_Version(2, 10, 0)
   } else if (domaintype == "BOOL") {
-     buf->size = sizeof(uint8_t);
+    buf->size = sizeof(uint8_t);
 #endif
-  } else if (domaintype == "INT64" ||
-             domaintype == "UINT64" ||
-             domaintype == "DATETIME_YEAR" ||
-             domaintype == "DATETIME_MONTH" ||
-             domaintype == "DATETIME_WEEK" ||
-             domaintype == "DATETIME_DAY" ||
-             domaintype == "DATETIME_HR" ||
-             domaintype == "DATETIME_MIN" ||
-             domaintype == "DATETIME_SEC" ||
-             domaintype == "DATETIME_MS" ||
-             domaintype == "DATETIME_US" ||
-             domaintype == "DATETIME_NS" ||
-             domaintype == "DATETIME_PS" ||
-             domaintype == "DATETIME_FS" ||
+  } else if (domaintype == "INT64" || domaintype == "UINT64" ||
+             domaintype == "DATETIME_YEAR" || domaintype == "DATETIME_MONTH" ||
+             domaintype == "DATETIME_WEEK" || domaintype == "DATETIME_DAY" ||
+             domaintype == "DATETIME_HR" || domaintype == "DATETIME_MIN" ||
+             domaintype == "DATETIME_SEC" || domaintype == "DATETIME_MS" ||
+             domaintype == "DATETIME_US" || domaintype == "DATETIME_NS" ||
+             domaintype == "DATETIME_PS" || domaintype == "DATETIME_FS" ||
              domaintype == "DATETIME_AS") {
-     buf->size = sizeof(int64_t);
+    buf->size = sizeof(int64_t);
   } else if (domaintype == "FLOAT64") {
-     buf->size = sizeof(double);
+    buf->size = sizeof(double);
   } else if (domaintype == "FLOAT32") {
-     buf->size = sizeof(float);
+    buf->size = sizeof(float);
   } else {
-     Rcpp::stop("Currently unsupported domain type '%s'", domaintype.c_str());
+    Rcpp::stop("Currently unsupported domain type '%s'", domaintype.c_str());
   }
   buf->dtype = _string_to_tiledb_datatype(domaintype);
   buf->ncells = ncells;
   buf->vec.resize(ncells * buf->size);
-  if (nullable) buf->validity_map.resize(ncells/numvar);
+  if (nullable)
+    buf->validity_map.resize(ncells / numvar);
   buf->numvar = numvar;
   buf->nullable = nullable;
   return buf;
 }
 
 // [[Rcpp::export]]
-XPtr<query_buf_t> libtiledb_query_buffer_assign_ptr(XPtr<query_buf_t> buf, std::string dtype,
-                                                    SEXP vec, bool asint64 = false) {
+XPtr<query_buf_t> libtiledb_query_buffer_assign_ptr(XPtr<query_buf_t> buf,
+                                                    std::string dtype, SEXP vec,
+                                                    bool asint64 = false) {
   check_xptr_tag<query_buf_t>(buf);
   if (dtype == "INT32") {
     IntegerVector v(vec);
-    std::memcpy(buf->vec.data(), &(v[0]), buf->ncells*buf->size);
+    std::memcpy(buf->vec.data(), &(v[0]), buf->ncells * buf->size);
     if (buf->nullable)
-        getValidityMapFromInteger(v, buf->validity_map, buf->numvar);
+      getValidityMapFromInteger(v, buf->validity_map, buf->numvar);
   } else if (dtype == "FLOAT64") {
     NumericVector v(vec);
-    std::memcpy(buf->vec.data(), &(v[0]), buf->ncells*buf->size);
+    std::memcpy(buf->vec.data(), &(v[0]), buf->ncells * buf->size);
     if (buf->nullable)
-        getValidityMapFromNumeric(v, buf->validity_map, buf->numvar);
-  } else if (dtype == "INT64" ||
-             (asint64 && is_datetime_column(buf->dtype))) {
+      getValidityMapFromNumeric(v, buf->validity_map, buf->numvar);
+  } else if (dtype == "INT64" || (asint64 && is_datetime_column(buf->dtype))) {
     // integer64 from the bit64 package uses doubles, sees nanosecond
     NumericVector v(vec);
-    std::memcpy(buf->vec.data(), &(v[0]), buf->ncells*buf->size);
+    std::memcpy(buf->vec.data(), &(v[0]), buf->ncells * buf->size);
     if (buf->nullable)
-        getValidityMapFromInt64(v, buf->validity_map, buf->numvar);
-  } else if (dtype == "DATETIME_YEAR" ||
-             dtype == "DATETIME_MONTH" ||
-             dtype == "DATETIME_WEEK" ||
-             dtype == "DATETIME_DAY") {
+      getValidityMapFromInt64(v, buf->validity_map, buf->numvar);
+  } else if (dtype == "DATETIME_YEAR" || dtype == "DATETIME_MONTH" ||
+             dtype == "DATETIME_WEEK" || dtype == "DATETIME_DAY") {
     DateVector v(vec);
-    std::vector<int64_t> tt = dates_to_int64(v, _string_to_tiledb_datatype(dtype));
+    std::vector<int64_t> tt =
+        dates_to_int64(v, _string_to_tiledb_datatype(dtype));
     std::memcpy(buf->vec.data(), tt.data(), buf->ncells * buf->size);
-  } else if (dtype == "DATETIME_MS" ||
-             dtype == "DATETIME_US" ||
-             dtype == "DATETIME_SEC"||
-             dtype == "DATETIME_MIN"||
-             dtype == "DATETIME_HR"   ) {
+  } else if (dtype == "DATETIME_MS" || dtype == "DATETIME_US" ||
+             dtype == "DATETIME_SEC" || dtype == "DATETIME_MIN" ||
+             dtype == "DATETIME_HR") {
     DatetimeVector v(vec);
-    std::vector<int64_t> tt = datetimes_to_int64(v, _string_to_tiledb_datatype(dtype));
+    std::vector<int64_t> tt =
+        datetimes_to_int64(v, _string_to_tiledb_datatype(dtype));
     std::memcpy(buf->vec.data(), tt.data(), buf->ncells * buf->size);
   } else if (dtype == "DATETIME_NS") {
     // nanosecond time uses the nanotime package which uses the bit64 package
     // to store the int64_t 'payload' on 64-bit double, so memcpy does the trick
     NumericVector v(vec);
-    std::memcpy(buf->vec.data(), &(v[0]), buf->ncells*buf->size);
-  } else if (dtype == "DATETIME_PS" ||
-             dtype == "DATETIME_FS" ||
+    std::memcpy(buf->vec.data(), &(v[0]), buf->ncells * buf->size);
+  } else if (dtype == "DATETIME_PS" || dtype == "DATETIME_FS" ||
              dtype == "DATETIME_AS") {
     NumericVector v(vec);
-    std::vector<int64_t> tt = subnano_to_int64(v, _string_to_tiledb_datatype(dtype));
+    std::vector<int64_t> tt =
+        subnano_to_int64(v, _string_to_tiledb_datatype(dtype));
     std::memcpy(buf->vec.data(), tt.data(), buf->ncells * buf->size);
   } else if (dtype == "UINT64") {
-    // R has no native uint64_t representation so this comes in as numeric; we then
-    // use our int64_t <-> integer64 machinery for null maps but store as uint64_t
+    // R has no native uint64_t representation so this comes in as numeric; we
+    // then use our int64_t <-> integer64 machinery for null maps but store as
+    // uint64_t
     NumericVector v(vec);
     std::vector<int64_t> iv = fromInteger64(v);
     if (buf->nullable)
-        getValidityMapFromInt64(v, buf->validity_map, buf->numvar);
+      getValidityMapFromInt64(v, buf->validity_map, buf->numvar);
     auto n = v.length();
     std::vector<uint64_t> uiv(n);
-    for (auto i=0; i<n; i++) {
+    for (auto i = 0; i < n; i++) {
       uiv[i] = static_cast<uint64_t>(iv[i]);
     }
-    std::memcpy(buf->vec.data(), &(uiv[0]), buf->ncells*buf->size);
+    std::memcpy(buf->vec.data(), &(uiv[0]), buf->ncells * buf->size);
   } else if (dtype == "UINT32") {
     IntegerVector v(vec);
     auto n = v.length();
     std::vector<uint32_t> x(n);
-    for (auto i=0; i<n; i++) {
+    for (auto i = 0; i < n; i++) {
       x[i] = static_cast<uint32_t>(v[i]);
     }
-    std::memcpy(buf->vec.data(), &(x[0]), buf->ncells*buf->size);
+    std::memcpy(buf->vec.data(), &(x[0]), buf->ncells * buf->size);
     if (buf->nullable)
-        getValidityMapFromInteger(v, buf->validity_map, buf->numvar);
+      getValidityMapFromInteger(v, buf->validity_map, buf->numvar);
   } else if (dtype == "INT16") {
     IntegerVector v(vec);
     auto n = v.length();
     std::vector<int16_t> x(n);
-    for (auto i=0; i<n; i++) {
+    for (auto i = 0; i < n; i++) {
       x[i] = static_cast<int16_t>(v[i]);
     }
-    std::memcpy(buf->vec.data(), &(x[0]), buf->ncells*buf->size);
+    std::memcpy(buf->vec.data(), &(x[0]), buf->ncells * buf->size);
     if (buf->nullable)
-        getValidityMapFromInteger(v, buf->validity_map, buf->numvar);
+      getValidityMapFromInteger(v, buf->validity_map, buf->numvar);
   } else if (dtype == "UINT16") {
     IntegerVector v(vec);
     auto n = v.length();
     std::vector<uint16_t> x(n);
-    for (auto i=0; i<n; i++) {
+    for (auto i = 0; i < n; i++) {
       x[i] = static_cast<uint16_t>(v[i]);
     }
-    std::memcpy(buf->vec.data(), &(x[0]), buf->ncells*buf->size);
+    std::memcpy(buf->vec.data(), &(x[0]), buf->ncells * buf->size);
     if (buf->nullable)
-        getValidityMapFromInteger(v, buf->validity_map, buf->numvar);
+      getValidityMapFromInteger(v, buf->validity_map, buf->numvar);
   } else if (dtype == "INT8") {
     IntegerVector v(vec);
     auto n = v.length();
     std::vector<int8_t> x(n);
-    for (auto i=0; i<n; i++) {
+    for (auto i = 0; i < n; i++) {
       x[i] = static_cast<int8_t>(v[i]);
     }
-    std::memcpy(buf->vec.data(), &(x[0]), buf->ncells*buf->size);
+    std::memcpy(buf->vec.data(), &(x[0]), buf->ncells * buf->size);
     if (buf->nullable)
-        getValidityMapFromInteger(v, buf->validity_map, buf->numvar);
+      getValidityMapFromInteger(v, buf->validity_map, buf->numvar);
   } else if (dtype == "UINT8") {
     IntegerVector v(vec);
     auto n = v.length();
     std::vector<uint8_t> x(n);
-    for (auto i=0; i<n; i++) {
+    for (auto i = 0; i < n; i++) {
       x[i] = static_cast<uint8_t>(v[i]);
     }
-    std::memcpy(buf->vec.data(), &(x[0]), buf->ncells*buf->size);
+    std::memcpy(buf->vec.data(), &(x[0]), buf->ncells * buf->size);
     if (buf->nullable)
-        getValidityMapFromInteger(v, buf->validity_map, buf->numvar);
+      getValidityMapFromInteger(v, buf->validity_map, buf->numvar);
   } else if (dtype == "FLOAT32") {
     NumericVector v(vec);
     if (buf->nullable)
-        getValidityMapFromNumeric(v, buf->validity_map, buf->numvar);
+      getValidityMapFromNumeric(v, buf->validity_map, buf->numvar);
     auto n = v.length();
     std::vector<float> x(n);
-    for (auto i=0; i<n; i++) {
+    for (auto i = 0; i < n; i++) {
       x[i] = static_cast<float>(v[i]);
     }
-    std::memcpy(buf->vec.data(), &(x[0]), buf->ncells*buf->size);
-#if TILEDB_VERSION >= TileDB_Version(2,10,0)
+    std::memcpy(buf->vec.data(), &(x[0]), buf->ncells * buf->size);
+#if TILEDB_VERSION >= TileDB_Version(2, 10, 0)
   } else if (dtype == "BOOL") {
     LogicalVector v(vec);
     auto n = v.length();
     std::vector<uint8_t> x(n);
-    for (auto i=0; i<n; i++) {
+    for (auto i = 0; i < n; i++) {
       x[i] = static_cast<uint8_t>(v[i]);
     }
-    std::memcpy(buf->vec.data(), &(x[0]), buf->ncells*buf->size);
+    std::memcpy(buf->vec.data(), &(x[0]), buf->ncells * buf->size);
     if (buf->nullable)
-        getValidityMapFromLogical(v, buf->validity_map, buf->numvar);
+      getValidityMapFromLogical(v, buf->validity_map, buf->numvar);
 #endif
   } else {
     Rcpp::stop("Assignment to '%s' currently unsupported.", dtype.c_str());
@@ -3456,168 +3680,170 @@ XPtr<query_buf_t> libtiledb_query_buffer_assign_ptr(XPtr<query_buf_t> buf, std::
 XPtr<tiledb::Query> libtiledb_query_set_buffer_ptr(XPtr<tiledb::Query> query,
                                                    std::string attr,
                                                    XPtr<query_buf_t> buf) {
-    check_xptr_tag<tiledb::Query>(query);
-    if (buf->nullable) {
-        query->set_validity_buffer(attr, buf->validity_map);
-    }
-    query->set_data_buffer(attr, static_cast<void*>(buf->vec.data()), buf->ncells);
-    return query;
+  check_xptr_tag<tiledb::Query>(query);
+  if (buf->nullable) {
+    query->set_validity_buffer(attr, buf->validity_map);
+  }
+  query->set_data_buffer(attr, static_cast<void *>(buf->vec.data()),
+                         buf->ncells);
+  return query;
 }
 
 // [[Rcpp::export]]
 IntegerVector length_from_vlcbuf(XPtr<vlc_buf_t> buf) {
-    check_xptr_tag<vlc_buf_t>(buf);
-    IntegerVector v = IntegerVector::create(buf->offsets.size(), buf->str.length());
-    return v;
+  check_xptr_tag<vlc_buf_t>(buf);
+  IntegerVector v =
+      IntegerVector::create(buf->offsets.size(), buf->str.length());
+  return v;
 }
 
 // [[Rcpp::export]]
-RObject libtiledb_query_get_buffer_ptr(XPtr<query_buf_t> buf, bool asint64 = false) {
+RObject libtiledb_query_get_buffer_ptr(XPtr<query_buf_t> buf,
+                                       bool asint64 = false) {
   spdl::debug("[libtiledb_query_get_buffer_ptr] before buf type check");
   check_xptr_tag<query_buf_t>(buf);
   std::string dtype = _tiledb_datatype_to_string(buf->dtype);
-  //Rcpp::Rcout << dtype << " " << buf->ncells << " " << buf->size << " " << buf->nullable << std::endl;
+  // Rcpp::Rcout << dtype << " " << buf->ncells << " " << buf->size << " " <<
+  // buf->nullable << std::endl;
   spdl::debug(tfm::format("[libtiledb_query_get_buffer_ptr] type %s", dtype));
   if (dtype == "INT32") {
     IntegerVector v(buf->ncells);
-    std::memcpy(&(v[0]), (void*) buf->vec.data(), buf->ncells * buf->size);
+    std::memcpy(&(v[0]), (void *)buf->vec.data(), buf->ncells * buf->size);
     if (buf->nullable)
-        setValidityMapForInteger(v, buf->validity_map, buf->numvar);
+      setValidityMapForInteger(v, buf->validity_map, buf->numvar);
     return v;
   } else if (dtype == "UINT32") {
     IntegerVector v(buf->ncells);
-    std::memcpy(&(v[0]), (void*) buf->vec.data(), buf->ncells * buf->size);
+    std::memcpy(&(v[0]), (void *)buf->vec.data(), buf->ncells * buf->size);
     if (buf->nullable)
-        setValidityMapForInteger(v, buf->validity_map, buf->numvar);
+      setValidityMapForInteger(v, buf->validity_map, buf->numvar);
     return v;
   } else if (dtype == "FLOAT64") {
     NumericVector v(buf->ncells);
-    std::memcpy(&(v[0]), (void*) buf->vec.data(), buf->ncells * buf->size);
+    std::memcpy(&(v[0]), (void *)buf->vec.data(), buf->ncells * buf->size);
     if (buf->nullable)
-        setValidityMapForNumeric(v, buf->validity_map, buf->numvar);
+      setValidityMapForNumeric(v, buf->validity_map, buf->numvar);
     return v;
   } else if (dtype == "FLOAT32") {
     std::vector<float> v(buf->ncells);
-    std::memcpy(&(v[0]), (void*) buf->vec.data(), buf->ncells * buf->size);
+    std::memcpy(&(v[0]), (void *)buf->vec.data(), buf->ncells * buf->size);
     NumericVector w(wrap(v));
     if (buf->nullable)
-        setValidityMapForNumeric(w, buf->validity_map, buf->numvar);
+      setValidityMapForNumeric(w, buf->validity_map, buf->numvar);
     return w;
   } else if (dtype == "UINT64") {
     auto n = buf->ncells;
     std::vector<uint64_t> uv(n);
-    std::memcpy(&(uv[0]), (void*) buf->vec.data(), buf->ncells * buf->size);
+    std::memcpy(&(uv[0]), (void *)buf->vec.data(), buf->ncells * buf->size);
     std::vector<int64_t> iv(n);
-    for (auto i=0; i<n; i++) {
+    for (auto i = 0; i < n; i++) {
       iv[i] = static_cast<int64_t>(uv[i]);
     }
     NumericVector res = wrap(iv);
     if (buf->nullable)
-        setValidityMapForNumeric(res, buf->validity_map, buf->numvar);
-    //return toInteger64(iv); // we could return as int64,
-    return res;                 // but current 'contract' is return as NumericVector
+      setValidityMapForNumeric(res, buf->validity_map, buf->numvar);
+    // return toInteger64(iv); // we could return as int64,
+    return res; // but current 'contract' is return as NumericVector
   } else if (dtype == "INT64") {
     std::vector<int64_t> v(buf->ncells);
-    std::memcpy(&(v[0]), (void*) buf->vec.data(), buf->ncells * buf->size);
+    std::memcpy(&(v[0]), (void *)buf->vec.data(), buf->ncells * buf->size);
     if (buf->nullable)
-        setValidityMapForInt64(v, buf->validity_map, buf->numvar);
+      setValidityMapForInt64(v, buf->validity_map, buf->numvar);
     return toInteger64(v);
   } else if (asint64 && is_datetime_column(buf->dtype)) {
     std::vector<int64_t> v(buf->ncells);
-    std::memcpy(&(v[0]), (void*) buf->vec.data(), buf->ncells * buf->size);
+    std::memcpy(&(v[0]), (void *)buf->vec.data(), buf->ncells * buf->size);
     return toInteger64(v);
-  } else if (dtype == "DATETIME_FS" ||
-             dtype == "DATETIME_PS" ||
+  } else if (dtype == "DATETIME_FS" || dtype == "DATETIME_PS" ||
              dtype == "DATETIME_AS") {
     std::vector<int64_t> v(buf->ncells);
-    std::memcpy(&(v[0]), (void*) buf->vec.data(), buf->ncells * buf->size);
-    Rcpp::NumericVector dv = int64_to_subnano(v, _string_to_tiledb_datatype(dtype));
+    std::memcpy(&(v[0]), (void *)buf->vec.data(), buf->ncells * buf->size);
+    Rcpp::NumericVector dv =
+        int64_to_subnano(v, _string_to_tiledb_datatype(dtype));
     return dv;
-  } else if (dtype == "DATETIME_YEAR" ||
-             dtype == "DATETIME_MONTH" ||
-             dtype == "DATETIME_WEEK" ||
-             dtype == "DATETIME_DAY") {
+  } else if (dtype == "DATETIME_YEAR" || dtype == "DATETIME_MONTH" ||
+             dtype == "DATETIME_WEEK" || dtype == "DATETIME_DAY") {
     std::vector<int64_t> v(buf->ncells);
-    std::memcpy(&(v[0]), (void*) buf->vec.data(), buf->ncells * buf->size);
+    std::memcpy(&(v[0]), (void *)buf->vec.data(), buf->ncells * buf->size);
     DateVector dv = int64_to_dates(v, _string_to_tiledb_datatype(dtype));
     return dv;
-  } else if (dtype == "DATETIME_HR" ||
-             dtype == "DATETIME_MIN" ||
-             dtype == "DATETIME_SEC" ||
-             dtype == "DATETIME_MS" ||
+  } else if (dtype == "DATETIME_HR" || dtype == "DATETIME_MIN" ||
+             dtype == "DATETIME_SEC" || dtype == "DATETIME_MS" ||
              dtype == "DATETIME_US") {
     std::vector<int64_t> v(buf->ncells);
-    std::memcpy(&(v[0]), (void*) buf->vec.data(), buf->ncells * buf->size);
-    DatetimeVector dv = int64_to_datetimes(v, _string_to_tiledb_datatype(dtype));
+    std::memcpy(&(v[0]), (void *)buf->vec.data(), buf->ncells * buf->size);
+    DatetimeVector dv =
+        int64_to_datetimes(v, _string_to_tiledb_datatype(dtype));
     return dv;
   } else if (dtype == "DATETIME_NS") {
     int n = buf->ncells;
     std::vector<int64_t> vec(n);
-    std::memcpy(vec.data(), buf->vec.data(), n*buf->size);
+    std::memcpy(vec.data(), buf->vec.data(), n * buf->size);
     return toNanotime(vec);
   } else if (dtype == "INT16") {
     size_t n = buf->ncells;
     std::vector<int16_t> intvec(n);
-    std::memcpy(intvec.data(), buf->vec.data(), n*buf->size);
+    std::memcpy(intvec.data(), buf->vec.data(), n * buf->size);
     Rcpp::IntegerVector out(buf->ncells);
-    for (size_t i=0; i<n; i++) {
+    for (size_t i = 0; i < n; i++) {
       out[i] = static_cast<int32_t>(intvec[i]);
     }
     if (buf->nullable)
-        setValidityMapForInteger(out, buf->validity_map, buf->numvar);
+      setValidityMapForInteger(out, buf->validity_map, buf->numvar);
     return out;
   } else if (dtype == "UINT16") {
     size_t n = buf->ncells;
     std::vector<uint16_t> intvec(n);
-    std::memcpy(intvec.data(), buf->vec.data(), n*buf->size);
+    std::memcpy(intvec.data(), buf->vec.data(), n * buf->size);
     Rcpp::IntegerVector out(buf->ncells);
-    for (size_t i=0; i<n; i++) {
+    for (size_t i = 0; i < n; i++) {
       out[i] = static_cast<int32_t>(intvec[i]);
     }
     if (buf->nullable)
-        setValidityMapForInteger(out, buf->validity_map, buf->numvar);
+      setValidityMapForInteger(out, buf->validity_map, buf->numvar);
     return out;
   } else if (dtype == "INT8") {
     size_t n = buf->ncells;
     std::vector<int8_t> intvec(n);
-    std::memcpy(intvec.data(), buf->vec.data(), n*buf->size);
+    std::memcpy(intvec.data(), buf->vec.data(), n * buf->size);
     Rcpp::IntegerVector out(buf->ncells);
-    for (size_t i=0; i<n; i++) {
+    for (size_t i = 0; i < n; i++) {
       out[i] = static_cast<int32_t>(intvec[i]);
     }
     if (buf->nullable)
-        setValidityMapForInteger(out, buf->validity_map, buf->numvar);
+      setValidityMapForInteger(out, buf->validity_map, buf->numvar);
     return out;
   } else if (dtype == "UINT8") {
     size_t n = buf->ncells;
     std::vector<uint8_t> uintvec(n);
-    std::memcpy(uintvec.data(), buf->vec.data(), n*buf->size);
+    std::memcpy(uintvec.data(), buf->vec.data(), n * buf->size);
     Rcpp::IntegerVector out(buf->ncells);
-    for (size_t i=0; i<n; i++) {
+    for (size_t i = 0; i < n; i++) {
       out[i] = static_cast<int32_t>(uintvec[i]);
     }
     if (buf->nullable)
-        setValidityMapForInteger(out, buf->validity_map, buf->numvar);
+      setValidityMapForInteger(out, buf->validity_map, buf->numvar);
     return out;
   } else if (dtype == "BLOB") {
     size_t n = buf->ncells;
     Rcpp::RawVector out(n);
-    std::memcpy(out.begin(), buf->vec.data(), n*buf->size);
+    std::memcpy(out.begin(), buf->vec.data(), n * buf->size);
     // -- raw has no NA type so no mapping possible here
     // if (buf->nullable)
     //    setValidityMapForRaw(out, buf->validity_map);
     return out;
-#if TILEDB_VERSION >= TileDB_Version(2,10,0)
+#if TILEDB_VERSION >= TileDB_Version(2, 10, 0)
   } else if (dtype == "BOOL") {
     size_t n = buf->ncells;
     std::vector<uint8_t> uintvec(n);
-    std::memcpy(uintvec.data(), buf->vec.data(), n*buf->size);
+    std::memcpy(uintvec.data(), buf->vec.data(), n * buf->size);
     Rcpp::LogicalVector out(buf->ncells);
-    for (size_t i=0; i<n; i++) {
-      out[i] = static_cast<int32_t>(uintvec[i]); // logical is int32_t internally
+    for (size_t i = 0; i < n; i++) {
+      out[i] =
+          static_cast<int32_t>(uintvec[i]); // logical is int32_t internally
     }
     if (buf->nullable)
-        setValidityMapForLogical(out, buf->validity_map, buf->numvar);
+      setValidityMapForLogical(out, buf->validity_map, buf->numvar);
     return out;
 #endif
   } else {
@@ -3644,27 +3870,27 @@ XPtr<tiledb::Query> libtiledb_query_finalize(XPtr<tiledb::Query> query) {
 
 std::string _query_status_to_string(tiledb::Query::Status status) {
   switch (status) {
-    case tiledb::Query::Status::COMPLETE:
-      return "COMPLETE";
-    case tiledb::Query::Status::FAILED:
-      return "FAILED";
-    case tiledb::Query::Status::INPROGRESS:
-      return "INPROGRESS";
-    case tiledb::Query::Status::INCOMPLETE:
-      return "INCOMPLETE";
-    case tiledb::Query::Status::UNINITIALIZED:
-    default:
-      return "UNINITIALIZED";
+  case tiledb::Query::Status::COMPLETE:
+    return "COMPLETE";
+  case tiledb::Query::Status::FAILED:
+    return "FAILED";
+  case tiledb::Query::Status::INPROGRESS:
+    return "INPROGRESS";
+  case tiledb::Query::Status::INCOMPLETE:
+    return "INCOMPLETE";
+  case tiledb::Query::Status::UNINITIALIZED:
+  default:
+    return "UNINITIALIZED";
   }
 }
-
 
 // [[Rcpp::export]]
 std::string libtiledb_query_status(XPtr<tiledb::Query> query) {
   check_xptr_tag<tiledb::Query>(query);
   tiledb::Query::Status status = query->query_status();
   std::string status_text = _query_status_to_string(status);
-  spdl::debug(tfm::format("[libtiledb_query_status] status = %s", status_text.c_str()));
+  spdl::debug(
+      tfm::format("[libtiledb_query_status] status = %s", status_text.c_str()));
   return status_text;
 }
 
@@ -3672,31 +3898,30 @@ std::string libtiledb_query_status(XPtr<tiledb::Query> query) {
 R_xlen_t libtiledb_query_result_buffer_elements(XPtr<tiledb::Query> query,
                                                 std::string attribute,
                                                 int32_t which = 1) {
-    check_xptr_tag<tiledb::Query>(query);
-    auto nelements = query->result_buffer_elements()[attribute];
-    spdl::debug(tfm::format("[libtiledb_query_result_buffer_elements] attribute %s : (%d,%d)",
-                            attribute, nelements.first, nelements.second));
-    R_xlen_t nelem = (which == 0 ? nelements.first : nelements.second);
-    return nelem;
+  check_xptr_tag<tiledb::Query>(query);
+  auto nelements = query->result_buffer_elements()[attribute];
+  spdl::debug(tfm::format(
+      "[libtiledb_query_result_buffer_elements] attribute %s : (%d,%d)",
+      attribute, nelements.first, nelements.second));
+  R_xlen_t nelem = (which == 0 ? nelements.first : nelements.second);
+  return nelem;
 }
 
 // [[Rcpp::export]]
-NumericVector libtiledb_query_result_buffer_elements_vec(XPtr<tiledb::Query> query,
-                                                         std::string attribute,
-                                                         bool nullable = false) {
-    check_xptr_tag<tiledb::Query>(query);
-    if (nullable) {
-        auto nelem = query->result_buffer_elements_nullable()[attribute];
-        auto vec = NumericVector( {
-                static_cast<double>(std::get<0>(nelem)),
-                static_cast<double>(std::get<1>(nelem)),
-                static_cast<double>(std::get<2>(nelem))
-            });
-        return vec;
-    } else {
-        auto nelem = query->result_buffer_elements()[attribute];
-        return NumericVector( { static_cast<double>(nelem.first), static_cast<double>(nelem.second) });
-    }
+NumericVector libtiledb_query_result_buffer_elements_vec(
+    XPtr<tiledb::Query> query, std::string attribute, bool nullable = false) {
+  check_xptr_tag<tiledb::Query>(query);
+  if (nullable) {
+    auto nelem = query->result_buffer_elements_nullable()[attribute];
+    auto vec = NumericVector({static_cast<double>(std::get<0>(nelem)),
+                              static_cast<double>(std::get<1>(nelem)),
+                              static_cast<double>(std::get<2>(nelem))});
+    return vec;
+  } else {
+    auto nelem = query->result_buffer_elements()[attribute];
+    return NumericVector(
+        {static_cast<double>(nelem.first), static_cast<double>(nelem.second)});
+  }
 }
 
 // [[Rcpp::export]]
@@ -3709,7 +3934,8 @@ int libtiledb_query_get_fragment_num(XPtr<tiledb::Query> query) {
 }
 
 // [[Rcpp::export]]
-std::string libtiledb_query_get_fragment_uri(XPtr<tiledb::Query> query, int idx) {
+std::string libtiledb_query_get_fragment_uri(XPtr<tiledb::Query> query,
+                                             int idx) {
   check_xptr_tag<tiledb::Query>(query);
   if (query->query_type() != TILEDB_WRITE) {
     Rcpp::stop("Fragment URI only applicable to 'write' queries.");
@@ -3719,14 +3945,17 @@ std::string libtiledb_query_get_fragment_uri(XPtr<tiledb::Query> query, int idx)
 }
 
 // [[Rcpp::export]]
-Rcpp::DatetimeVector libtiledb_query_get_fragment_timestamp_range(XPtr<tiledb::Query> query, int idx) {
+Rcpp::DatetimeVector
+libtiledb_query_get_fragment_timestamp_range(XPtr<tiledb::Query> query,
+                                             int idx) {
   check_xptr_tag<tiledb::Query>(query);
   if (query->query_type() != TILEDB_WRITE) {
     Rcpp::stop("Fragment URI only applicable to 'write' queries.");
   }
   uint32_t uidx = static_cast<uint32_t>(idx);
   std::pair<uint64_t, uint64_t> range = query->fragment_timestamp_range(uidx);
-  return Rcpp::DatetimeVector::create(range.first/1000.0, range.second/1000.0);
+  return Rcpp::DatetimeVector::create(range.first / 1000.0,
+                                      range.second / 1000.0);
 }
 
 // Subarray functions replacing old Query functionality
@@ -3734,186 +3963,215 @@ Rcpp::DatetimeVector libtiledb_query_get_fragment_timestamp_range(XPtr<tiledb::Q
 
 // [[Rcpp::export]]
 XPtr<tiledb::Subarray> libtiledb_subarray(XPtr<tiledb::Query> query) {
-    return make_xptr<tiledb::Subarray>(new tiledb::Subarray(query->ctx(), query->array()));
+  return make_xptr<tiledb::Subarray>(
+      new tiledb::Subarray(query->ctx(), query->array()));
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::Subarray> libtiledb_subarray_add_range(XPtr<tiledb::Subarray> subarr,
-                                                    int iidx, SEXP starts, SEXP ends,
-                                                    SEXP strides = R_NilValue) {
-    check_xptr_tag<tiledb::Subarray>(subarr);
-    spdl::debug("libtiledb_query_add_range] setting subarray");
-    if (TYPEOF(starts) != TYPEOF(ends)) {
-        Rcpp::stop("'start' and 'end' must be of identical types");
-    }
-    uint32_t uidx = static_cast<uint32_t>(iidx);
-    if (TYPEOF(starts) == INTSXP) {
-        int32_t start = as<int32_t>(starts);
-        int32_t end = as<int32_t>(ends);
-        int32_t stride = (strides == R_NilValue) ? 0 : Rcpp::as<int32_t>(strides);
-        subarr->add_range(uidx, start, end, stride);
-    } else if (TYPEOF(starts) == REALSXP) {
-        double start = as<double>(starts);
-        double end = as<double>(ends);
-        double stride = (strides == R_NilValue) ? 0 : Rcpp::as<double_t>(strides);
-        subarr->add_range(uidx, start, end, stride);
-    } else if (TYPEOF(starts) == STRSXP) {
-        std::string start = as<std::string>(starts);
-        std::string end = as<std::string>(ends);
-        if (strides == R_NilValue) {
-            subarr->add_range(uidx, start, end);
-        } else {
-            Rcpp::stop("Non-emoty stride for string not supported yet.");
-        }
+XPtr<tiledb::Subarray>
+libtiledb_subarray_add_range(XPtr<tiledb::Subarray> subarr, int iidx,
+                             SEXP starts, SEXP ends,
+                             SEXP strides = R_NilValue) {
+  check_xptr_tag<tiledb::Subarray>(subarr);
+  spdl::debug("libtiledb_query_add_range] setting subarray");
+  if (TYPEOF(starts) != TYPEOF(ends)) {
+    Rcpp::stop("'start' and 'end' must be of identical types");
+  }
+  uint32_t uidx = static_cast<uint32_t>(iidx);
+  if (TYPEOF(starts) == INTSXP) {
+    int32_t start = as<int32_t>(starts);
+    int32_t end = as<int32_t>(ends);
+    int32_t stride = (strides == R_NilValue) ? 0 : Rcpp::as<int32_t>(strides);
+    subarr->add_range(uidx, start, end, stride);
+  } else if (TYPEOF(starts) == REALSXP) {
+    double start = as<double>(starts);
+    double end = as<double>(ends);
+    double stride = (strides == R_NilValue) ? 0 : Rcpp::as<double_t>(strides);
+    subarr->add_range(uidx, start, end, stride);
+  } else if (TYPEOF(starts) == STRSXP) {
+    std::string start = as<std::string>(starts);
+    std::string end = as<std::string>(ends);
+    if (strides == R_NilValue) {
+      subarr->add_range(uidx, start, end);
     } else {
-        Rcpp::stop("Invalid data type for query range: '%s'", Rcpp::type2name(starts));
+      Rcpp::stop("Non-emoty stride for string not supported yet.");
     }
-    return subarr;
+  } else {
+    Rcpp::stop("Invalid data type for query range: '%s'",
+               Rcpp::type2name(starts));
+  }
+  return subarr;
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::Subarray> libtiledb_subarray_add_range_with_type(XPtr<tiledb::Subarray> subarr,
-                                                              int iidx,
-                                                              std::string typestr,
-                                                              SEXP starts, SEXP ends,
-                                                              SEXP strides = R_NilValue) {
+XPtr<tiledb::Subarray>
+libtiledb_subarray_add_range_with_type(XPtr<tiledb::Subarray> subarr, int iidx,
+                                       std::string typestr, SEXP starts,
+                                       SEXP ends, SEXP strides = R_NilValue) {
 
-    check_xptr_tag<tiledb::Subarray>(subarr);
-    if (TYPEOF(starts) != TYPEOF(ends)) {
-        Rcpp::stop("'start' and 'end' must be of identical types");
-    }
-    uint32_t uidx = static_cast<uint32_t>(iidx);
+  check_xptr_tag<tiledb::Subarray>(subarr);
+  if (TYPEOF(starts) != TYPEOF(ends)) {
+    Rcpp::stop("'start' and 'end' must be of identical types");
+  }
+  uint32_t uidx = static_cast<uint32_t>(iidx);
 
-    if (typestr == "INT32") {
-        int32_t start = as<int32_t>(starts);
-        int32_t end = as<int32_t>(ends);
-        int32_t stride = (strides == R_NilValue) ? 0 : Rcpp::as<int32_t>(strides);
-        subarr->add_range(uidx, start, end, stride);
-        spdl::debug(tfm::format("[libtiledb_subarry_add_range_with type] %s dim %d added %d to %d by %d", typestr, uidx, start, end, stride));
-    } else if (typestr == "FLOAT64") {
-        double start = as<double>(starts);
-        double end = as<double>(ends);
-        double stride = (strides == R_NilValue) ? 0 : Rcpp::as<double_t>(strides);
-        subarr->add_range(uidx, start, end, stride);
-        spdl::debug(tfm::format("[libtiledb_subarry_add_range_with type] %s dim %d added %f to %f by %f", typestr, uidx, start, end, stride));
-    } else if (typestr == "INT64") {
-        int64_t start = fromInteger64(as<double>(starts));
-        int64_t end = fromInteger64(as<double>(ends));
-        int64_t stride = (strides == R_NilValue) ? 0 : fromInteger64(as<double>(strides));
-        subarr->add_range(uidx, start, end, stride);
-        spdl::debug(tfm::format("[libtiledb_subarry_add_range_with type] %s dim %d added %d to %d by %d", typestr, uidx, start, end, stride));
-    } else if (typestr == "UINT64") {
-        uint64_t start = static_cast<uint64_t>(fromInteger64(as<double>(starts)));
-        uint64_t end = static_cast<uint64_t>(fromInteger64(as<double>(ends)));
-        uint64_t stride = (strides == R_NilValue) ? 0 : fromInteger64(as<double>(strides));
-        subarr->add_range(uidx, start, end, stride);
-        spdl::debug(tfm::format("[libtiledb_subarry_add_range_with type] %s dim %d added %d to %d by %d", typestr, uidx, start, end, stride));
-    } else if (typestr == "UINT32") {
-        uint32_t start = as<uint32_t>(starts);
-        uint32_t end   = as<uint32_t>(ends);
-        uint32_t stride = (strides == R_NilValue) ? 0 : as<int32_t>(strides);
-        subarr->add_range(uidx, start, end, stride);
-        spdl::debug(tfm::format("[libtiledb_subarry_add_range_with type] %s dim %d added %d to %d by %d", typestr, uidx, start, end, stride));
-    } else if (typestr == "INT16") {
-        int16_t start = as<int16_t>(starts);
-        int16_t end   = as<int16_t>(ends);
-        int16_t stride = (strides == R_NilValue) ? 0 : as<int16_t>(strides);
-        subarr->add_range(uidx, start, end, stride);
-        spdl::debug(tfm::format("[libtiledb_subarry_add_range_with type] %s dim %d added %d to %d by %d", typestr, uidx, start, end, stride));
-    } else if (typestr == "UINT16") {
-        uint16_t start = as<uint16_t>(starts);
-        uint16_t end   = as<uint16_t>(ends);
-        uint16_t stride = (strides == R_NilValue) ? 0 : as<uint16_t>(strides);
-        subarr->add_range(uidx, start, end, stride);
-        spdl::debug(tfm::format("[libtiledb_subarry_add_range_with type] %s dim %d added %d to %d by %d", typestr, uidx, start, end, stride));
-    } else if (typestr == "INT8") {
-        int8_t start = as<int16_t>(starts);
-        int8_t end   = as<int16_t>(ends);
-        int8_t stride = (strides == R_NilValue) ? 0 : as<int16_t>(strides);
-        subarr->add_range(uidx, start, end, stride);
-        spdl::debug(tfm::format("[libtiledb_subarry_add_range_with type] %s dim %d added %d to %d by %d", typestr, uidx, start, end, stride));
-    } else if (typestr == "UINT8") {
-        uint8_t start = as<uint16_t>(starts);
-        uint8_t end   = as<uint16_t>(ends);
-        uint8_t stride = (strides == R_NilValue) ? 0 : as<uint16_t>(strides);
-        subarr->add_range(uidx, start, end, stride);
-        spdl::debug(tfm::format("[libtiledb_subarry_add_range_with type] %s dim %d added %d to %d by %d", typestr, uidx, start, end, stride));
-    } else if (typestr == "DATETIME_YEAR"  ||
-               typestr == "DATETIME_MONTH" ||
-               typestr == "DATETIME_WEEK"  ||
-               typestr == "DATETIME_DAY"   ||
-               typestr == "DATETIME_HR"    ||
-               typestr == "DATETIME_MIN"   ||
-               typestr == "DATETIME_SEC"   ||
-               typestr == "DATETIME_MS"    ||
-               typestr == "DATETIME_US"    ||
-               typestr == "DATETIME_NS"    ||
-               typestr == "DATETIME_FS"    ||
-               typestr == "DATETIME_PS"    ||
-               typestr == "DATETIME_AS") {
-        int64_t start = fromInteger64(as<double>(starts));
-        int64_t end = fromInteger64(as<double>(ends));
-        int64_t stride = (strides == R_NilValue) ? 0 : fromInteger64(as<double>(strides));
-        subarr->add_range(uidx, start, end, stride);
-        spdl::debug(tfm::format("[libtiledb_subarry_add_range_with type] %s dim %d added %d to %d by %d", typestr, uidx, start, end, stride));
-    } else if (typestr == "ASCII" || typestr == "CHAR") {
-        std::string start = as<std::string>(starts);
-        std::string end = as<std::string>(ends);
-        if (strides != R_NilValue) {
-            Rcpp::stop("Non-empty stride for string not supported yet.");
-        }
-        subarr->add_range(uidx, start, end);
-        spdl::debug(tfm::format("[libtiledb_subarry_add_range_with type] %s dim %d added %s to %s", typestr, uidx, start, end));
-    } else if (typestr == "FLOAT32") {
-        float start = as<float>(starts);
-        float end = as<float>(ends);
-        float stride = (strides == R_NilValue) ? 0 : Rcpp::as<float>(strides);
-        subarr->add_range(uidx, start, end, stride);
-        spdl::debug(tfm::format("[libtiledb_subarry_add_range_with type] %s dim %d added %f to %f by %f", typestr, uidx, start, end, stride));
+  if (typestr == "INT32") {
+    int32_t start = as<int32_t>(starts);
+    int32_t end = as<int32_t>(ends);
+    int32_t stride = (strides == R_NilValue) ? 0 : Rcpp::as<int32_t>(strides);
+    subarr->add_range(uidx, start, end, stride);
+    spdl::debug(tfm::format("[libtiledb_subarry_add_range_with type] %s dim %d "
+                            "added %d to %d by %d",
+                            typestr, uidx, start, end, stride));
+  } else if (typestr == "FLOAT64") {
+    double start = as<double>(starts);
+    double end = as<double>(ends);
+    double stride = (strides == R_NilValue) ? 0 : Rcpp::as<double_t>(strides);
+    subarr->add_range(uidx, start, end, stride);
+    spdl::debug(tfm::format("[libtiledb_subarry_add_range_with type] %s dim %d "
+                            "added %f to %f by %f",
+                            typestr, uidx, start, end, stride));
+  } else if (typestr == "INT64") {
+    int64_t start = fromInteger64(as<double>(starts));
+    int64_t end = fromInteger64(as<double>(ends));
+    int64_t stride =
+        (strides == R_NilValue) ? 0 : fromInteger64(as<double>(strides));
+    subarr->add_range(uidx, start, end, stride);
+    spdl::debug(tfm::format("[libtiledb_subarry_add_range_with type] %s dim %d "
+                            "added %d to %d by %d",
+                            typestr, uidx, start, end, stride));
+  } else if (typestr == "UINT64") {
+    uint64_t start = static_cast<uint64_t>(fromInteger64(as<double>(starts)));
+    uint64_t end = static_cast<uint64_t>(fromInteger64(as<double>(ends)));
+    uint64_t stride =
+        (strides == R_NilValue) ? 0 : fromInteger64(as<double>(strides));
+    subarr->add_range(uidx, start, end, stride);
+    spdl::debug(tfm::format("[libtiledb_subarry_add_range_with type] %s dim %d "
+                            "added %d to %d by %d",
+                            typestr, uidx, start, end, stride));
+  } else if (typestr == "UINT32") {
+    uint32_t start = as<uint32_t>(starts);
+    uint32_t end = as<uint32_t>(ends);
+    uint32_t stride = (strides == R_NilValue) ? 0 : as<int32_t>(strides);
+    subarr->add_range(uidx, start, end, stride);
+    spdl::debug(tfm::format("[libtiledb_subarry_add_range_with type] %s dim %d "
+                            "added %d to %d by %d",
+                            typestr, uidx, start, end, stride));
+  } else if (typestr == "INT16") {
+    int16_t start = as<int16_t>(starts);
+    int16_t end = as<int16_t>(ends);
+    int16_t stride = (strides == R_NilValue) ? 0 : as<int16_t>(strides);
+    subarr->add_range(uidx, start, end, stride);
+    spdl::debug(tfm::format("[libtiledb_subarry_add_range_with type] %s dim %d "
+                            "added %d to %d by %d",
+                            typestr, uidx, start, end, stride));
+  } else if (typestr == "UINT16") {
+    uint16_t start = as<uint16_t>(starts);
+    uint16_t end = as<uint16_t>(ends);
+    uint16_t stride = (strides == R_NilValue) ? 0 : as<uint16_t>(strides);
+    subarr->add_range(uidx, start, end, stride);
+    spdl::debug(tfm::format("[libtiledb_subarry_add_range_with type] %s dim %d "
+                            "added %d to %d by %d",
+                            typestr, uidx, start, end, stride));
+  } else if (typestr == "INT8") {
+    int8_t start = as<int16_t>(starts);
+    int8_t end = as<int16_t>(ends);
+    int8_t stride = (strides == R_NilValue) ? 0 : as<int16_t>(strides);
+    subarr->add_range(uidx, start, end, stride);
+    spdl::debug(tfm::format("[libtiledb_subarry_add_range_with type] %s dim %d "
+                            "added %d to %d by %d",
+                            typestr, uidx, start, end, stride));
+  } else if (typestr == "UINT8") {
+    uint8_t start = as<uint16_t>(starts);
+    uint8_t end = as<uint16_t>(ends);
+    uint8_t stride = (strides == R_NilValue) ? 0 : as<uint16_t>(strides);
+    subarr->add_range(uidx, start, end, stride);
+    spdl::debug(tfm::format("[libtiledb_subarry_add_range_with type] %s dim %d "
+                            "added %d to %d by %d",
+                            typestr, uidx, start, end, stride));
+  } else if (typestr == "DATETIME_YEAR" || typestr == "DATETIME_MONTH" ||
+             typestr == "DATETIME_WEEK" || typestr == "DATETIME_DAY" ||
+             typestr == "DATETIME_HR" || typestr == "DATETIME_MIN" ||
+             typestr == "DATETIME_SEC" || typestr == "DATETIME_MS" ||
+             typestr == "DATETIME_US" || typestr == "DATETIME_NS" ||
+             typestr == "DATETIME_FS" || typestr == "DATETIME_PS" ||
+             typestr == "DATETIME_AS") {
+    int64_t start = fromInteger64(as<double>(starts));
+    int64_t end = fromInteger64(as<double>(ends));
+    int64_t stride =
+        (strides == R_NilValue) ? 0 : fromInteger64(as<double>(strides));
+    subarr->add_range(uidx, start, end, stride);
+    spdl::debug(tfm::format("[libtiledb_subarry_add_range_with type] %s dim %d "
+                            "added %d to %d by %d",
+                            typestr, uidx, start, end, stride));
+  } else if (typestr == "ASCII" || typestr == "CHAR") {
+    std::string start = as<std::string>(starts);
+    std::string end = as<std::string>(ends);
+    if (strides != R_NilValue) {
+      Rcpp::stop("Non-empty stride for string not supported yet.");
     }
-    return subarr;
+    subarr->add_range(uidx, start, end);
+    spdl::debug(tfm::format(
+        "[libtiledb_subarry_add_range_with type] %s dim %d added %s to %s",
+        typestr, uidx, start, end));
+  } else if (typestr == "FLOAT32") {
+    float start = as<float>(starts);
+    float end = as<float>(ends);
+    float stride = (strides == R_NilValue) ? 0 : Rcpp::as<float>(strides);
+    subarr->add_range(uidx, start, end, stride);
+    spdl::debug(tfm::format("[libtiledb_subarry_add_range_with type] %s dim %d "
+                            "added %f to %f by %f",
+                            typestr, uidx, start, end, stride));
+  }
+  return subarr;
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::Query> libtiledb_query_set_subarray_object(XPtr<tiledb::Query> query, XPtr<tiledb::Subarray> subarr) {
-    check_xptr_tag<tiledb::Query>(query);
-    check_xptr_tag<tiledb::Subarray>(subarr);
-    query->set_subarray(*subarr.get());
-    return query;
+XPtr<tiledb::Query>
+libtiledb_query_set_subarray_object(XPtr<tiledb::Query> query,
+                                    XPtr<tiledb::Subarray> subarr) {
+  check_xptr_tag<tiledb::Query>(query);
+  check_xptr_tag<tiledb::Subarray>(subarr);
+  query->set_subarray(*subarr.get());
+  return query;
 }
 
-
 // [[Rcpp::export]]
-R_xlen_t libtiledb_query_get_est_result_size(XPtr<tiledb::Query> query, std::string attr) {
+R_xlen_t libtiledb_query_get_est_result_size(XPtr<tiledb::Query> query,
+                                             std::string attr) {
   check_xptr_tag<tiledb::Query>(query);
   uint64_t est = query->est_result_size(attr);
   return static_cast<R_xlen_t>(est);
 }
 
-
 // [[Rcpp::export]]
-NumericVector libtiledb_query_get_est_result_size_nullable(XPtr<tiledb::Query> query, std::string attr) {
-    check_xptr_tag<tiledb::Query>(query);
-    std::array<uint64_t, 2> est = query->est_result_size_nullable(attr);
-    return Rcpp::NumericVector::create(static_cast<R_xlen_t>(est[0]),
-                                       static_cast<R_xlen_t>(est[1]));
+NumericVector
+libtiledb_query_get_est_result_size_nullable(XPtr<tiledb::Query> query,
+                                             std::string attr) {
+  check_xptr_tag<tiledb::Query>(query);
+  std::array<uint64_t, 2> est = query->est_result_size_nullable(attr);
+  return Rcpp::NumericVector::create(static_cast<R_xlen_t>(est[0]),
+                                     static_cast<R_xlen_t>(est[1]));
 }
 
-
 // [[Rcpp::export]]
-NumericVector libtiledb_query_get_est_result_size_var(XPtr<tiledb::Query> query, std::string attr) {
+NumericVector libtiledb_query_get_est_result_size_var(XPtr<tiledb::Query> query,
+                                                      std::string attr) {
   check_xptr_tag<tiledb::Query>(query);
   std::array<uint64_t, 2> est = query->est_result_size_var(attr);
-  return NumericVector::create(static_cast<R_xlen_t>(est[0]), static_cast<R_xlen_t>(est[1]));
+  return NumericVector::create(static_cast<R_xlen_t>(est[0]),
+                               static_cast<R_xlen_t>(est[1]));
 }
 
 // [[Rcpp::export]]
-NumericVector libtiledb_query_get_est_result_size_var_nullable(XPtr<tiledb::Query> query, std::string attr) {
-    check_xptr_tag<tiledb::Query>(query);
-    std::array<uint64_t, 3> est = query->est_result_size_var_nullable(attr);
-    return Rcpp::NumericVector::create(static_cast<R_xlen_t>(est[0]),
-                                       static_cast<R_xlen_t>(est[1]),
-                                       static_cast<R_xlen_t>(est[2]));
+NumericVector
+libtiledb_query_get_est_result_size_var_nullable(XPtr<tiledb::Query> query,
+                                                 std::string attr) {
+  check_xptr_tag<tiledb::Query>(query);
+  std::array<uint64_t, 3> est = query->est_result_size_var_nullable(attr);
+  return Rcpp::NumericVector::create(static_cast<R_xlen_t>(est[0]),
+                                     static_cast<R_xlen_t>(est[1]),
+                                     static_cast<R_xlen_t>(est[2]));
 }
 
 // [[Rcpp::export]]
@@ -3928,84 +4186,93 @@ double libtiledb_query_get_range_num(XPtr<tiledb::Query> query, int dim_idx) {
 }
 
 // [[Rcpp::export]]
-IntegerVector libtiledb_query_get_range(XPtr<tiledb::Query> query, int dim_idx, int rng_idx) {
+IntegerVector libtiledb_query_get_range(XPtr<tiledb::Query> query, int dim_idx,
+                                        int rng_idx) {
   check_xptr_tag<tiledb::Query>(query);
   tiledb::Array arr = query->array();
   tiledb::Context ctx = query->ctx();
   tiledb::Subarray sub(ctx, arr);
   query->update_subarray_from_query(&sub);
-  std::array<int32_t, 3> rng = sub.range<int32_t>(static_cast<unsigned int>(dim_idx),
-                                                  static_cast<unsigned int>(rng_idx));
-  return IntegerVector::create(rng[0], 	// start
+  std::array<int32_t, 3> rng = sub.range<int32_t>(
+      static_cast<unsigned int>(dim_idx), static_cast<unsigned int>(rng_idx));
+  return IntegerVector::create(rng[0],  // start
                                rng[1],  // end
                                rng[2]); // stride
 }
 
 // [[Rcpp::export]]
-CharacterVector libtiledb_query_get_range_var(XPtr<tiledb::Query> query, int dim_idx, int rng_idx) {
+CharacterVector libtiledb_query_get_range_var(XPtr<tiledb::Query> query,
+                                              int dim_idx, int rng_idx) {
   check_xptr_tag<tiledb::Query>(query);
   tiledb::Array arr = query->array();
   tiledb::Context ctx = query->ctx();
   tiledb::Subarray sub(ctx, arr);
   query->update_subarray_from_query(&sub);
-  std::array<std::string, 2> rng = sub.range(static_cast<unsigned int>(dim_idx), static_cast<uint64_t>(rng_idx));
-  return CharacterVector::create(rng[0], rng[1]);	 // start and end
+  std::array<std::string, 2> rng = sub.range(static_cast<unsigned int>(dim_idx),
+                                             static_cast<uint64_t>(rng_idx));
+  return CharacterVector::create(rng[0], rng[1]); // start and end
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::Query> libtiledb_query_set_condition(XPtr<tiledb::Query> query,
-                                                  XPtr<tiledb::QueryCondition> query_cond) {
+XPtr<tiledb::Query>
+libtiledb_query_set_condition(XPtr<tiledb::Query> query,
+                              XPtr<tiledb::QueryCondition> query_cond) {
   check_xptr_tag<tiledb::Query>(query);
   query->set_condition(*query_cond.get());
   return query;
 }
 
-// Note that the Array pointer returned here from a Query object is not owned and will not
-// outlive the query object
+// Note that the Array pointer returned here from a Query object is not owned
+// and will not outlive the query object
 //
 // [[Rcpp::export]]
-XPtr<tiledb::Array> libtiledb_query_get_array(XPtr<tiledb::Query> query, XPtr<tiledb::Context> ctx) {
-    check_xptr_tag<tiledb::Query>(query);
-    check_xptr_tag<tiledb::Context>(ctx);
-    auto arr = query->array();
-    auto cptr = arr.ptr().get();
-    return make_xptr<tiledb::Array>(new tiledb::Array(*ctx.get(), cptr, false));
+XPtr<tiledb::Array> libtiledb_query_get_array(XPtr<tiledb::Query> query,
+                                              XPtr<tiledb::Context> ctx) {
+  check_xptr_tag<tiledb::Query>(query);
+  check_xptr_tag<tiledb::Context>(ctx);
+  auto arr = query->array();
+  auto cptr = arr.ptr().get();
+  return make_xptr<tiledb::Array>(new tiledb::Array(*ctx.get(), cptr, false));
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::ArraySchema> libtiledb_query_get_schema(XPtr<tiledb::Query> query,
-                                                     XPtr<tiledb::Context> ctx) {
-    check_xptr_tag<tiledb::Query>(query);
-    auto arr = query->array();
-    return libtiledb_array_schema_load(ctx, arr.uri()); // returns an XPtr<tiledb::ArraySchema>
+XPtr<tiledb::ArraySchema>
+libtiledb_query_get_schema(XPtr<tiledb::Query> query,
+                           XPtr<tiledb::Context> ctx) {
+  check_xptr_tag<tiledb::Query>(query);
+  auto arr = query->array();
+  return libtiledb_array_schema_load(
+      ctx, arr.uri()); // returns an XPtr<tiledb::ArraySchema>
 }
 
 // [[Rcpp::export]]
 std::string libtiledb_query_stats(XPtr<tiledb::Query> query) {
-    check_xptr_tag<tiledb::Query>(query);
-    return query->stats();
+  check_xptr_tag<tiledb::Query>(query);
+  return query->stats();
 }
 
 // [[Rcpp::export]]
 XPtr<tiledb::Context> libtiledb_query_get_ctx(XPtr<tiledb::Query> query) {
-    check_xptr_tag<tiledb::Query>(query);
-    auto ctx = query->ctx();
-    return make_xptr<tiledb::Context>(new tiledb::Context(ctx));
+  check_xptr_tag<tiledb::Query>(query);
+  auto ctx = query->ctx();
+  return make_xptr<tiledb::Context>(new tiledb::Context(ctx));
 }
 
 template <typename T>
-SEXP apply_unary_aggregate(XPtr<tiledb::Query> query, std::string operator_name, bool nullable = false) {
-#if TILEDB_VERSION >= TileDB_Version(2,18,0)
-    T result = 0;
-    std::vector<uint8_t> nulls = { 0 };
-    uint64_t size = 1;
-    query->set_data_buffer(operator_name, &result, size);
-    if (nullable) query->set_validity_buffer(operator_name, nulls);
-    query->submit();
-    SEXP res = Rcpp::wrap(result);
-    return res;
+SEXP apply_unary_aggregate(XPtr<tiledb::Query> query, std::string operator_name,
+                           bool nullable = false) {
+#if TILEDB_VERSION >= TileDB_Version(2, 18, 0)
+  T result = 0;
+  std::vector<uint8_t> nulls = {0};
+  uint64_t size = 1;
+  query->set_data_buffer(operator_name, &result, size);
+  if (nullable)
+    query->set_validity_buffer(operator_name, nulls);
+  query->submit();
+  SEXP res = Rcpp::wrap(result);
+  return res;
 #else
-    return Rcpp::wrap(R_NaReal);
+  return Rcpp::wrap(R_NaReal);
 #endif
 }
 
@@ -4014,285 +4281,328 @@ SEXP libtiledb_query_apply_aggregate(XPtr<tiledb::Query> query,
                                      std::string attribute_name,
                                      std::string operator_name,
                                      bool nullable = false) {
-#if TILEDB_VERSION >= TileDB_Version(2,18,0)
-    check_xptr_tag<tiledb::Query>(query);
-    tiledb::QueryChannel channel = tiledb::QueryExperimental::get_default_channel(*query.get());
-    if (operator_name == "Sum") {
-        tiledb::ChannelOperation operation = tiledb::QueryExperimental::create_unary_aggregate<tiledb::SumOperator>(*query.get(), attribute_name);
-        channel.apply_aggregate(operator_name, operation);
-    } else if (operator_name == "Min") {
-        tiledb::ChannelOperation operation = tiledb::QueryExperimental::create_unary_aggregate<tiledb::MinOperator>(*query.get(), attribute_name);
-        channel.apply_aggregate(operator_name, operation);
-    } else if (operator_name == "Max") {
-        tiledb::ChannelOperation operation = tiledb::QueryExperimental::create_unary_aggregate<tiledb::MaxOperator>(*query.get(), attribute_name);
-        channel.apply_aggregate(operator_name, operation);
-    } else if (operator_name == "Mean") {
-        tiledb::ChannelOperation operation = tiledb::QueryExperimental::create_unary_aggregate<tiledb::MeanOperator>(*query.get(), attribute_name);
-        channel.apply_aggregate(operator_name, operation);
-    } else if (operator_name == "NullCount") {
-        tiledb::ChannelOperation operation = tiledb::QueryExperimental::create_unary_aggregate<tiledb::NullCountOperator>(*query.get(), attribute_name);
-        channel.apply_aggregate(operator_name, operation);
-    } else if (operator_name == "Count") {
-        channel.apply_aggregate(operator_name, tiledb::CountOperation());
-    } else {
-        Rcpp::stop("Invalid aggregation operator '%s' specified.", operator_name.c_str());
+#if TILEDB_VERSION >= TileDB_Version(2, 18, 0)
+  check_xptr_tag<tiledb::Query>(query);
+  tiledb::QueryChannel channel =
+      tiledb::QueryExperimental::get_default_channel(*query.get());
+  if (operator_name == "Sum") {
+    tiledb::ChannelOperation operation =
+        tiledb::QueryExperimental::create_unary_aggregate<tiledb::SumOperator>(
+            *query.get(), attribute_name);
+    channel.apply_aggregate(operator_name, operation);
+  } else if (operator_name == "Min") {
+    tiledb::ChannelOperation operation =
+        tiledb::QueryExperimental::create_unary_aggregate<tiledb::MinOperator>(
+            *query.get(), attribute_name);
+    channel.apply_aggregate(operator_name, operation);
+  } else if (operator_name == "Max") {
+    tiledb::ChannelOperation operation =
+        tiledb::QueryExperimental::create_unary_aggregate<tiledb::MaxOperator>(
+            *query.get(), attribute_name);
+    channel.apply_aggregate(operator_name, operation);
+  } else if (operator_name == "Mean") {
+    tiledb::ChannelOperation operation =
+        tiledb::QueryExperimental::create_unary_aggregate<tiledb::MeanOperator>(
+            *query.get(), attribute_name);
+    channel.apply_aggregate(operator_name, operation);
+  } else if (operator_name == "NullCount") {
+    tiledb::ChannelOperation operation =
+        tiledb::QueryExperimental::create_unary_aggregate<
+            tiledb::NullCountOperator>(*query.get(), attribute_name);
+    channel.apply_aggregate(operator_name, operation);
+  } else if (operator_name == "Count") {
+    channel.apply_aggregate(operator_name, tiledb::CountOperation());
+  } else {
+    Rcpp::stop("Invalid aggregation operator '%s' specified.",
+               operator_name.c_str());
+  }
+  std::vector<uint8_t> nulls = {0};
+  uint64_t size = 1;
+  if (operator_name == "NullCount" || operator_name == "Count") {
+    // Count and null count take uint64_t.
+    uint64_t result = 0;
+    query->set_data_buffer(operator_name, &result, size);
+    if (nullable &&
+        operator_name != "NullCount") { // no validity buffer for NullCount
+      query->set_validity_buffer(operator_name, nulls);
     }
-    std::vector<uint8_t> nulls = { 0 };
-    uint64_t size = 1;
-    if (operator_name == "NullCount" || operator_name == "Count") {
-        // Count and null count take uint64_t.
-        uint64_t result = 0;
-        query->set_data_buffer(operator_name, &result, size);
-        if (nullable && operator_name != "NullCount") {   // no validity buffer for NullCount
-            query->set_validity_buffer(operator_name, nulls);
-        }
-        query->submit();
-        return Rcpp::wrap(result);
-    } else if (operator_name == "Mean") {
-        // Mean always takes in a double.
-        return apply_unary_aggregate<double>(query, operator_name, nullable);
-    } else if (operator_name == "Sum") {
-        // Sum will take int64_t for signed integers, uint64_t for unsigned integers
-        // and double for floating point values.
-        tiledb::Context ctx = query->ctx();
-        auto arr = query->array();
-        auto sch = tiledb::ArraySchema(ctx, arr.uri());
-        auto attr = tiledb::Attribute(sch.attribute(attribute_name));
-        std::string type_name = _tiledb_datatype_to_string(attr.type());
-        if (type_name == "INT8" || type_name == "INT16" ||
-            type_name == "INT32" || type_name == "INT64") {
-            return apply_unary_aggregate<int64_t>(query, operator_name, nullable);
-        } else if (type_name == "UINT8" || type_name == "UINT16" ||
-                   type_name == "UINT32" || type_name == "UINT64") {
-            return apply_unary_aggregate<uint64_t>(query, operator_name, nullable);
-        } else if (type_name == "FLOAT32" || type_name == "FLOAT64") {
-            return apply_unary_aggregate<double>(query, operator_name, nullable);
-        } else {
-            Rcpp::stop("'Sum' operator not valid for attribute '%s' of type '%s'",
-                       attribute_name, type_name);
-        }
-    } else if (operator_name == "Min" || operator_name == "Max") {
-        // Min/max will take whatever the datatype of the column is.
-        tiledb::Context ctx = query->ctx();
-        auto arr = query->array();
-        auto sch = tiledb::ArraySchema(ctx, arr.uri());
-        auto attr = tiledb::Attribute(sch.attribute(attribute_name));
-        std::string type_name = _tiledb_datatype_to_string(attr.type());
-        switch (attr.type()) {
-        case TILEDB_INT8:    return apply_unary_aggregate<int16_t>(query, operator_name, nullable);  // int8_t bites char
-        case TILEDB_INT16:   return apply_unary_aggregate<int16_t>(query, operator_name, nullable);
-        case TILEDB_INT32:   return apply_unary_aggregate<int32_t>(query, operator_name, nullable);
-        case TILEDB_INT64:   return apply_unary_aggregate<int64_t>(query, operator_name, nullable);
-        case TILEDB_UINT8:   return apply_unary_aggregate<uint16_t>(query, operator_name, nullable); // uint8_t bites char
-        case TILEDB_UINT16:  return apply_unary_aggregate<uint16_t>(query, operator_name, nullable);
-        case TILEDB_UINT32:  return apply_unary_aggregate<uint32_t>(query, operator_name, nullable);
-        case TILEDB_UINT64:  return apply_unary_aggregate<uint64_t>(query, operator_name, nullable);
-        case TILEDB_FLOAT32: return apply_unary_aggregate<float>(query, operator_name, nullable);
-        case TILEDB_FLOAT64: return apply_unary_aggregate<double>(query, operator_name, nullable);
-        default: Rcpp::stop("'%s' is not defined for attribute '%s' of type '%s'",
-                            operator_name, attribute_name, type_name);
-        }
+    query->submit();
+    return Rcpp::wrap(result);
+  } else if (operator_name == "Mean") {
+    // Mean always takes in a double.
+    return apply_unary_aggregate<double>(query, operator_name, nullable);
+  } else if (operator_name == "Sum") {
+    // Sum will take int64_t for signed integers, uint64_t for unsigned integers
+    // and double for floating point values.
+    tiledb::Context ctx = query->ctx();
+    auto arr = query->array();
+    auto sch = tiledb::ArraySchema(ctx, arr.uri());
+    auto attr = tiledb::Attribute(sch.attribute(attribute_name));
+    std::string type_name = _tiledb_datatype_to_string(attr.type());
+    if (type_name == "INT8" || type_name == "INT16" || type_name == "INT32" ||
+        type_name == "INT64") {
+      return apply_unary_aggregate<int64_t>(query, operator_name, nullable);
+    } else if (type_name == "UINT8" || type_name == "UINT16" ||
+               type_name == "UINT32" || type_name == "UINT64") {
+      return apply_unary_aggregate<uint64_t>(query, operator_name, nullable);
+    } else if (type_name == "FLOAT32" || type_name == "FLOAT64") {
+      return apply_unary_aggregate<double>(query, operator_name, nullable);
     } else {
-        Rcpp::stop("'%s' is not implemented for '%s'", operator_name, attribute_name);
+      Rcpp::stop("'Sum' operator not valid for attribute '%s' of type '%s'",
+                 attribute_name, type_name);
     }
+  } else if (operator_name == "Min" || operator_name == "Max") {
+    // Min/max will take whatever the datatype of the column is.
+    tiledb::Context ctx = query->ctx();
+    auto arr = query->array();
+    auto sch = tiledb::ArraySchema(ctx, arr.uri());
+    auto attr = tiledb::Attribute(sch.attribute(attribute_name));
+    std::string type_name = _tiledb_datatype_to_string(attr.type());
+    switch (attr.type()) {
+    case TILEDB_INT8:
+      return apply_unary_aggregate<int16_t>(query, operator_name,
+                                            nullable); // int8_t bites char
+    case TILEDB_INT16:
+      return apply_unary_aggregate<int16_t>(query, operator_name, nullable);
+    case TILEDB_INT32:
+      return apply_unary_aggregate<int32_t>(query, operator_name, nullable);
+    case TILEDB_INT64:
+      return apply_unary_aggregate<int64_t>(query, operator_name, nullable);
+    case TILEDB_UINT8:
+      return apply_unary_aggregate<uint16_t>(query, operator_name,
+                                             nullable); // uint8_t bites char
+    case TILEDB_UINT16:
+      return apply_unary_aggregate<uint16_t>(query, operator_name, nullable);
+    case TILEDB_UINT32:
+      return apply_unary_aggregate<uint32_t>(query, operator_name, nullable);
+    case TILEDB_UINT64:
+      return apply_unary_aggregate<uint64_t>(query, operator_name, nullable);
+    case TILEDB_FLOAT32:
+      return apply_unary_aggregate<float>(query, operator_name, nullable);
+    case TILEDB_FLOAT64:
+      return apply_unary_aggregate<double>(query, operator_name, nullable);
+    default:
+      Rcpp::stop("'%s' is not defined for attribute '%s' of type '%s'",
+                 operator_name, attribute_name, type_name);
+    }
+  } else {
+    Rcpp::stop("'%s' is not implemented for '%s'", operator_name,
+               attribute_name);
+  }
 #else
-    return Rcpp::wrap(R_NaReal);
+  return Rcpp::wrap(R_NaReal);
 #endif
 }
 
 /**
  * Query Condition
  */
-const char* _tiledb_query_condition_op_to_string(tiledb_query_condition_op_t op) {
-    switch (op) {
-    case TILEDB_LT:
-        return "LT";
-    case TILEDB_LE:
-        return "LE";
-    case TILEDB_GT:
-        return "GT";
-    case TILEDB_GE:
-        return "GE";
-    case TILEDB_EQ:
-        return "EQ";
-    case TILEDB_NE:
-        return "NE";
-#if TILEDB_VERSION >= TileDB_Version(2,17,0)
-    case TILEDB_IN:
-        return "IN";
-    case TILEDB_NOT_IN:
-        return "NOT_IN";
+const char *
+_tiledb_query_condition_op_to_string(tiledb_query_condition_op_t op) {
+  switch (op) {
+  case TILEDB_LT:
+    return "LT";
+  case TILEDB_LE:
+    return "LE";
+  case TILEDB_GT:
+    return "GT";
+  case TILEDB_GE:
+    return "GE";
+  case TILEDB_EQ:
+    return "EQ";
+  case TILEDB_NE:
+    return "NE";
+#if TILEDB_VERSION >= TileDB_Version(2, 17, 0)
+  case TILEDB_IN:
+    return "IN";
+  case TILEDB_NOT_IN:
+    return "NOT_IN";
 #endif
-    default:
-        Rcpp::stop("Unknown condition op (%d)", op);
-    }
+  default:
+    Rcpp::stop("Unknown condition op (%d)", op);
+  }
 }
 
-tiledb_query_condition_op_t _tiledb_query_string_to_condition_op(const std::string& opstr) {
-    if (opstr == "LT") {
-        return TILEDB_LT;
-    } else if (opstr == "LE") {
-        return TILEDB_LE;
-    } else if (opstr == "GT") {
-        return TILEDB_GT;
-    } else if (opstr == "GE") {
-        return TILEDB_GE;
-    } else if (opstr == "EQ") {
-        return TILEDB_EQ;
-    } else if (opstr == "NE") {
-        return TILEDB_NE;
-#if TILEDB_VERSION >= TileDB_Version(2,17,0)
-    } else if (opstr == "IN") {
-        return TILEDB_IN;
-    } else if (opstr == "NOT_IN") {
-        return TILEDB_NOT_IN;
+tiledb_query_condition_op_t
+_tiledb_query_string_to_condition_op(const std::string &opstr) {
+  if (opstr == "LT") {
+    return TILEDB_LT;
+  } else if (opstr == "LE") {
+    return TILEDB_LE;
+  } else if (opstr == "GT") {
+    return TILEDB_GT;
+  } else if (opstr == "GE") {
+    return TILEDB_GE;
+  } else if (opstr == "EQ") {
+    return TILEDB_EQ;
+  } else if (opstr == "NE") {
+    return TILEDB_NE;
+#if TILEDB_VERSION >= TileDB_Version(2, 17, 0)
+  } else if (opstr == "IN") {
+    return TILEDB_IN;
+  } else if (opstr == "NOT_IN") {
+    return TILEDB_NOT_IN;
 #endif
-    } else {
-        Rcpp::stop("Unknown TileDB op string '%s'", opstr.c_str());
-    }
+  } else {
+    Rcpp::stop("Unknown TileDB op string '%s'", opstr.c_str());
+  }
 }
 
-const char* _tiledb_query_condition_combination_op_to_string(tiledb_query_condition_combination_op_t op) {
-    switch (op) {
-    case TILEDB_AND:
-        return "AND";
-    case TILEDB_OR:
-        return "OR";
-    case TILEDB_NOT:
-        return "NOT";
-    default:
-        Rcpp::stop("Unknown condition combination op (%d)", op);
-    }
+const char *_tiledb_query_condition_combination_op_to_string(
+    tiledb_query_condition_combination_op_t op) {
+  switch (op) {
+  case TILEDB_AND:
+    return "AND";
+  case TILEDB_OR:
+    return "OR";
+  case TILEDB_NOT:
+    return "NOT";
+  default:
+    Rcpp::stop("Unknown condition combination op (%d)", op);
+  }
 }
 
-tiledb_query_condition_combination_op_t _tiledb_query_string_to_condition_combination_op(const std::string& opstr) {
-    if (opstr == "AND") {
-        return TILEDB_AND;
-    } else if (opstr == "OR") {
-        return TILEDB_OR;
-    } else if (opstr == "NOT") {
-        return TILEDB_NOT;
-    } else {
-        Rcpp::stop("Unknown TileDB combination op string '%s'", opstr.c_str());
-    }
+tiledb_query_condition_combination_op_t
+_tiledb_query_string_to_condition_combination_op(const std::string &opstr) {
+  if (opstr == "AND") {
+    return TILEDB_AND;
+  } else if (opstr == "OR") {
+    return TILEDB_OR;
+  } else if (opstr == "NOT") {
+    return TILEDB_NOT;
+  } else {
+    Rcpp::stop("Unknown TileDB combination op string '%s'", opstr.c_str());
+  }
 }
-
 
 // [[Rcpp::export]]
-XPtr<tiledb::QueryCondition> libtiledb_query_condition(XPtr<tiledb::Context> ctx) {
-    check_xptr_tag<tiledb::Context>(ctx);
-    auto ptr = make_xptr<tiledb::QueryCondition>(new tiledb::QueryCondition(*ctx.get()));
-    return ptr;
+XPtr<tiledb::QueryCondition>
+libtiledb_query_condition(XPtr<tiledb::Context> ctx) {
+  check_xptr_tag<tiledb::Context>(ctx);
+  auto ptr =
+      make_xptr<tiledb::QueryCondition>(new tiledb::QueryCondition(*ctx.get()));
+  return ptr;
 }
 
 // [[Rcpp::export]]
 void libtiledb_query_condition_init(XPtr<tiledb::QueryCondition> query_cond,
-                                    const std::string& attr_name,
+                                    const std::string &attr_name,
                                     SEXP condition_value,
-                                    const std::string& cond_val_type,
-                                    const std::string& cond_op_string) {
-    check_xptr_tag<tiledb::QueryCondition>(query_cond);
-    tiledb_query_condition_op_t op = _tiledb_query_string_to_condition_op(cond_op_string);
-    if (cond_val_type == "INT32"  || cond_val_type == "UINT32") {
-        int v = as<int>(condition_value);
-        uint64_t cond_val_size = sizeof(int);
-        query_cond->init(attr_name, (void*) &v, cond_val_size, op);
-    } else if (cond_val_type == "FLOAT64") {
-        double v = as<double>(condition_value);
-        uint64_t cond_val_size = sizeof(double);
-        query_cond->init(attr_name, (void*) &v, cond_val_size, op);
-    } else if (cond_val_type == "INT64" || cond_val_type == "UINT64") {
-        int64_t v = fromInteger64( as<double>(condition_value) );
-        uint64_t cond_val_size = sizeof(int64_t);
-        query_cond->init(attr_name, (void*) &v, cond_val_size, op);
-    } else if (cond_val_type == "INT8" || cond_val_type == "UINT8") {
-        int v = as<int>(condition_value);
-        uint64_t cond_val_size = sizeof(int8_t);
-        query_cond->init(attr_name, (void*) &v, cond_val_size, op);
-    } else if (cond_val_type == "INT16" || cond_val_type == "UINT16") {
-        int v = as<int>(condition_value);
-        uint64_t cond_val_size = sizeof(int16_t);
-        query_cond->init(attr_name, (void*) &v, cond_val_size, op);
-    } else if (cond_val_type == "FLOAT32") {
-        float v = static_cast<float>(as<double>(condition_value));
-        uint64_t cond_val_size = sizeof(float);
-        query_cond->init(attr_name, (void*) &v, cond_val_size, op);
-    } else if (cond_val_type == "ASCII" || cond_val_type == "UTF8") {
-        std::string v = as<std::string>(condition_value);
-        query_cond->init(attr_name, v, op);
-    } else if (cond_val_type == "BOOL") {
-        bool v = as<bool>(condition_value);
-        uint64_t cond_val_size = sizeof(bool);
-        query_cond->init(attr_name, (void*) &v, cond_val_size, op);
-    } else if (cond_val_type == "DATETIME_MS") {
-        int64_t v = static_cast<int64_t>(as<double>(condition_value) * 1000);
-        uint64_t cond_val_size = sizeof(int64_t);
-        query_cond->init(attr_name, (void*) &v, cond_val_size, op);
-    } else if (cond_val_type == "DATETIME_DAY") {
-        int64_t v = static_cast<int64_t>(as<double>(condition_value));
-        uint64_t cond_val_size = sizeof(int64_t);
-        query_cond->init(attr_name, (void*) &v, cond_val_size, op);
-    } else {
-        Rcpp::stop("Currently unsupported type: %s", cond_val_type);
-    }
+                                    const std::string &cond_val_type,
+                                    const std::string &cond_op_string) {
+  check_xptr_tag<tiledb::QueryCondition>(query_cond);
+  tiledb_query_condition_op_t op =
+      _tiledb_query_string_to_condition_op(cond_op_string);
+  if (cond_val_type == "INT32" || cond_val_type == "UINT32") {
+    int v = as<int>(condition_value);
+    uint64_t cond_val_size = sizeof(int);
+    query_cond->init(attr_name, (void *)&v, cond_val_size, op);
+  } else if (cond_val_type == "FLOAT64") {
+    double v = as<double>(condition_value);
+    uint64_t cond_val_size = sizeof(double);
+    query_cond->init(attr_name, (void *)&v, cond_val_size, op);
+  } else if (cond_val_type == "INT64" || cond_val_type == "UINT64") {
+    int64_t v = fromInteger64(as<double>(condition_value));
+    uint64_t cond_val_size = sizeof(int64_t);
+    query_cond->init(attr_name, (void *)&v, cond_val_size, op);
+  } else if (cond_val_type == "INT8" || cond_val_type == "UINT8") {
+    int v = as<int>(condition_value);
+    uint64_t cond_val_size = sizeof(int8_t);
+    query_cond->init(attr_name, (void *)&v, cond_val_size, op);
+  } else if (cond_val_type == "INT16" || cond_val_type == "UINT16") {
+    int v = as<int>(condition_value);
+    uint64_t cond_val_size = sizeof(int16_t);
+    query_cond->init(attr_name, (void *)&v, cond_val_size, op);
+  } else if (cond_val_type == "FLOAT32") {
+    float v = static_cast<float>(as<double>(condition_value));
+    uint64_t cond_val_size = sizeof(float);
+    query_cond->init(attr_name, (void *)&v, cond_val_size, op);
+  } else if (cond_val_type == "ASCII" || cond_val_type == "UTF8") {
+    std::string v = as<std::string>(condition_value);
+    query_cond->init(attr_name, v, op);
+  } else if (cond_val_type == "BOOL") {
+    bool v = as<bool>(condition_value);
+    uint64_t cond_val_size = sizeof(bool);
+    query_cond->init(attr_name, (void *)&v, cond_val_size, op);
+  } else if (cond_val_type == "DATETIME_MS") {
+    int64_t v = static_cast<int64_t>(as<double>(condition_value) * 1000);
+    uint64_t cond_val_size = sizeof(int64_t);
+    query_cond->init(attr_name, (void *)&v, cond_val_size, op);
+  } else if (cond_val_type == "DATETIME_DAY") {
+    int64_t v = static_cast<int64_t>(as<double>(condition_value));
+    uint64_t cond_val_size = sizeof(int64_t);
+    query_cond->init(attr_name, (void *)&v, cond_val_size, op);
+  } else {
+    Rcpp::stop("Currently unsupported type: %s", cond_val_type);
+  }
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::QueryCondition> libtiledb_query_condition_combine(XPtr<tiledb::QueryCondition> lhs,
-                                                               XPtr<tiledb::QueryCondition> rhs,
-                                                               const std::string& str) {
-    check_xptr_tag<tiledb::QueryCondition>(lhs);
-    check_xptr_tag<tiledb::QueryCondition>(lhs);
-    tiledb_query_condition_combination_op_t op = _tiledb_query_string_to_condition_combination_op(str);
-    tiledb::QueryCondition res = lhs->combine(*rhs.get(), op);
-    auto query_cond = make_xptr<tiledb::QueryCondition>(new tiledb::QueryCondition(res));
-    return query_cond;
+XPtr<tiledb::QueryCondition>
+libtiledb_query_condition_combine(XPtr<tiledb::QueryCondition> lhs,
+                                  XPtr<tiledb::QueryCondition> rhs,
+                                  const std::string &str) {
+  check_xptr_tag<tiledb::QueryCondition>(lhs);
+  check_xptr_tag<tiledb::QueryCondition>(lhs);
+  tiledb_query_condition_combination_op_t op =
+      _tiledb_query_string_to_condition_combination_op(str);
+  tiledb::QueryCondition res = lhs->combine(*rhs.get(), op);
+  auto query_cond =
+      make_xptr<tiledb::QueryCondition>(new tiledb::QueryCondition(res));
+  return query_cond;
 }
 
 // [[Rcpp::export]]
-void libtiledb_query_condition_set_use_enumeration(XPtr<tiledb::Context> ctx,
-                                                   XPtr<tiledb::QueryCondition> cond,
-                                                   bool use_enumeration) {
-    check_xptr_tag<tiledb::Context>(ctx);
-    check_xptr_tag<tiledb::QueryCondition>(cond);
-#if TILEDB_VERSION >= TileDB_Version(2,17,0)
-    tiledb::QueryConditionExperimental::set_use_enumeration(*ctx.get(), *cond.get(), use_enumeration);
+void libtiledb_query_condition_set_use_enumeration(
+    XPtr<tiledb::Context> ctx, XPtr<tiledb::QueryCondition> cond,
+    bool use_enumeration) {
+  check_xptr_tag<tiledb::Context>(ctx);
+  check_xptr_tag<tiledb::QueryCondition>(cond);
+#if TILEDB_VERSION >= TileDB_Version(2, 17, 0)
+  tiledb::QueryConditionExperimental::set_use_enumeration(
+      *ctx.get(), *cond.get(), use_enumeration);
 #endif
 }
 
 // [[Rcpp::export]]
 XPtr<tiledb::QueryCondition>
-libtiledb_query_condition_create(XPtr<tiledb::Context> ctx, const std::string& name,
-                                 SEXP vec, const std::string& cond_op_string) {
-    check_xptr_tag<tiledb::Context>(ctx);
-#if TILEDB_VERSION >= TileDB_Version(2,17,0)
-    tiledb_query_condition_op_t op = _tiledb_query_string_to_condition_op(cond_op_string);
-    // consider three cases of 'vec' based on R types:  int, double and int64-as-double
-    if (TYPEOF(vec) == INTSXP) {
-        std::vector<int32_t> iv = Rcpp::as<std::vector<int32_t>>(vec);
-        auto qc = tiledb::QueryConditionExperimental::create<int32_t>(*ctx.get(), name, iv, op);
-        return make_xptr<tiledb::QueryCondition>(new tiledb::QueryCondition(qc));
-    } else if (TYPEOF(vec) == REALSXP) {
-        if (Rcpp::isInteger64(vec)) {
-            std::vector<int64_t> dv = Rcpp::fromInteger64(Rcpp::NumericVector(vec));
-            auto qc = tiledb::QueryConditionExperimental::create<int64_t>(*ctx.get(), name, dv, op);
-            return make_xptr<tiledb::QueryCondition>(new tiledb::QueryCondition(qc));
-        } else {
-            std::vector<double> dv = Rcpp::as<std::vector<double>>(vec);
-            auto qc = tiledb::QueryConditionExperimental::create<double>(*ctx.get(), name, dv, op);
-            return make_xptr<tiledb::QueryCondition>(new tiledb::QueryCondition(qc));
-        }
-    } else if (TYPEOF(vec) == STRSXP) {
-        std::vector<std::string> sv = Rcpp::as<std::vector<std::string>>(vec);
-        auto qc = tiledb::QueryConditionExperimental::create(*ctx.get(), name, sv, op);
-        return make_xptr<tiledb::QueryCondition>(new tiledb::QueryCondition(qc));
+libtiledb_query_condition_create(XPtr<tiledb::Context> ctx,
+                                 const std::string &name, SEXP vec,
+                                 const std::string &cond_op_string) {
+  check_xptr_tag<tiledb::Context>(ctx);
+#if TILEDB_VERSION >= TileDB_Version(2, 17, 0)
+  tiledb_query_condition_op_t op =
+      _tiledb_query_string_to_condition_op(cond_op_string);
+  // consider three cases of 'vec' based on R types:  int, double and
+  // int64-as-double
+  if (TYPEOF(vec) == INTSXP) {
+    std::vector<int32_t> iv = Rcpp::as<std::vector<int32_t>>(vec);
+    auto qc = tiledb::QueryConditionExperimental::create<int32_t>(*ctx.get(),
+                                                                  name, iv, op);
+    return make_xptr<tiledb::QueryCondition>(new tiledb::QueryCondition(qc));
+  } else if (TYPEOF(vec) == REALSXP) {
+    if (Rcpp::isInteger64(vec)) {
+      std::vector<int64_t> dv = Rcpp::fromInteger64(Rcpp::NumericVector(vec));
+      auto qc = tiledb::QueryConditionExperimental::create<int64_t>(
+          *ctx.get(), name, dv, op);
+      return make_xptr<tiledb::QueryCondition>(new tiledb::QueryCondition(qc));
     } else {
-        Rcpp::stop("No support (yet) for type '%s'.", Rcpp::type2name(vec));
+      std::vector<double> dv = Rcpp::as<std::vector<double>>(vec);
+      auto qc = tiledb::QueryConditionExperimental::create<double>(
+          *ctx.get(), name, dv, op);
+      return make_xptr<tiledb::QueryCondition>(new tiledb::QueryCondition(qc));
     }
+  } else if (TYPEOF(vec) == STRSXP) {
+    std::vector<std::string> sv = Rcpp::as<std::vector<std::string>>(vec);
+    auto qc =
+        tiledb::QueryConditionExperimental::create(*ctx.get(), name, sv, op);
+    return make_xptr<tiledb::QueryCondition>(new tiledb::QueryCondition(qc));
+  } else {
+    Rcpp::stop("No support (yet) for type '%s'.", Rcpp::type2name(vec));
+  }
 #endif
-    return make_xptr<tiledb::QueryCondition>(R_NilValue);
+  return make_xptr<tiledb::QueryCondition>(R_NilValue);
 }
-
 
 /**
  * Array helper functions
@@ -4333,7 +4643,6 @@ IntegerVector libtiledb_zip_coords_integer(List coords, R_xlen_t coord_length) {
   return result;
 }
 
-
 /**
  * Object functionality
  */
@@ -4346,13 +4655,13 @@ std::string libtiledb_create_group(XPtr<tiledb::Context> ctx, std::string uri) {
 
 std::string _object_type_to_string(tiledb::Object::Type otype) {
   switch (otype) {
-    case tiledb::Object::Type::Array:
-      return "ARRAY";
-    case tiledb::Object::Type::Group:
-      return "GROUP";
-    case tiledb::Object::Type::Invalid:
-    default:
-      return "INVALID";
+  case tiledb::Object::Type::Array:
+    return "ARRAY";
+  case tiledb::Object::Type::Group:
+    return "GROUP";
+  case tiledb::Object::Type::Invalid:
+  default:
+    return "INVALID";
   }
 }
 
@@ -4364,14 +4673,16 @@ std::string libtiledb_object_type(XPtr<tiledb::Context> ctx, std::string uri) {
 }
 
 // [[Rcpp::export]]
-std::string libtiledb_object_remove(XPtr<tiledb::Context> ctx, std::string uri) {
+std::string libtiledb_object_remove(XPtr<tiledb::Context> ctx,
+                                    std::string uri) {
   check_xptr_tag<tiledb::Context>(ctx);
   tiledb::Object::remove(*ctx.get(), uri);
   return uri;
 }
 
 // [[Rcpp::export]]
-std::string libtiledb_object_move(XPtr<tiledb::Context> ctx, std::string old_uri, std::string new_uri) {
+std::string libtiledb_object_move(XPtr<tiledb::Context> ctx,
+                                  std::string old_uri, std::string new_uri) {
   check_xptr_tag<tiledb::Context>(ctx);
   tiledb::Object::move(*ctx.get(), old_uri, new_uri);
   return new_uri;
@@ -4388,53 +4699,59 @@ tiledb::Object::Type _string_to_object_type(std::string otype) {
 }
 
 // [[Rcpp::export]]
-DataFrame libtiledb_object_walk(XPtr<tiledb::Context> ctx,
-                                std::string uri, std::string order, bool recursive = false) {
-    check_xptr_tag<tiledb::Context>(ctx);
-    std::vector<std::string> uris;
-    std::vector<std::string> types;
-    tiledb::ObjectIter obj_iter(*ctx.get(), uri);
-    if (recursive) {
-        if (! ((order == "PREORDER") || (order == "POSTORDER"))) {
-            Rcpp::stop("invalid recursive walk order, must be \"PREORDER\" or \"POSTORDER\"");
-        }
-        tiledb_walk_order_t walk_order = (order == "PREORDER") ? TILEDB_PREORDER : TILEDB_POSTORDER;
-        obj_iter.set_recursive(walk_order);
-    } else {
-        obj_iter.set_non_recursive();
+DataFrame libtiledb_object_walk(XPtr<tiledb::Context> ctx, std::string uri,
+                                std::string order, bool recursive = false) {
+  check_xptr_tag<tiledb::Context>(ctx);
+  std::vector<std::string> uris;
+  std::vector<std::string> types;
+  tiledb::ObjectIter obj_iter(*ctx.get(), uri);
+  if (recursive) {
+    if (!((order == "PREORDER") || (order == "POSTORDER"))) {
+      Rcpp::stop("invalid recursive walk order, must be \"PREORDER\" or "
+                 "\"POSTORDER\"");
     }
-    for (const auto& object : obj_iter) {
-        uris.push_back(object.uri());
-        types.push_back(_object_type_to_string(object.type()));
-    }
-    return Rcpp::DataFrame::create(Rcpp::Named("TYPE") = types,
-                                   Rcpp::Named("URI") = uris);
+    tiledb_walk_order_t walk_order =
+        (order == "PREORDER") ? TILEDB_PREORDER : TILEDB_POSTORDER;
+    obj_iter.set_recursive(walk_order);
+  } else {
+    obj_iter.set_non_recursive();
+  }
+  for (const auto &object : obj_iter) {
+    uris.push_back(object.uri());
+    types.push_back(_object_type_to_string(object.type()));
+  }
+  return Rcpp::DataFrame::create(Rcpp::Named("TYPE") = types,
+                                 Rcpp::Named("URI") = uris);
 }
 
 /**
  * VFS functionality
  */
 // [[Rcpp::export]]
-XPtr<tiledb::VFS> libtiledb_vfs(XPtr<tiledb::Context> ctx,
-                                Nullable<XPtr<tiledb::Config>> config=R_NilValue) {
+XPtr<tiledb::VFS>
+libtiledb_vfs(XPtr<tiledb::Context> ctx,
+              Nullable<XPtr<tiledb::Config>> config = R_NilValue) {
   check_xptr_tag<tiledb::Context>(ctx);
   if (config.isNull()) {
     return make_xptr<tiledb::VFS>(new tiledb::VFS(*ctx.get()));
   } else {
     XPtr<tiledb::Config> config_xptr(config);
-    return make_xptr<tiledb::VFS>(new tiledb::VFS(*ctx.get(), *config_xptr.get()));
+    return make_xptr<tiledb::VFS>(
+        new tiledb::VFS(*ctx.get(), *config_xptr.get()));
   }
 }
 
 // [[Rcpp::export]]
-std::string libtiledb_vfs_create_bucket(XPtr<tiledb::VFS> vfs, std::string uri) {
+std::string libtiledb_vfs_create_bucket(XPtr<tiledb::VFS> vfs,
+                                        std::string uri) {
   check_xptr_tag<tiledb::VFS>(vfs);
   vfs->create_bucket(uri);
   return uri;
 }
 
 // [[Rcpp::export]]
-std::string libtiledb_vfs_remove_bucket(XPtr<tiledb::VFS> vfs, std::string uri) {
+std::string libtiledb_vfs_remove_bucket(XPtr<tiledb::VFS> vfs,
+                                        std::string uri) {
   check_xptr_tag<tiledb::VFS>(vfs);
   vfs->remove_bucket(uri);
   return uri;
@@ -4468,8 +4785,8 @@ std::string libtiledb_vfs_create_dir(XPtr<tiledb::VFS> vfs, std::string uri) {
 
 // [[Rcpp::export]]
 bool libtiledb_vfs_is_dir(XPtr<tiledb::VFS> vfs, std::string uri) {
-    check_xptr_tag<tiledb::VFS>(vfs);
-    return vfs->is_dir(uri);
+  check_xptr_tag<tiledb::VFS>(vfs);
+  return vfs->is_dir(uri);
 }
 
 // [[Rcpp::export]]
@@ -4503,14 +4820,16 @@ R_xlen_t libtiledb_vfs_file_size(XPtr<tiledb::VFS> vfs, std::string uri) {
 }
 
 // [[Rcpp::export]]
-std::string libtiledb_vfs_move_file(XPtr<tiledb::VFS> vfs, std::string old_uri, std::string new_uri) {
+std::string libtiledb_vfs_move_file(XPtr<tiledb::VFS> vfs, std::string old_uri,
+                                    std::string new_uri) {
   check_xptr_tag<tiledb::VFS>(vfs);
   vfs->move_file(old_uri, new_uri);
   return new_uri;
 }
 
 // [[Rcpp::export]]
-std::string libtiledb_vfs_move_dir(XPtr<tiledb::VFS> vfs, std::string old_uri, std::string new_uri) {
+std::string libtiledb_vfs_move_dir(XPtr<tiledb::VFS> vfs, std::string old_uri,
+                                   std::string new_uri) {
   check_xptr_tag<tiledb::VFS>(vfs);
   vfs->move_dir(old_uri, new_uri);
   return new_uri;
@@ -4523,15 +4842,15 @@ std::string libtiledb_vfs_touch(XPtr<tiledb::VFS> vfs, std::string uri) {
   return uri;
 }
 
-
 // [[Rcpp::export]]
-XPtr<vfs_fh_t> libtiledb_vfs_open(XPtr<tiledb::Context> ctxxp, XPtr<tiledb::VFS> vfsxp,
-                                  std::string uri, std::string mode) {
+XPtr<vfs_fh_t> libtiledb_vfs_open(XPtr<tiledb::Context> ctxxp,
+                                  XPtr<tiledb::VFS> vfsxp, std::string uri,
+                                  std::string mode) {
   check_xptr_tag<tiledb::Context>(ctxxp);
   check_xptr_tag<tiledb::VFS>(vfsxp);
   std::shared_ptr<tiledb_ctx_t> ctx = ctxxp.get()->ptr();
   std::shared_ptr<tiledb_vfs_t> vfs = vfsxp.get()->ptr();
-#if TILEDB_VERSION >= TileDB_Version(2,15,0)
+#if TILEDB_VERSION >= TileDB_Version(2, 15, 0)
   tiledb_vfs_fh_handle_t *fh = nullptr;
 #else
   tiledb_vfs_fh_t *fh = nullptr;
@@ -4557,12 +4876,13 @@ void libtiledb_vfs_write(XPtr<tiledb::Context> ctxxp, XPtr<vfs_fh_t> fh,
   check_xptr_tag<tiledb::Context>(ctxxp);
   check_xptr_tag<vfs_fh_t>(fh);
   std::shared_ptr<tiledb_ctx_t> ctx = ctxxp.get()->ptr();
-  tiledb_vfs_write(ctx.get(), fh->fh, &(vec[0]), vec.size()*sizeof(int));
+  tiledb_vfs_write(ctx.get(), fh->fh, &(vec[0]), vec.size() * sizeof(int));
 }
 
 // [[Rcpp::export]]
-Rcpp::IntegerVector libtiledb_vfs_read(XPtr<tiledb::Context> ctxxp, XPtr<vfs_fh_t> fh,
-                                       double offset, double nbytes) {
+Rcpp::IntegerVector libtiledb_vfs_read(XPtr<tiledb::Context> ctxxp,
+                                       XPtr<vfs_fh_t> fh, double offset,
+                                       double nbytes) {
   check_xptr_tag<tiledb::Context>(ctxxp);
   check_xptr_tag<vfs_fh_t>(fh);
   std::shared_ptr<tiledb_ctx_t> ctx = ctxxp.get()->ptr();
@@ -4583,63 +4903,67 @@ void libtiledb_vfs_sync(XPtr<tiledb::Context> ctxxp, XPtr<vfs_fh_t> fh) {
 
 // [[Rcpp::export]]
 double libtiledb_vfs_dir_size(XPtr<tiledb::VFS> vfs, std::string uri) {
-    check_xptr_tag<tiledb::VFS>(vfs);
-    return static_cast<double>(vfs->dir_size(uri)); // uint64_t to double for R
+  check_xptr_tag<tiledb::VFS>(vfs);
+  return static_cast<double>(vfs->dir_size(uri)); // uint64_t to double for R
 }
 
 // [[Rcpp::export]]
-std::vector<std::string> libtiledb_vfs_ls(XPtr<tiledb::VFS> vfs, std::string uri) {
-    check_xptr_tag<tiledb::VFS>(vfs);
-    return vfs->ls(uri);
+std::vector<std::string> libtiledb_vfs_ls(XPtr<tiledb::VFS> vfs,
+                                          std::string uri) {
+  check_xptr_tag<tiledb::VFS>(vfs);
+  return vfs->ls(uri);
 }
 
 // [[Rcpp::export]]
-std::string libtiledb_vfs_copy_file(XPtr<tiledb::VFS> vfs, std::string old_uri, std::string new_uri) {
-    check_xptr_tag<tiledb::VFS>(vfs);
-    vfs->copy_file(old_uri, new_uri);
-    return new_uri;
+std::string libtiledb_vfs_copy_file(XPtr<tiledb::VFS> vfs, std::string old_uri,
+                                    std::string new_uri) {
+  check_xptr_tag<tiledb::VFS>(vfs);
+  vfs->copy_file(old_uri, new_uri);
+  return new_uri;
 }
 
 // [[Rcpp::export]]
 void libtiledb_vfs_fh_free(XPtr<vfs_fh_t> fhxp) {
-    check_xptr_tag<vfs_fh_t>(fhxp);
-    spdl::trace("[libtiledb_vfs_clear_handle] entered");
-    vfs_fh_t* strptr = fhxp.get();
-#if TILEDB_VERSION >= TileDB_Version(2,15,0)
-    tiledb_vfs_fh_handle_t *fh = strptr->fh;
-    tiledb_vfs_fh_free(&fh);
+  check_xptr_tag<vfs_fh_t>(fhxp);
+  spdl::trace("[libtiledb_vfs_clear_handle] entered");
+  vfs_fh_t *strptr = fhxp.get();
+#if TILEDB_VERSION >= TileDB_Version(2, 15, 0)
+  tiledb_vfs_fh_handle_t *fh = strptr->fh;
+  tiledb_vfs_fh_free(&fh);
 #endif
 }
 
 // [[Rcpp::export]]
 Rcpp::DataFrame libtiledb_vfs_ls_recursive(XPtr<tiledb::Context> ctx,
                                            XPtr<tiledb::VFS> vfs,
-                                           const std::string& uri) {
-    check_xptr_tag<tiledb::Context>(ctx);
-    check_xptr_tag<tiledb::VFS>(vfs);
+                                           const std::string &uri) {
+  check_xptr_tag<tiledb::Context>(ctx);
+  check_xptr_tag<tiledb::VFS>(vfs);
 
-#if TILEDB_VERSION >= TileDB_Version(2,22,0)
-    // standard / default list object (a vector of a pair<string, uint64_t?>) and callback
-    tiledb::VFSExperimental::LsObjects ls_objects;
-    tiledb::VFSExperimental::LsCallback cb = [&](const std::string_view& path, uint64_t size) {
-        ls_objects.emplace_back(path, size);
-        return true;  // Continue traversal to next entry.
-    };
-    tiledb::VFSExperimental::ls_recursive(*ctx.get(), *vfs.get(), uri, cb);
+#if TILEDB_VERSION >= TileDB_Version(2, 22, 0)
+  // standard / default list object (a vector of a pair<string, uint64_t?>) and
+  // callback
+  tiledb::VFSExperimental::LsObjects ls_objects;
+  tiledb::VFSExperimental::LsCallback cb = [&](const std::string_view &path,
+                                               uint64_t size) {
+    ls_objects.emplace_back(path, size);
+    return true; // Continue traversal to next entry.
+  };
+  tiledb::VFSExperimental::ls_recursive(*ctx.get(), *vfs.get(), uri, cb);
 
-    size_t n = ls_objects.size();
-    Rcpp::CharacterVector path(n);
-    std::vector<int64_t> size(n);
-    for (size_t i=0; i<n; i++) {
-        auto obj = ls_objects[i];
-        path[i] = obj.first;
-        size[i] = static_cast<int64_t>(obj.second);
-    }
-    return Rcpp::DataFrame::create(Rcpp::Named("path") = path,
-                                   Rcpp::Named("size") = Rcpp::toInteger64(size));
+  size_t n = ls_objects.size();
+  Rcpp::CharacterVector path(n);
+  std::vector<int64_t> size(n);
+  for (size_t i = 0; i < n; i++) {
+    auto obj = ls_objects[i];
+    path[i] = obj.first;
+    size[i] = static_cast<int64_t>(obj.second);
+  }
+  return Rcpp::DataFrame::create(Rcpp::Named("path") = path,
+                                 Rcpp::Named("size") = Rcpp::toInteger64(size));
 #else
-    return Rcpp::DataFrame::create(Rcpp::Named("path") = Rcpp::CharacterVector(),
-                                   Rcpp::Named("size") = Rcpp::NumericVector());
+  return Rcpp::DataFrame::create(Rcpp::Named("path") = Rcpp::CharacterVector(),
+                                 Rcpp::Named("size") = Rcpp::NumericVector());
 #endif
 }
 
@@ -4648,26 +4972,20 @@ Rcpp::DataFrame libtiledb_vfs_ls_recursive(XPtr<tiledb::Context> ctx,
  */
 
 // [[Rcpp::export]]
-void libtiledb_stats_enable() {
-  tiledb::Stats::enable();
-}
+void libtiledb_stats_enable() { tiledb::Stats::enable(); }
 
 // [[Rcpp::export]]
-void libtiledb_stats_disable() {
-  tiledb::Stats::disable();
-}
+void libtiledb_stats_disable() { tiledb::Stats::disable(); }
 
 // [[Rcpp::export]]
-void libtiledb_stats_reset() {
-  tiledb::Stats::reset();
-}
+void libtiledb_stats_reset() { tiledb::Stats::reset(); }
 
 // [[Rcpp::export]]
 void libtiledb_stats_dump(std::string path = "") {
   if (path == "") {
     tiledb::Stats::dump();
   } else {
-    FILE* fptr = nullptr;
+    FILE *fptr = nullptr;
     fptr = fopen(path.c_str(), "w");
     if (fptr == nullptr) {
       Rcpp::stop("error opening stats dump file for writing");
@@ -4679,15 +4997,16 @@ void libtiledb_stats_dump(std::string path = "") {
 
 // [[Rcpp::export]]
 std::string libtiledb_stats_raw_dump() {
-    std::string txt;
-    tiledb::Stats::raw_dump(&txt);
-    return txt;
+  std::string txt;
+  tiledb::Stats::raw_dump(&txt);
+  return txt;
 }
 
 // [[Rcpp::export]]
 std::string libtiledb_stats_raw_get() {
-    Rcpp::message(Rcpp::wrap("This function is deprecated, please use 'libtiledb_stats_raw_dump'."));
-    return libtiledb_stats_raw_dump();
+  Rcpp::message(Rcpp::wrap(
+      "This function is deprecated, please use 'libtiledb_stats_raw_dump'."));
+  return libtiledb_stats_raw_dump();
 }
 
 /**
@@ -4695,586 +5014,592 @@ std::string libtiledb_stats_raw_get() {
  */
 // [[Rcpp::export]]
 XPtr<tiledb::FragmentInfo> libtiledb_fragment_info(XPtr<tiledb::Context> ctx,
-                                                   const std::string& uri) {
-    auto ptr = make_xptr<tiledb::FragmentInfo>(new tiledb::FragmentInfo(*ctx.get(), uri));
-    ptr->load();                // also load
-    return ptr;
+                                                   const std::string &uri) {
+  auto ptr = make_xptr<tiledb::FragmentInfo>(
+      new tiledb::FragmentInfo(*ctx.get(), uri));
+  ptr->load(); // also load
+  return ptr;
 }
 
 // [[Rcpp::export]]
-std::string libtiledb_fragment_info_uri(XPtr<tiledb::FragmentInfo> fi, int32_t fid) {
-    check_xptr_tag<tiledb::FragmentInfo>(fi);
-    return fi->fragment_uri(static_cast<uint32_t>(fid));
+std::string libtiledb_fragment_info_uri(XPtr<tiledb::FragmentInfo> fi,
+                                        int32_t fid) {
+  check_xptr_tag<tiledb::FragmentInfo>(fi);
+  return fi->fragment_uri(static_cast<uint32_t>(fid));
 }
 
 // [[Rcpp::export]]
-Rcpp::NumericVector libtiledb_fragment_info_get_non_empty_domain_index(XPtr<tiledb::FragmentInfo> fi,
-                                                                       int32_t fid, int32_t did,
-                                                                       const std::string& typestr) {
-    check_xptr_tag<tiledb::FragmentInfo>(fi);
-    if (typestr == "INT64") {
-        std::vector<int64_t> non_empty_dom(2);
-        fi->get_non_empty_domain(fid, did, &non_empty_dom[0]);
-        return toInteger64(non_empty_dom);
-    } else if (typestr == "UINT64") {
-        std::vector<uint64_t> ned(2);
-        fi->get_non_empty_domain(fid, did, &ned[0]);
-        std::vector<int64_t> v{ static_cast<int64_t>(ned[0]), static_cast<int64_t>(ned[1]) };
-        return toInteger64(v);
-    } else if (typestr == "INT32") {
-        std::vector<int32_t> non_empty_dom(2);
-        fi->get_non_empty_domain(fid, did, &non_empty_dom[0]);
-        return NumericVector::create(non_empty_dom[0], non_empty_dom[1]);
-    } else if (typestr == "UINT32") {
-        std::vector<uint32_t> non_empty_dom(2);
-        fi->get_non_empty_domain(fid, did, &non_empty_dom[0]);
-        return NumericVector::create(non_empty_dom[0], non_empty_dom[1]);
-    } else if (typestr == "INT16") {
-        std::vector<int16_t> non_empty_dom(2);
-        fi->get_non_empty_domain(fid, did, &non_empty_dom[0]);
-        return NumericVector::create(non_empty_dom[0], non_empty_dom[1]);
-    } else if (typestr == "UINT16") {
-        std::vector<uint16_t> non_empty_dom(2);
-        fi->get_non_empty_domain(fid, did, &non_empty_dom[0]);
-        return NumericVector::create(non_empty_dom[0], non_empty_dom[1]);
-    } else if (typestr == "INT8") {
-        std::vector<int8_t> non_empty_dom(2);
-        fi->get_non_empty_domain(fid, did, &non_empty_dom[0]);
-        return NumericVector::create(non_empty_dom[0], non_empty_dom[1]);
-    } else if (typestr == "UINT8") {
-        std::vector<uint8_t> non_empty_dom(2);
-        fi->get_non_empty_domain(fid, did, &non_empty_dom[0]);
-        return NumericVector::create(non_empty_dom[0], non_empty_dom[1]);
-    } else if (typestr == "FLOAT64") {
-        std::vector<double> non_empty_dom(2);
-        fi->get_non_empty_domain(fid, did, &non_empty_dom[0]);
-        return NumericVector::create(non_empty_dom[0], non_empty_dom[1]);
-    } else if (typestr == "FLOAT32") {
-        std::vector<float> non_empty_dom(2);
-        fi->get_non_empty_domain(fid, did, &non_empty_dom[0]);
-        return NumericVector::create(non_empty_dom[0], non_empty_dom[1]);
-    } else if (typestr == "DATETIME_YEAR" ||
-             typestr == "DATETIME_MONTH" ||
-             typestr == "DATETIME_WEEK" ||
-             typestr == "DATETIME_DAY" ||
-             typestr == "DATETIME_HR"  ||
-             typestr == "DATETIME_MIN" ||
-             typestr == "DATETIME_SEC" ||
-             typestr == "DATETIME_MS"  ||
-             typestr == "DATETIME_US"  ||
-             typestr == "DATETIME_PS"  ||
-             typestr == "DATETIME_FS"  ||
-             typestr == "DATETIME_AS"    ) {
-        // type_check() from exception.h gets invoked and wants an int64_t
-        std::vector<int64_t> non_empty_dom(2);
-        fi->get_non_empty_domain(fid, did, &non_empty_dom[0]);
-        return toInteger64(non_empty_dom);
-    } else if (typestr == "DATETIME_NS") {
-        std::vector<int64_t> non_empty_dom(2);
-        fi->get_non_empty_domain(fid, did, &non_empty_dom[0]);
-        return toNanotime(non_empty_dom);
-    } else {
-        Rcpp::stop("Currently unsupported tiledb domain type: '%s'", typestr.c_str());
-        return NumericVector::create(NA_REAL, NA_REAL); // not reached
-    }
-}
-
-// [[Rcpp::export]]
-Rcpp::NumericVector libtiledb_fragment_info_get_non_empty_domain_name(XPtr<tiledb::FragmentInfo> fi,
-                                                                      int32_t fid,
-                                                                      const std::string& dim_name,
-                                                                      const std::string& typestr) {
-    check_xptr_tag<tiledb::FragmentInfo>(fi);
-    if (typestr == "INT64") {
-        std::vector<int64_t> non_empty_dom(2);
-        fi->get_non_empty_domain(fid, dim_name, &non_empty_dom[0]);
-        return toInteger64(non_empty_dom);
-    } else if (typestr == "UINT64") {
-        std::vector<uint64_t> ned(2);
-        fi->get_non_empty_domain(fid, dim_name, &ned[0]);
-        std::vector<int64_t> v{ static_cast<int64_t>(ned[0]), static_cast<int64_t>(ned[1]) };
-        return toInteger64(v);
-    } else if (typestr == "INT32") {
-        std::vector<int32_t> non_empty_dom(2);
-        fi->get_non_empty_domain(fid, dim_name, &non_empty_dom[0]);
-        return NumericVector::create(non_empty_dom[0], non_empty_dom[1]);
-    } else if (typestr == "UINT32") {
-        std::vector<uint32_t> non_empty_dom(2);
-        fi->get_non_empty_domain(fid, dim_name, &non_empty_dom[0]);
-        return NumericVector::create(non_empty_dom[0], non_empty_dom[1]);
-    } else if (typestr == "INT16") {
-        std::vector<int16_t> non_empty_dom(2);
-        fi->get_non_empty_domain(fid, dim_name, &non_empty_dom[0]);
-        return NumericVector::create(non_empty_dom[0], non_empty_dom[1]);
-    } else if (typestr == "UINT16") {
-        std::vector<uint16_t> non_empty_dom(2);
-        fi->get_non_empty_domain(fid, dim_name, &non_empty_dom[0]);
-        return NumericVector::create(non_empty_dom[0], non_empty_dom[1]);
+Rcpp::NumericVector libtiledb_fragment_info_get_non_empty_domain_index(
+    XPtr<tiledb::FragmentInfo> fi, int32_t fid, int32_t did,
+    const std::string &typestr) {
+  check_xptr_tag<tiledb::FragmentInfo>(fi);
+  if (typestr == "INT64") {
+    std::vector<int64_t> non_empty_dom(2);
+    fi->get_non_empty_domain(fid, did, &non_empty_dom[0]);
+    return toInteger64(non_empty_dom);
+  } else if (typestr == "UINT64") {
+    std::vector<uint64_t> ned(2);
+    fi->get_non_empty_domain(fid, did, &ned[0]);
+    std::vector<int64_t> v{static_cast<int64_t>(ned[0]),
+                           static_cast<int64_t>(ned[1])};
+    return toInteger64(v);
+  } else if (typestr == "INT32") {
+    std::vector<int32_t> non_empty_dom(2);
+    fi->get_non_empty_domain(fid, did, &non_empty_dom[0]);
+    return NumericVector::create(non_empty_dom[0], non_empty_dom[1]);
+  } else if (typestr == "UINT32") {
+    std::vector<uint32_t> non_empty_dom(2);
+    fi->get_non_empty_domain(fid, did, &non_empty_dom[0]);
+    return NumericVector::create(non_empty_dom[0], non_empty_dom[1]);
+  } else if (typestr == "INT16") {
+    std::vector<int16_t> non_empty_dom(2);
+    fi->get_non_empty_domain(fid, did, &non_empty_dom[0]);
+    return NumericVector::create(non_empty_dom[0], non_empty_dom[1]);
+  } else if (typestr == "UINT16") {
+    std::vector<uint16_t> non_empty_dom(2);
+    fi->get_non_empty_domain(fid, did, &non_empty_dom[0]);
+    return NumericVector::create(non_empty_dom[0], non_empty_dom[1]);
   } else if (typestr == "INT8") {
-        std::vector<int8_t> non_empty_dom(2);
-        fi->get_non_empty_domain(fid, dim_name, &non_empty_dom[0]);
-        return NumericVector::create(non_empty_dom[0], non_empty_dom[1]);
+    std::vector<int8_t> non_empty_dom(2);
+    fi->get_non_empty_domain(fid, did, &non_empty_dom[0]);
+    return NumericVector::create(non_empty_dom[0], non_empty_dom[1]);
   } else if (typestr == "UINT8") {
-        std::vector<uint8_t> non_empty_dom(2);
-        fi->get_non_empty_domain(fid, dim_name, &non_empty_dom[0]);
-        return NumericVector::create(non_empty_dom[0], non_empty_dom[1]);
+    std::vector<uint8_t> non_empty_dom(2);
+    fi->get_non_empty_domain(fid, did, &non_empty_dom[0]);
+    return NumericVector::create(non_empty_dom[0], non_empty_dom[1]);
   } else if (typestr == "FLOAT64") {
-        std::vector<double> non_empty_dom(2);
-        fi->get_non_empty_domain(fid, dim_name, &non_empty_dom[0]);
-        return NumericVector::create(non_empty_dom[0], non_empty_dom[1]);
+    std::vector<double> non_empty_dom(2);
+    fi->get_non_empty_domain(fid, did, &non_empty_dom[0]);
+    return NumericVector::create(non_empty_dom[0], non_empty_dom[1]);
   } else if (typestr == "FLOAT32") {
-        std::vector<float> non_empty_dom(2);
-        fi->get_non_empty_domain(fid, dim_name, &non_empty_dom[0]);
-        return NumericVector::create(non_empty_dom[0], non_empty_dom[1]);
-  } else if (typestr == "DATETIME_YEAR" ||
-             typestr == "DATETIME_MONTH" ||
-             typestr == "DATETIME_WEEK" ||
-             typestr == "DATETIME_DAY" ||
-             typestr == "DATETIME_HR"  ||
-             typestr == "DATETIME_MIN" ||
-             typestr == "DATETIME_SEC" ||
-             typestr == "DATETIME_MS"  ||
-             typestr == "DATETIME_US"  ||
-             typestr == "DATETIME_PS"  ||
-             typestr == "DATETIME_FS"  ||
-             typestr == "DATETIME_AS"    ) {
-        // type_check() from exception.h gets invoked and wants an int64_t
-        std::vector<int64_t> non_empty_dom(2);
-        fi->get_non_empty_domain(fid, dim_name, &non_empty_dom[0]);
-        return toInteger64(non_empty_dom);
-    } else if (typestr == "DATETIME_NS") {
-        std::vector<int64_t> non_empty_dom(2);
-        fi->get_non_empty_domain(fid, dim_name, &non_empty_dom[0]);
-        return toNanotime(non_empty_dom);
-    } else {
-        Rcpp::stop("Currently unsupported tiledb domain type: '%s'", typestr.c_str());
-        return NumericVector::create(NA_REAL, NA_REAL); // not reached
-    }
+    std::vector<float> non_empty_dom(2);
+    fi->get_non_empty_domain(fid, did, &non_empty_dom[0]);
+    return NumericVector::create(non_empty_dom[0], non_empty_dom[1]);
+  } else if (typestr == "DATETIME_YEAR" || typestr == "DATETIME_MONTH" ||
+             typestr == "DATETIME_WEEK" || typestr == "DATETIME_DAY" ||
+             typestr == "DATETIME_HR" || typestr == "DATETIME_MIN" ||
+             typestr == "DATETIME_SEC" || typestr == "DATETIME_MS" ||
+             typestr == "DATETIME_US" || typestr == "DATETIME_PS" ||
+             typestr == "DATETIME_FS" || typestr == "DATETIME_AS") {
+    // type_check() from exception.h gets invoked and wants an int64_t
+    std::vector<int64_t> non_empty_dom(2);
+    fi->get_non_empty_domain(fid, did, &non_empty_dom[0]);
+    return toInteger64(non_empty_dom);
+  } else if (typestr == "DATETIME_NS") {
+    std::vector<int64_t> non_empty_dom(2);
+    fi->get_non_empty_domain(fid, did, &non_empty_dom[0]);
+    return toNanotime(non_empty_dom);
+  } else {
+    Rcpp::stop("Currently unsupported tiledb domain type: '%s'",
+               typestr.c_str());
+    return NumericVector::create(NA_REAL, NA_REAL); // not reached
+  }
 }
 
 // [[Rcpp::export]]
-Rcpp::CharacterVector
-libtiledb_fragment_info_get_non_empty_domain_var_index(XPtr<tiledb::FragmentInfo> fi,
-                                                       int32_t fid, int32_t did) {
-    check_xptr_tag<tiledb::FragmentInfo>(fi);
-    auto sp = fi->non_empty_domain_var(static_cast<uint32_t>(fid), static_cast<uint32_t>(did));
-    return CharacterVector::create(sp.first, sp.second);
+Rcpp::NumericVector libtiledb_fragment_info_get_non_empty_domain_name(
+    XPtr<tiledb::FragmentInfo> fi, int32_t fid, const std::string &dim_name,
+    const std::string &typestr) {
+  check_xptr_tag<tiledb::FragmentInfo>(fi);
+  if (typestr == "INT64") {
+    std::vector<int64_t> non_empty_dom(2);
+    fi->get_non_empty_domain(fid, dim_name, &non_empty_dom[0]);
+    return toInteger64(non_empty_dom);
+  } else if (typestr == "UINT64") {
+    std::vector<uint64_t> ned(2);
+    fi->get_non_empty_domain(fid, dim_name, &ned[0]);
+    std::vector<int64_t> v{static_cast<int64_t>(ned[0]),
+                           static_cast<int64_t>(ned[1])};
+    return toInteger64(v);
+  } else if (typestr == "INT32") {
+    std::vector<int32_t> non_empty_dom(2);
+    fi->get_non_empty_domain(fid, dim_name, &non_empty_dom[0]);
+    return NumericVector::create(non_empty_dom[0], non_empty_dom[1]);
+  } else if (typestr == "UINT32") {
+    std::vector<uint32_t> non_empty_dom(2);
+    fi->get_non_empty_domain(fid, dim_name, &non_empty_dom[0]);
+    return NumericVector::create(non_empty_dom[0], non_empty_dom[1]);
+  } else if (typestr == "INT16") {
+    std::vector<int16_t> non_empty_dom(2);
+    fi->get_non_empty_domain(fid, dim_name, &non_empty_dom[0]);
+    return NumericVector::create(non_empty_dom[0], non_empty_dom[1]);
+  } else if (typestr == "UINT16") {
+    std::vector<uint16_t> non_empty_dom(2);
+    fi->get_non_empty_domain(fid, dim_name, &non_empty_dom[0]);
+    return NumericVector::create(non_empty_dom[0], non_empty_dom[1]);
+  } else if (typestr == "INT8") {
+    std::vector<int8_t> non_empty_dom(2);
+    fi->get_non_empty_domain(fid, dim_name, &non_empty_dom[0]);
+    return NumericVector::create(non_empty_dom[0], non_empty_dom[1]);
+  } else if (typestr == "UINT8") {
+    std::vector<uint8_t> non_empty_dom(2);
+    fi->get_non_empty_domain(fid, dim_name, &non_empty_dom[0]);
+    return NumericVector::create(non_empty_dom[0], non_empty_dom[1]);
+  } else if (typestr == "FLOAT64") {
+    std::vector<double> non_empty_dom(2);
+    fi->get_non_empty_domain(fid, dim_name, &non_empty_dom[0]);
+    return NumericVector::create(non_empty_dom[0], non_empty_dom[1]);
+  } else if (typestr == "FLOAT32") {
+    std::vector<float> non_empty_dom(2);
+    fi->get_non_empty_domain(fid, dim_name, &non_empty_dom[0]);
+    return NumericVector::create(non_empty_dom[0], non_empty_dom[1]);
+  } else if (typestr == "DATETIME_YEAR" || typestr == "DATETIME_MONTH" ||
+             typestr == "DATETIME_WEEK" || typestr == "DATETIME_DAY" ||
+             typestr == "DATETIME_HR" || typestr == "DATETIME_MIN" ||
+             typestr == "DATETIME_SEC" || typestr == "DATETIME_MS" ||
+             typestr == "DATETIME_US" || typestr == "DATETIME_PS" ||
+             typestr == "DATETIME_FS" || typestr == "DATETIME_AS") {
+    // type_check() from exception.h gets invoked and wants an int64_t
+    std::vector<int64_t> non_empty_dom(2);
+    fi->get_non_empty_domain(fid, dim_name, &non_empty_dom[0]);
+    return toInteger64(non_empty_dom);
+  } else if (typestr == "DATETIME_NS") {
+    std::vector<int64_t> non_empty_dom(2);
+    fi->get_non_empty_domain(fid, dim_name, &non_empty_dom[0]);
+    return toNanotime(non_empty_dom);
+  } else {
+    Rcpp::stop("Currently unsupported tiledb domain type: '%s'",
+               typestr.c_str());
+    return NumericVector::create(NA_REAL, NA_REAL); // not reached
+  }
 }
 
 // [[Rcpp::export]]
-Rcpp::CharacterVector
-libtiledb_fragment_info_get_non_empty_domain_var_name(XPtr<tiledb::FragmentInfo> fi,
-                                                      int32_t fid,
-                                                      const std::string& dim_name) {
-    check_xptr_tag<tiledb::FragmentInfo>(fi);
-    auto sp = fi->non_empty_domain_var(static_cast<uint32_t>(fid), dim_name);
-    return CharacterVector::create(sp.first, sp.second);
+Rcpp::CharacterVector libtiledb_fragment_info_get_non_empty_domain_var_index(
+    XPtr<tiledb::FragmentInfo> fi, int32_t fid, int32_t did) {
+  check_xptr_tag<tiledb::FragmentInfo>(fi);
+  auto sp = fi->non_empty_domain_var(static_cast<uint32_t>(fid),
+                                     static_cast<uint32_t>(did));
+  return CharacterVector::create(sp.first, sp.second);
+}
+
+// [[Rcpp::export]]
+Rcpp::CharacterVector libtiledb_fragment_info_get_non_empty_domain_var_name(
+    XPtr<tiledb::FragmentInfo> fi, int32_t fid, const std::string &dim_name) {
+  check_xptr_tag<tiledb::FragmentInfo>(fi);
+  auto sp = fi->non_empty_domain_var(static_cast<uint32_t>(fid), dim_name);
+  return CharacterVector::create(sp.first, sp.second);
 }
 
 // [[Rcpp::export]]
 double libtiledb_fragment_info_num(XPtr<tiledb::FragmentInfo> fi) {
-    check_xptr_tag<tiledb::FragmentInfo>(fi);
-    return static_cast<double>(fi->fragment_num());
+  check_xptr_tag<tiledb::FragmentInfo>(fi);
+  return static_cast<double>(fi->fragment_num());
 }
 
 // [[Rcpp::export]]
-double libtiledb_fragment_info_size(XPtr<tiledb::FragmentInfo> fi, int32_t fid) {
-    check_xptr_tag<tiledb::FragmentInfo>(fi);
-    return static_cast<double>(fi->fragment_size(static_cast<uint32_t>(fid)));
+double libtiledb_fragment_info_size(XPtr<tiledb::FragmentInfo> fi,
+                                    int32_t fid) {
+  check_xptr_tag<tiledb::FragmentInfo>(fi);
+  return static_cast<double>(fi->fragment_size(static_cast<uint32_t>(fid)));
 }
 
 // [[Rcpp::export]]
 bool libtiledb_fragment_info_dense(XPtr<tiledb::FragmentInfo> fi, int32_t fid) {
-    check_xptr_tag<tiledb::FragmentInfo>(fi);
-    return fi->dense(static_cast<uint32_t>(fid));
+  check_xptr_tag<tiledb::FragmentInfo>(fi);
+  return fi->dense(static_cast<uint32_t>(fid));
 }
 
 // [[Rcpp::export]]
-bool libtiledb_fragment_info_sparse(XPtr<tiledb::FragmentInfo> fi, int32_t fid) {
-    check_xptr_tag<tiledb::FragmentInfo>(fi);
-    return fi->sparse(static_cast<uint32_t>(fid));
+bool libtiledb_fragment_info_sparse(XPtr<tiledb::FragmentInfo> fi,
+                                    int32_t fid) {
+  check_xptr_tag<tiledb::FragmentInfo>(fi);
+  return fi->sparse(static_cast<uint32_t>(fid));
 }
 
 // [[Rcpp::export]]
 Rcpp::DatetimeVector
-libtiledb_fragment_info_timestamp_range(XPtr<tiledb::FragmentInfo> fi, int32_t fid) {
-    check_xptr_tag<tiledb::FragmentInfo>(fi);
-    auto range = fi->timestamp_range(static_cast<uint32_t>(fid));
-    return Rcpp::DatetimeVector::create(range.first/1000.0, range.second/1000.0);
+libtiledb_fragment_info_timestamp_range(XPtr<tiledb::FragmentInfo> fi,
+                                        int32_t fid) {
+  check_xptr_tag<tiledb::FragmentInfo>(fi);
+  auto range = fi->timestamp_range(static_cast<uint32_t>(fid));
+  return Rcpp::DatetimeVector::create(range.first / 1000.0,
+                                      range.second / 1000.0);
 }
 
 // [[Rcpp::export]]
-double libtiledb_fragment_info_cell_num(XPtr<tiledb::FragmentInfo> fi, int32_t fid) {
-    check_xptr_tag<tiledb::FragmentInfo>(fi);
-    return static_cast<double>(fi->cell_num(static_cast<uint32_t>(fid)));
+double libtiledb_fragment_info_cell_num(XPtr<tiledb::FragmentInfo> fi,
+                                        int32_t fid) {
+  check_xptr_tag<tiledb::FragmentInfo>(fi);
+  return static_cast<double>(fi->cell_num(static_cast<uint32_t>(fid)));
 }
 
 // [[Rcpp::export]]
-int libtiledb_fragment_info_version(XPtr<tiledb::FragmentInfo> fi, int32_t fid) {
-    check_xptr_tag<tiledb::FragmentInfo>(fi);
-    return static_cast<int>(fi->version(static_cast<uint32_t>(fid)));
+int libtiledb_fragment_info_version(XPtr<tiledb::FragmentInfo> fi,
+                                    int32_t fid) {
+  check_xptr_tag<tiledb::FragmentInfo>(fi);
+  return static_cast<int>(fi->version(static_cast<uint32_t>(fid)));
 }
 
 // [[Rcpp::export]]
-bool libtiledb_fragment_info_has_consolidated_metadata(XPtr<tiledb::FragmentInfo> fi, int32_t fid) {
-    check_xptr_tag<tiledb::FragmentInfo>(fi);
-    return fi->has_consolidated_metadata(static_cast<uint32_t>(fid));
+bool libtiledb_fragment_info_has_consolidated_metadata(
+    XPtr<tiledb::FragmentInfo> fi, int32_t fid) {
+  check_xptr_tag<tiledb::FragmentInfo>(fi);
+  return fi->has_consolidated_metadata(static_cast<uint32_t>(fid));
 }
 
 // [[Rcpp::export]]
-double libtiledb_fragment_info_unconsolidated_metadata_num(XPtr<tiledb::FragmentInfo> fi) {
-    check_xptr_tag<tiledb::FragmentInfo>(fi);
-    return static_cast<double>(fi->unconsolidated_metadata_num());
+double libtiledb_fragment_info_unconsolidated_metadata_num(
+    XPtr<tiledb::FragmentInfo> fi) {
+  check_xptr_tag<tiledb::FragmentInfo>(fi);
+  return static_cast<double>(fi->unconsolidated_metadata_num());
 }
 
 // [[Rcpp::export]]
 double libtiledb_fragment_info_to_vacuum_num(XPtr<tiledb::FragmentInfo> fi) {
-    check_xptr_tag<tiledb::FragmentInfo>(fi);
-    return static_cast<double>(fi->to_vacuum_num());
+  check_xptr_tag<tiledb::FragmentInfo>(fi);
+  return static_cast<double>(fi->to_vacuum_num());
 }
 
 // [[Rcpp::export]]
-std::string libtiledb_fragment_info_to_vacuum_uri(XPtr<tiledb::FragmentInfo> fi, int32_t fid) {
-    check_xptr_tag<tiledb::FragmentInfo>(fi);
-    return fi->to_vacuum_uri(static_cast<uint32_t>(fid));
+std::string libtiledb_fragment_info_to_vacuum_uri(XPtr<tiledb::FragmentInfo> fi,
+                                                  int32_t fid) {
+  check_xptr_tag<tiledb::FragmentInfo>(fi);
+  return fi->to_vacuum_uri(static_cast<uint32_t>(fid));
 }
 
 // [[Rcpp::export]]
 void libtiledb_fragment_info_dump(XPtr<tiledb::FragmentInfo> fi) {
-    check_xptr_tag<tiledb::FragmentInfo>(fi);
-#if TILEDB_VERSION >= TileDB_Version(2,27,0)
-    std::stringstream ss;
-    ss << *fi;
-    Rcpp::Rcout << ss.str();
+  check_xptr_tag<tiledb::FragmentInfo>(fi);
+#if TILEDB_VERSION >= TileDB_Version(2, 27, 0)
+  std::stringstream ss;
+  ss << *fi;
+  Rcpp::Rcout << ss.str();
 #else
-    fi->dump();
+  fi->dump();
 #endif
 }
 
 // [[Rcpp::export]]
 std::string libtiledb_error_message(XPtr<tiledb::Context> ctx) {
-    check_xptr_tag<tiledb::Context>(ctx);
-    tiledb::Error error(*ctx.get());
-    std::string txt(error.error_message());
-    return txt;
+  check_xptr_tag<tiledb::Context>(ctx);
+  tiledb::Error error(*ctx.get());
+  std::string txt(error.error_message());
+  return txt;
 }
-
-
 
 /**
  * Groups
  */
 // [[Rcpp::export]]
 XPtr<tiledb::Group> libtiledb_group(XPtr<tiledb::Context> ctx,
-                                    const std::string& uri,
-                                    const std::string& querytypestr) {
-    check_xptr_tag<tiledb::Context>(ctx);
-#if TILEDB_VERSION >= TileDB_Version(2,8,0)
-    tiledb_query_type_t querytype = _string_to_tiledb_query_type(querytypestr);
-    auto p = new tiledb::Group(*ctx.get(), uri, querytype);
-    XPtr<tiledb::Group> ptr = make_xptr<tiledb::Group>(p);
+                                    const std::string &uri,
+                                    const std::string &querytypestr) {
+  check_xptr_tag<tiledb::Context>(ctx);
+#if TILEDB_VERSION >= TileDB_Version(2, 8, 0)
+  tiledb_query_type_t querytype = _string_to_tiledb_query_type(querytypestr);
+  auto p = new tiledb::Group(*ctx.get(), uri, querytype);
+  XPtr<tiledb::Group> ptr = make_xptr<tiledb::Group>(p);
 #else
-    XPtr<tiledb::Group> ptr(new tiledb::Group()); // placeholder
+  XPtr<tiledb::Group> ptr(new tiledb::Group()); // placeholder
 #endif
-    return ptr;
+  return ptr;
 }
 
 // Interfaces to R are C-based so we cannot overload just on signature
 // [[Rcpp::export]]
 XPtr<tiledb::Group> libtiledb_group_with_config(XPtr<tiledb::Context> ctx,
-                                                const std::string& uri,
-                                                const std::string& querytypestr,
+                                                const std::string &uri,
+                                                const std::string &querytypestr,
                                                 XPtr<tiledb::Config> cfg) {
-    check_xptr_tag<tiledb::Context>(ctx);
-    check_xptr_tag<tiledb::Config>(cfg);
-    tiledb_query_type_t querytype = _string_to_tiledb_query_type(querytypestr);
-#if TILEDB_VERSION >= TileDB_Version(2,15,1)
-    auto p = new tiledb::Group(*ctx.get(), uri, querytype, *cfg.get());
-    XPtr<tiledb::Group> ptr = make_xptr<tiledb::Group>(p);
-#elif TILEDB_VERSION >= TileDB_Version(2,8,0)
-    Rcpp::warning("libtiledb_group_with_config should only called with TileDB 2.15.1 or later");
-    auto p = new tiledb::Group(*ctx.get(), uri, querytype); // placeholder
-    XPtr<tiledb::Group> ptr = make_xptr<tiledb::Group>(p);
+  check_xptr_tag<tiledb::Context>(ctx);
+  check_xptr_tag<tiledb::Config>(cfg);
+  tiledb_query_type_t querytype = _string_to_tiledb_query_type(querytypestr);
+#if TILEDB_VERSION >= TileDB_Version(2, 15, 1)
+  auto p = new tiledb::Group(*ctx.get(), uri, querytype, *cfg.get());
+  XPtr<tiledb::Group> ptr = make_xptr<tiledb::Group>(p);
+#elif TILEDB_VERSION >= TileDB_Version(2, 8, 0)
+  Rcpp::warning("libtiledb_group_with_config should only called with TileDB "
+                "2.15.1 or later");
+  auto p = new tiledb::Group(*ctx.get(), uri, querytype); // placeholder
+  XPtr<tiledb::Group> ptr = make_xptr<tiledb::Group>(p);
 #else
-    XPtr<tiledb::Group> ptr(new tiledb::Group()); // placeholder
+  XPtr<tiledb::Group> ptr(new tiledb::Group()); // placeholder
 #endif
-    return ptr;
+  return ptr;
 }
-
 
 // [[Rcpp::export]]
 XPtr<tiledb::Group> libtiledb_group_open(XPtr<tiledb::Group> grp,
-                                         const std::string& querytypestr) {
-    check_xptr_tag<tiledb::Group>(grp);
-#if TILEDB_VERSION >= TileDB_Version(2,8,0)
-    tiledb_query_type_t querytype = _string_to_tiledb_query_type(querytypestr);
-    grp->open(querytype);
+                                         const std::string &querytypestr) {
+  check_xptr_tag<tiledb::Group>(grp);
+#if TILEDB_VERSION >= TileDB_Version(2, 8, 0)
+  tiledb_query_type_t querytype = _string_to_tiledb_query_type(querytypestr);
+  grp->open(querytype);
 #endif
-    return grp;
+  return grp;
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::Group> libtiledb_group_set_config(XPtr<tiledb::Group> grp, XPtr<tiledb::Config> cfg) {
-    check_xptr_tag<tiledb::Group>(grp);
-    check_xptr_tag<tiledb::Config>(cfg);
-#if TILEDB_VERSION >= TileDB_Version(2,8,0)
-    grp->set_config(*cfg.get());
+XPtr<tiledb::Group> libtiledb_group_set_config(XPtr<tiledb::Group> grp,
+                                               XPtr<tiledb::Config> cfg) {
+  check_xptr_tag<tiledb::Group>(grp);
+  check_xptr_tag<tiledb::Config>(cfg);
+#if TILEDB_VERSION >= TileDB_Version(2, 8, 0)
+  grp->set_config(*cfg.get());
 #endif
-    return grp;
+  return grp;
 }
 
 // [[Rcpp::export]]
 XPtr<tiledb::Config> libtiledb_group_get_config(XPtr<tiledb::Group> grp) {
-    check_xptr_tag<tiledb::Group>(grp);
-#if TILEDB_VERSION >= TileDB_Version(2,8,0)
-    auto ptr = make_xptr<tiledb::Config>(new tiledb::Config(grp.get()->config()));
-    return ptr;
+  check_xptr_tag<tiledb::Group>(grp);
+#if TILEDB_VERSION >= TileDB_Version(2, 8, 0)
+  auto ptr = make_xptr<tiledb::Config>(new tiledb::Config(grp.get()->config()));
+  return ptr;
 #else
-    return make_xptr<tiledb::Config>(new tiledb::Config());
+  return make_xptr<tiledb::Config>(new tiledb::Config());
 #endif
 }
 
 // [[Rcpp::export]]
 XPtr<tiledb::Group> libtiledb_group_close(XPtr<tiledb::Group> grp) {
-    check_xptr_tag<tiledb::Group>(grp);
-#if TILEDB_VERSION >= TileDB_Version(2,8,0)
-    grp->close();
+  check_xptr_tag<tiledb::Group>(grp);
+#if TILEDB_VERSION >= TileDB_Version(2, 8, 0)
+  grp->close();
 #endif
-    return grp;
+  return grp;
 }
 
 // [[Rcpp::export]]
-std::string libtiledb_group_create(XPtr<tiledb::Context> ctx, const std::string& uri) {
-    check_xptr_tag<tiledb::Context>(ctx);
-#if TILEDB_VERSION >= TileDB_Version(2,8,0)
-    tiledb::Group::create(*ctx.get(), uri);
+std::string libtiledb_group_create(XPtr<tiledb::Context> ctx,
+                                   const std::string &uri) {
+  check_xptr_tag<tiledb::Context>(ctx);
+#if TILEDB_VERSION >= TileDB_Version(2, 8, 0)
+  tiledb::Group::create(*ctx.get(), uri);
 #endif
-    return uri;
+  return uri;
 }
 
 // [[Rcpp::export]]
 bool libtiledb_group_is_open(XPtr<tiledb::Group> grp) {
-    check_xptr_tag<tiledb::Group>(grp);
-#if TILEDB_VERSION >= TileDB_Version(2,8,0)
-    return grp->is_open();
+  check_xptr_tag<tiledb::Group>(grp);
+#if TILEDB_VERSION >= TileDB_Version(2, 8, 0)
+  return grp->is_open();
 #else
-    return FALSE;
+  return FALSE;
 #endif
 }
 
 // [[Rcpp::export]]
 std::string libtiledb_group_uri(XPtr<tiledb::Group> grp) {
-    check_xptr_tag<tiledb::Group>(grp);
-#if TILEDB_VERSION >= TileDB_Version(2,8,0)
-    return grp->uri();
+  check_xptr_tag<tiledb::Group>(grp);
+#if TILEDB_VERSION >= TileDB_Version(2, 8, 0)
+  return grp->uri();
 #else
-    return std::string("");
+  return std::string("");
 #endif
 }
 
 // [[Rcpp::export]]
 std::string libtiledb_group_query_type(XPtr<tiledb::Group> grp) {
-    check_xptr_tag<tiledb::Group>(grp);
-#if TILEDB_VERSION >= TileDB_Version(2,8,0)
-    return _tiledb_query_type_to_string(grp->query_type());
+  check_xptr_tag<tiledb::Group>(grp);
+#if TILEDB_VERSION >= TileDB_Version(2, 8, 0)
+  return _tiledb_query_type_to_string(grp->query_type());
 #else
-    return std::string("");
+  return std::string("");
 #endif
 }
 
 // [[Rcpp::export]]
-bool libtiledb_group_put_metadata(XPtr<tiledb::Group> grp, std::string key, SEXP obj) {
-    check_xptr_tag<tiledb::Group>(grp);
-#if TILEDB_VERSION >= TileDB_Version(2,8,0)
-    // we implement a simpler interface here as the 'type' is given from
-    // the supplied SEXP, as is the extent
-    switch(TYPEOF(obj)) {
-    case VECSXP: {
-        Rcpp::stop("List objects are not supported.");
-        break;// not reached
-        }
-    case REALSXP: {
-        Rcpp::NumericVector v(obj);
-        grp->put_metadata(key, TILEDB_FLOAT64, v.size(), v.begin());
-        break;
-    }
-    case INTSXP: {
-        Rcpp::IntegerVector v(obj);
-        grp->put_metadata(key, TILEDB_INT32, v.size(), v.begin());
-        break;
-    }
-    case STRSXP: {
-        Rcpp::CharacterVector v(obj);
-        std::string s(v[0]);
-        // We use TILEDB_CHAR interchangeably with TILEDB_STRING_ASCII is this best string type?
-        grp->put_metadata(key, TILEDB_STRING_ASCII, s.length(), s.c_str());
-        break;
-    }
-    case LGLSXP: {              // experimental: map R logical (ie TRUE, FALSE, NA) to int8
-        Rcpp::stop("Logical vector objects are not supported.");
-        break;// not reached
-    }
-    default: {
-        Rcpp::stop("No support (yet) for type '%s'.", Rf_type2char(TYPEOF(obj)));
-        break; // not reached
-    }
-    }
+bool libtiledb_group_put_metadata(XPtr<tiledb::Group> grp, std::string key,
+                                  SEXP obj) {
+  check_xptr_tag<tiledb::Group>(grp);
+#if TILEDB_VERSION >= TileDB_Version(2, 8, 0)
+  // we implement a simpler interface here as the 'type' is given from
+  // the supplied SEXP, as is the extent
+  switch (TYPEOF(obj)) {
+  case VECSXP: {
+    Rcpp::stop("List objects are not supported.");
+    break; // not reached
+  }
+  case REALSXP: {
+    Rcpp::NumericVector v(obj);
+    grp->put_metadata(key, TILEDB_FLOAT64, v.size(), v.begin());
+    break;
+  }
+  case INTSXP: {
+    Rcpp::IntegerVector v(obj);
+    grp->put_metadata(key, TILEDB_INT32, v.size(), v.begin());
+    break;
+  }
+  case STRSXP: {
+    Rcpp::CharacterVector v(obj);
+    std::string s(v[0]);
+    // We use TILEDB_CHAR interchangeably with TILEDB_STRING_ASCII is this best
+    // string type?
+    grp->put_metadata(key, TILEDB_STRING_ASCII, s.length(), s.c_str());
+    break;
+  }
+  case LGLSXP: { // experimental: map R logical (ie TRUE, FALSE, NA) to int8
+    Rcpp::stop("Logical vector objects are not supported.");
+    break; // not reached
+  }
+  default: {
+    Rcpp::stop("No support (yet) for type '%s'.", Rf_type2char(TYPEOF(obj)));
+    break; // not reached
+  }
+  }
 #endif
-    return true;
+  return true;
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::Group> libtiledb_group_delete_metadata(XPtr<tiledb::Group> grp, std::string key) {
-    check_xptr_tag<tiledb::Group>(grp);
-#if TILEDB_VERSION >= TileDB_Version(2,8,0)
-    grp->delete_metadata(key);
+XPtr<tiledb::Group> libtiledb_group_delete_metadata(XPtr<tiledb::Group> grp,
+                                                    std::string key) {
+  check_xptr_tag<tiledb::Group>(grp);
+#if TILEDB_VERSION >= TileDB_Version(2, 8, 0)
+  grp->delete_metadata(key);
 #endif
-    return grp;
+  return grp;
 }
 
 // [[Rcpp::export]]
 SEXP libtiledb_group_get_metadata(XPtr<tiledb::Group> grp, std::string key) {
-    check_xptr_tag<tiledb::Group>(grp);
-#if TILEDB_VERSION >= TileDB_Version(2,8,0)
-    tiledb_datatype_t v_type;
-    uint32_t v_num;
-    const void* v;
-    grp->get_metadata(key, &v_type, &v_num, &v);
-    if (v == NULL) {
-        return R_NilValue;
-    }
-    RObject vec = _metadata_to_sexp(v_type, v_num, v);
-    vec.attr("key") = Rcpp::CharacterVector::create(key);
-    return vec;
-#else
+  check_xptr_tag<tiledb::Group>(grp);
+#if TILEDB_VERSION >= TileDB_Version(2, 8, 0)
+  tiledb_datatype_t v_type;
+  uint32_t v_num;
+  const void *v;
+  grp->get_metadata(key, &v_type, &v_num, &v);
+  if (v == NULL) {
     return R_NilValue;
+  }
+  RObject vec = _metadata_to_sexp(v_type, v_num, v);
+  vec.attr("key") = Rcpp::CharacterVector::create(key);
+  return vec;
+#else
+  return R_NilValue;
 #endif
 }
 
 // [[Rcpp::export]]
 bool libtiledb_group_has_metadata(XPtr<tiledb::Group> grp, std::string key) {
-    check_xptr_tag<tiledb::Group>(grp);
-#if TILEDB_VERSION >= TileDB_Version(2,8,0)
-    tiledb_datatype_t value_type; // set by C++ API on return, not returned to R
-    return grp->has_metadata(key, &value_type);
+  check_xptr_tag<tiledb::Group>(grp);
+#if TILEDB_VERSION >= TileDB_Version(2, 8, 0)
+  tiledb_datatype_t value_type; // set by C++ API on return, not returned to R
+  return grp->has_metadata(key, &value_type);
 #else
-    return false;
+  return false;
 #endif
 }
 
 // [[Rcpp::export]]
 double libtiledb_group_metadata_num(XPtr<tiledb::Group> grp) {
-    check_xptr_tag<tiledb::Group>(grp);
-#if TILEDB_VERSION >= TileDB_Version(2,8,0)
-    return grp->metadata_num();
+  check_xptr_tag<tiledb::Group>(grp);
+#if TILEDB_VERSION >= TileDB_Version(2, 8, 0)
+  return grp->metadata_num();
 #else
-    return 0;
+  return 0;
 #endif
 }
 
 // [[Rcpp::export]]
 SEXP libtiledb_group_get_metadata_from_index(XPtr<tiledb::Group> grp, int idx) {
-    check_xptr_tag<tiledb::Group>(grp);
-#if TILEDB_VERSION >= TileDB_Version(2,8,0)
-    std::string key;
-    tiledb_datatype_t v_type;
-    uint32_t v_num;
-    const void* v;
-    grp->get_metadata_from_index(static_cast<uint64_t>(idx), &key, &v_type, &v_num, &v);
-    if (v == NULL) {
-        return R_NilValue;
-    }
-    RObject vec = _metadata_to_sexp(v_type, v_num, v);
-    vec.attr("key") = Rcpp::CharacterVector::create(key);
-    return vec;
-#else
+  check_xptr_tag<tiledb::Group>(grp);
+#if TILEDB_VERSION >= TileDB_Version(2, 8, 0)
+  std::string key;
+  tiledb_datatype_t v_type;
+  uint32_t v_num;
+  const void *v;
+  grp->get_metadata_from_index(static_cast<uint64_t>(idx), &key, &v_type,
+                               &v_num, &v);
+  if (v == NULL) {
     return R_NilValue;
+  }
+  RObject vec = _metadata_to_sexp(v_type, v_num, v);
+  vec.attr("key") = Rcpp::CharacterVector::create(key);
+  return vec;
+#else
+  return R_NilValue;
 #endif
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::Group> libtiledb_group_add_member(XPtr<tiledb::Group> grp,
-                                               std::string uri, bool relative,
-                                               Nullable<Rcpp::String> optional_name = R_NilValue) {
-    check_xptr_tag<tiledb::Group>(grp);
-#if TILEDB_VERSION >= TileDB_Version(2,8,0)
-    if (optional_name.isNotNull()) {
-        Rcpp::String string_name(optional_name);
-        std::string name(string_name);
-        grp->add_member(uri, relative, name);
-    } else {
-        grp->add_member(uri, relative);
-    }
+XPtr<tiledb::Group>
+libtiledb_group_add_member(XPtr<tiledb::Group> grp, std::string uri,
+                           bool relative,
+                           Nullable<Rcpp::String> optional_name = R_NilValue) {
+  check_xptr_tag<tiledb::Group>(grp);
+#if TILEDB_VERSION >= TileDB_Version(2, 8, 0)
+  if (optional_name.isNotNull()) {
+    Rcpp::String string_name(optional_name);
+    std::string name(string_name);
+    grp->add_member(uri, relative, name);
+  } else {
+    grp->add_member(uri, relative);
+  }
 #endif
-    return grp;
+  return grp;
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::Group> libtiledb_group_remove_member(XPtr<tiledb::Group> grp, std::string uri) {
-    check_xptr_tag<tiledb::Group>(grp);
-#if TILEDB_VERSION >= TileDB_Version(2,8,0)
-    grp->remove_member(uri);
+XPtr<tiledb::Group> libtiledb_group_remove_member(XPtr<tiledb::Group> grp,
+                                                  std::string uri) {
+  check_xptr_tag<tiledb::Group>(grp);
+#if TILEDB_VERSION >= TileDB_Version(2, 8, 0)
+  grp->remove_member(uri);
 #endif
-    return grp;
+  return grp;
 }
 
 // [[Rcpp::export]]
 double libtiledb_group_member_count(XPtr<tiledb::Group> grp) {
-    check_xptr_tag<tiledb::Group>(grp);
-#if TILEDB_VERSION >= TileDB_Version(2,8,0)
-    return grp->member_count();
+  check_xptr_tag<tiledb::Group>(grp);
+#if TILEDB_VERSION >= TileDB_Version(2, 8, 0)
+  return grp->member_count();
 #else
-    return 0;
+  return 0;
 #endif
 }
 
 // [[Rcpp::export]]
 CharacterVector libtiledb_group_member(XPtr<tiledb::Group> grp, int idx) {
-    check_xptr_tag<tiledb::Group>(grp);
-#if TILEDB_VERSION >= TileDB_Version(2,8,0)
-    tiledb::Object obj = grp->member(idx);
-    CharacterVector v = CharacterVector::create(_object_type_to_string(obj.type()), obj.uri(), obj.name().value_or(""));
+  check_xptr_tag<tiledb::Group>(grp);
+#if TILEDB_VERSION >= TileDB_Version(2, 8, 0)
+  tiledb::Object obj = grp->member(idx);
+  CharacterVector v = CharacterVector::create(
+      _object_type_to_string(obj.type()), obj.uri(), obj.name().value_or(""));
 #else
-    CharacterVector v = CharacterVector::create("", "", "");
+  CharacterVector v = CharacterVector::create("", "", "");
 #endif
-    return v;
+  return v;
 }
 
 // [[Rcpp::export]]
 std::string libtiledb_group_dump(XPtr<tiledb::Group> grp, bool recursive) {
-    check_xptr_tag<tiledb::Group>(grp);
-#if TILEDB_VERSION >= TileDB_Version(2,8,0)
-    return grp->dump(recursive);
+  check_xptr_tag<tiledb::Group>(grp);
+#if TILEDB_VERSION >= TileDB_Version(2, 8, 0)
+  return grp->dump(recursive);
 #else
-    return std::string("");
+  return std::string("");
 #endif
 }
 
 // [[Rcpp::export]]
-bool libtiledb_group_is_relative(XPtr<tiledb::Group> grp, const std::string &name) {
-    check_xptr_tag<tiledb::Group>(grp);
-#if TILEDB_VERSION >= TileDB_Version(2,12,0)
-    return grp->is_relative(name);
+bool libtiledb_group_is_relative(XPtr<tiledb::Group> grp,
+                                 const std::string &name) {
+  check_xptr_tag<tiledb::Group>(grp);
+#if TILEDB_VERSION >= TileDB_Version(2, 12, 0)
+  return grp->is_relative(name);
 #else
-    return false;
+  return false;
 #endif
 }
 
 // See comments in group.h: the group has to be opened in MODIFY_EXCLUSIVE mode
 // The function throws (creating an R error) is that condition is not met
 // [[Rcpp::export]]
-void libtiledb_group_delete(XPtr<tiledb::Group> grp,
-                            const std::string& uri,
+void libtiledb_group_delete(XPtr<tiledb::Group> grp, const std::string &uri,
                             const bool recursive = false) {
-    check_xptr_tag<tiledb::Group>(grp);
-#if TILEDB_VERSION >= TileDB_Version(2,14,0)
-    grp->delete_group(uri, recursive);
+  check_xptr_tag<tiledb::Group>(grp);
+#if TILEDB_VERSION >= TileDB_Version(2, 14, 0)
+  grp->delete_group(uri, recursive);
 #else
-    Rcpp::message(Rcpp::wrap("This function is only available with TileDB Core 2.14.0 or later"));
+  Rcpp::message(Rcpp::wrap(
+      "This function is only available with TileDB Core 2.14.0 or later"));
 #endif
 }
-
-
 
 /**
  * Filestore (via tiledb_experimental.h)
@@ -5282,23 +5607,23 @@ void libtiledb_group_delete(XPtr<tiledb::Group> grp,
 
 // Creates array schema based on URL, or default schema if no URI provided
 // [[Rcpp::export]]
-XPtr<tiledb::ArraySchema> libtiledb_filestore_schema_create(XPtr<tiledb::Context> ctx,
-                                                            std::string uri) {
-#if TILEDB_VERSION >= TileDB_Version(2,9,0)
-    tiledb_ctx_t* ctx_ptr = ctx->ptr().get();
-    tiledb_array_schema_t* schema_type_ptr;
-    if (tiledb_filestore_schema_create(ctx_ptr,
-                                       (uri == "" ? nullptr : uri.c_str()),
-                                       &schema_type_ptr) == TILEDB_ERR) {
-        Rcpp::stop("Error creating array schema from defaults");
-    }
-    auto schptr = new tiledb::ArraySchema(*ctx.get(), schema_type_ptr);
-    auto schema = make_xptr<tiledb::ArraySchema>(schptr);
-    return schema;
+XPtr<tiledb::ArraySchema>
+libtiledb_filestore_schema_create(XPtr<tiledb::Context> ctx, std::string uri) {
+#if TILEDB_VERSION >= TileDB_Version(2, 9, 0)
+  tiledb_ctx_t *ctx_ptr = ctx->ptr().get();
+  tiledb_array_schema_t *schema_type_ptr;
+  if (tiledb_filestore_schema_create(ctx_ptr,
+                                     (uri == "" ? nullptr : uri.c_str()),
+                                     &schema_type_ptr) == TILEDB_ERR) {
+    Rcpp::stop("Error creating array schema from defaults");
+  }
+  auto schptr = new tiledb::ArraySchema(*ctx.get(), schema_type_ptr);
+  auto schema = make_xptr<tiledb::ArraySchema>(schptr);
+  return schema;
 #else
-    auto schptr = new tiledb::ArraySchema(*ctx.get(), TILEDB_SPARSE);
-    auto schema = make_xptr<tiledb::ArraySchema>(schptr);
-    return schema;
+  auto schptr = new tiledb::ArraySchema(*ctx.get(), TILEDB_SPARSE);
+  auto schema = make_xptr<tiledb::ArraySchema>(schptr);
+  return schema;
 #endif
 }
 
@@ -5307,18 +5632,18 @@ XPtr<tiledb::ArraySchema> libtiledb_filestore_schema_create(XPtr<tiledb::Context
 bool libtiledb_filestore_uri_import(XPtr<tiledb::Context> ctx,
                                     std::string filestore_uri,
                                     std::string file_uri) {
-#if TILEDB_VERSION >= TileDB_Version(2,9,0)
-    tiledb_ctx_t* ctx_ptr = ctx->ptr().get();
-    if (tiledb_filestore_uri_import(ctx_ptr, filestore_uri.c_str(),
-                                    file_uri.c_str(), TILEDB_MIME_AUTODETECT) == TILEDB_ERR) {
-        Rcpp::stop("Error importing file into filestore");
-        return false;           // not reached
-    }
-    return true;
+#if TILEDB_VERSION >= TileDB_Version(2, 9, 0)
+  tiledb_ctx_t *ctx_ptr = ctx->ptr().get();
+  if (tiledb_filestore_uri_import(ctx_ptr, filestore_uri.c_str(),
+                                  file_uri.c_str(),
+                                  TILEDB_MIME_AUTODETECT) == TILEDB_ERR) {
+    Rcpp::stop("Error importing file into filestore");
+    return false; // not reached
+  }
+  return true;
 #else
-    return false;
+  return false;
 #endif
-
 }
 
 // Export from a TileDB filestore array into a file uri
@@ -5326,15 +5651,16 @@ bool libtiledb_filestore_uri_import(XPtr<tiledb::Context> ctx,
 bool libtiledb_filestore_uri_export(XPtr<tiledb::Context> ctx,
                                     std::string file_uri,
                                     std::string filestore_uri) {
-#if TILEDB_VERSION >= TileDB_Version(2,9,0)
-    tiledb_ctx_t* ctx_ptr = ctx->ptr().get();
-    if (tiledb_filestore_uri_export(ctx_ptr, file_uri.c_str(), filestore_uri.c_str())  == TILEDB_ERR) {
-        Rcpp::stop("Error exporting file from filestore");
-        return false;           // not reached
-    }
-    return true;
+#if TILEDB_VERSION >= TileDB_Version(2, 9, 0)
+  tiledb_ctx_t *ctx_ptr = ctx->ptr().get();
+  if (tiledb_filestore_uri_export(ctx_ptr, file_uri.c_str(),
+                                  filestore_uri.c_str()) == TILEDB_ERR) {
+    Rcpp::stop("Error exporting file from filestore");
+    return false; // not reached
+  }
+  return true;
 #else
-    return false;
+  return false;
 #endif
 }
 
@@ -5343,17 +5669,17 @@ bool libtiledb_filestore_uri_export(XPtr<tiledb::Context> ctx,
 bool libtiledb_filestore_buffer_import(XPtr<tiledb::Context> ctx,
                                        std::string filestore_uri,
                                        std::string buf, size_t size) {
-#if TILEDB_VERSION >= TileDB_Version(2,9,0)
-    tiledb_ctx_t* ctx_ptr = ctx->ptr().get();
-    if (tiledb_filestore_buffer_import(ctx_ptr, filestore_uri.c_str(),
-                                       static_cast<void*>(buf.data()), size,
-                                       TILEDB_MIME_AUTODETECT) == TILEDB_ERR) {
-        Rcpp::stop("Error importing file into filestore");
-        return false;           // not reached
-    }
-    return true;
+#if TILEDB_VERSION >= TileDB_Version(2, 9, 0)
+  tiledb_ctx_t *ctx_ptr = ctx->ptr().get();
+  if (tiledb_filestore_buffer_import(ctx_ptr, filestore_uri.c_str(),
+                                     static_cast<void *>(buf.data()), size,
+                                     TILEDB_MIME_AUTODETECT) == TILEDB_ERR) {
+    Rcpp::stop("Error importing file into filestore");
+    return false; // not reached
+  }
+  return true;
 #else
-    return false;
+  return false;
 #endif
 }
 
@@ -5362,281 +5688,290 @@ bool libtiledb_filestore_buffer_import(XPtr<tiledb::Context> ctx,
 std::string libtiledb_filestore_buffer_export(XPtr<tiledb::Context> ctx,
                                               std::string filestore_uri,
                                               size_t offset, size_t size) {
-    std::string buf("");
-#if TILEDB_VERSION >= TileDB_Version(2,9,0)
-    tiledb_ctx_t* ctx_ptr = ctx->ptr().get();
-    buf.resize(size);
-    if (tiledb_filestore_buffer_export(ctx_ptr, filestore_uri.c_str(), offset,
-                                       static_cast<void*>(buf.data()), size) == TILEDB_ERR) {
-        Rcpp::stop("Error exporting file from filestore");
-    }
+  std::string buf("");
+#if TILEDB_VERSION >= TileDB_Version(2, 9, 0)
+  tiledb_ctx_t *ctx_ptr = ctx->ptr().get();
+  buf.resize(size);
+  if (tiledb_filestore_buffer_export(ctx_ptr, filestore_uri.c_str(), offset,
+                                     static_cast<void *>(buf.data()),
+                                     size) == TILEDB_ERR) {
+    Rcpp::stop("Error exporting file from filestore");
+  }
 #endif
-    return buf;
-
+  return buf;
 }
 
 // Get size of uncompressed TileDB filestore array
 // [[Rcpp::export]]
-size_t libtiledb_filestore_size(XPtr<tiledb::Context> ctx, std::string filestore_uri) {
-    size_t sz = 0;
-#if TILEDB_VERSION >= TileDB_Version(2,9,0)
-    tiledb_ctx_t* ctx_ptr = ctx->ptr().get();
-    if (tiledb_filestore_size(ctx_ptr, filestore_uri.c_str(), &sz) == TILEDB_ERR) {
-        Rcpp::stop("Error accessize filestore uri size");
-    }
+size_t libtiledb_filestore_size(XPtr<tiledb::Context> ctx,
+                                std::string filestore_uri) {
+  size_t sz = 0;
+#if TILEDB_VERSION >= TileDB_Version(2, 9, 0)
+  tiledb_ctx_t *ctx_ptr = ctx->ptr().get();
+  if (tiledb_filestore_size(ctx_ptr, filestore_uri.c_str(), &sz) ==
+      TILEDB_ERR) {
+    Rcpp::stop("Error accessize filestore uri size");
+  }
 #endif
-    return sz;
+  return sz;
 }
 
 // Get MIME type of TileDB filestore as string
 // [[Rcpp::export]]
 std::string libtiledb_mime_type_to_str(int32_t mime_type) {
-#if TILEDB_VERSION >= TileDB_Version(2,9,0)
-    const char* ptr;
-    if (tiledb_mime_type_to_str(static_cast<tiledb_mime_type_t>(mime_type),
-                                &ptr) == TILEDB_ERR) {
-        Rcpp::stop("Error converting mime type to string");
-    }
-    return std::string(ptr);
+#if TILEDB_VERSION >= TileDB_Version(2, 9, 0)
+  const char *ptr;
+  if (tiledb_mime_type_to_str(static_cast<tiledb_mime_type_t>(mime_type),
+                              &ptr) == TILEDB_ERR) {
+    Rcpp::stop("Error converting mime type to string");
+  }
+  return std::string(ptr);
 #else
-    return std::string("");
+  return std::string("");
 #endif
 }
 
 // Create MIME type of TileDB filestore from string
 // [[Rcpp::export]]
 int32_t libtiledb_mime_type_from_str(std::string mime_type) {
-#if TILEDB_VERSION >= TileDB_Version(2,9,0)
-    tiledb_mime_type_t mt;
-    if (tiledb_mime_type_from_str(mime_type.c_str(), &mt) == TILEDB_ERR) {
-        Rcpp::stop("Error converting mime type from string");
-    }
-    return static_cast<int32_t>(mt);
+#if TILEDB_VERSION >= TileDB_Version(2, 9, 0)
+  tiledb_mime_type_t mt;
+  if (tiledb_mime_type_from_str(mime_type.c_str(), &mt) == TILEDB_ERR) {
+    Rcpp::stop("Error converting mime type from string");
+  }
+  return static_cast<int32_t>(mt);
 #else
-    return -1;
+  return -1;
 #endif
 }
-
 
 /**
  * NDRectangle (2.25.0 or later)
  */
 
 // [[Rcpp::export]]
-XPtr<tiledb::NDRectangle> libtiledb_ndrectangle_create(XPtr<tiledb::Context> ctx,
-                                                       XPtr<tiledb::Domain> dom) {
-    check_xptr_tag<tiledb::Context>(ctx);
-    check_xptr_tag<tiledb::Domain>(dom);
-#if TILEDB_VERSION >= TileDB_Version(2,25,0)
-    auto ndr = new tiledb::NDRectangle(*ctx.get(), *dom.get());
+XPtr<tiledb::NDRectangle>
+libtiledb_ndrectangle_create(XPtr<tiledb::Context> ctx,
+                             XPtr<tiledb::Domain> dom) {
+  check_xptr_tag<tiledb::Context>(ctx);
+  check_xptr_tag<tiledb::Domain>(dom);
+#if TILEDB_VERSION >= TileDB_Version(2, 25, 0)
+  auto ndr = new tiledb::NDRectangle(*ctx.get(), *dom.get());
 #else
-    auto ndr = new tiledb::NDRectangle();
+  auto ndr = new tiledb::NDRectangle();
 #endif
-    auto ptr = make_xptr<tiledb::NDRectangle>(ndr);
-    return ptr;
+  auto ptr = make_xptr<tiledb::NDRectangle>(ndr);
+  return ptr;
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::NDRectangle> libtiledb_ndrectangle_set_range(XPtr<tiledb::NDRectangle> ndr,
-                                                          std::string& datatype,
-                                                          std::string& dimname,
-                                                          SEXP start, SEXP end) {
-    check_xptr_tag<tiledb::NDRectangle>(ndr);
-#if TILEDB_VERSION >= TileDB_Version(2,25,0)
-    auto dtype = _string_to_tiledb_datatype(datatype);
-    if (dtype == TILEDB_CHAR ||         // branch for 'string'
-        dtype == TILEDB_STRING_ASCII ||
-        dtype == TILEDB_STRING_UTF8) {
-        ndr->set_range(dimname, Rcpp::as<std::string>(start), Rcpp::as<std::string>(end));
-    } else if (dtype == TILEDB_INT64) {
-        ndr->set_range<int64_t>(dimname, Rcpp::fromInteger64(start), Rcpp::fromInteger64(end));
-    } else if (dtype == TILEDB_UINT64) {
-        ndr->set_range<int64_t>(dimname,
-                                static_cast<uint64_t>(Rcpp::fromInteger64(Rcpp::as<double>(start))),
-                                static_cast<uint64_t>(Rcpp::fromInteger64(Rcpp::as<double>(end))));
-    } else if (dtype == TILEDB_INT32) {
-        ndr->set_range<int32_t>(dimname, Rcpp::as<int32_t>(start), Rcpp::as<int32_t>(end));
-    } else if (dtype == TILEDB_UINT32) {
-        ndr->set_range<uint32_t>(dimname,
-                                 static_cast<uint32_t>(Rcpp::as<int32_t>(start)),
-                                 static_cast<uint32_t>(Rcpp::as<int32_t>(end)));
-    } else if (dtype == TILEDB_INT16) {
-        ndr->set_range<int16_t>(dimname,
-                                static_cast<int16_t>(Rcpp::as<int32_t>(start)),
-                                static_cast<int16_t>(Rcpp::as<int32_t>(end)));
-    } else if (dtype == TILEDB_UINT16) {
-        ndr->set_range<uint16_t>(dimname,
-                                 static_cast<uint16_t>(Rcpp::as<int32_t>(start)),
-                                 static_cast<uint16_t>(Rcpp::as<int32_t>(end)));
-    } else if (dtype == TILEDB_INT8) {
-        ndr->set_range<int8_t>(dimname,
-                               static_cast<int8_t>(Rcpp::as<int32_t>(start)),
-                               static_cast<int8_t>(Rcpp::as<int32_t>(end)));
-    } else if (dtype == TILEDB_UINT8) {
-        ndr->set_range<uint8_t>(dimname,
-                                static_cast<uint8_t>(Rcpp::as<int32_t>(start)),
-                                static_cast<uint8_t>(Rcpp::as<int32_t>(end)));
-    } else if (dtype == TILEDB_FLOAT64) {
-        ndr->set_range<double>(dimname, Rcpp::as<double>(start), Rcpp::as<double>(end));
-    } else if (dtype == TILEDB_FLOAT32) {
-        ndr->set_range<float>(dimname,
-                              static_cast<float>(Rcpp::as<double>(start)),
-                              static_cast<float>(Rcpp::as<double>(end)));
-    } else {
-        Rcpp::stop("Domain datatype '%s' of dimname '%s' is not currently supported",
-                   _tiledb_datatype_to_string(dtype), dimname);
-    }
+XPtr<tiledb::NDRectangle>
+libtiledb_ndrectangle_set_range(XPtr<tiledb::NDRectangle> ndr,
+                                std::string &datatype, std::string &dimname,
+                                SEXP start, SEXP end) {
+  check_xptr_tag<tiledb::NDRectangle>(ndr);
+#if TILEDB_VERSION >= TileDB_Version(2, 25, 0)
+  auto dtype = _string_to_tiledb_datatype(datatype);
+  if (dtype == TILEDB_CHAR || // branch for 'string'
+      dtype == TILEDB_STRING_ASCII || dtype == TILEDB_STRING_UTF8) {
+    ndr->set_range(dimname, Rcpp::as<std::string>(start),
+                   Rcpp::as<std::string>(end));
+  } else if (dtype == TILEDB_INT64) {
+    ndr->set_range<int64_t>(dimname, Rcpp::fromInteger64(start),
+                            Rcpp::fromInteger64(end));
+  } else if (dtype == TILEDB_UINT64) {
+    ndr->set_range<int64_t>(
+        dimname,
+        static_cast<uint64_t>(Rcpp::fromInteger64(Rcpp::as<double>(start))),
+        static_cast<uint64_t>(Rcpp::fromInteger64(Rcpp::as<double>(end))));
+  } else if (dtype == TILEDB_INT32) {
+    ndr->set_range<int32_t>(dimname, Rcpp::as<int32_t>(start),
+                            Rcpp::as<int32_t>(end));
+  } else if (dtype == TILEDB_UINT32) {
+    ndr->set_range<uint32_t>(dimname,
+                             static_cast<uint32_t>(Rcpp::as<int32_t>(start)),
+                             static_cast<uint32_t>(Rcpp::as<int32_t>(end)));
+  } else if (dtype == TILEDB_INT16) {
+    ndr->set_range<int16_t>(dimname,
+                            static_cast<int16_t>(Rcpp::as<int32_t>(start)),
+                            static_cast<int16_t>(Rcpp::as<int32_t>(end)));
+  } else if (dtype == TILEDB_UINT16) {
+    ndr->set_range<uint16_t>(dimname,
+                             static_cast<uint16_t>(Rcpp::as<int32_t>(start)),
+                             static_cast<uint16_t>(Rcpp::as<int32_t>(end)));
+  } else if (dtype == TILEDB_INT8) {
+    ndr->set_range<int8_t>(dimname,
+                           static_cast<int8_t>(Rcpp::as<int32_t>(start)),
+                           static_cast<int8_t>(Rcpp::as<int32_t>(end)));
+  } else if (dtype == TILEDB_UINT8) {
+    ndr->set_range<uint8_t>(dimname,
+                            static_cast<uint8_t>(Rcpp::as<int32_t>(start)),
+                            static_cast<uint8_t>(Rcpp::as<int32_t>(end)));
+  } else if (dtype == TILEDB_FLOAT64) {
+    ndr->set_range<double>(dimname, Rcpp::as<double>(start),
+                           Rcpp::as<double>(end));
+  } else if (dtype == TILEDB_FLOAT32) {
+    ndr->set_range<float>(dimname, static_cast<float>(Rcpp::as<double>(start)),
+                          static_cast<float>(Rcpp::as<double>(end)));
+  } else {
+    Rcpp::stop(
+        "Domain datatype '%s' of dimname '%s' is not currently supported",
+        _tiledb_datatype_to_string(dtype), dimname);
+  }
 #endif
-    return ndr;
+  return ndr;
 }
 
 // NB maybe not exporting as we need a type which we get from current domain
 // [[Rcpp::export]]
 SEXP libtiledb_ndrectangle_get_range(XPtr<tiledb::NDRectangle> ndr,
-                                     std::string& dimname, std::string& dtype) {
-    check_xptr_tag<tiledb::NDRectangle>(ndr);
-#if TILEDB_VERSION >= TileDB_Version(2,25,0)
-    if (dtype == "CHAR" || dtype == "ASCII" || dtype == "UTF8") {
-        auto range = ndr->range<std::string>(dimname);
-        return Rcpp::CharacterVector::create(range[0], range[1]);
-    } else if (dtype == "INT64") {
-        auto range = ndr->range<int64_t>(dimname);
-        return Rcpp::toInteger64( std::vector<int64_t>{range[0], range[1] } );
-    } else if (dtype == "UINT64") {
-        auto range = ndr->range<uint64_t>(dimname);
-        return Rcpp::toInteger64( std::vector<int64_t>{ static_cast<int64_t>(range[0]),
-                                                        static_cast<int64_t>(range[1]) } );
-    } else if (dtype == "INT32") {
-        auto range = ndr->range<int32_t>(dimname);
-        return Rcpp::IntegerVector::create(range[0], range[1]);
-    } else if (dtype == "UINT32") {
-        auto range = ndr->range<uint32_t>(dimname);
-        return Rcpp::IntegerVector::create( static_cast<int32_t>(range[0]),
-                                            static_cast<int32_t>(range[1]) );
-    } else if (dtype == "INT16") {
-        auto range = ndr->range<int16_t>(dimname);
-        return Rcpp::IntegerVector::create( static_cast<int32_t>(range[0]),
-                                            static_cast<int32_t>(range[1]) );
-    } else if (dtype == "UINT16") {
-        auto range = ndr->range<uint16_t>(dimname);
-        return Rcpp::IntegerVector::create( static_cast<int32_t>(range[0]),
-                                            static_cast<int32_t>(range[1]) );
-    } else if (dtype == "INT8") {
-        auto range = ndr->range<int8_t>(dimname);
-        return Rcpp::IntegerVector::create( static_cast<int32_t>(range[0]),
-                                            static_cast<int32_t>(range[1]) );
-    } else if (dtype == "UINT8") {
-        auto range = ndr->range<uint8_t>(dimname);
-        return Rcpp::IntegerVector::create( static_cast<int32_t>(range[0]),
-                                            static_cast<int32_t>(range[1]) );
-    } else if (dtype == "FLOAT64") {
-        auto range = ndr->range<double>(dimname);
-        return Rcpp::NumericVector::create(range[0], range[1]);
-    } else if (dtype == "FLOAT32") {
-        auto range = ndr->range<float>(dimname);
-        return Rcpp::NumericVector::create( static_cast<double>(range[0]),
-                                            static_cast<double>(range[1]));
-    } else {
-        Rcpp::stop("Domain datatype '%s' of dimname '%s' is not currently supported", dtype, dimname);
-    }
+                                     std::string &dimname, std::string &dtype) {
+  check_xptr_tag<tiledb::NDRectangle>(ndr);
+#if TILEDB_VERSION >= TileDB_Version(2, 25, 0)
+  if (dtype == "CHAR" || dtype == "ASCII" || dtype == "UTF8") {
+    auto range = ndr->range<std::string>(dimname);
+    return Rcpp::CharacterVector::create(range[0], range[1]);
+  } else if (dtype == "INT64") {
+    auto range = ndr->range<int64_t>(dimname);
+    return Rcpp::toInteger64(std::vector<int64_t>{range[0], range[1]});
+  } else if (dtype == "UINT64") {
+    auto range = ndr->range<uint64_t>(dimname);
+    return Rcpp::toInteger64(std::vector<int64_t>{
+        static_cast<int64_t>(range[0]), static_cast<int64_t>(range[1])});
+  } else if (dtype == "INT32") {
+    auto range = ndr->range<int32_t>(dimname);
+    return Rcpp::IntegerVector::create(range[0], range[1]);
+  } else if (dtype == "UINT32") {
+    auto range = ndr->range<uint32_t>(dimname);
+    return Rcpp::IntegerVector::create(static_cast<int32_t>(range[0]),
+                                       static_cast<int32_t>(range[1]));
+  } else if (dtype == "INT16") {
+    auto range = ndr->range<int16_t>(dimname);
+    return Rcpp::IntegerVector::create(static_cast<int32_t>(range[0]),
+                                       static_cast<int32_t>(range[1]));
+  } else if (dtype == "UINT16") {
+    auto range = ndr->range<uint16_t>(dimname);
+    return Rcpp::IntegerVector::create(static_cast<int32_t>(range[0]),
+                                       static_cast<int32_t>(range[1]));
+  } else if (dtype == "INT8") {
+    auto range = ndr->range<int8_t>(dimname);
+    return Rcpp::IntegerVector::create(static_cast<int32_t>(range[0]),
+                                       static_cast<int32_t>(range[1]));
+  } else if (dtype == "UINT8") {
+    auto range = ndr->range<uint8_t>(dimname);
+    return Rcpp::IntegerVector::create(static_cast<int32_t>(range[0]),
+                                       static_cast<int32_t>(range[1]));
+  } else if (dtype == "FLOAT64") {
+    auto range = ndr->range<double>(dimname);
+    return Rcpp::NumericVector::create(range[0], range[1]);
+  } else if (dtype == "FLOAT32") {
+    auto range = ndr->range<float>(dimname);
+    return Rcpp::NumericVector::create(static_cast<double>(range[0]),
+                                       static_cast<double>(range[1]));
+  } else {
+    Rcpp::stop(
+        "Domain datatype '%s' of dimname '%s' is not currently supported",
+        dtype, dimname);
+  }
 #endif
-    return R_NilValue;          // not reached
+  return R_NilValue; // not reached
 }
 
 // [[Rcpp::export]]
 int libtiledb_ndrectangle_dim_num(XPtr<tiledb::NDRectangle> ndr) {
-    check_xptr_tag<tiledb::NDRectangle>(ndr);
-#if TILEDB_VERSION >= TileDB_Version(2,26,0)
-    return static_cast<int32_t>(ndr->dim_num());
+  check_xptr_tag<tiledb::NDRectangle>(ndr);
+#if TILEDB_VERSION >= TileDB_Version(2, 26, 0)
+  return static_cast<int32_t>(ndr->dim_num());
 #else
-    return R_NaInt;
+  return R_NaInt;
 #endif
 }
 
 // [[Rcpp::export]]
-std::string libtiledb_ndrectangle_datatype(XPtr<tiledb::NDRectangle> ndr, const std::string& name) {
-    check_xptr_tag<tiledb::NDRectangle>(ndr);
-#if TILEDB_VERSION >= TileDB_Version(2,26,0)
-    return _tiledb_datatype_to_string(ndr->range_dtype(name));
+std::string libtiledb_ndrectangle_datatype(XPtr<tiledb::NDRectangle> ndr,
+                                           const std::string &name) {
+  check_xptr_tag<tiledb::NDRectangle>(ndr);
+#if TILEDB_VERSION >= TileDB_Version(2, 26, 0)
+  return _tiledb_datatype_to_string(ndr->range_dtype(name));
 #else
-    Rcpp::stop("This function requires TileDB 2.26.0 or later.");
-    return std::string{Rcpp::as<std::string>(R_NaString)}; // not reached
+  Rcpp::stop("This function requires TileDB 2.26.0 or later.");
+  return std::string{Rcpp::as<std::string>(R_NaString)}; // not reached
 #endif
 }
 
 // [[Rcpp::export]]
-std::string libtiledb_ndrectangle_datatype_by_ind(XPtr<tiledb::NDRectangle> ndr, int dim) {
-    check_xptr_tag<tiledb::NDRectangle>(ndr);
-#if TILEDB_VERSION >= TileDB_Version(2,26,0)
-    return _tiledb_datatype_to_string(ndr->range_dtype(static_cast<uint32_t>(dim)));
+std::string libtiledb_ndrectangle_datatype_by_ind(XPtr<tiledb::NDRectangle> ndr,
+                                                  int dim) {
+  check_xptr_tag<tiledb::NDRectangle>(ndr);
+#if TILEDB_VERSION >= TileDB_Version(2, 26, 0)
+  return _tiledb_datatype_to_string(
+      ndr->range_dtype(static_cast<uint32_t>(dim)));
 #else
-    Rcpp::stop("This function requires TileDB 2.26.0 or later.");
-    return std::string{Rcpp::as<std::string>(R_NaString)}; // not reached
+  Rcpp::stop("This function requires TileDB 2.26.0 or later.");
+  return std::string{Rcpp::as<std::string>(R_NaString)}; // not reached
 #endif
 }
-
-
-
-
 
 /**
  * Current Domain (2.25.0 or later)
  */
 
 // [[Rcpp::export]]
-XPtr<tiledb::CurrentDomain> libtiledb_current_domain_create(XPtr<tiledb::Context> ctx) {
-    check_xptr_tag<tiledb::Context>(ctx);
-#if TILEDB_VERSION >= TileDB_Version(2,25,0)
-    auto cd = new tiledb::CurrentDomain(*ctx.get());
+XPtr<tiledb::CurrentDomain>
+libtiledb_current_domain_create(XPtr<tiledb::Context> ctx) {
+  check_xptr_tag<tiledb::Context>(ctx);
+#if TILEDB_VERSION >= TileDB_Version(2, 25, 0)
+  auto cd = new tiledb::CurrentDomain(*ctx.get());
 #else
-    auto cd = new tiledb::CurrentDomain();
+  auto cd = new tiledb::CurrentDomain();
 #endif
-    auto ptr = make_xptr<tiledb::CurrentDomain>(cd);
-    return ptr;
+  auto ptr = make_xptr<tiledb::CurrentDomain>(cd);
+  return ptr;
 }
 
 // [[Rcpp::export]]
 std::string libtiledb_current_domain_type(XPtr<tiledb::CurrentDomain> cd) {
-    check_xptr_tag<tiledb::CurrentDomain>(cd);
-#if TILEDB_VERSION >= TileDB_Version(2,25,0)
-    auto tp = cd->type();
-    auto str = std::string(_tiledb_current_domain_type_to_string(tp));
-    return str;
+  check_xptr_tag<tiledb::CurrentDomain>(cd);
+#if TILEDB_VERSION >= TileDB_Version(2, 25, 0)
+  auto tp = cd->type();
+  auto str = std::string(_tiledb_current_domain_type_to_string(tp));
+  return str;
 #else
-    return std::string();
+  return std::string();
 #endif
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::CurrentDomain> libtiledb_current_domain_set_ndrectangle(XPtr<tiledb::CurrentDomain> cd,
-                                                                     XPtr<tiledb::NDRectangle> ndr) {
-    check_xptr_tag<tiledb::CurrentDomain>(cd);
-    check_xptr_tag<tiledb::NDRectangle>(ndr);
-#if TILEDB_VERSION >= TileDB_Version(2,25,0)
-    cd->set_ndrectangle(*ndr.get());
+XPtr<tiledb::CurrentDomain>
+libtiledb_current_domain_set_ndrectangle(XPtr<tiledb::CurrentDomain> cd,
+                                         XPtr<tiledb::NDRectangle> ndr) {
+  check_xptr_tag<tiledb::CurrentDomain>(cd);
+  check_xptr_tag<tiledb::NDRectangle>(ndr);
+#if TILEDB_VERSION >= TileDB_Version(2, 25, 0)
+  cd->set_ndrectangle(*ndr.get());
 #endif
-    return cd;
+  return cd;
 }
 
 // [[Rcpp::export]]
-XPtr<tiledb::NDRectangle> libtiledb_current_domain_get_ndrectangle(XPtr<tiledb::CurrentDomain> cd) {
-    check_xptr_tag<tiledb::CurrentDomain>(cd);
-#if TILEDB_VERSION >= TileDB_Version(2,25,0)
-    auto nd = new tiledb::NDRectangle(cd->ndrectangle());
+XPtr<tiledb::NDRectangle>
+libtiledb_current_domain_get_ndrectangle(XPtr<tiledb::CurrentDomain> cd) {
+  check_xptr_tag<tiledb::CurrentDomain>(cd);
+#if TILEDB_VERSION >= TileDB_Version(2, 25, 0)
+  auto nd = new tiledb::NDRectangle(cd->ndrectangle());
 #else
-    auto nd = new tiledb::NDRectangle;
+  auto nd = new tiledb::NDRectangle;
 #endif
-    auto ptr = make_xptr<tiledb::NDRectangle>(nd);
-    return ptr;
-
+  auto ptr = make_xptr<tiledb::NDRectangle>(nd);
+  return ptr;
 }
 
 // [[Rcpp::export]]
 bool libtiledb_current_domain_is_empty(XPtr<tiledb::CurrentDomain> cd) {
-    check_xptr_tag<tiledb::CurrentDomain>(cd);
-#if TILEDB_VERSION >= TileDB_Version(2,25,0)
-    return cd->is_empty();
+  check_xptr_tag<tiledb::CurrentDomain>(cd);
+#if TILEDB_VERSION >= TileDB_Version(2, 25, 0)
+  return cd->is_empty();
 #else
-    return false;
+  return false;
 #endif
 }

--- a/src/libtiledb.h
+++ b/src/libtiledb.h
@@ -3,22 +3,22 @@
 //  Copyright (c) 2017-2024 TileDB Inc.
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
-//  of this software and associated documentation files (the "Software"), to deal
-//  in the Software without restriction, including without limitation the rights
-//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-//  copies of the Software, and to permit persons to whom the Software is
+//  of this software and associated documentation files (the "Software"), to
+//  deal in the Software without restriction, including without limitation the
+//  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the Software is
 //  furnished to do so, subject to the following conditions:
 //
-//  The above copyright notice and this permission notice shall be included in all
-//  copies or substantial portions of the Software.
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
 //
 //  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 //  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 //  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 //  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-//  SOFTWARE.
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+//  IN THE SOFTWARE.
 
 #ifndef __libtiledb_h__
 #define __libtiledb_h__
@@ -26,7 +26,8 @@
 // in inst/include so that Rcpp code generation can use the types for glue code
 #include "tiledb.h"
 
-// logging support in RcppSpdlog namespace without making recourse to fmt::format
+// logging support in RcppSpdlog namespace without making recourse to
+// fmt::format
 #include <tinyspdl.h>
 
 // int64 conversion helpers from header package RcppInt64
@@ -52,152 +53,223 @@ Rcpp::CharacterVector tiledb_config_get(Rcpp::XPtr<tiledb::Config> xconfig,
 void tiledb_config_dump(Rcpp::XPtr<tiledb::Config> config);
 
 // Conversion helpers
-//Rcpp::NumericVector makeNanotime(const std::vector<int64_t>& vec);
-//Rcpp::NumericVector makeInteger64(const std::vector<int64_t>& vec);
-//int64_t makeScalarInteger64(const double val);
-//std::vector<int64_t> getInt64Vector(Rcpp::NumericVector vec);
-//bool isInteger64(Rcpp::NumericVector v);
+// Rcpp::NumericVector makeNanotime(const std::vector<int64_t>& vec);
+// Rcpp::NumericVector makeInteger64(const std::vector<int64_t>& vec);
+// int64_t makeScalarInteger64(const double val);
+// std::vector<int64_t> getInt64Vector(Rcpp::NumericVector vec);
+// bool isInteger64(Rcpp::NumericVector v);
 bool is_datetime_column(const tiledb_datatype_t dtype);
 
 // duration helpers
-std::vector<int64_t> dates_to_int64(Rcpp::DateVector dv, tiledb_datatype_t dtype);
+std::vector<int64_t> dates_to_int64(Rcpp::DateVector dv,
+                                    tiledb_datatype_t dtype);
 Rcpp::DateVector int64_to_dates(std::vector<int64_t>, tiledb_datatype_t dtype);
-std::vector<int64_t> datetimes_to_int64(Rcpp::DatetimeVector dv, tiledb_datatype_t dtype);
-Rcpp::DatetimeVector int64_to_datetimes(std::vector<int64_t> iv, tiledb_datatype_t dtype);
-std::vector<int64_t> subnano_to_int64(NumericVector nv, tiledb_datatype_t dtype);
-Rcpp::NumericVector int64_to_subnano(std::vector<int64_t> iv, tiledb_datatype_t dtype);
+std::vector<int64_t> datetimes_to_int64(Rcpp::DatetimeVector dv,
+                                        tiledb_datatype_t dtype);
+Rcpp::DatetimeVector int64_to_datetimes(std::vector<int64_t> iv,
+                                        tiledb_datatype_t dtype);
+std::vector<int64_t> subnano_to_int64(NumericVector nv,
+                                      tiledb_datatype_t dtype);
+Rcpp::NumericVector int64_to_subnano(std::vector<int64_t> iv,
+                                     tiledb_datatype_t dtype);
 
 // nullable helpers
-void getValidityMapFromInteger(Rcpp::IntegerVector & vec, std::vector<uint8_t> & map, int32_t nc);
-void setValidityMapForInteger(Rcpp::IntegerVector & vec, const std::vector<uint8_t> & map, int32_t nc);
-void getValidityMapFromNumeric(Rcpp::NumericVector & vec, std::vector<uint8_t> & map, int32_t nc);
-void setValidityMapForNumeric(Rcpp::NumericVector & vec, const std::vector<uint8_t> & map, int32_t nc);
-void getValidityMapFromInt64(Rcpp::NumericVector & vec, std::vector<uint8_t> & map, int32_t nc);
-void setValidityMapForInt64(std::vector<int64_t> & vec, const std::vector<uint8_t> & map, int32_t nc);
-void getValidityMapFromLogical(Rcpp::LogicalVector & vec, std::vector<uint8_t> & map, int32_t nc);
-void setValidityMapForLogical(Rcpp::LogicalVector & vec, const std::vector<uint8_t> & map, int32_t nc);
+void getValidityMapFromInteger(Rcpp::IntegerVector &vec,
+                               std::vector<uint8_t> &map, int32_t nc);
+void setValidityMapForInteger(Rcpp::IntegerVector &vec,
+                              const std::vector<uint8_t> &map, int32_t nc);
+void getValidityMapFromNumeric(Rcpp::NumericVector &vec,
+                               std::vector<uint8_t> &map, int32_t nc);
+void setValidityMapForNumeric(Rcpp::NumericVector &vec,
+                              const std::vector<uint8_t> &map, int32_t nc);
+void getValidityMapFromInt64(Rcpp::NumericVector &vec,
+                             std::vector<uint8_t> &map, int32_t nc);
+void setValidityMapForInt64(std::vector<int64_t> &vec,
+                            const std::vector<uint8_t> &map, int32_t nc);
+void getValidityMapFromLogical(Rcpp::LogicalVector &vec,
+                               std::vector<uint8_t> &map, int32_t nc);
+void setValidityMapForLogical(Rcpp::LogicalVector &vec,
+                              const std::vector<uint8_t> &map, int32_t nc);
 
 // type and size helper
 tiledb_datatype_t _string_to_tiledb_datatype(std::string typestr);
 
-
 // enum for TileDB XPtr Object type using int32_t payload (for R)
 enum tiledb_xptr_object : int32_t {};
-const tiledb_xptr_object tiledb_xptr_default                     { 0 };
-const tiledb_xptr_object tiledb_xptr_object_array                { 10 };
-const tiledb_xptr_object tiledb_xptr_object_arrayschema          { 20 };
-const tiledb_xptr_object tiledb_xptr_object_arrayschemaevolution { 30 };
-const tiledb_xptr_object tiledb_xptr_object_attribute            { 40 };
-const tiledb_xptr_object tiledb_xptr_object_config               { 50 };
-const tiledb_xptr_object tiledb_xptr_object_context              { 60 };
-const tiledb_xptr_object tiledb_xptr_object_dimension            { 70 };
-const tiledb_xptr_object tiledb_xptr_object_domain               { 80 };
-const tiledb_xptr_object tiledb_xptr_object_filter               { 90 };
-const tiledb_xptr_object tiledb_xptr_object_filterlist           { 100 };
-const tiledb_xptr_object tiledb_xptr_object_fragmentinfo         { 110 };
-const tiledb_xptr_object tiledb_xptr_object_group                { 120 };
-const tiledb_xptr_object tiledb_xptr_object_query                { 130 };
-const tiledb_xptr_object tiledb_xptr_object_querycondition       { 140 };
-const tiledb_xptr_object tiledb_xptr_object_vfs                  { 150 };
-const tiledb_xptr_object tiledb_xptr_vfs_fh_t              		 { 160 };
-const tiledb_xptr_object tiledb_xptr_vlc_buf_t                   { 170 };
-const tiledb_xptr_object tiledb_xptr_vlv_buf_t                   { 180 };
-const tiledb_xptr_object tiledb_xptr_query_buf_t                 { 190 };
-const tiledb_xptr_object tiledb_xptr_object_subarray             { 200 };
-const tiledb_xptr_object tiledb_xptr_column_buffer               { 210 };
-const tiledb_xptr_object tiledb_xptr_array_buffers               { 220 };
-const tiledb_xptr_object tiledb_xptr_map_to_col_buf_t            { 230 };
+const tiledb_xptr_object tiledb_xptr_default{0};
+const tiledb_xptr_object tiledb_xptr_object_array{10};
+const tiledb_xptr_object tiledb_xptr_object_arrayschema{20};
+const tiledb_xptr_object tiledb_xptr_object_arrayschemaevolution{30};
+const tiledb_xptr_object tiledb_xptr_object_attribute{40};
+const tiledb_xptr_object tiledb_xptr_object_config{50};
+const tiledb_xptr_object tiledb_xptr_object_context{60};
+const tiledb_xptr_object tiledb_xptr_object_dimension{70};
+const tiledb_xptr_object tiledb_xptr_object_domain{80};
+const tiledb_xptr_object tiledb_xptr_object_filter{90};
+const tiledb_xptr_object tiledb_xptr_object_filterlist{100};
+const tiledb_xptr_object tiledb_xptr_object_fragmentinfo{110};
+const tiledb_xptr_object tiledb_xptr_object_group{120};
+const tiledb_xptr_object tiledb_xptr_object_query{130};
+const tiledb_xptr_object tiledb_xptr_object_querycondition{140};
+const tiledb_xptr_object tiledb_xptr_object_vfs{150};
+const tiledb_xptr_object tiledb_xptr_vfs_fh_t{160};
+const tiledb_xptr_object tiledb_xptr_vlc_buf_t{170};
+const tiledb_xptr_object tiledb_xptr_vlv_buf_t{180};
+const tiledb_xptr_object tiledb_xptr_query_buf_t{190};
+const tiledb_xptr_object tiledb_xptr_object_subarray{200};
+const tiledb_xptr_object tiledb_xptr_column_buffer{210};
+const tiledb_xptr_object tiledb_xptr_array_buffers{220};
+const tiledb_xptr_object tiledb_xptr_map_to_col_buf_t{230};
 
-// the definitions above are internal to tiledb-r but we need a new value here if we want tag the external pointer
-const tiledb_xptr_object tiledb_arrow_array_t                    { 300 };
-const tiledb_xptr_object tiledb_arrow_schema_t                   { 310 };
+// the definitions above are internal to tiledb-r but we need a new value here
+// if we want tag the external pointer
+const tiledb_xptr_object tiledb_arrow_array_t{300};
+const tiledb_xptr_object tiledb_arrow_schema_t{310};
 
 // templated checkers for external pointer tags
-template <typename T> const int32_t XPtrTagType                            = tiledb_xptr_default; // clang++ wants a value
-template <> inline const int32_t XPtrTagType<tiledb::Array>                = tiledb_xptr_object_array;
-template <> inline const int32_t XPtrTagType<tiledb::ArraySchema>          = tiledb_xptr_object_arrayschema;
-template <> inline const int32_t XPtrTagType<tiledb::ArraySchemaEvolution> = tiledb_xptr_object_arrayschemaevolution;
-template <> inline const int32_t XPtrTagType<tiledb::Attribute>            = tiledb_xptr_object_attribute;
-template <> inline const int32_t XPtrTagType<tiledb::Config>               = tiledb_xptr_object_config;
-template <> inline const int32_t XPtrTagType<tiledb::Context>              = tiledb_xptr_object_context;
-template <> inline const int32_t XPtrTagType<tiledb::Dimension>            = tiledb_xptr_object_dimension;
-template <> inline const int32_t XPtrTagType<tiledb::Domain>               = tiledb_xptr_object_domain;
-template <> inline const int32_t XPtrTagType<tiledb::Filter>               = tiledb_xptr_object_filter;
-template <> inline const int32_t XPtrTagType<tiledb::FilterList>           = tiledb_xptr_object_filterlist;
-template <> inline const int32_t XPtrTagType<tiledb::FragmentInfo>         = tiledb_xptr_object_fragmentinfo;
-template <> inline const int32_t XPtrTagType<tiledb::Group>                = tiledb_xptr_object_group;
-template <> inline const int32_t XPtrTagType<tiledb::Query>                = tiledb_xptr_object_query;
-template <> inline const int32_t XPtrTagType<tiledb::QueryCondition>       = tiledb_xptr_object_querycondition;
-template <> inline const int32_t XPtrTagType<tiledb::VFS>                  = tiledb_xptr_object_vfs;
-template <> inline const int32_t XPtrTagType<vfs_fh_t>                     = tiledb_xptr_vfs_fh_t;
-template <> inline const int32_t XPtrTagType<vlc_buf_t>                    = tiledb_xptr_vlc_buf_t;
-template <> inline const int32_t XPtrTagType<vlv_buf_t>                    = tiledb_xptr_vlv_buf_t;
-template <> inline const int32_t XPtrTagType<query_buf_t>                  = tiledb_xptr_query_buf_t;
-template <> inline const int32_t XPtrTagType<tiledb::Subarray>             = tiledb_xptr_object_subarray;
-template <> inline const int32_t XPtrTagType<tiledb::ColumnBuffer>         = tiledb_xptr_column_buffer;
-template <> inline const int32_t XPtrTagType<tiledb::ArrayBuffers>         = tiledb_xptr_array_buffers;
-template <> inline const int32_t XPtrTagType<map_to_col_buf_t>             = tiledb_xptr_map_to_col_buf_t;
+template <typename T>
+const int32_t XPtrTagType = tiledb_xptr_default; // clang++ wants a value
+template <>
+inline const int32_t XPtrTagType<tiledb::Array> = tiledb_xptr_object_array;
+template <>
+inline const int32_t XPtrTagType<tiledb::ArraySchema> =
+    tiledb_xptr_object_arrayschema;
+template <>
+inline const int32_t XPtrTagType<tiledb::ArraySchemaEvolution> =
+    tiledb_xptr_object_arrayschemaevolution;
+template <>
+inline const int32_t XPtrTagType<tiledb::Attribute> =
+    tiledb_xptr_object_attribute;
+template <>
+inline const int32_t XPtrTagType<tiledb::Config> = tiledb_xptr_object_config;
+template <>
+inline const int32_t XPtrTagType<tiledb::Context> = tiledb_xptr_object_context;
+template <>
+inline const int32_t XPtrTagType<tiledb::Dimension> =
+    tiledb_xptr_object_dimension;
+template <>
+inline const int32_t XPtrTagType<tiledb::Domain> = tiledb_xptr_object_domain;
+template <>
+inline const int32_t XPtrTagType<tiledb::Filter> = tiledb_xptr_object_filter;
+template <>
+inline const int32_t XPtrTagType<tiledb::FilterList> =
+    tiledb_xptr_object_filterlist;
+template <>
+inline const int32_t XPtrTagType<tiledb::FragmentInfo> =
+    tiledb_xptr_object_fragmentinfo;
+template <>
+inline const int32_t XPtrTagType<tiledb::Group> = tiledb_xptr_object_group;
+template <>
+inline const int32_t XPtrTagType<tiledb::Query> = tiledb_xptr_object_query;
+template <>
+inline const int32_t XPtrTagType<tiledb::QueryCondition> =
+    tiledb_xptr_object_querycondition;
+template <>
+inline const int32_t XPtrTagType<tiledb::VFS> = tiledb_xptr_object_vfs;
+template <> inline const int32_t XPtrTagType<vfs_fh_t> = tiledb_xptr_vfs_fh_t;
+template <> inline const int32_t XPtrTagType<vlc_buf_t> = tiledb_xptr_vlc_buf_t;
+template <> inline const int32_t XPtrTagType<vlv_buf_t> = tiledb_xptr_vlv_buf_t;
+template <>
+inline const int32_t XPtrTagType<query_buf_t> = tiledb_xptr_query_buf_t;
+template <>
+inline const int32_t XPtrTagType<tiledb::Subarray> =
+    tiledb_xptr_object_subarray;
+template <>
+inline const int32_t XPtrTagType<tiledb::ColumnBuffer> =
+    tiledb_xptr_column_buffer;
+template <>
+inline const int32_t XPtrTagType<tiledb::ArrayBuffers> =
+    tiledb_xptr_array_buffers;
+template <>
+inline const int32_t XPtrTagType<map_to_col_buf_t> =
+    tiledb_xptr_map_to_col_buf_t;
 
-template <> inline const int32_t XPtrTagType<ArrowArray>             	   = tiledb_arrow_array_t;
-template <> inline const int32_t XPtrTagType<ArrowSchema>             	   = tiledb_arrow_schema_t;
+template <> inline const int32_t XPtrTagType<ArrowArray> = tiledb_arrow_array_t;
+template <>
+inline const int32_t XPtrTagType<ArrowSchema> = tiledb_arrow_schema_t;
 
-constexpr const char* xptrObjToString(tiledb_xptr_object xp) {
-    switch (xp) {
-    case tiledb_xptr_default:                     return "Default";
-    case tiledb_xptr_object_array:                return "Array";
-    case tiledb_xptr_object_arrayschema:          return "ArraySchema";
-    case tiledb_xptr_object_arrayschemaevolution: return "ArraySchemaEvolution";
-    case tiledb_xptr_object_attribute:            return "Attribute";
-    case tiledb_xptr_object_config:               return "Config";
-    case tiledb_xptr_object_context:              return "Context";
-    case tiledb_xptr_object_dimension:            return "Dimension";
-    case tiledb_xptr_object_domain:               return "Domain";
-    case tiledb_xptr_object_filter:               return "Filter";
-    case tiledb_xptr_object_filterlist:           return "FilterList";
-    case tiledb_xptr_object_fragmentinfo:         return "FragmentInfo";
-    case tiledb_xptr_object_group:                return "Group";
-    case tiledb_xptr_object_query:                return "Query";
-    case tiledb_xptr_object_querycondition:       return "QueryCondition";
-    case tiledb_xptr_object_vfs:                  return "VFS";
-    case tiledb_xptr_vfs_fh_t:                    return "vfs_fh_t";
-    case tiledb_xptr_vlc_buf_t:                   return "vlc_buf_t";
-    case tiledb_xptr_vlv_buf_t:                   return "vlv_buf_t";
-    case tiledb_xptr_query_buf_t:                 return "query_buf_t";
-    case tiledb_xptr_object_subarray:             return "Subarray";
-    case tiledb_xptr_column_buffer:               return "ColumnBuffer";
-    case tiledb_xptr_array_buffers:               return "ArrayBuffers";
-    case tiledb_xptr_map_to_col_buf_t:            return "map_to_col_buf_t";
-    case tiledb_arrow_array_t:                    return "ArrowArray";
-    case tiledb_arrow_schema_t:                   return "ArrowSchema";
-    default: Rcpp::stop("Unimplemented case (%d)", xp);
-    }
+constexpr const char *xptrObjToString(tiledb_xptr_object xp) {
+  switch (xp) {
+  case tiledb_xptr_default:
+    return "Default";
+  case tiledb_xptr_object_array:
+    return "Array";
+  case tiledb_xptr_object_arrayschema:
+    return "ArraySchema";
+  case tiledb_xptr_object_arrayschemaevolution:
+    return "ArraySchemaEvolution";
+  case tiledb_xptr_object_attribute:
+    return "Attribute";
+  case tiledb_xptr_object_config:
+    return "Config";
+  case tiledb_xptr_object_context:
+    return "Context";
+  case tiledb_xptr_object_dimension:
+    return "Dimension";
+  case tiledb_xptr_object_domain:
+    return "Domain";
+  case tiledb_xptr_object_filter:
+    return "Filter";
+  case tiledb_xptr_object_filterlist:
+    return "FilterList";
+  case tiledb_xptr_object_fragmentinfo:
+    return "FragmentInfo";
+  case tiledb_xptr_object_group:
+    return "Group";
+  case tiledb_xptr_object_query:
+    return "Query";
+  case tiledb_xptr_object_querycondition:
+    return "QueryCondition";
+  case tiledb_xptr_object_vfs:
+    return "VFS";
+  case tiledb_xptr_vfs_fh_t:
+    return "vfs_fh_t";
+  case tiledb_xptr_vlc_buf_t:
+    return "vlc_buf_t";
+  case tiledb_xptr_vlv_buf_t:
+    return "vlv_buf_t";
+  case tiledb_xptr_query_buf_t:
+    return "query_buf_t";
+  case tiledb_xptr_object_subarray:
+    return "Subarray";
+  case tiledb_xptr_column_buffer:
+    return "ColumnBuffer";
+  case tiledb_xptr_array_buffers:
+    return "ArrayBuffers";
+  case tiledb_xptr_map_to_col_buf_t:
+    return "map_to_col_buf_t";
+  case tiledb_arrow_array_t:
+    return "ArrowArray";
+  case tiledb_arrow_schema_t:
+    return "ArrowSchema";
+  default:
+    Rcpp::stop("Unimplemented case (%d)", xp);
+  }
 }
 
-
-
-template <typename T> XPtr<T> make_xptr(T* p, bool finalize=true) {
-    return XPtr<T>(p, finalize, Rcpp::wrap(XPtrTagType<T>), R_NilValue);
+template <typename T> XPtr<T> make_xptr(T *p, bool finalize = true) {
+  return XPtr<T>(p, finalize, Rcpp::wrap(XPtrTagType<T>), R_NilValue);
 }
 
 template <typename T> XPtr<T> make_xptr(SEXP p) {
-    return XPtr<T>(p); 	// the default XPtr ctor with deleter on and tag and prot nil
+  return XPtr<T>(
+      p); // the default XPtr ctor with deleter on and tag and prot nil
 }
 
-template<typename T> void check_xptr_tag(XPtr<T> ptr) {
-    spdl::trace("[check_xptr_tag]");
-    if (R_ExternalPtrTag(ptr) == R_NilValue) {
-        Rcpp::stop("External pointer without tag, expected tag '%s'\n",
-                   xptrObjToString((tiledb_xptr_object) XPtrTagType<T>) );
+template <typename T> void check_xptr_tag(XPtr<T> ptr) {
+  spdl::trace("[check_xptr_tag]");
+  if (R_ExternalPtrTag(ptr) == R_NilValue) {
+    Rcpp::stop("External pointer without tag, expected tag '%s'\n",
+               xptrObjToString((tiledb_xptr_object)XPtrTagType<T>));
+  }
+  if (R_ExternalPtrTag(ptr) != R_NilValue) {
+    int32_t tag = Rcpp::as<int32_t>(R_ExternalPtrTag(ptr));
+    if (XPtrTagType<T> != tag) {
+      Rcpp::stop("Wrong tag type: expected '%s' but received '%s'\n",
+                 xptrObjToString((tiledb_xptr_object)XPtrTagType<T>),
+                 xptrObjToString((tiledb_xptr_object)tag));
     }
-    if (R_ExternalPtrTag(ptr) != R_NilValue) {
-        int32_t tag = Rcpp::as<int32_t>(R_ExternalPtrTag(ptr));
-        if (XPtrTagType<T> != tag) {
-            Rcpp::stop("Wrong tag type: expected '%s' but received '%s'\n",
-                       xptrObjToString((tiledb_xptr_object) XPtrTagType<T>),
-                       xptrObjToString((tiledb_xptr_object) tag));
-        }
-    }
+  }
 }
-
 
 #endif

--- a/src/nullable.cpp
+++ b/src/nullable.cpp
@@ -3,130 +3,156 @@
 //  Copyright (c) 2021-2023 TileDB Inc.
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
-//  of this software and associated documentation files (the "Software"), to deal
-//  in the Software without restriction, including without limitation the rights
-//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-//  copies of the Software, and to permit persons to whom the Software is
+//  of this software and associated documentation files (the "Software"), to
+//  deal in the Software without restriction, including without limitation the
+//  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the Software is
 //  furnished to do so, subject to the following conditions:
 //
-//  The above copyright notice and this permission notice shall be included in all
-//  copies or substantial portions of the Software.
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
 //
 //  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 //  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 //  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 //  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-//  SOFTWARE.
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+//  IN THE SOFTWARE.
 
 #include "libtiledb.h"
 
-// In principle, the following functions could be templated. In practive it is a little
-// harder as the NA values are not IEEE 754 generic (beyond double)
+// In principle, the following functions could be templated. In practive it is a
+// little harder as the NA values are not IEEE 754 generic (beyond double)
 
-void getValidityMapFromInteger(Rcpp::IntegerVector & vec, std::vector<uint8_t> & map, const int32_t nc) {
-    if (static_cast<size_t>(vec.size()) != nc * map.size())
-        Rcpp::stop("Unequal length between vector (%d) and map * nc (%d) in int getter.", vec.size(), nc * map.size());
+void getValidityMapFromInteger(Rcpp::IntegerVector &vec,
+                               std::vector<uint8_t> &map, const int32_t nc) {
+  if (static_cast<size_t>(vec.size()) != nc * map.size())
+    Rcpp::stop(
+        "Unequal length between vector (%d) and map * nc (%d) in int getter.",
+        vec.size(), nc * map.size());
 
-    for (auto i=0; i < vec.size(); i += nc) {
-        uint8_t m = 1;  // default to no NA/NaN
-        for (auto j=0; j<nc && m==1; j++) {
-            if (vec[i + j] == R_NaInt) {
-                m = 0;
-            }
-        }
-        map[i / nc] = m;
+  for (auto i = 0; i < vec.size(); i += nc) {
+    uint8_t m = 1; // default to no NA/NaN
+    for (auto j = 0; j < nc && m == 1; j++) {
+      if (vec[i + j] == R_NaInt) {
+        m = 0;
+      }
     }
+    map[i / nc] = m;
+  }
 }
 
-void setValidityMapForInteger(Rcpp::IntegerVector & vec, const std::vector<uint8_t> & map, const int32_t nc) {
-    if (static_cast<size_t>(vec.size()) != nc * map.size())
-        Rcpp::stop("Unequal length between vector (%d) and map * nc (%d) in int setter.", vec.size(), nc * map.size());
+void setValidityMapForInteger(Rcpp::IntegerVector &vec,
+                              const std::vector<uint8_t> &map,
+                              const int32_t nc) {
+  if (static_cast<size_t>(vec.size()) != nc * map.size())
+    Rcpp::stop(
+        "Unequal length between vector (%d) and map * nc (%d) in int setter.",
+        vec.size(), nc * map.size());
 
-    for (auto i=0; i < vec.size(); i++)
-        if (map[i/nc] == 0)
-            vec[i] = R_NaInt;
+  for (auto i = 0; i < vec.size(); i++)
+    if (map[i / nc] == 0)
+      vec[i] = R_NaInt;
 }
 
-void getValidityMapFromNumeric(Rcpp::NumericVector & vec, std::vector<uint8_t> & map, const int32_t nc) {
-    if (static_cast<size_t>(vec.size()) != nc * map.size())
-        Rcpp::stop("Unequal length between vector (%d) and map * nc (%d) in numeric getter.", vec.size(), nc * map.size());
+void getValidityMapFromNumeric(Rcpp::NumericVector &vec,
+                               std::vector<uint8_t> &map, const int32_t nc) {
+  if (static_cast<size_t>(vec.size()) != nc * map.size())
+    Rcpp::stop("Unequal length between vector (%d) and map * nc (%d) in "
+               "numeric getter.",
+               vec.size(), nc * map.size());
 
-    for (auto i=0; i < vec.size(); i += nc) {
-        uint8_t m = 1;  // default to no NA/NaN
-        for (auto j=0; j<nc && m==1; j++) {
-            // see R_ext/Arith.h: true for both NA and NaN
-            if (R_isnancpp(vec[i + j])) {
-                m = 0;
-            }
-        }
-        map[i / nc] = m;
-        //Rprintf("getMap (%d) vec %f map %d\n", i, vec[i], map[i/nc]);
+  for (auto i = 0; i < vec.size(); i += nc) {
+    uint8_t m = 1; // default to no NA/NaN
+    for (auto j = 0; j < nc && m == 1; j++) {
+      // see R_ext/Arith.h: true for both NA and NaN
+      if (R_isnancpp(vec[i + j])) {
+        m = 0;
+      }
     }
+    map[i / nc] = m;
+    // Rprintf("getMap (%d) vec %f map %d\n", i, vec[i], map[i/nc]);
+  }
 }
 
-void setValidityMapForNumeric(Rcpp::NumericVector & vec, const std::vector<uint8_t> & map, const int32_t nc) {
-    if (static_cast<size_t>(vec.size()) != nc * map.size())
-        Rcpp::stop("Unequal length between vector (%d) and map * nc (%d) in numeric setter.", vec.size(), nc * map.size());
+void setValidityMapForNumeric(Rcpp::NumericVector &vec,
+                              const std::vector<uint8_t> &map,
+                              const int32_t nc) {
+  if (static_cast<size_t>(vec.size()) != nc * map.size())
+    Rcpp::stop("Unequal length between vector (%d) and map * nc (%d) in "
+               "numeric setter.",
+               vec.size(), nc * map.size());
 
-    for (auto i=0; i < vec.size(); i++) {
-        if (map[i/nc] == 0)
-            vec[i] = R_NaReal;
-        //Rprintf("setMap (%d) vec %f map %d\n", i, vec[i], map[i/nc]);
-    }
+  for (auto i = 0; i < vec.size(); i++) {
+    if (map[i / nc] == 0)
+      vec[i] = R_NaReal;
+    // Rprintf("setMap (%d) vec %f map %d\n", i, vec[i], map[i/nc]);
+  }
 }
 
 // as defined in the bit64 package file integer64.h
 #define NA_INTEGER64 LLONG_MIN
-#define ISNA_INTEGER64(X)((X)==NA_INTEGER64)
+#define ISNA_INTEGER64(X) ((X) == NA_INTEGER64)
 
-void getValidityMapFromInt64(Rcpp::NumericVector & vec, std::vector<uint8_t> & map, const int32_t nc) {
-    if (static_cast<size_t>(vec.size()) != nc * map.size())
-        Rcpp::stop("Unequal length between vector (%d) and map * nc (%d) in int64 getter.", vec.size(), nc * map.size());
+void getValidityMapFromInt64(Rcpp::NumericVector &vec,
+                             std::vector<uint8_t> &map, const int32_t nc) {
+  if (static_cast<size_t>(vec.size()) != nc * map.size())
+    Rcpp::stop(
+        "Unequal length between vector (%d) and map * nc (%d) in int64 getter.",
+        vec.size(), nc * map.size());
 
-    std::vector<int64_t> ivec = fromInteger64(vec);
+  std::vector<int64_t> ivec = fromInteger64(vec);
 
-    for (auto i=0; i < vec.size(); i += nc) {
-        uint8_t m = 1;  // default to no NA/NaN
-        for (auto j=0; j<nc && m==1; j++) {
-            if (ISNA_INTEGER64(ivec[i + j])) {
-                m = 0;
-            }
-        }
-        map[i / nc] = m;
+  for (auto i = 0; i < vec.size(); i += nc) {
+    uint8_t m = 1; // default to no NA/NaN
+    for (auto j = 0; j < nc && m == 1; j++) {
+      if (ISNA_INTEGER64(ivec[i + j])) {
+        m = 0;
+      }
     }
+    map[i / nc] = m;
+  }
 }
 
-void setValidityMapForInt64(std::vector<int64_t> & vec, const std::vector<uint8_t> & map, const int32_t nc) {
-    if (static_cast<size_t>(vec.size()) != nc * map.size())
-        Rcpp::stop("Unequal length between vector (%d) and map * nc (%d) in int64 setter.", vec.size(), nc * map.size());
+void setValidityMapForInt64(std::vector<int64_t> &vec,
+                            const std::vector<uint8_t> &map, const int32_t nc) {
+  if (static_cast<size_t>(vec.size()) != nc * map.size())
+    Rcpp::stop(
+        "Unequal length between vector (%d) and map * nc (%d) in int64 setter.",
+        vec.size(), nc * map.size());
 
-    for (size_t i=0; i < vec.size(); i++)
-        if (map[i/nc] == 0)
-            vec[i] = NA_INTEGER64;
+  for (size_t i = 0; i < vec.size(); i++)
+    if (map[i / nc] == 0)
+      vec[i] = NA_INTEGER64;
 }
 
-void getValidityMapFromLogical(Rcpp::LogicalVector & vec, std::vector<uint8_t> & map, const int32_t nc) {
-    if (static_cast<size_t>(vec.size()) != nc * map.size())
-        Rcpp::stop("Unequal length between vector (%d) and map * nc (%d) in int getter.", vec.size(), nc * map.size());
+void getValidityMapFromLogical(Rcpp::LogicalVector &vec,
+                               std::vector<uint8_t> &map, const int32_t nc) {
+  if (static_cast<size_t>(vec.size()) != nc * map.size())
+    Rcpp::stop(
+        "Unequal length between vector (%d) and map * nc (%d) in int getter.",
+        vec.size(), nc * map.size());
 
-    for (auto i=0; i < vec.size(); i += nc) {
-        uint8_t m = 1;  // default to no NA/NaN
-        for (auto j=0; j<nc && m==1; j++) {
-            if (vec[i + j] == NA_LOGICAL) {
-                m = 0;
-            }
-        }
-        map[i / nc] = m;
+  for (auto i = 0; i < vec.size(); i += nc) {
+    uint8_t m = 1; // default to no NA/NaN
+    for (auto j = 0; j < nc && m == 1; j++) {
+      if (vec[i + j] == NA_LOGICAL) {
+        m = 0;
+      }
     }
+    map[i / nc] = m;
+  }
 }
 
-void setValidityMapForLogical(Rcpp::LogicalVector & vec, const std::vector<uint8_t> & map, const int32_t nc) {
-    if (static_cast<size_t>(vec.size()) != nc * map.size())
-        Rcpp::stop("Unequal length between vector (%d) and map (%d) in int setter.", vec.size(), nc * map.size());
+void setValidityMapForLogical(Rcpp::LogicalVector &vec,
+                              const std::vector<uint8_t> &map,
+                              const int32_t nc) {
+  if (static_cast<size_t>(vec.size()) != nc * map.size())
+    Rcpp::stop("Unequal length between vector (%d) and map (%d) in int setter.",
+               vec.size(), nc * map.size());
 
-    for (auto i=0; i < vec.size(); i++)
-        if (map[i/nc] == 0)
-            vec[i] = NA_LOGICAL;
+  for (auto i = 0; i < vec.size(); i++)
+    if (map[i / nc] == 0)
+      vec[i] = NA_LOGICAL;
 }

--- a/src/shmem.cpp
+++ b/src/shmem.cpp
@@ -3,29 +3,30 @@
 //  Copyright (c) 2021-2023 TileDB Inc.
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
-//  of this software and associated documentation files (the "Software"), to deal
-//  in the Software without restriction, including without limitation the rights
-//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-//  copies of the Software, and to permit persons to whom the Software is
+//  of this software and associated documentation files (the "Software"), to
+//  deal in the Software without restriction, including without limitation the
+//  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the Software is
 //  furnished to do so, subject to the following conditions:
 //
-//  The above copyright notice and this permission notice shall be included in all
-//  copies or substantial portions of the Software.
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
 //
 //  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 //  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 //  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 //  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-//  SOFTWARE.
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+//  IN THE SOFTWARE.
 
-// The functions in this file are of less general use or interest as they rely on the
-// 'handshakes' from the TileDB Cloud backend, which is not published as open source.
-// They simply constitute an alternate mechanism of filling result data structures taking
-// advantage of an auxiliary parallel query tp TileDB Embedded (that is done solely for
-// performance reasons in the context of TileDB Cloud). They are also made conditional
-// on building on Linux as the shared memory inter-process communication is only use there.
+// The functions in this file are of less general use or interest as they rely
+// on the 'handshakes' from the TileDB Cloud backend, which is not published as
+// open source. They simply constitute an alternate mechanism of filling result
+// data structures taking advantage of an auxiliary parallel query tp TileDB
+// Embedded (that is done solely for performance reasons in the context of
+// TileDB Cloud). They are also made conditional on building on Linux as the
+// shared memory inter-process communication is only use there.
 
 #include "libtiledb.h"
 #include "tiledb_version.h"
@@ -42,171 +43,206 @@
 
 #ifdef __CAN_COMPILE_SHMEN__
 
-#include <sys/types.h>
-#include <sys/mman.h>
-#include <sys/stat.h>
 #include <fcntl.h>
-#include <unistd.h>
 #include <filesystem>
 #include <regex>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
 
 static const bool debug = false;
 
 static std::string _datafile(const std::string dir, const std::string name) {
-    std::string path = std::string("/dev/shm/") + dir + std::string("/buffers/data/");
-    if (!std::filesystem::is_directory(path)) std::filesystem::create_directories(path);
-    return path + name;
+  std::string path =
+      std::string("/dev/shm/") + dir + std::string("/buffers/data/");
+  if (!std::filesystem::is_directory(path))
+    std::filesystem::create_directories(path);
+  return path + name;
 }
 
 static std::string _offsetsfile(const std::string dir, const std::string name) {
-    std::string path = std::string("/dev/shm/") + dir + std::string("/buffers/offsets/");
-    if (!std::filesystem::is_directory(path)) std::filesystem::create_directories(path);
-    return path + name;
+  std::string path =
+      std::string("/dev/shm/") + dir + std::string("/buffers/offsets/");
+  if (!std::filesystem::is_directory(path))
+    std::filesystem::create_directories(path);
+  return path + name;
 }
 
-static std::string _validityfile(const std::string dir, const std::string name) {
-    std::string path = std::string("/dev/shm/") + dir + std::string("/buffers/validity/");
-    if (!std::filesystem::is_directory(path)) std::filesystem::create_directories(path);
-    return path + name;
+static std::string _validityfile(const std::string dir,
+                                 const std::string name) {
+  std::string path =
+      std::string("/dev/shm/") + dir + std::string("/buffers/validity/");
+  if (!std::filesystem::is_directory(path))
+    std::filesystem::create_directories(path);
+  return path + name;
 }
 
-void write_buffer(std::string bufferpath, int numelem, int elemsize, void *data_ptr) {
-    if (debug) Rcpp::Rcout << "Writing " << bufferpath << " ";
-    int mode = S_IRWXU | S_IRWXG | S_IRWXO;
-    int fd = open(bufferpath.c_str(), O_RDWR | O_CREAT | O_TRUNC, mode);
-    int bytes = numelem * elemsize;
-    void *dest = mmap(NULL,      				// kernel picks address
-                      bytes,  	 		   		// length
-                      PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
-    lseek (fd, bytes-1, SEEK_SET); 				// seek to n, write an empty char to allocate block, then memcpy in
-    if (write (fd, "", 1) != 1) Rcpp::stop("write error");
-    memcpy (dest, data_ptr, bytes);
-    close(fd);
-    if (debug) Rcpp::Rcout << " ... done\n";
+void write_buffer(std::string bufferpath, int numelem, int elemsize,
+                  void *data_ptr) {
+  if (debug)
+    Rcpp::Rcout << "Writing " << bufferpath << " ";
+  int mode = S_IRWXU | S_IRWXG | S_IRWXO;
+  int fd = open(bufferpath.c_str(), O_RDWR | O_CREAT | O_TRUNC, mode);
+  int bytes = numelem * elemsize;
+  void *dest = mmap(NULL,  // kernel picks address
+                    bytes, // length
+                    PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+  lseek(fd, bytes - 1, SEEK_SET); // seek to n, write an empty char to allocate
+                                  // block, then memcpy in
+  if (write(fd, "", 1) != 1)
+    Rcpp::stop("write error");
+  memcpy(dest, data_ptr, bytes);
+  close(fd);
+  if (debug)
+    Rcpp::Rcout << " ... done\n";
 }
 
 template <class T>
-void read_buffer(std::string bufferpath, std::vector<T> & vec) {
-    // // open shared memory region, and set up mmap
-    int fd = open(bufferpath.c_str(), O_RDONLY);
-    if (fd < 0) Rcpp::stop("Cannot open %s for reading", bufferpath.c_str());
-    struct stat statbuf;
-    if (fstat(fd,&statbuf) < 0) Rcpp::stop("Cannot fstat %s", bufferpath.c_str());
-    int sz = statbuf.st_size;
-    void *src = mmap (0, sz, PROT_READ, MAP_SHARED, fd, 0);
-    if (src == (caddr_t) -1) Rcpp::stop("mmap error");
+void read_buffer(std::string bufferpath, std::vector<T> &vec) {
+  // // open shared memory region, and set up mmap
+  int fd = open(bufferpath.c_str(), O_RDONLY);
+  if (fd < 0)
+    Rcpp::stop("Cannot open %s for reading", bufferpath.c_str());
+  struct stat statbuf;
+  if (fstat(fd, &statbuf) < 0)
+    Rcpp::stop("Cannot fstat %s", bufferpath.c_str());
+  int sz = statbuf.st_size;
+  void *src = mmap(0, sz, PROT_READ, MAP_SHARED, fd, 0);
+  if (src == (caddr_t)-1)
+    Rcpp::stop("mmap error");
 
-    vec.resize(sz / sizeof(T));
-    memcpy(vec.data(), src, sz);
-    close(fd);
+  vec.resize(sz / sizeof(T));
+  memcpy(vec.data(), src, sz);
+  close(fd);
 }
 
-void read_string(std::string bufferpath, std::string & str) {
-    // // open shared memory region, and set up mmap
-    int fd = open(bufferpath.c_str(), O_RDONLY);
-    if (fd < 0) Rcpp::stop("Cannot open %s for reading", bufferpath.c_str());
-    struct stat statbuf;
-    if (fstat(fd,&statbuf) < 0) Rcpp::stop("Cannot fstat %s", bufferpath.c_str());
-    int sz = statbuf.st_size;
-    void *src = mmap (0, sz, PROT_READ, MAP_SHARED, fd, 0);
-    if (src == (caddr_t) -1) Rcpp::stop("mmap error");
+void read_string(std::string bufferpath, std::string &str) {
+  // // open shared memory region, and set up mmap
+  int fd = open(bufferpath.c_str(), O_RDONLY);
+  if (fd < 0)
+    Rcpp::stop("Cannot open %s for reading", bufferpath.c_str());
+  struct stat statbuf;
+  if (fstat(fd, &statbuf) < 0)
+    Rcpp::stop("Cannot fstat %s", bufferpath.c_str());
+  int sz = statbuf.st_size;
+  void *src = mmap(0, sz, PROT_READ, MAP_SHARED, fd, 0);
+  if (src == (caddr_t)-1)
+    Rcpp::stop("mmap error");
 
-    str.resize(sz);
-    memcpy(str.data(), src, sz);
-    close(fd);
+  str.resize(sz);
+  memcpy(str.data(), src, sz);
+  close(fd);
 }
 
 #endif
 
 // [[Rcpp::export]]
-void vecbuf_to_shmem(std::string dir, std::string name, XPtr<query_buf_t> buf, int sz, int numvar) {
+void vecbuf_to_shmem(std::string dir, std::string name, XPtr<query_buf_t> buf,
+                     int sz, int numvar) {
 #ifdef __CAN_COMPILE_SHMEN__
-    check_xptr_tag<query_buf_t>(buf);
-    std::string bufferpath = _datafile(dir, name);
-    write_buffer(bufferpath, sz, buf->size, buf->vec.data());
-    if (buf->nullable) {
-        std::string validitypath = _validityfile(dir, name);
-        write_buffer(validitypath, numvar, sizeof(uint8_t), buf->validity_map.data());
-    }
+  check_xptr_tag<query_buf_t>(buf);
+  std::string bufferpath = _datafile(dir, name);
+  write_buffer(bufferpath, sz, buf->size, buf->vec.data());
+  if (buf->nullable) {
+    std::string validitypath = _validityfile(dir, name);
+    write_buffer(validitypath, numvar, sizeof(uint8_t),
+                 buf->validity_map.data());
+  }
 #endif
 }
 
 // [[Rcpp::export]]
-void vlcbuf_to_shmem(std::string dir, std::string name, XPtr<vlc_buf_t> buf, IntegerVector vec) {
+void vlcbuf_to_shmem(std::string dir, std::string name, XPtr<vlc_buf_t> buf,
+                     IntegerVector vec) {
 #ifdef __CAN_COMPILE_SHMEN__
-    check_xptr_tag<vlc_buf_t>(buf);
-    std::string bufferpath = _datafile(dir, name);
-    write_buffer(bufferpath, std::strlen(buf->str.c_str()), 1L, (void*)buf->str.c_str());
+  check_xptr_tag<vlc_buf_t>(buf);
+  std::string bufferpath = _datafile(dir, name);
+  write_buffer(bufferpath, std::strlen(buf->str.c_str()), 1L,
+               (void *)buf->str.c_str());
 
-    bufferpath = _offsetsfile(dir, name);
-    write_buffer(bufferpath, vec[0], sizeof(uint64_t), buf->offsets.data());
+  bufferpath = _offsetsfile(dir, name);
+  write_buffer(bufferpath, vec[0], sizeof(uint64_t), buf->offsets.data());
 
-    if (buf->nullable) {
-        std::string validitypath = _validityfile(dir, name);
-        write_buffer(validitypath, vec[0], sizeof(uint8_t), buf->validity_map.data());
-    }
+  if (buf->nullable) {
+    std::string validitypath = _validityfile(dir, name);
+    write_buffer(validitypath, vec[0], sizeof(uint8_t),
+                 buf->validity_map.data());
+  }
 #endif
 }
 
 // [[Rcpp::export]]
 XPtr<query_buf_t> querybuf_from_shmem(std::string path, std::string dtype) {
 #ifdef __CAN_COMPILE_SHMEN__
-    // allocate buffer, then set up buffer
-    XPtr<query_buf_t> buf = make_xptr<query_buf_t>(new query_buf_t);
-    buf->dtype = _string_to_tiledb_datatype(dtype);
-    buf->size = static_cast<int32_t>(tiledb_datatype_size(_string_to_tiledb_datatype(dtype)));
-    buf->nullable = false; // default, overriden if buffer in validity path seen
-    buf->numvar = 1;       // gets overridden with validity_map size ratio to vec size
-    read_buffer<int8_t>(path, buf->vec);
-    buf->ncells = buf->vec.size() / buf->size;
-    if (debug) Rcpp::Rcout << path << " " << " dtype " << dtype << " sizeof:" << buf->size
-                           << " ncells:" << buf->ncells << " vecsize:" << buf->size * buf->ncells;
+  // allocate buffer, then set up buffer
+  XPtr<query_buf_t> buf = make_xptr<query_buf_t>(new query_buf_t);
+  buf->dtype = _string_to_tiledb_datatype(dtype);
+  buf->size = static_cast<int32_t>(
+      tiledb_datatype_size(_string_to_tiledb_datatype(dtype)));
+  buf->nullable = false; // default, overriden if buffer in validity path seen
+  buf->numvar = 1; // gets overridden with validity_map size ratio to vec size
+  read_buffer<int8_t>(path, buf->vec);
+  buf->ncells = buf->vec.size() / buf->size;
+  if (debug)
+    Rcpp::Rcout << path << " "
+                << " dtype " << dtype << " sizeof:" << buf->size
+                << " ncells:" << buf->ncells
+                << " vecsize:" << buf->size * buf->ncells;
 
-    std::string validitypath = std::regex_replace(path, std::regex("/data/"), "/validity/");
-    if (std::filesystem::is_regular_file(validitypath)) {
-        if (debug) Rcpp::Rcout << " seeing " << validitypath;
-        read_buffer<uint8_t>(validitypath, buf->validity_map);
-        buf->nullable = true;
-        buf->numvar = buf->ncells / buf->validity_map.size();
-    }
-    if (debug) Rcpp::Rcout << std::endl;
-    return buf;
+  std::string validitypath =
+      std::regex_replace(path, std::regex("/data/"), "/validity/");
+  if (std::filesystem::is_regular_file(validitypath)) {
+    if (debug)
+      Rcpp::Rcout << " seeing " << validitypath;
+    read_buffer<uint8_t>(validitypath, buf->validity_map);
+    buf->nullable = true;
+    buf->numvar = buf->ncells / buf->validity_map.size();
+  }
+  if (debug)
+    Rcpp::Rcout << std::endl;
+  return buf;
 #else
-    Rcpp::stop("This function is only available under (recent enough) Linux.");
-    // not reached
-    XPtr<query_buf_t> buf = make_xptr<query_buf_t>(new query_buf_t);
-    return buf;
+  Rcpp::stop("This function is only available under (recent enough) Linux.");
+  // not reached
+  XPtr<query_buf_t> buf = make_xptr<query_buf_t>(new query_buf_t);
+  return buf;
 #endif
 }
 
 // [[Rcpp::export]]
 XPtr<vlc_buf_t> vlcbuf_from_shmem(std::string datapath, std::string dtype) {
 #ifdef __CAN_COMPILE_SHMEN__
-    // allocate buffer, then set up buffer
-    XPtr<vlc_buf_t> buf = make_xptr<vlc_buf_t>(new vlc_buf_t);
-    read_string(datapath, buf->str);
-    std::string offsetspath = std::regex_replace(datapath, std::regex("/data/"), "/offsets/");
-    read_buffer<uint64_t>(offsetspath, buf->offsets);
-    buf->rows = buf->offsets.size();
-    buf->cols = 2;              // value not used
-    buf->nullable = false;      // default, overridden below if validity path used
-    buf->legacy_validity = false; // may need to open door to config option here too
-    if (debug) Rcpp::Rcout << datapath << " " << offsetspath
-                           << " data:" << buf->str.size()
-                           << " offsets:" << buf->offsets.size();
+  // allocate buffer, then set up buffer
+  XPtr<vlc_buf_t> buf = make_xptr<vlc_buf_t>(new vlc_buf_t);
+  read_string(datapath, buf->str);
+  std::string offsetspath =
+      std::regex_replace(datapath, std::regex("/data/"), "/offsets/");
+  read_buffer<uint64_t>(offsetspath, buf->offsets);
+  buf->rows = buf->offsets.size();
+  buf->cols = 2;         // value not used
+  buf->nullable = false; // default, overridden below if validity path used
+  buf->legacy_validity =
+      false; // may need to open door to config option here too
+  if (debug)
+    Rcpp::Rcout << datapath << " " << offsetspath << " data:" << buf->str.size()
+                << " offsets:" << buf->offsets.size();
 
-    std::string validitypath = std::regex_replace(datapath, std::regex("/data/"), "/validity/");
-    if (std::filesystem::is_regular_file(validitypath)) {
-        if (debug) Rcpp::Rcout << " validity: " << validitypath;
-        read_buffer<uint8_t>(validitypath, buf->validity_map);
-        buf->nullable = true;
-    }
-    if (debug) Rcpp::Rcout << std::endl;
-    return buf;
+  std::string validitypath =
+      std::regex_replace(datapath, std::regex("/data/"), "/validity/");
+  if (std::filesystem::is_regular_file(validitypath)) {
+    if (debug)
+      Rcpp::Rcout << " validity: " << validitypath;
+    read_buffer<uint8_t>(validitypath, buf->validity_map);
+    buf->nullable = true;
+  }
+  if (debug)
+    Rcpp::Rcout << std::endl;
+  return buf;
 #else
-    Rcpp::stop("This function is only available under (recent enough) Linux.");
-    // not reached
-    XPtr<vlc_buf_t> buf = make_xptr<vlc_buf_t>(new vlc_buf_t);
-    return buf;
+  Rcpp::stop("This function is only available under (recent enough) Linux.");
+  // not reached
+  XPtr<vlc_buf_t> buf = make_xptr<vlc_buf_t>(new vlc_buf_t);
+  return buf;
 #endif
 }

--- a/src/tiledb_arrowio.h
+++ b/src/tiledb_arrowio.h
@@ -55,7 +55,7 @@ class ArrowExporter;
 class ArrowAdapter {
 public:
   /* Constructs an ArrowAdapter wrapping the given TileDB C++ Query */
-  ArrowAdapter(Context* ctx, Query* query);
+  ArrowAdapter(Context *ctx, Query *query);
   ~ArrowAdapter();
 
   /**
@@ -67,7 +67,7 @@ public:
    * @param arrow_schema Pointer to pre-allocated ArrowSchema struct
    * @throws tiledb::TileDBError with error-specific message.
    */
-  void export_buffer(const char* name, void* arrow_array, void* arrow_schema);
+  void export_buffer(const char *name, void *arrow_array, void *arrow_schema);
 
   /**
    * Set named Query buffer from ArrowArray/ArrowSchema struct pair
@@ -79,14 +79,14 @@ public:
    * @param arrow_schema Pointer to pre-allocated ArrowSchema struct
    * @throws tiledb::TileDBError with error-specific message.
    */
-  void import_buffer(const char* name, void* arrow_array, void* arrow_schema);
+  void import_buffer(const char *name, void *arrow_array, void *arrow_schema);
 
 private:
-  ArrowImporter* importer_;
-  ArrowExporter* exporter_;
+  ArrowImporter *importer_;
+  ArrowExporter *exporter_;
 };
 
-}  // end namespace arrow
-}  // end namespace tiledb
+} // end namespace arrow
+} // end namespace tiledb
 
 #include "updated_arrow_io_impl.h"

--- a/src/virtualfile.cpp
+++ b/src/virtualfile.cpp
@@ -2,35 +2,36 @@
 // This file borrows, with acknowledgements, from the MIT-licensed code in the
 // repository at https://github.com/coolbutuseless/rconnection and adapts it (in
 // a slightly simplified version) to TileDB. It also uses the approach employed
-// in the also MIT-licensed repository https://github.com/r-lib/archive to deploy
-// a connection from within R without triggering a warning from package checks.
+// in the also MIT-licensed repository https://github.com/r-lib/archive to
+// deploy a connection from within R without triggering a warning from package
+// checks.
 
-#include <Rcpp/Lighter>         				// for Rcpp
-#include <tinyspdl.h>                           // for spdl logging
-#include "connection/connection.h"              // for connections
+#include "connection/connection.h" // for connections
 #include "tiledb.h"
+#include <Rcpp/Lighter> // for Rcpp
+#include <tinyspdl.h>   // for spdl logging
 
 extern "C" SEXP vfile_c_impl_(SEXP, SEXP, SEXP);
-
 //' Create a custom file connection
 //'
 //' @details
-//' This \code{vfs_file()} connection works like the \code{file()} connection in R itself.
+//' This \code{vfs_file()} connection works like the \code{file()} connection
+//' in R itself.
 //'
 //' This connection works with both ASCII and binary data, e.g. using
 //' \code{readLines()} and \code{readBin()}.
 //'
-//' @param description path to a filename; contrary to \code{rconnection} a connection
-//' object is not supported.
-//' @param mode character string. A description of how to open the connection if
-//' it is to be opened upon creation e.g. "rb". Default "" (empty string) means
-//' to not open the connection on creation - user must still call \code{open()}.
-//' Note: If an "open" string is provided, the user must still call \code{close()}
-//' otherwise the contents of the file aren't completely flushed until the
-//' connection is garbage collected.
+//' @param description path to a filename; contrary to \code{rconnection} a
+//' connection object is not supported.
+//' @param mode character string. A description of how to open the connection
+//' if it is to be opened upon creation e.g. "rb". Default "" (empty string)
+//' means to not open the connection on creation - user must still call
+//' \code{open()}.  Note: If an "open" string is provided, the user must still
+//' call \code{close()} otherwise the contents of the file aren't completely
+//' flushed until the connection is garbage collected.
 //' @param verbosity integer value 0, 1, or 2. Default: 0.
-//' Set to \code{0} for no debugging messages, \code{1} for some high-level messages
-//' and \code{verbosity = 2} for all debugging messages.
+//' Set to \code{0} for no debugging messages, \code{1} for some high-level
+//' messages and \code{verbosity = 2} for all debugging messages.
 //'
 //' @export
 //'
@@ -42,9 +43,11 @@ extern "C" SEXP vfile_c_impl_(SEXP, SEXP, SEXP);
 //' readBin(vfs_file(tmp),  raw(), 1000)
 //' }
 // [[Rcpp::export]]
-SEXP vfs_file(std::string description, std::string mode = "", int verbosity = 0) {
-    spdl::debug("[vfile_] entered");
-    return vfile_c_impl_(Rcpp::wrap(description), Rcpp::wrap(mode), Rcpp::wrap(verbosity));
+SEXP vfs_file(std::string description, std::string mode = "",
+              int verbosity = 0) {
+  spdl::debug("[vfile_] entered");
+  return vfile_c_impl_(Rcpp::wrap(description), Rcpp::wrap(mode),
+                       Rcpp::wrap(verbosity));
 }
 
 extern "C" {
@@ -55,15 +58,15 @@ extern "C" {
 //     passed to each callback function
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 typedef struct {
-    Rboolean is_file;  // Is this a file or a connection we're writing to?
-    FILE *fp;          // FilePointer if accessing a file
-    Rconnection inner; // inner connection if accessing a connection
-    int verbosity;     // For debugging!
-    tiledb::Context *ctx;
-    tiledb::VFS *vfs;
-    char* uri;
-    std::vector<std::byte> buf;
-    size_t nread;
+  Rboolean is_file;  // Is this a file or a connection we're writing to?
+  FILE *fp;          // FilePointer if accessing a file
+  Rconnection inner; // inner connection if accessing a connection
+  int verbosity;     // For debugging!
+  tiledb::Context *ctx;
+  tiledb::VFS *vfs;
+  char *uri;
+  std::vector<std::byte> buf;
+  size_t nread;
 } vfile_state;
 
 Rboolean vfile_open(struct Rconn *rconn);
@@ -75,144 +78,146 @@ void vfile_truncate(struct Rconn *rconn);
 int vfile_fflush(struct Rconn *rconn);
 size_t vfile_read(void *dst, size_t size, size_t nitems, struct Rconn *rconn);
 int vfile_fgetc(struct Rconn *rconn);
-size_t vfile_write(const void *src, size_t size, size_t nitems, struct Rconn *rconn);
-int vfile_vfprintf(struct Rconn *rconn, const char* fmt, va_list ap);
+size_t vfile_write(const void *src, size_t size, size_t nitems,
+                   struct Rconn *rconn);
+int vfile_vfprintf(struct Rconn *rconn, const char *fmt, va_list ap);
 
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // Initialize a vfile() R connection object to return to the user
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 SEXP vfile_c_impl_(SEXP description_, SEXP mode_, SEXP verbosity_) {
 
-    spdl::debug("[vfile_c_impl_] entered");
-    //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    // Initialize User State
-    //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    vfile_state *vstate = (vfile_state *)calloc(1, sizeof(vfile_state));
-    vstate->ctx = new tiledb::Context();
-    vstate->vfs = new tiledb::VFS(*vstate->ctx);
-    vstate->verbosity = Rf_asInteger(verbosity_);
+  spdl::debug("[vfile_c_impl_] entered");
+  //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  // Initialize User State
+  //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  vfile_state *vstate = (vfile_state *)calloc(1, sizeof(vfile_state));
+  vstate->ctx = new tiledb::Context();
+  vstate->vfs = new tiledb::VFS(*vstate->ctx);
+  vstate->verbosity = Rf_asInteger(verbosity_);
 
-    //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    // Set information regarding file vs connection handling
-    //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    char *description;
-    if (TYPEOF(description_) == STRSXP) {
-        vstate->is_file = TRUE;
-        description = (char *)CHAR(STRING_ELT(description_, 0));
-        spdl::debug(tfm::format("[vfile_c_impl_] file %s", description));
-        vstate->uri = description;
-    } else {
-        /* vstate->is_file = FALSE; */
-        /* description = "vfile(connection)"; */
-        /* vstate->inner = R_GetConnection(description_); */
-        /* if (vstate->inner->isopen) { */
-        /*   error("vfile_(): inner connection must not already be open"); */
-        /* } */
-        /* // Ensure we start with EOF not set, as this is not zeroed in all cases */
-        /* // within R/connections.c */
-        /* vstate->inner->EOF_signalled = FALSE; */
-    }
+  //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  // Set information regarding file vs connection handling
+  //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  char *description;
+  if (TYPEOF(description_) == STRSXP) {
+    vstate->is_file = TRUE;
+    description = (char *)CHAR(STRING_ELT(description_, 0));
+    spdl::debug(tfm::format("[vfile_c_impl_] file %s", description));
+    vstate->uri = description;
+  } else {
+    /* vstate->is_file = FALSE; */
+    /* description = "vfile(connection)"; */
+    /* vstate->inner = R_GetConnection(description_); */
+    /* if (vstate->inner->isopen) { */
+    /*   error("vfile_(): inner connection must not already be open"); */
+    /* } */
+    /* // Ensure we start with EOF not set, as this is not zeroed in all cases
+     */
+    /* // within R/connections.c */
+    /* vstate->inner->EOF_signalled = FALSE; */
+  }
 
+  //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  // R will alloc for 'con' within R_new_custom_connection() and then
+  // I think it takes responsibility for freeing it later.
+  //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  Rconnection con = NULL;
+  // SEXP rc = PROTECT(R_new_custom_connection(description, "rb", "vfile",
+  // &con));
+  SEXP rc = PROTECT(new_connection(description, "rb", "vfile", &con));
 
-    //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    // R will alloc for 'con' within R_new_custom_connection() and then
-    // I think it takes responsibility for freeing it later.
-    //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    Rconnection con = NULL;
-    //SEXP rc = PROTECT(R_new_custom_connection(description, "rb", "vfile", &con));
-    SEXP rc = PROTECT(new_connection(description, "rb", "vfile", &con));
+  //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  // text       - true if connection operates on text
+  // isopen     - true if connection is open
+  // incomplete - used in @code{do_readLines}, @code{do_isincomplete},
+  //              and text_vfprintf, From `?connections`: true if last
+  //              read was blocked, or for an output text connection whether
+  //              there is unflushed output
+  // canread    - true if connection is readable
+  // canwrite   - true if connection is writable
+  // canseek    - true if connection is seekable
+  // blocking   - true if connection reads are blocking
+  // isGzcon    - true if connection operates on gzip compressed data
+  //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  con->isopen = FALSE;    // not open initially.
+  con->incomplete = TRUE; // NFI. Data write hasn't been completed?
+  con->text = FALSE;      // binary connection by default
+  con->canread = TRUE;    // read-only for now
+  con->canwrite = TRUE;   // read-only for now
+  con->canseek = FALSE;   // not possible in this implementation
+  con->blocking = TRUE;   // blacking IO
+  con->isGzcon = FALSE;   // Not a gzcon
 
-    //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    // text       - true if connection operates on text
-    // isopen     - true if connection is open
-    // incomplete - used in @code{do_readLines}, @code{do_isincomplete},
-    //              and text_vfprintf, From `?connections`: true if last
-    //              read was blocked, or for an output text connection whether
-    //              there is unflushed output
-    // canread    - true if connection is readable
-    // canwrite   - true if connection is writable
-    // canseek    - true if connection is seekable
-    // blocking   - true if connection reads are blocking
-    // isGzcon    - true if connection operates on gzip compressed data
-    //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    con->isopen     = FALSE; // not open initially.
-    con->incomplete =  TRUE; // NFI. Data write hasn't been completed?
-    con->text       = FALSE; // binary connection by default
-    con->canread    =  TRUE; // read-only for now
-    con->canwrite   =  TRUE; // read-only for now
-    con->canseek    = FALSE; // not possible in this implementation
-    con->blocking   =  TRUE; // blacking IO
-    con->isGzcon    = FALSE; // Not a gzcon
+  //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  // In base R's connections, EOF_signalled is set to zero during 'set_iconv()'
+  // I'm not setting any text conversion stuff, so
+  //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  con->EOF_signalled = FALSE;
 
-    //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    // In base R's connections, EOF_signalled is set to zero during 'set_iconv()'
-    // I'm not setting any text conversion stuff, so
-    //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    con->EOF_signalled = FALSE;
+  //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  // Not sure what this really means, but vfile() is not going to do
+  // any character conversion, so let's pretend any text returned in readLines()
+  // is utf8.
+  //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  con->UTF8out = TRUE;
 
-    //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    // Not sure what this really means, but vfile() is not going to do
-    // any character conversion, so let's pretend any text returned in readLines()
-    // is utf8.
-    //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    con->UTF8out =  TRUE;
+  //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  // This private data is user data that will be available in each of the
+  // following callbacks
+  //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  con->private_ptr = vstate;
 
-    //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    // This private data is user data that will be available in each of the
-    // following callbacks
-    //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    con->private_ptr = vstate;
+  //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  // Callbacks
+  //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  con->open = vfile_open;
+  con->close = vfile_close;
+  con->destroy = vfile_destroy;
+  con->vfprintf = vfile_vfprintf;
+  con->fgetc = vfile_fgetc;
+  con->fgetc_internal = vfile_fgetc_internal;
+  con->seek = vfile_seek;
+  con->truncate = vfile_truncate;
+  con->fflush = vfile_fflush;
+  con->read = vfile_read;
+  con->write = vfile_write;
 
-    //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    // Callbacks
-    //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    con->open           = vfile_open;
-    con->close          = vfile_close;
-    con->destroy        = vfile_destroy;
-    con->vfprintf       = vfile_vfprintf;
-    con->fgetc          = vfile_fgetc;
-    con->fgetc_internal = vfile_fgetc_internal;
-    con->seek           = vfile_seek;
-    con->truncate       = vfile_truncate;
-    con->fflush         = vfile_fflush;
-    con->read           = vfile_read;
-    con->write          = vfile_write;
+  //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  // Auto open if 'mode' is set to something other than the empty string.
+  // An issue is that without the context stuff (not exported from R?),
+  // I don't think I can get the context to auto-close!
+  //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  const char *mode = CHAR(STRING_ELT(mode_, 0));
+  strncpy(con->mode, mode, 4);
+  con->mode[4] = '\0';
+  if (strlen(mode) > 0) {
+    con->open(con);
+  }
 
-    //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    // Auto open if 'mode' is set to something other than the empty string.
-    // An issue is that without the context stuff (not exported from R?),
-    // I don't think I can get the context to auto-close!
-    //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    const char *mode = CHAR(STRING_ELT(mode_, 0));
-    strncpy(con->mode, mode, 4);
-    con->mode[4] = '\0';
-    if (strlen(mode) > 0) {
-        con->open(con);
-    }
-
-    UNPROTECT(1);
-    return rc;
+  UNPROTECT(1);
+  return rc;
 }
-
 
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // From R source code: 'src/main/connections.c'
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // SEXP   R_new_custom_connection(
-//            const char *description,  // the filename related to this particular instance
-//            const char *mode,         // read/write/binarymode/textmode
-//            const char *class_name,   // 'vfile'
-//            Rconnection *ptr          // Rconnection pointer
+//            const char *description,  // the filename related to this
+//            particular instance const char *mode,         //
+//            read/write/binarymode/textmode const char *class_name,   //
+//            'vfile' Rconnection *ptr          // Rconnection pointer
 //        );
 //
-// The returned value is the R-side instance. To avoid additional call to getConnection()
-//  the internal Rconnection pointer will be placed in ptr[0] if ptr is not NULL.
-//  It is the responsibility of the caller to customize callbacks in the structure,
-//  they are initialized to dummy_ (where available) and null_ (all others) callbacks.
-//  Also note that the resulting object has a finalizer, so any clean up (including after
-//  errors) is done by garbage collection - the caller may not free anything in the
-//  structure explicitly (that includes the con->private_ptr pointer!).
-
+// The returned value is the R-side instance. To avoid additional call to
+// getConnection()
+//  the internal Rconnection pointer will be placed in ptr[0] if ptr is not
+//  NULL. It is the responsibility of the caller to customize callbacks in the
+//  structure, they are initialized to dummy_ (where available) and null_ (all
+//  others) callbacks. Also note that the resulting object has a finalizer, so
+//  any clean up (including after errors) is done by garbage collection - the
+//  caller may not free anything in the structure explicitly (that includes the
+//  con->private_ptr pointer!).
 
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // From Matthew Shotwell
@@ -262,7 +267,8 @@ SEXP vfile_c_impl_(SEXP description_, SEXP mode_, SEXP verbosity_) {
 //   void (*close)(struct Rconn *); /* routine closing after auto open */
 //
 //
-//   /** destroy - called after the connection is closed in order to free memory,
+//   /** destroy - called after the connection is closed in order to free
+//   memory,
 //    and other cleanup tasks
 //    args: struct Rconn * - a connection to be closed
 //    **/
@@ -321,7 +327,8 @@ SEXP vfile_c_impl_(SEXP description_, SEXP mode_, SEXP verbosity_) {
 //   void (*truncate)(struct Rconn *);
 //
 //
-//   /** fflush - called when the connection should flush internal read/write buffers
+//   /** fflush - called when the connection should flush internal read/write
+//   buffers
 //    args: struct Rconn * - a connection to be flushed
 //    return: int - zero on success, non-zero otherwise
 //    **/
@@ -399,9 +406,6 @@ SEXP vfile_c_impl_(SEXP description_, SEXP mode_, SEXP verbosity_) {
 //   void *private;
 // };
 
-
-
-
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // Vfile state.
 //   - This is user/private data stored with the 'Rconn' struct that gets
@@ -414,12 +418,11 @@ SEXP vfile_c_impl_(SEXP description_, SEXP mode_, SEXP verbosity_) {
 //     int verbosity;     // For debugging!
 // } vfile_state;
 
-
-
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // open()
 //  - this may be called explicitly by a user call to open(con, mode)
-//  - this is also called implicitly by readBin()/writeBin()/readLines()/writeLines();
+//  - this is also called implicitly by
+//  readBin()/writeBin()/readLines()/writeLines();
 //
 // Possible Modes
 //    - "r" or "rt"    Open for reading in text mode.
@@ -440,89 +443,91 @@ SEXP vfile_c_impl_(SEXP description_, SEXP mode_, SEXP verbosity_) {
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Rboolean vfile_open(struct Rconn *rconn) {
 
-    vfile_state *vstate = (vfile_state *)rconn->private_ptr;
-    if (vstate->verbosity > 0)
-        Rprintf("vfile_open('%s', mode = '%s')\n", rconn->description, rconn->mode);
-    spdl::debug(tfm::format("[vfile_open] entered for '%s' with '%s'",
-                            rconn->description, rconn->mode));
+  vfile_state *vstate = (vfile_state *)rconn->private_ptr;
+  if (vstate->verbosity > 0)
+    Rprintf("vfile_open('%s', mode = '%s')\n", rconn->description, rconn->mode);
+  spdl::debug(tfm::format("[vfile_open] entered for '%s' with '%s'",
+                          rconn->description, rconn->mode));
 
-    if (rconn->isopen) {
-        Rf_error("vfile(): Connection is already open. Cannot open twice");
-    }
+  if (rconn->isopen) {
+    Rf_error("vfile(): Connection is already open. Cannot open twice");
+  }
 
-    if (strchr(rconn->mode, 'a') != NULL) {
-        Rf_error("vfile() does not support append.");
-    } else if (strchr(rconn->mode, '+') != NULL) {
-        Rf_error("vfile() does not support simultaneous r/w.");
-    }
+  if (strchr(rconn->mode, 'a') != NULL) {
+    Rf_error("vfile() does not support append.");
+  } else if (strchr(rconn->mode, '+') != NULL) {
+    Rf_error("vfile() does not support simultaneous r/w.");
+  }
 
-    rconn->text   = strchr(rconn->mode, 'b') ? FALSE : TRUE;
-    rconn->isopen = TRUE;
+  rconn->text = strchr(rconn->mode, 'b') ? FALSE : TRUE;
+  rconn->isopen = TRUE;
 
-    if (strchr(rconn->mode, 'w') == NULL) {
-        rconn->canread  =  TRUE;
-        rconn->canwrite = FALSE;
+  if (strchr(rconn->mode, 'w') == NULL) {
+    rconn->canread = TRUE;
+    rconn->canwrite = FALSE;
+  } else {
+    rconn->canread = FALSE;
+    rconn->canwrite = TRUE;
+  }
+
+  //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  // Setup file pointer
+  //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  if (rconn->canread) {
+    if (vstate->is_file) {
+      // vstate->fp = fopen(rconn->description, "rb");
+      // if (vstate->fp == NULL) {
+      //     Rf_error("vfile_(): Couldn't open input file '%s' with mode '%s'",
+      //     rconn->description, rconn->mode);
+      // }
     } else {
-        rconn->canread  = FALSE;
-        rconn->canwrite =  TRUE;
+      /* memset(vstate->inner->mode, '\0', 5); */
+      /* strcpy(vstate->inner->mode, "rb"); */
+      /* int res = vstate->inner->open(vstate->inner); */
+      /* if (!res || !vstate->inner->isopen) { */
+      /*   Rf_error("vfile_(): Couldn't open connection for reading"); */
+      /* } */
     }
-
-    //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    // Setup file pointer
-    //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    if (rconn->canread) {
-        if (vstate->is_file) {
-            // vstate->fp = fopen(rconn->description, "rb");
-            // if (vstate->fp == NULL) {
-            //     Rf_error("vfile_(): Couldn't open input file '%s' with mode '%s'", rconn->description, rconn->mode);
-            // }
-        } else {
-            /* memset(vstate->inner->mode, '\0', 5); */
-            /* strcpy(vstate->inner->mode, "rb"); */
-            /* int res = vstate->inner->open(vstate->inner); */
-            /* if (!res || !vstate->inner->isopen) { */
-            /*   Rf_error("vfile_(): Couldn't open connection for reading"); */
-            /* } */
-        }
+  } else {
+    if (vstate->is_file) {
+      // vstate->fp = fopen(rconn->description, "wb");
+      // if (vstate->fp == NULL) {
+      //     Rf_error("vfile_(): Couldn't open output file '%s' with mode '%s'",
+      //     rconn->description, rconn->mode);
+      // }
     } else {
-        if (vstate->is_file) {
-            // vstate->fp = fopen(rconn->description, "wb");
-            // if (vstate->fp == NULL) {
-            //     Rf_error("vfile_(): Couldn't open output file '%s' with mode '%s'", rconn->description, rconn->mode);
-            // }
-        } else {
-            /* memset(vstate->inner->mode, '\0', 5); */
-            /* strcpy(vstate->inner->mode, "wb"); */
-            /* int res = vstate->inner->open(vstate->inner); */
-            /* if (!res || !vstate->inner->isopen) { */
-            /*   Rf_error("vfile_(): Couldn't open connection for writing"); */
-            /* } */
-        }
+      /* memset(vstate->inner->mode, '\0', 5); */
+      /* strcpy(vstate->inner->mode, "wb"); */
+      /* int res = vstate->inner->open(vstate->inner); */
+      /* if (!res || !vstate->inner->isopen) { */
+      /*   Rf_error("vfile_(): Couldn't open connection for writing"); */
+      /* } */
     }
+  }
 
-    if (rconn->text && rconn->canread) {
-        tiledb::VFS::filebuf sbuf(*vstate->vfs);
-        sbuf.open(vstate->uri, std::ios::in);
-        std::istream is(&sbuf);
-        if (!is.good()) {
-            Rcpp::stop("Error opening uri '%s' in text mode\n", vstate->uri);
-        }
-        auto file_size = vstate->vfs->file_size(vstate->uri);
-        vstate->buf.resize(file_size);
-        is.read((char*) vstate->buf.data(), file_size);
-        vstate->nread = 0;
-        sbuf.close();
+  if (rconn->text && rconn->canread) {
+    tiledb::VFS::filebuf sbuf(*vstate->vfs);
+    sbuf.open(vstate->uri, std::ios::in);
+    std::istream is(&sbuf);
+    if (!is.good()) {
+      Rcpp::stop("Error opening uri '%s' in text mode\n", vstate->uri);
     }
+    auto file_size = vstate->vfs->file_size(vstate->uri);
+    vstate->buf.resize(file_size);
+    is.read((char *)vstate->buf.data(), file_size);
+    vstate->nread = 0;
+    sbuf.close();
+  }
 
-    if (rconn->canwrite) {
-        if (vstate->vfs->is_file(vstate->uri)) {
-            if (vstate->verbosity > 0)
-                Rprintf("Uri '%s' exists, removing", vstate->uri);
-            vstate->vfs->remove_file(vstate->uri);
-        }
+  if (rconn->canwrite) {
+    if (vstate->vfs->is_file(vstate->uri)) {
+      if (vstate->verbosity > 0)
+        Rprintf("Uri '%s' exists, removing", vstate->uri);
+      vstate->vfs->remove_file(vstate->uri);
     }
+  }
 
-    return TRUE;
+  return TRUE;
 }
 
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -532,24 +537,24 @@ Rboolean vfile_open(struct Rconn *rconn) {
 //    by the garbage collector.
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 void vfile_close(struct Rconn *rconn) {
-    spdl::debug("[vfile_close] entered");
+  spdl::debug("[vfile_close] entered");
 
-    vfile_state *vstate = (vfile_state *)rconn->private_ptr;
-    if (vstate->verbosity > 0)Rprintf("vfile_close('%s')\n", rconn->description);
+  vfile_state *vstate = (vfile_state *)rconn->private_ptr;
+  if (vstate->verbosity > 0)
+    Rprintf("vfile_close('%s')\n", rconn->description);
 
-    rconn->isopen = FALSE;
+  rconn->isopen = FALSE;
 
-    //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    // Close the file
-    //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    if (vstate->is_file && vstate->fp) {
-        fclose(vstate->fp);
-        vstate->fp = NULL;
-    }
-    /* if (!vstate->is_file) { */
-    /*   vstate->inner->close(vstate->inner); */
-    /* } */
-
+  //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  // Close the file
+  //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  if (vstate->is_file && vstate->fp) {
+    fclose(vstate->fp);
+    vstate->fp = NULL;
+  }
+  /* if (!vstate->is_file) { */
+  /*   vstate->inner->close(vstate->inner); */
+  /* } */
 }
 
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -559,14 +564,15 @@ void vfile_close(struct Rconn *rconn) {
 //   - Only really have to take care of 'rconn->private_ptr' (?)
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 void vfile_destroy(struct Rconn *rconn) {
-    spdl::debug("[vfile_destroy] entered");
+  spdl::debug("[vfile_destroy] entered");
 
-    vfile_state *vstate = (vfile_state *)rconn->private_ptr;
-    if (vstate->verbosity > 0) Rprintf("vfile_destroy()\n");
-    delete vstate->ctx;
-    delete vstate->vfs;
+  vfile_state *vstate = (vfile_state *)rconn->private_ptr;
+  if (vstate->verbosity > 0)
+    Rprintf("vfile_destroy()\n");
+  delete vstate->ctx;
+  delete vstate->vfs;
 
-    free(vstate);
+  free(vstate);
 }
 
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -575,12 +581,13 @@ void vfile_destroy(struct Rconn *rconn) {
 // @return int - a character, or R_EOF
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 int vfile_fgetc_internal(struct Rconn *rconn) {
-    spdl::debug("[vfile_fgetc_internal] entered");
+  spdl::debug("[vfile_fgetc_internal] entered");
 
-    vfile_state *vstate = (vfile_state *)rconn->private_ptr;
-    if (vstate->verbosity > 0) Rprintf("vfile_fgetc_internal()\n");
+  vfile_state *vstate = (vfile_state *)rconn->private_ptr;
+  if (vstate->verbosity > 0)
+    Rprintf("vfile_fgetc_internal()\n");
 
-    return rconn->fgetc(rconn);
+  return rconn->fgetc(rconn);
 }
 
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -603,8 +610,8 @@ int vfile_fgetc_internal(struct Rconn *rconn) {
 //          avoid integer types
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 double vfile_seek(struct Rconn *rconn, double x, int y, int z) {
-    Rf_error("vfile_seek() - not supported");
-    return 0;
+  Rf_error("vfile_seek() - not supported");
+  return 0;
 }
 
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -612,7 +619,7 @@ double vfile_seek(struct Rconn *rconn, double x, int y, int z) {
 //   - vfile() will not support truncation
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 void vfile_truncate(struct Rconn *rconn) {
-    Rf_error("vfile_truncate() - not supported");
+  Rf_error("vfile_truncate() - not supported");
 }
 
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -622,20 +629,22 @@ void vfile_truncate(struct Rconn *rconn) {
 // @return int zero on success. Non-zero otherwise
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 int vfile_fflush(struct Rconn *rconn) {
-    Rf_error("vfile_fflush() - not supported\n");
-    return 1;
+  Rf_error("vfile_fflush() - not supported\n");
+  return 1;
 }
 
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // readBin()
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 size_t vfile_read(void *dst, size_t size, size_t nitems, struct Rconn *rconn) {
-    spdl::debug("[vfile_read] entered");
+  spdl::debug("[vfile_read] entered");
 
-    vfile_state *vstate = (vfile_state *)rconn->private_ptr;
-    if (vstate->verbosity > 0) Rprintf("vfile_read(size = %zu, nitems = %zu)\n", size, nitems);
-    spdl::debug(tfm::format("[vfile_read] reading from '%s' up to size '%zu' times '%zu'",
-                            vstate->uri, size, nitems));
+  vfile_state *vstate = (vfile_state *)rconn->private_ptr;
+  if (vstate->verbosity > 0)
+    Rprintf("vfile_read(size = %zu, nitems = %zu)\n", size, nitems);
+  spdl::debug(
+      tfm::format("[vfile_read] reading from '%s' up to size '%zu' times '%zu'",
+                  vstate->uri, size, nitems));
 
 #if 0
     if (vstate->is_file && feof(vstate->fp)) {
@@ -658,20 +667,19 @@ size_t vfile_read(void *dst, size_t size, size_t nitems, struct Rconn *rconn) {
     }
     return nread;
 #else
-    tiledb::VFS::filebuf sbuf(*vstate->vfs);
-    sbuf.open(vstate->uri, std::ios::in);
-    std::istream is(&sbuf);
-    if (!is.good()) {
-        Rcpp::stop("Error opening uri '%s' for reads\n", vstate->uri);
-    }
-    size_t file_size = static_cast<size_t>(vstate->vfs->file_size(vstate->uri));
-    auto nread = std::min(size * nitems, file_size);
-    is.read((char*)dst, nread);
-    sbuf.close();
-    return nread;
+  tiledb::VFS::filebuf sbuf(*vstate->vfs);
+  sbuf.open(vstate->uri, std::ios::in);
+  std::istream is(&sbuf);
+  if (!is.good()) {
+    Rcpp::stop("Error opening uri '%s' for reads\n", vstate->uri);
+  }
+  size_t file_size = static_cast<size_t>(vstate->vfs->file_size(vstate->uri));
+  auto nread = std::min(size * nitems, file_size);
+  is.read((char *)dst, nread);
+  sbuf.close();
+  return nread;
 #endif
 }
-
 
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // readLines()
@@ -682,12 +690,13 @@ size_t vfile_read(void *dst, size_t size, size_t nitems, struct Rconn *rconn) {
 // @return int - a (re-encoded) character, or R_EOF
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 int vfile_fgetc(struct Rconn *rconn) {
-    spdl::debug("[vfile_fgetc] entered");
+  spdl::debug("[vfile_fgetc] entered");
 
-    vfile_state *vstate = (vfile_state *)rconn->private_ptr;
-    if (vstate->verbosity > 1) Rprintf("vfile_fgetc()\n");
+  vfile_state *vstate = (vfile_state *)rconn->private_ptr;
+  if (vstate->verbosity > 1)
+    Rprintf("vfile_fgetc()\n");
 
-    int c;
+  int c;
 
 #if 0
     if (vstate->is_file) {
@@ -703,26 +712,27 @@ int vfile_fgetc(struct Rconn *rconn) {
     }
 #endif
 
-    if (vstate->nread == vstate->buf.size()) {
-        c = -1;
-    } else {
-        c = static_cast<int>(vstate->buf[vstate->nread++]);
-    }
+  if (vstate->nread == vstate->buf.size()) {
+    c = -1;
+  } else {
+    c = static_cast<int>(vstate->buf[vstate->nread++]);
+  }
 
-    return c;
+  return c;
 }
-
 
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // writeBin()
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-size_t vfile_write(const void *src, size_t size, size_t nitems, struct Rconn *rconn) {
-    spdl::debug("[vfile_write] entered");
+size_t vfile_write(const void *src, size_t size, size_t nitems,
+                   struct Rconn *rconn) {
+  spdl::debug("[vfile_write] entered");
 
-    vfile_state *vstate = (vfile_state *)rconn->private_ptr;
-    if (vstate->verbosity > 0) Rprintf("vfile_write(size = %zu, nitems = %zu)\n", size, nitems);
+  vfile_state *vstate = (vfile_state *)rconn->private_ptr;
+  if (vstate->verbosity > 0)
+    Rprintf("vfile_write(size = %zu, nitems = %zu)\n", size, nitems);
 
-    size_t wlen = 0;
+  size_t wlen = 0;
 #if 0
     if (vstate->is_file) {
         wlen = fwrite(src, 1, size * nitems, vstate->fp);
@@ -730,20 +740,19 @@ size_t vfile_write(const void *src, size_t size, size_t nitems, struct Rconn *rc
         /* wlen = R_WriteConnection(vstate->inner, (void *)src, size * nitems); */
     }
 #else
-    tiledb::VFS::filebuf sbuf(*vstate->vfs);
-    sbuf.open(vstate->uri, std::ios::out);
-    std::ostream os(&sbuf);
-    if (!os.good()) {
-        Rcpp::stop("Error opening uri '%s' for writes\n", vstate->uri);
-    }
-    wlen = size * nitems;
-    os.write((char*)src, wlen);
-    os.flush();
-    sbuf.close();
+  tiledb::VFS::filebuf sbuf(*vstate->vfs);
+  sbuf.open(vstate->uri, std::ios::out);
+  std::ostream os(&sbuf);
+  if (!os.good()) {
+    Rcpp::stop("Error opening uri '%s' for writes\n", vstate->uri);
+  }
+  wlen = size * nitems;
+  os.write((char *)src, wlen);
+  os.flush();
+  sbuf.close();
 #endif
-    return wlen;
+  return wlen;
 }
-
 
 #define BUFSIZE 32768
 
@@ -751,50 +760,51 @@ size_t vfile_write(const void *src, size_t size, size_t nitems, struct Rconn *rc
 // Used in writeLines
 // @return int - number of characters printed, negative on failure
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-int vfile_vfprintf(struct Rconn *rconn, const char* fmt, va_list ap) {
-    spdl::debug("[vfile_vfprintf] entered");
+int vfile_vfprintf(struct Rconn *rconn, const char *fmt, va_list ap) {
+  spdl::debug("[vfile_vfprintf] entered");
 
-    vfile_state *vstate = (vfile_state *)rconn->private_ptr;
+  vfile_state *vstate = (vfile_state *)rconn->private_ptr;
 
-    unsigned char str_buf[BUFSIZE + 1];
+  unsigned char str_buf[BUFSIZE + 1];
 
-    //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    // vsnprintf() return value:
-    //   The number of characters written if successful or negative value if an
-    //   error occurred. If the resulting string gets truncated due to buf_size
-    //   limit, function returns the total number of characters (not including the
-    //   terminating null-byte) which would have been written, if the limit
-    //   was not imposed.
-    //
-    // So when vsnprintf() overflows the given size, it returns the number of
-    // characters it couldn't write.  Tell it the buffer size is '0' and it
-    // will just return how long a buffer would be needed to contain the string!
-    //
-    // Note: need to copy the 'va_list', since you can't (officially) use it twice!
-    // ubuntu platform complains
-    //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    va_list apc;
-    va_copy(apc, ap);
-    // n = vsnprintf(p, size, fmt, apc);
-    int slen = vsnprintf((char *)(str_buf), 0, fmt, apc);
-    va_end(apc);
+  //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  // vsnprintf() return value:
+  //   The number of characters written if successful or negative value if an
+  //   error occurred. If the resulting string gets truncated due to buf_size
+  //   limit, function returns the total number of characters (not including the
+  //   terminating null-byte) which would have been written, if the limit
+  //   was not imposed.
+  //
+  // So when vsnprintf() overflows the given size, it returns the number of
+  // characters it couldn't write.  Tell it the buffer size is '0' and it
+  // will just return how long a buffer would be needed to contain the string!
+  //
+  // Note: need to copy the 'va_list', since you can't (officially) use it
+  // twice! ubuntu platform complains
+  //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  va_list apc;
+  va_copy(apc, ap);
+  // n = vsnprintf(p, size, fmt, apc);
+  int slen = vsnprintf((char *)(str_buf), 0, fmt, apc);
+  va_end(apc);
 
-    int wlen = slen;
-    if (wlen > BUFSIZE) {
-        Rf_warning("vfile_vfprintf(): Long string truncated to length = %i\n", BUFSIZE);
-        wlen = BUFSIZE;
-    }
+  int wlen = slen;
+  if (wlen > BUFSIZE) {
+    Rf_warning("vfile_vfprintf(): Long string truncated to length = %i\n",
+               BUFSIZE);
+    wlen = BUFSIZE;
+  }
 
+  slen = vsnprintf((char *)(str_buf), BUFSIZE, fmt, ap);
+  if (slen < 0) {
+    Rf_error("vfile_vfprintf(): error in 'vsnprintf()");
+  }
 
-    slen = vsnprintf((char *)(str_buf), BUFSIZE, fmt, ap);
-    if (slen < 0) {
-        Rf_error("vfile_vfprintf(): error in 'vsnprintf()");
-    }
-
-    unsigned char display_buf[40+1];
-    strncpy((char *)display_buf, (char *)str_buf, 40);
-    display_buf[40] = '\0';
-    if (vstate->verbosity > 0) Rprintf("vfile_vfprintf('%s ...')\n", display_buf);
+  unsigned char display_buf[40 + 1];
+  strncpy((char *)display_buf, (char *)str_buf, 40);
+  display_buf[40] = '\0';
+  if (vstate->verbosity > 0)
+    Rprintf("vfile_vfprintf('%s ...')\n", display_buf);
 
 #if 0
     if (vstate->is_file) {
@@ -803,19 +813,18 @@ int vfile_vfprintf(struct Rconn *rconn, const char* fmt, va_list ap) {
         /* R_WriteConnection(vstate->inner, str_buf, wlen);   */
     }
 #else
-    tiledb::VFS::filebuf sbuf(*vstate->vfs);
-    sbuf.open(vstate->uri, std::ios::app);
-    std::ostream os(&sbuf);
-    if (!os.good()) {
-        Rcpp::stop("Error opening uri '%s' for writes\n", vstate->uri);
-    }
-    os.write((char*)str_buf, wlen);
-    os.flush();
-    sbuf.close();
+  tiledb::VFS::filebuf sbuf(*vstate->vfs);
+  sbuf.open(vstate->uri, std::ios::app);
+  std::ostream os(&sbuf);
+  if (!os.good()) {
+    Rcpp::stop("Error opening uri '%s' for writes\n", vstate->uri);
+  }
+  os.write((char *)str_buf, wlen);
+  os.flush();
+  sbuf.close();
 #endif
-    return wlen;
+  return wlen;
 }
-
 }
 
 // Setup initialization
@@ -824,14 +833,14 @@ SEXP new_connection_xptr;
 
 // [[Rcpp::export]]
 void tldb_init_(SEXP nc_xptr) {
-    new_connection_xptr = nc_xptr;
-    R_PreserveObject(nc_xptr);
+  new_connection_xptr = nc_xptr;
+  R_PreserveObject(nc_xptr);
 }
 
-SEXP new_connection(const char* description, const char* mode,
-                    const char* class_name, Rconnection* ptr) {
-    auto new_connection_ptr =
-        reinterpret_cast<SEXP (*)(const char*, const char*,
-                                  const char*, Rconnection*)>(R_ExternalPtrAddr(new_connection_xptr));
-    return new_connection_ptr(description, mode, class_name, ptr);
+SEXP new_connection(const char *description, const char *mode,
+                    const char *class_name, Rconnection *ptr) {
+  auto new_connection_ptr = reinterpret_cast<SEXP (*)(
+      const char *, const char *, const char *, Rconnection *)>(
+      R_ExternalPtrAddr(new_connection_xptr));
+  return new_connection_ptr(description, mode, class_name, ptr);
 }

--- a/src/virtualfile.cpp
+++ b/src/virtualfile.cpp
@@ -6,9 +6,10 @@
 // deploy a connection from within R without triggering a warning from package
 // checks.
 
+#include <Rcpp/Lighter> // for Rcpp
+
 #include "connection/connection.h" // for connections
 #include "tiledb.h"
-#include <Rcpp/Lighter> // for Rcpp
 #include <tinyspdl.h>   // for spdl logging
 
 extern "C" SEXP vfile_c_impl_(SEXP, SEXP, SEXP);


### PR DESCRIPTION
Skip `Rcpp/RcppExports.cpp` since that is autogenerateed