### PR TITLE
Support parentheses in query conditions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ docs/articles/md/
 docs/articles/rmd/
 docs/articles/water.css
 vignettes/md/
+# vim
+.sw?
+.*.sw?

--- a/R/QueryCondition.R
+++ b/R/QueryCondition.R
@@ -189,6 +189,9 @@ parse_query_condition <- function(expr, ta=NULL, debug=FALSE, strict=TRUE, use_i
     .makeExpr <- function(x, debug=FALSE) {
         if (is.symbol(x)) {
             stop("Unexpected symbol in expression: ", format(x))
+        } else if (x[[1]] == '(') {
+            if (debug) cat("-- [(", as.character(x[2]), ")]\n", sep="")
+            .makeExpr(x[[2]])
         } else if (.isBooleanOperator(x[1])) {
             if (debug) cat("-- [", as.character(x[2]), "]",
                            " ", as.character(x[1]),

--- a/inst/tinytest/test_querycondition.R
+++ b/inst/tinytest/test_querycondition.R
@@ -413,6 +413,10 @@ expect_equal(nrow(D), nrow(chk) + 2)
 chk <- tiledb_array(uri, query_condition=parse_query_condition(key == "ñ" || key == "Ø"), return_as="data.frame")[]
 expect_equal(nrow(chk), 2)
 
+## include two with parentheses
+chk <- tiledb_array(uri, query_condition=parse_query_condition((key == "ñ") || (key == "Ø")), return_as="data.frame")[]
+expect_equal(nrow(chk), 2)
+
 
 ## Test minimal version
 if (tiledb_version(TRUE) < "2.16.0") exit_file("Remainder needs 2.16.* or later")


### PR DESCRIPTION
Found on https://github.com/single-cell-data/TileDB-SOMA/pull/3198

Fixes:

```
  Unexpected token in expression: (key == "ñ")
```