### PR TITLE
TileDB-R 0.31.1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tiledb
 Type: Package
-Version: 0.31.0.5
+Version: 0.31.1
 Title: Modern Database Engine for Complex Data Based on Multi-Dimensional Arrays
 Authors@R: c(
   person("TileDB, Inc.", role = c("aut", "cph")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# Unreleased
+# tiledb 0.31.1
 
 * Allow `parse_query_condition()` to work on dimensions when an array is passed
 * Add `tiledb_vfs_copy_dir()`, a wrapper for the `vfs_copy_dir()` function


### PR DESCRIPTION
This PR formalizes release 0.31.1, addressing CRAN checks not resolved by 0.31.0; namely:

 - addresses ASAN check failures
 - fix broken URLs due to new GH pages deployment
 - remove static libraries from installed package for R >= 4.5