### PR TITLE
Update minimum version of R

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,6 +23,8 @@ SystemRequirements: A C++17 compiler is required; on macOS compilation version 1
   build selected); on x86_64 and M1 platforms pre-built TileDB Embedded libraries
   are available at GitHub and are used if no TileDB installation is detected, and
   no other option to build or download was specified by the user.
+Depends:
+    R (>= 4.3)
 Imports:
     methods,
     Rcpp (>= 1.0.8),


### PR DESCRIPTION
CRAN checks are throwing a NOTE for use of pipe/shorthand notation without pinning minimum version of R. This PR sets the minimum version to R 4.3 as that's currently R-oldrelease

[SC-65370](https://app.shortcut.com/tiledb-inc/story/65370)