### PR TITLE
Remove static libraries from final build of tiledb-r on Windows

### DIFF
--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -18,7 +18,7 @@ PKG_LIBS = \
 
 LIB_CON = ../inst/lib$(R_ARCH)/libconnection.dll
 
-all: winlibs $(OBJECTS) $(SHLIB) $(LIB_CON)
+all: winlibs $(OBJECTS) $(SHLIB) $(LIB_CON) purify
 
 $(LIB_CON): connection/connection.o
 	mkdir -p $(dir $(LIB_CON))
@@ -30,4 +30,7 @@ winlibs:
 clean:
 	rm -f $(SHLIB) $(OBJECTS) $(LIB_CON) connection/connection.o
 
-.PHONY: all clean
+purify: $(OBJECTS) $(SHLIB) $(LIB_CON)
+	rm -rf $(RWINLIB)/lib/ || true
+
+.PHONY: all clean purify

--- a/tools/winlibs.R
+++ b/tools/winlibs.R
@@ -5,17 +5,18 @@ if (!file.exists(dcffile)) stop("TileDB Version file not found.")
 dcf <- read.dcf(dcffile)
 ver <- dcf[[1, "version"]]
 
-if (!file.exists("../inst/tiledb/include/tiledb/tiledb.h")) {
-    if (getRversion() < "4") stop("This package requires Rtools40 or newer")
-    op <- options(timeout = 180) # CRAN request to have patient download settings
-    zipfile <- tempfile(tmpdir = tempdir(check = TRUE), fileext = '.zip')
-    download.file(
-      sprintf("https://github.com/TileDB-Inc/rwinlib-tiledb/archive/v%s.zip", ver),
-      destfile = zipfile,
-      quiet = !isTRUE(getOption('verbose', default = FALSE))
-    )
-    options(op)
-    unzip(zipfile, exdir = "../inst")
-    file.rename(sprintf("../inst/rwinlib-tiledb-%s", ver), "../inst/tiledb")
-    unlink(zipfile, force = TRUE)
+if (!file.exists("../inst/tiledb/include/tiledb/tiledb.h") || !dir.exists("../inst/tiledb/lib/")) {
+  if (getRversion() < "4") stop("This package requires Rtools40 or newer")
+  if (dir.exists("../inst/tiledb")) unlink("../inst/tiledb", recursive = TRUE, force = TRUE)
+  op <- options(timeout = 180) # CRAN request to have patient download settings
+  zipfile <- tempfile(tmpdir = tempdir(check = TRUE), fileext = '.zip')
+  download.file(
+    sprintf("https://github.com/TileDB-Inc/rwinlib-tiledb/archive/v%s.zip", ver),
+    destfile = zipfile,
+    quiet = !isTRUE(getOption('verbose', default = FALSE))
+  )
+  options(op)
+  unzip(zipfile, exdir = "../inst")
+  file.rename(sprintf("../inst/rwinlib-tiledb-%s", ver), "../inst/tiledb")
+  unlink(zipfile, force = TRUE)
 }


### PR DESCRIPTION
R 4.5 has begun introducing checks of static libraries bundled as part of the package; this PR removes said static libraries as they were failing CRAN checks