### PR TITLE
Fix nightly build by updating branch name from "dev" to "main"

### DIFF
--- a/tools/ci/valgrind/buildTileDB.sh
+++ b/tools/ci/valgrind/buildTileDB.sh
@@ -20,7 +20,7 @@ echo "::group::Setup sources"
 if [ ${isrelease} -eq 0 ]; then
     git clone --single-branch --branch ${version} https://github.com/TileDB-Inc/TileDB.git TileDB-${version}
     git log --graph --pretty=format:'%h - %d %s (%cr) <%an>' --abbrev-commit | head
-elif [ ${version} = "dev" ]; then
+elif [ ${version} = "main" ]; then
     wget https://github.com/TileDB-Inc/TileDB/archive/refs/heads/${version}.zip
     unzip ${version}.zip
     rm ${version}.zip

--- a/tools/fetchTileDBSrc.R
+++ b/tools/fetchTileDBSrc.R
@@ -43,9 +43,9 @@ if (!file.exists("tiledb.tar.gz")) {
         cat("Converting zip to tar.gz ...\n")
         unzip("tiledb.tar.gz")
         unlink("tiledb.tar.gz")
-        Sys.chmod("TileDB-dev/bootstrap", mode="0755")
+        Sys.chmod("TileDB-main/bootstrap", mode="0755")
         options(warn=-1)
-        tar("tiledb.tar.gz", "TileDB-dev", compression="gzip")
+        tar("tiledb.tar.gz", "TileDB-main", compression="gzip")
     }
 
     options(op)

--- a/vignettes/introduction.Rmd
+++ b/vignettes/introduction.Rmd
@@ -182,7 +182,7 @@ column *reduces to a vector* as this happens at the R side:
 
 Basic reading returns the coordinates and any attributes. The following
 examples use the array created by the
-[quickstart_sparse](https://github.com/TileDB-Inc/TileDB/blob/dev/examples/cpp_api/quickstart_sparse.cc)
+[quickstart_sparse](https://github.com/TileDB-Inc/TileDB/blob/main/examples/cpp_api/quickstart_sparse.cc)
 example.
 
 ``` r


### PR DESCRIPTION
Closes #791

Follow-up to https://github.com/TileDB-Inc/TileDB-R/pull/789

cc: @ihnorton, @johnkerl 

What is the plan for rebuilding the documentation? Similar to the update from @cgiachalis in #794, the updates to `_pkgdown.yml` and vignette `.Rmd` files will not be reflected in `docs/` until they are rebuilt. Can I send a follow-up PR to rebuild them?