### PR TITLE
Fix package config on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ TileDB-R.Rproj
 src/*.o
 src/*.so
 src/*.dll
+src/connection/*.o
 # Output files from R CMD build
 /*.tar.gz
 # Output files from R CMD check
@@ -49,3 +50,5 @@ vignettes/md/
 # vim
 .sw?
 .*.sw?
+inst/tiledb/
+inst/lib/

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,15 +24,30 @@ SystemRequirements: A C++17 compiler is required; on macOS compilation version 1
   build selected); on x86_64 and M1 platforms pre-built TileDB Embedded libraries
   are available at GitHub and are used if no TileDB installation is detected, and
   no other option to build or download was specified by the user.
-Imports: 
+Depends:
+    R (>= 4.2)
+Imports:
     methods,
-    Rcpp (>= 1.0.8),
-    nanotime,
-    spdl,
     nanoarrow,
+    nanotime,
+    Rcpp (>= 1.0.8),
+    spdl,
     tools
-LinkingTo: Rcpp, RcppInt64, nanoarrow
-Suggests: tinytest, simplermarkdown, curl, bit64, Matrix, palmerpenguins, nycflights13, data.table, tibble, arrow
+LinkingTo:
+    nanoarrow,
+    Rcpp,
+    RcppInt64
+Suggests:
+    arrow,
+    bit64,
+    curl,
+    data.table,
+    Matrix,
+    nycflights13,
+    palmerpenguins,
+    simplermarkdown,
+    tibble,
+    tinytest
 VignetteBuilder: simplermarkdown
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.2

--- a/TileDB-R.Rproj
+++ b/TileDB-R.Rproj
@@ -2,7 +2,7 @@ Version: 1.0
 
 RestoreWorkspace: No
 SaveWorkspace: No
-AlwaysSaveHistory: Yes
+AlwaysSaveHistory: Default
 
 EnableCodeIndexing: Yes
 UseSpacesForTab: Yes
@@ -19,3 +19,5 @@ BuildType: Package
 PackageUseDevtools: Yes
 PackageInstallArgs: --no-multiarch --with-keep.source --install-tests
 PackageRoxygenize: rd,namespace
+
+QuitChildProcessesOnExit: Yes


### PR DESCRIPTION
Fix issues with `.pkg_config()` on Windows; include new include and linking flags as suggested by @LTLA

[SC-60076](https://app.shortcut.com/tiledb-inc/story/60076)

resolves #780