### PR TITLE
Remove whitespace after operator""

### DIFF
--- a/src/nanoarrow.hpp
+++ b/src/nanoarrow.hpp
@@ -906,7 +906,7 @@ inline bool operator==(ArrowStringView l, ArrowStringView r) {
 }
 
 /// \brief User literal operator allowing ArrowStringView construction like "str"_sv
-inline ArrowStringView operator"" _v(const char* data, std::size_t size_bytes) {
+inline ArrowStringView operator""_v(const char* data, std::size_t size_bytes) {
   return {data, static_cast<int64_t>(size_bytes)};
 }
 /// @}


### PR DESCRIPTION
The space after `""` is deprecated since it creates ambiguity with reserved `_`-initial names per:

https://en.cppreference.com/w/cpp/language/user_literal

This might start throwing compiler warnings under `clang++-20`.