### PR TITLE
Fix error message in `tiledb_array()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tiledb
 Type: Package
-Version: 0.32.0.5
+Version: 0.32.0.6
 Title: Modern Database Engine for Complex Data Based on Multi-Dimensional Arrays
 Authors@R: c(
   person("TileDB, Inc.", role = c("aut", "cph")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,8 @@
 
 * Schema-dump output is no longer truncated in the case that there are any null fill values in the schema (@johnkerl in [#825](https://github.com/TileDB-Inc/TileDB-R/pull/825))
 * `tiledb_attr()` now prints the attribute object as expected and documentation has been corrected (@cgiachalis in [#823](https://github.com/TileDB-Inc/TileDB-R/pull/823))
-* `tiledb_attr` now works when setting `ncells=NA` to signal variable length (@johnkerl in [#830](https://github.com/TileDB-Inc/TileDB-R/pull/830))
+* `tiledb_attr()` now works when setting `ncells=NA` to signal variable length (@johnkerl in [#830](https://github.com/TileDB-Inc/TileDB-R/pull/830))
+* `tiledb_array()` now emits the correct error message when using `selected_points` argument (@cgiachalis in [#833](https://github.com/TileDB-Inc/TileDB-R/issues/833)
 
 ## Documentation
 

--- a/R/Array.R
+++ b/R/Array.R
@@ -245,7 +245,7 @@ tiledb_array_delete_fragments_list <- function(
 ##' Check for Enumeration (aka Factor aka Dictionary)
 ##'
 ##' @param arr A TileDB Array object
-##' @return A boolean indicating if the array has homogeneous domains
+##' @return A logical vector indicating which attribute has enumeration
 ##' @export
 tiledb_array_has_enumeration <- function(arr) {
   stopifnot("The 'arr' argument must be a tiledb_array object" = .isArray(arr))

--- a/R/Config.R
+++ b/R/Config.R
@@ -39,7 +39,7 @@ tiledb_config.from_ptr <- function(ptr) {
 #' Note that for actually setting persistent values, the (altered) config
 #' object needs to used to create (or update) the \code{tiledb_ctx} object. Similarly,
 #' to check whether values are set, one should use the \code{config} method
-#' of the of the \code{tiledb_ctx} object. Examples for this are
+#' of the \code{tiledb_ctx} object. Examples for this are
 #' \code{ctx <- tiledb_ctx(limitTileDBCores())} to use updated configuration values to
 #' create a context object, and \code{cfg <- config(ctx)} to retrieve it.
 #' @param config (optional) character vector of config parameter names, values

--- a/R/QueryCondition.R
+++ b/R/QueryCondition.R
@@ -86,7 +86,7 @@ tiledb_query_condition_init <- function(attr, value, dtype, op, qc = tiledb_quer
 
 #' Combine two 'tiledb_query_condition' objects
 #'
-#' Combines two query condition object using a relatiional operator. Support for operator
+#' Combines two query condition object using a relational operator. Support for operator
 #' 'AND' is generally available, the 'OR' operator is available if TileDB 2.10 or newer is
 #' used.
 #' @param lhs A 'tiledb_query_condition' object on the left-hand side of the relation
@@ -116,7 +116,7 @@ tiledb_query_condition_combine <- function(lhs, rhs, op) {
 #' around \code{%in%)} which extends R a little for this use case.
 #'
 #' Expressions are parsed locally by this function. The \code{debug=TRUE} option may help if an issue
-#' has to be diagnosed. In most cases of an errroneous parse, it generally helps to supply the
+#' has to be diagnosed. In most cases of an erroneous parse, it generally helps to supply the
 #' \code{tiledb_array} providing schema information. One example are numeric and integer columns where
 #' the data type is difficult to guess. Also, when using the \code{"%in%"} or \code{"%nin%"} operators,
 #' the argument is mandatory.
@@ -124,9 +124,9 @@ tiledb_query_condition_combine <- function(lhs, rhs, op) {
 #' @param expr An expression that is understood by the TileDB grammar for query conditions.
 #' @param ta A tiledb_array object that the query condition is applied to; this argument is optional
 #' in some cases but required in some others.
-#' @param debug A boolean toogle to enable more verbose operations, defaults
+#' @param debug A boolean toggle to enable more verbose operations, defaults
 #' to 'FALSE'.
-#' @param strict A boolean toogle to, if set, errors if a non-existing attribute is selected
+#' @param strict A boolean toggle to, if set, errors if a non-existing attribute is selected
 #' or filtered on, defaults to 'TRUE'; if 'FALSE' a warning is shown by execution proceeds.
 #' @param use_int64 A boolean toggle to switch to \code{integer64} if \code{integer} is seen,
 #' default is false to remain as a default four-byte \code{int}
@@ -297,7 +297,7 @@ parse_query_condition <- function(expr, ta = NULL, debug = FALSE, strict = TRUE,
 
 #' Enable use of enumeration in query condition
 #'
-#' Set a boolean toggle to signal use of enumeration in query condtion (TileDB 2.17 or later)
+#' Set a boolean toggle to signal use of enumeration in query condition (TileDB 2.17 or later)
 #' @param qc A 'tiledb_query_condition' object
 #' @param use_enum A boolean to set (if TRUE) or unset (if FALSE) enumeration use
 #' @param ctx (optional) A TileDB Ctx object; if not supplied the default
@@ -317,9 +317,9 @@ tiledb_query_condition_set_use_enumeration <- function(qc, use_enum, ctx = tiled
 #' Create a query condition for vector 'IN' and 'NOT_IN' operations
 #'
 #' Uses \sQuote{IN} and \sQuote{NOT_IN} operators on given attribute
-#' @param name A character value with the scheme attribute name
-#' @param values A vector wiith the given values, supported types are integer, double,
-#' integer64 and charactor
+#' @param name A character value with attribute name
+#' @param values A vector with the given values, supported types are integer, double,
+#' integer64 and character
 #' @param op (optional) A character value with the chosen set operation, this must be one of
 #' \sQuote{IN} or \sQuote{NOT_IN}; default to \sQuote{IN}
 #' @param ctx (optional) A TileDB Ctx object; if not supplied the default

--- a/R/QueryCondition.R
+++ b/R/QueryCondition.R
@@ -49,10 +49,10 @@ tiledb_query_condition <- function(ctx = tiledb_get_context()) {
 #' Initialize a 'tiledb_query_condition' object
 #'
 #' Initializes (and possibly allocates) a query condition object using a triplet of
-#' attribute name, comparison value, and operator.  Six types of conditions are supported,
+#' attribute name, comparison value, and operator. Six types of conditions are supported,
 #' they all take a single scalar comparison argument and attribute to compare against.
 #' At present only integer or numeric attribute comparisons are implemented.
-#' @param attr A character value with the scheme attribute name
+#' @param attr A character value with the attribute name
 #' @param value A scalar value that the attribute is compared against
 #' @param dtype A character value with the TileDB data type of the attribute column, for
 #' example 'FLOAT64' or 'INT32'

--- a/R/QueryCondition.R
+++ b/R/QueryCondition.R
@@ -329,7 +329,7 @@ tiledb_query_condition_set_use_enumeration <- function(qc, use_enum, ctx = tiled
 tiledb_query_condition_create <- function(name, values, op = "IN", ctx = tiledb_get_context()) {
   stopifnot(
     "Argument 'name' must be character" = is.character(name),
-    "Argument 'values' must be int, double, int64 ir char" =
+    "Argument 'values' must be int, double, int64 or char" =
       (is.numeric(values) || bit64::is.integer64(values) || is.character(values)),
     "Argument 'op' must be one of 'IN' or 'NOT_IN'" = op %in% c("IN", "NOT_IN"),
     "The 'ctx' argument must be a context object" = is(ctx, "tiledb_ctx"),

--- a/R/TileDBArray.R
+++ b/R/TileDBArray.R
@@ -393,7 +393,7 @@ setValidity("tiledb_array", function(object) {
       if (!is.null(object@selected_points[[i]])) {
         if (!is.vector(object@selected_points[[i]]) && !inherits(object@selected_points[[i]], "integer64")) {
           valid <- FALSE
-          msg <- c(msg, sprintf("Element '%d' of 'selected_ranges' is not a vector.", i))
+          msg <- c(msg, sprintf("Element '%d' of 'selected_points' is not a vector.", i))
         }
       }
     }

--- a/R/TileDBArray.R
+++ b/R/TileDBArray.R
@@ -1979,8 +1979,8 @@ array_vacuum <- function(
 #' @param arr A TileDB Array
 #' @param idx An integer index between one and the number of dimensions
 #' @return A two-element object is returned describing the domain of selected
-#' dimension; it will either be a numeric vector in case of a fixed-size
-#' fixed-sized dimensions, or a character vector for a variable-sized one.
+#' dimension; it will either be a numeric vector in case of a fixed-sized
+#' dimension or a character vector for a variable-sized one.
 #' @export
 tiledb_array_get_non_empty_domain_from_index <- function(arr, idx) {
   stopifnot(
@@ -2009,8 +2009,8 @@ tiledb_array_get_non_empty_domain_from_index <- function(arr, idx) {
 #' @param arr A TileDB Array
 #' @param name An character variable with a dimension name
 #' @return A two-element object is returned describing the domain of selected
-#' dimension; it will either be a numeric vector in case of a fixed-size
-#' fixed-sized dimensions, or a character vector for a variable-sized one.
+#' dimension; it will either be a numeric vector in case of a fixed-sized
+#' dimension or a character vector for a variable-sized one.
 #' @export
 tiledb_array_get_non_empty_domain_from_name <- function(arr, name) {
   stopifnot(

--- a/R/TileDBArray.R
+++ b/R/TileDBArray.R
@@ -101,7 +101,7 @@ setClass(
 #'
 #' tiledb_array returns a new object. This class is experimental.
 #'
-#' @param uri uri path to the tiledb dense array
+#' @param uri uri path to the tiledb array
 #' @param query_type optionally loads the array in "READ" or "WRITE" only modes.
 #' @param is.sparse optional logical switch, defaults to "NA"
 #' letting array determine it
@@ -1251,7 +1251,7 @@ setMethod(
 #'
 #' For sparse matrices, row and column indices can either be supplied
 #' as part of the left-hand side object, or as part of the data.frame
-#' provided approrpiate column names.
+#' provided appropriate column names.
 #'
 #' This function may still still change; the current implementation should be
 #' considered as an initial draft.
@@ -1977,7 +1977,7 @@ array_vacuum <- function(
 #' switches internally.
 #'
 #' @param arr A TileDB Array
-#' @param idx An integer index between one the number of dimensions
+#' @param idx An integer index between one and the number of dimensions
 #' @return A two-element object is returned describing the domain of selected
 #' dimension; it will either be a numeric vector in case of a fixed-size
 #' fixed-sized dimensions, or a character vector for a variable-sized one.

--- a/man/parse_query_condition.Rd
+++ b/man/parse_query_condition.Rd
@@ -18,10 +18,10 @@ parse_query_condition(
 \item{ta}{A tiledb_array object that the query condition is applied to; this argument is optional
 in some cases but required in some others.}
 
-\item{debug}{A boolean toogle to enable more verbose operations, defaults
+\item{debug}{A boolean toggle to enable more verbose operations, defaults
 to 'FALSE'.}
 
-\item{strict}{A boolean toogle to, if set, errors if a non-existing attribute is selected
+\item{strict}{A boolean toggle to, if set, errors if a non-existing attribute is selected
 or filtered on, defaults to 'TRUE'; if 'FALSE' a warning is shown by execution proceeds.}
 
 \item{use_int64}{A boolean toggle to switch to \code{integer64} if \code{integer} is seen,
@@ -39,7 +39,7 @@ around \code{\%in\%)} which extends R a little for this use case.
 }
 \details{
 Expressions are parsed locally by this function. The \code{debug=TRUE} option may help if an issue
-has to be diagnosed. In most cases of an errroneous parse, it generally helps to supply the
+has to be diagnosed. In most cases of an erroneous parse, it generally helps to supply the
 \code{tiledb_array} providing schema information. One example are numeric and integer columns where
 the data type is difficult to guess. Also, when using the \code{"\%in\%"} or \code{"\%nin\%"} operators,
 the argument is mandatory.

--- a/man/subset-tiledb_array-ANY-ANY-ANY-method.Rd
+++ b/man/subset-tiledb_array-ANY-ANY-ANY-method.Rd
@@ -31,7 +31,7 @@ something that can be coerced to a data.frame, to a tiledb array.
 \details{
 For sparse matrices, row and column indices can either be supplied
 as part of the left-hand side object, or as part of the data.frame
-provided approrpiate column names.
+provided appropriate column names.
 
 This function may still still change; the current implementation should be
 considered as an initial draft.

--- a/man/tiledb_array.Rd
+++ b/man/tiledb_array.Rd
@@ -36,7 +36,7 @@ tiledb_dense(...)
 tiledb_sparse(...)
 }
 \arguments{
-\item{uri}{uri path to the tiledb dense array}
+\item{uri}{uri path to the tiledb array}
 
 \item{query_type}{optionally loads the array in "READ" or "WRITE" only modes.}
 

--- a/man/tiledb_array_get_non_empty_domain_from_index.Rd
+++ b/man/tiledb_array_get_non_empty_domain_from_index.Rd
@@ -13,8 +13,8 @@ tiledb_array_get_non_empty_domain_from_index(arr, idx)
 }
 \value{
 A two-element object is returned describing the domain of selected
-dimension; it will either be a numeric vector in case of a fixed-size
-fixed-sized dimensions, or a character vector for a variable-sized one.
+dimension; it will either be a numeric vector in case of a fixed-sized
+dimension or a character vector for a variable-sized one.
 }
 \description{
 This functions works for both fixed- and variable-sized dimensions and

--- a/man/tiledb_array_get_non_empty_domain_from_index.Rd
+++ b/man/tiledb_array_get_non_empty_domain_from_index.Rd
@@ -9,7 +9,7 @@ tiledb_array_get_non_empty_domain_from_index(arr, idx)
 \arguments{
 \item{arr}{A TileDB Array}
 
-\item{idx}{An integer index between one the number of dimensions}
+\item{idx}{An integer index between one and the number of dimensions}
 }
 \value{
 A two-element object is returned describing the domain of selected

--- a/man/tiledb_array_get_non_empty_domain_from_name.Rd
+++ b/man/tiledb_array_get_non_empty_domain_from_name.Rd
@@ -13,8 +13,8 @@ tiledb_array_get_non_empty_domain_from_name(arr, name)
 }
 \value{
 A two-element object is returned describing the domain of selected
-dimension; it will either be a numeric vector in case of a fixed-size
-fixed-sized dimensions, or a character vector for a variable-sized one.
+dimension; it will either be a numeric vector in case of a fixed-sized
+dimension or a character vector for a variable-sized one.
 }
 \description{
 This functions works for both fixed- and variable-sized dimensions and

--- a/man/tiledb_array_has_enumeration.Rd
+++ b/man/tiledb_array_has_enumeration.Rd
@@ -10,7 +10,7 @@ tiledb_array_has_enumeration(arr)
 \item{arr}{A TileDB Array object}
 }
 \value{
-A boolean indicating if the array has homogeneous domains
+A logical vector indicating which attribute has enumeration
 }
 \description{
 Check for Enumeration (aka Factor aka Dictionary)

--- a/man/tiledb_config.Rd
+++ b/man/tiledb_config.Rd
@@ -16,7 +16,7 @@ tiledb_config(config = NA_character_)
 Note that for actually setting persistent values, the (altered) config
 object needs to used to create (or update) the \code{tiledb_ctx} object. Similarly,
 to check whether values are set, one should use the \code{config} method
-of the of the \code{tiledb_ctx} object. Examples for this are
+of the \code{tiledb_ctx} object. Examples for this are
 \code{ctx <- tiledb_ctx(limitTileDBCores())} to use updated configuration values to
 create a context object, and \code{cfg <- config(ctx)} to retrieve it.
 }

--- a/man/tiledb_query_condition_combine.Rd
+++ b/man/tiledb_query_condition_combine.Rd
@@ -17,7 +17,7 @@ tiledb_query_condition_combine(lhs, rhs, op)
 The combined 'tiledb_query_condition' object
 }
 \description{
-Combines two query condition object using a relatiional operator. Support for operator
+Combines two query condition object using a relational operator. Support for operator
 'AND' is generally available, the 'OR' operator is available if TileDB 2.10 or newer is
 used.
 }

--- a/man/tiledb_query_condition_create.Rd
+++ b/man/tiledb_query_condition_create.Rd
@@ -12,10 +12,10 @@ tiledb_query_condition_create(
 )
 }
 \arguments{
-\item{name}{A character value with the scheme attribute name}
+\item{name}{A character value with attribute name}
 
-\item{values}{A vector wiith the given values, supported types are integer, double,
-integer64 and charactor}
+\item{values}{A vector with the given values, supported types are integer, double,
+integer64 and character}
 
 \item{op}{(optional) A character value with the chosen set operation, this must be one of
 \sQuote{IN} or \sQuote{NOT_IN}; default to \sQuote{IN}}

--- a/man/tiledb_query_condition_init.Rd
+++ b/man/tiledb_query_condition_init.Rd
@@ -13,7 +13,7 @@ tiledb_query_condition_init(
 )
 }
 \arguments{
-\item{attr}{A character value with the scheme attribute name}
+\item{attr}{A character value with the attribute name}
 
 \item{value}{A scalar value that the attribute is compared against}
 
@@ -31,7 +31,7 @@ The initialized 'tiledb_query_condition' object
 }
 \description{
 Initializes (and possibly allocates) a query condition object using a triplet of
-attribute name, comparison value, and operator.  Six types of conditions are supported,
+attribute name, comparison value, and operator. Six types of conditions are supported,
 they all take a single scalar comparison argument and attribute to compare against.
 At present only integer or numeric attribute comparisons are implemented.
 }

--- a/man/tiledb_query_condition_set_use_enumeration.Rd
+++ b/man/tiledb_query_condition_set_use_enumeration.Rd
@@ -22,5 +22,5 @@ context object is retrieved}
 Nothing is retuned, the function is invoked for the side effect
 }
 \description{
-Set a boolean toggle to signal use of enumeration in query condtion (TileDB 2.17 or later)
+Set a boolean toggle to signal use of enumeration in query condition (TileDB 2.17 or later)
 }


### PR DESCRIPTION
This PR  fixes an error message in `tiledb_array()` to reflect the right source ('selected_points' not 'selected_ranges').  Also, it cleans up various minor typos. 

``` r
library(tiledb)
df <- data.frame(key=letters[1:5], val=c(1:5))
uri <- tempfile()
fromDataFrame(df, uri, col_index = 1)

# selected_points accepts a vector but we passed a matrix
tiledb_array(uri, selected_points = list(key = cbind(0, 1)))[]
#> Error in validObject(.Object): invalid class "tiledb_array" object: Element '1' of 'selected_ranges' is not a vector.
                                                                                                 ^------------ Should be 'selected_points'
```
After
```
#> Error in validObject(.Object) : 
  invalid class “tiledb_array” object: Element '1' of 'selected_points' is not a vector.
```

