### PR TITLE
Execute script as bash script

### DIFF
--- a/tools/buildTileDB.sh
+++ b/tools/buildTileDB.sh
@@ -46,7 +46,7 @@ fi
 ## Build
 mkdir build
 cd build
-../tiledb-src/bootstrap --force-build-all-deps --enable-s3 --enable-serialization --linkage=shared
+bash ../tiledb-src/bootstrap --force-build-all-deps --enable-s3 --enable-serialization --linkage=shared
 make -j 2 tiledb install-tiledb
 cd ..
 


### PR DESCRIPTION
When downloading TileDB core library, the bootstrap file changes to not executable. This PR should fix that by simply calling it as a bash script.