### PR TITLE
Add flag `--use-C17` for nightly build with R 4.5.0

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -24,7 +24,7 @@ jobs:
         run: R CMD build --no-build-vignettes --no-manual .
       - name: Install Package
         # running an install step gives better logging on standard out than R CMD check which tucks this away
-        run: R CMD INSTALL --configure-args="--with-download=https://github.com/TileDB-Inc/TileDB/archive/refs/heads/main.zip" $(ls -1tr *.tar.gz | tail -1)
+        run: R CMD INSTALL --use-C17 --configure-args="--with-download=https://github.com/TileDB-Inc/TileDB/archive/refs/heads/main.zip" $(ls -1tr *.tar.gz | tail -1)
       - name: Run Tests
         # given that the package is installed and uses tinytest, we can easily run its tests
         run: Rscript -e 'tinytest::test_package("tiledb")'


### PR DESCRIPTION
Closes #814 

R 4.5.0 introduced C23, which broke the compilation of `blosc/src/shuffle.c` when building libtiledb from source.

I manually triggered a nightly build on my fork for this PR branch. It [passed](https://github.com/jdblischak/TileDB-R/actions/runs/14536722180).