### PR TITLE
Fix CI for #768

### DIFF
--- a/inst/tinytest/test_arrayschema.R
+++ b/inst/tinytest/test_arrayschema.R
@@ -151,5 +151,5 @@ dsch <- tiledb_array_schema(dom, attrs = attr, sparse = FALSE)
 if (tiledb_version(TRUE) < "2.27.0") {
   expect_error(tiledb_array_schema_set_current_domain(dsch, cd))
 } else {
-  expect_no_condition(tiledb_array_schema_set_current_domain(dsch, cd))
+  expect_silent(tiledb_array_schema_set_current_domain(dsch, cd))
 }


### PR DESCRIPTION
On #768 I used `expect_no_condition` which is valid in `testthat` but not in `tinytest`

For https://github.com/TileDB-Inc/TileDB-R/issues/769 and https://github.com/TileDB-Inc/centralized-tiledb-nightlies/issues/24#issuecomment-2418385740