### PR TITLE
Use core 2.28.0

### DIFF
--- a/.github/workflows/valgrind.yaml
+++ b/.github/workflows/valgrind.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tag: [ release-2.25, release-2.26, release-2.27, main ]
+        tag: [ release-2.26, release-2.27, release-2.28, main ]
 
     steps:
     - name: Checkout

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tiledb
 Type: Package
-Version: 0.31.1.1
+Version: 0.31.1.2
 Title: Modern Database Engine for Complex Data Based on Multi-Dimensional Arrays
 Authors@R: c(
   person("TileDB, Inc.", role = c("aut", "cph")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,7 @@
 * Add `tiledb_array_is_open_for_reading()/writing()` [#806](https://github.com/TileDB-Inc/TileDB-R/issues/806)
 * Fix static-linking checks for R >= 4.5
 * Depend on TileDB Embedded 2.28.0-rc0 [#818](https://github.com/TileDB-Inc/TileDB-R/issues/818)
+* Depend on TileDB Embedded 2.28.0 [#820](https://github.com/TileDB-Inc/TileDB-R/issues/820)
 
 # tiledb 0.31.0
 

--- a/tools/tiledbVersion.txt
+++ b/tools/tiledbVersion.txt
@@ -1,2 +1,2 @@
-version: 2.28.0-rc0
+version: 2.28.0
 sha: 4764907


### PR DESCRIPTION
This will fail until I get the `rwinlib-tiledb` PR as in

* https://github.com/TileDB-Inc/TileDB-R/pull/818
* https://github.com/TileDB-Inc/rwinlib-tiledb/pull/2

Update: done

* https://github.com/TileDB-Inc/rwinlib-tiledb/pull/3
* https://www.notion.so/Release-process-for-TileDB-R-11332650117580b79eece5ccff0e3e5f