### PR TITLE
`tiledb_attr` raises `std::bad_alloc` with variable length

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tiledb
 Type: Package
-Version: 0.32.0.3
+Version: 0.32.0.4
 Title: Modern Database Engine for Complex Data Based on Multi-Dimensional Arrays
 Authors@R: c(
   person("TileDB, Inc.", role = c("aut", "cph")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,7 @@
 
 * Schema-dump output is no longer truncated in the case that there are any null fill values in the schema (@johnkerl in [#825](https://github.com/TileDB-Inc/TileDB-R/pull/825))
 * `tiledb_attr()` now prints the attribute object as expected and documentation has been corrected (@cgiachalis in [#823](https://github.com/TileDB-Inc/TileDB-R/pull/823))
-* `tiledb_attr` raises `std::bad_alloc` with variable length (@johnkerl in [#830](https://github.com/TileDB-Inc/TileDB-R/pull/830))
+* `tiledb_attr` now works when setting `ncells=NA` to signal variable length (@johnkerl in [#830](https://github.com/TileDB-Inc/TileDB-R/pull/830))
 
 ## Documentation
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 
 * Schema-dump output is no longer truncated in the case that there are any null fill values in the schema (@johnkerl in [#825](https://github.com/TileDB-Inc/TileDB-R/pull/825))
 * `tiledb_attr()` now prints the attribute object as expected and documentation has been corrected (@cgiachalis in [#823](https://github.com/TileDB-Inc/TileDB-R/pull/823))
+* `tiledb_attr` raises `std::bad_alloc` with variable length (@johnkerl in [#830](https://github.com/TileDB-Inc/TileDB-R/pull/830))
 
 ## Documentation
 

--- a/src/libtiledb.cpp
+++ b/src/libtiledb.cpp
@@ -1517,6 +1517,10 @@ XPtr<tiledb::Attribute> libtiledb_attribute(XPtr<tiledb::Context> ctx,
   if (ncells < 1 && ncells != R_NaInt) {
     Rcpp::stop("ncells must be >= 1 (or NA for variable cells)");
   }
+  if (ncells == R_NaInt) {
+    ncells = TILEDB_VAR_NUM;
+  }
+
   // placeholder, overwritten in all branches below
   XPtr<tiledb::Attribute> attr =
       XPtr<tiledb::Attribute>(static_cast<tiledb::Attribute *>(nullptr));

--- a/src/libtiledb.cpp
+++ b/src/libtiledb.cpp
@@ -1517,9 +1517,9 @@ XPtr<tiledb::Attribute> libtiledb_attribute(XPtr<tiledb::Context> ctx,
   if (ncells < 1 && ncells != R_NaInt) {
     Rcpp::stop("ncells must be >= 1 (or NA for variable cells)");
   }
-  if (ncells == R_NaInt) {
-    ncells = TILEDB_VAR_NUM;
-  }
+  // R's NA is different from TileDB's NA so test for NA_integer_, else cast
+  uint64_t cell_val_num =
+      (ncells == R_NaInt) ? TILEDB_VAR_NUM : static_cast<uint64_t>(ncells);
 
   // placeholder, overwritten in all branches below
   XPtr<tiledb::Attribute> attr =
@@ -1540,7 +1540,6 @@ XPtr<tiledb::Attribute> libtiledb_attribute(XPtr<tiledb::Context> ctx,
       attr_dtype == TILEDB_DATETIME_AS) {
     attr = make_xptr<tiledb::Attribute>(
         new tiledb::Attribute(*ctx.get(), name, attr_dtype));
-    attr->set_cell_val_num(static_cast<uint64_t>(ncells));
   } else if (attr_dtype == TILEDB_CHAR || attr_dtype == TILEDB_STRING_ASCII ||
              attr_dtype == TILEDB_STRING_UTF8) {
     attr = make_xptr<tiledb::Attribute>(
@@ -1562,10 +1561,7 @@ XPtr<tiledb::Attribute> libtiledb_attribute(XPtr<tiledb::Context> ctx,
                "-- seeing %s which is not",
                type.c_str());
   }
-  // R's NA is different from TileDB's NA so test for NA_integer_, else cast
-  uint64_t num =
-      (ncells == R_NaInt) ? TILEDB_VAR_NUM : static_cast<uint64_t>(ncells);
-  attr->set_cell_val_num(num);
+  attr->set_cell_val_num(cell_val_num);
   attr->set_filter_list(*fltrlst);
   attr->set_nullable(nullable);
   return attr;


### PR DESCRIPTION
Fixes #828