### PR TITLE
Update unit tests to expect dense current domain

### DIFF
--- a/docs/deps/data-deps.txt
+++ b/docs/deps/data-deps.txt
@@ -1,4 +1,4 @@
-<script src="deps/jquery-3.6.0/jquery-3.6.0.min.js"></script>
+<script src="deps/jquery-3.6.1/jquery-3.6.1.min.js"></script>
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
 <link href="deps/bootstrap-5.3.1/bootstrap.min.css" rel="stylesheet" />
 <script src="deps/bootstrap-5.3.1/bootstrap.bundle.min.js"></script>

--- a/docs/pkgdown.js
+++ b/docs/pkgdown.js
@@ -152,11 +152,3 @@ async function searchFuse(query, callback) {
   });
   });
 })(window.jQuery || window.$)
-
-document.addEventListener('keydown', function(event) {
-  // Check if the pressed key is '/'
-  if (event.key === '/') {
-    event.preventDefault();  // Prevent any default action associated with the '/' key
-    document.getElementById('search-input').focus();  // Set focus to the search input
-  }
-});

--- a/docs/pkgdown.yml
+++ b/docs/pkgdown.yml
@@ -1,5 +1,5 @@
-pandoc: 3.1.12.3
-pkgdown: 2.1.1
+pandoc: '0'
+pkgdown: 2.1.0
 pkgdown_sha: ~
 articles:
   data-ingestion-from-sql: data-ingestion-from-sql.html
@@ -7,7 +7,7 @@ articles:
   installation-options: installation-options.html
   introduction: introduction.html
   tiledb-mariadb-examples: tiledb-mariadb-examples.html
-last_built: 2024-10-02T22:48Z
+last_built: 2024-10-03T15:05Z
 urls:
   reference: https://tiledb-inc.github.io/TileDB-R/reference
   article: https://tiledb-inc.github.io/TileDB-R/articles

--- a/inst/tinytest/test_arrayschema.R
+++ b/inst/tinytest/test_arrayschema.R
@@ -146,7 +146,10 @@ expect_true(allows_dups(sch))
 if (tiledb_version(TRUE) < "2.26.0") exit_file("Needs TileDB 2.26.* or later")
 expect_error(tiledb_array_schema_get_current_domain(dom))           # wrong object
 expect_silent(cd <- tiledb_array_schema_get_current_domain(sch))
-expect_silent(tiledb_array_schema_set_current_domain(sch, cd))
 
 dsch <- tiledb_array_schema(dom, attrs = attr, sparse = FALSE)
-expect_error(tiledb_array_schema_set_current_domain(dsch, cd)) 		# not for dense
+if (tiledb_version(TRUE) < "2.27.0") {
+  expect_error(tiledb_array_schema_set_current_domain(dsch, cd))
+} else {
+  expect_no_condition(tiledb_array_schema_set_current_domain(dsch, cd))
+}


### PR DESCRIPTION
https://github.com/TileDB-Inc/centralized-tiledb-nightlies/issues/24#issuecomment-2416979134

https://github.com/TileDB-Inc/TileDB/pull/5303

Fixes #767

Current-domain support is now available for dense arrays in the upcoming core 2.27