### PR TITLE
Allow `parse_query_condition()` to work on dimensions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tiledb
 Type: Package
-Version: 0.31.0
+Version: 0.31.0.1
 Title: Modern Database Engine for Complex Data Based on Multi-Dimensional Arrays
 Authors@R: c(
   person("TileDB, Inc.", role = c("aut", "cph")),
@@ -23,7 +23,7 @@ SystemRequirements: A C++17 compiler is required; on macOS compilation version 1
   build selected); on x86_64 and M1 platforms pre-built TileDB Embedded libraries
   are available at GitHub and are used if no TileDB installation is detected, and
   no other option to build or download was specified by the user.
-Imports: 
+Imports:
     methods,
     Rcpp (>= 1.0.8),
     nanotime,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Allow `parse_query_condition()` to work on dimensions when an array is passed
+
 # tiledb 0.31.0
 
 * Update docs with correct S4 methods

--- a/R/QueryCondition.R
+++ b/R/QueryCondition.R
@@ -163,10 +163,6 @@ parse_query_condition <- function(expr, ta = NULL, debug = FALSE, strict = TRUE,
       .errorFunction("No attribute '", attr, "' present.", call. = FALSE)
       return(NULL)
     }
-    if (ta@sil$status[ind] != 2) {
-      .errorFunction("Argument '", attr, "' is not an attribute.", call. = FALSE)
-      return(NULL)
-    }
     ind
   }
   .getType <- function(x, tp, use_int64 = FALSE) {
@@ -257,10 +253,6 @@ parse_query_condition <- function(expr, ta = NULL, debug = FALSE, strict = TRUE,
         ind <- match(attr, ta@sil$names)
         if (!is.finite(ind)) {
           .errorFunction("No attribute '", attr, "' present.", call. = FALSE)
-          return(NULL)
-        }
-        if (ta@sil$status[ind] != 2) {
-          .errorFunction("Argument '", attr, "' is not an attribute.", call. = FALSE)
           return(NULL)
         }
         dtype <- ta@sil$types[ind]


### PR DESCRIPTION
Remove check that limits `parse_query_condition()` to attribute queries when `ta` is provided

[SC-61458](https://app.shortcut.com/tiledb-inc/story/61458) 
resolves #793