### PR TITLE
Fix `match.arg()`  in `tiledb_group_open`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tiledb
 Type: Package
-Version: 0.32.0.6
+Version: 0.32.0.7
 Title: Modern Database Engine for Complex Data Based on Multi-Dimensional Arrays
 Authors@R: c(
   person("TileDB, Inc.", role = c("aut", "cph")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,9 +3,14 @@
 ## Improvements
 
 * Schema-dump output is no longer truncated in the case that there are any null fill values in the schema (@johnkerl in [#825](https://github.com/TileDB-Inc/TileDB-R/pull/825))
+
 * `tiledb_attr()` now prints the attribute object as expected and documentation has been corrected (@cgiachalis in [#823](https://github.com/TileDB-Inc/TileDB-R/pull/823))
+
 * `tiledb_attr()` now works when setting `ncells=NA` to signal variable length (@johnkerl in [#830](https://github.com/TileDB-Inc/TileDB-R/pull/830))
-* `tiledb_array()` now emits the correct error message when using `selected_points` argument (@cgiachalis in [#833](https://github.com/TileDB-Inc/TileDB-R/issues/833)
+
+* `tiledb_array()` now emits the correct error message when using `selected_points` argument (@cgiachalis in [#833](https://github.com/TileDB-Inc/TileDB-R/issues/833))
+
+* `tiledb_group_open()` now respects and defaults to the first option in `type` argument (@cgiachalis in [#838](https://github.com/TileDB-Inc/TileDB-R/issues/838))
 
 ## Documentation
 

--- a/R/Group.R
+++ b/R/Group.R
@@ -33,7 +33,7 @@ setClass("tiledb_group",
 #' Creates a 'tiledb_group' object
 #'
 #' @param uri Character variable with the URI of the new group object
-#' @param type Character variable with the query type value: one of 
+#' @param type Character variable with the query type value: one of
 #' \dQuote{READ} or \dQuote{WRITE}
 #' @param ctx (optional) A TileDB Context object; if not supplied the default
 #' context object is retrieved
@@ -41,9 +41,9 @@ setClass("tiledb_group",
 #' @return A 'group' object
 #' @export
 tiledb_group <- function(
-  uri, 
+  uri,
   type = c("READ", "WRITE"),
-  ctx = tiledb_get_context(), 
+  ctx = tiledb_get_context(),
   cfg = NULL
 ) {
   stopifnot(
@@ -65,30 +65,30 @@ tiledb_group <- function(
 
 ##' Open a TileDB Group
 ##'
-##' @param grp A TileDB Group object as for example returned by 
+##' @param grp A TileDB Group object as for example returned by
 ##' \code{tiledb_group()}
-##' @param type A character value that must be either \sQuote{READ}, 
+##' @param type A character value that must be either \sQuote{READ},
 ##' \sQuote{WRITE} or \sQuote{MODIFY_EXCLUSIVE}
 ##' @return The TileDB Group object but opened for reading or writing
 ##' @export
 tiledb_group_open <- function(
-  grp, 
+  grp,
   type = c("READ", "WRITE", "MODIFY_EXCLUSIVE")
 ) {
+  type <- match.arg(type)
   stopifnot(
     "The 'grp' argument must be a tiledb_group object" = is(grp, "tiledb_group"),
     "This function needs TileDB 2.8.*" = .tiledb28(),
     "Using 'MODIFY_EXCLUSIVE' needs TileDB 2.12.* or later" =
       type != "MODIFY_EXCLUSIVE" || tiledb_version(TRUE) >= "2.12.0"
   )
-  type <- match.arg(type)
   grp@ptr <- libtiledb_group_open(grp@ptr, type)
   grp
 }
 
 ##' Set a TileDB Config for a TileDB Group
 ##'
-##' @param grp A TileDB Group object as for example returned by 
+##' @param grp A TileDB Group object as for example returned by
 ##' \code{tiledb_group()}
 ##' @param cfg A TileDB Config object
 ##' @return The TileDB Group object with added Config
@@ -105,7 +105,7 @@ tiledb_group_set_config <- function(grp, cfg) {
 
 ##' Get a TileDB Config from a TileDB Group
 ##'
-##' @param grp A TileDB Group object as for example returned by 
+##' @param grp A TileDB Group object as for example returned by
 ##' \code{tiledb_group()}
 ##' @return The TileDB Config object of the TileDB Group object
 ##' @export
@@ -121,7 +121,7 @@ tiledb_group_get_config <- function(grp) {
 
 ##' Close a TileDB Group
 ##'
-##' @param grp A TileDB Group object as for example returned by 
+##' @param grp A TileDB Group object as for example returned by
 ##' \code{tiledb_group()}
 ##' @return The TileDB Group object but closed for reading or writing
 ##' @export
@@ -162,7 +162,7 @@ tiledb_group_create <- function(uri, ctx = tiledb_get_context()) {
 
 ##' Test if TileDB Group is open
 ##'
-##' @param grp A TileDB Group object as for example returned by 
+##' @param grp A TileDB Group object as for example returned by
 ##' \code{tiledb_group()}
 ##' @return A boolean indicating whether the TileDB Group object is open
 ##' @export
@@ -176,7 +176,7 @@ tiledb_group_is_open <- function(grp) {
 
 ##' Return a TileDB Group URI
 ##'
-##' @param grp A TileDB Group object as for example returned by 
+##' @param grp A TileDB Group object as for example returned by
 ##' \code{tiledb_group()}
 ##' @return A character value with the URI
 ##' @export
@@ -190,9 +190,9 @@ tiledb_group_uri <- function(grp) {
 
 ##' Return a TileDB Group query type
 ##'
-##' @param grp A TileDB Group object as for example returned by 
+##' @param grp A TileDB Group object as for example returned by
 ##' \code{tiledb_group()}
-##' @return A character value with the query type i.e. one of 
+##' @return A character value with the query type i.e. one of
 ##' \dQuote{READ} or \dQuote{WRITE}.
 ##' @export
 tiledb_group_query_type <- function(grp) {
@@ -205,9 +205,9 @@ tiledb_group_query_type <- function(grp) {
 
 ##' Write Metadata to a TileDB Group
 ##'
-##' @param grp A TileDB Group object as for example returned by 
+##' @param grp A TileDB Group object as for example returned by
 ##' \code{tiledb_group()}
-##' @param key A character value with they index under which the 
+##' @param key A character value with they index under which the
 ##' data will be written
 ##' @param val An R object (numeric, int, or char vector) that will be stored
 ##' @return On success boolean \sQuote{TRUE} is returned
@@ -223,9 +223,9 @@ tiledb_group_put_metadata <- function(grp, key, val) {
 
 ##' Deletes Metadata from a TileDB Group
 ##'
-##' @param grp A TileDB Group object as for example returned by 
+##' @param grp A TileDB Group object as for example returned by
 ##' \code{tiledb_group()}
-##' @param key A character value with they index under which the 
+##' @param key A character value with they index under which the
 ##' data will be written
 ##' @return The TileDB Group object, invisibly
 ##' @export
@@ -241,9 +241,9 @@ tiledb_group_delete_metadata <- function(grp, key) {
 
 ##' Accesses Metadata from a TileDB Group
 ##'
-##' @param grp A TileDB Group object as for example returned by 
+##' @param grp A TileDB Group object as for example returned by
 ##' \code{tiledb_group()}
-##' @param key A character value with the key of the metadata 
+##' @param key A character value with the key of the metadata
 ##' object to be retrieved
 ##' @return The requested object, or NULL is not found
 ##' @export
@@ -258,9 +258,9 @@ tiledb_group_get_metadata <- function(grp, key) {
 
 ##' Checks for Metadata in a TileDB Group
 ##'
-##' @param grp A TileDB Group object as for example returned by 
+##' @param grp A TileDB Group object as for example returned by
 ##' \code{tiledb_group()}
-##' @param key A character value with they index under which the 
+##' @param key A character value with they index under which the
 ##' data will be written
 ##' @return A boolean value indicating with the object is present
 ##' @export
@@ -275,7 +275,7 @@ tiledb_group_has_metadata <- function(grp, key) {
 
 ##' Returns Number of Metadata Objects a TileDB Group
 ##'
-##' @param grp A TileDB Group object as for example returned by 
+##' @param grp A TileDB Group object as for example returned by
 ##' \code{tiledb_group()}
 ##' @return A numeric value with the number of metadata objects
 ##' @export
@@ -290,7 +290,7 @@ tiledb_group_metadata_num <- function(grp) {
 
 ##' Accesses Metadata by Index from a TileDB Group
 ##'
-##' @param grp A TileDB Group object as for example returned by 
+##' @param grp A TileDB Group object as for example returned by
 ##' \code{tiledb_group()}
 ##' @param idx A numeric value with the index of the metadata object to be retrieved
 ##' @return The requested object, or NULL is not found
@@ -307,7 +307,7 @@ tiledb_group_get_metadata_from_index <- function(grp, idx) {
 
 ##' Return all Metadata from a TileDB Group
 ##'
-##' @param grp A TileDB Group object as for example returned by 
+##' @param grp A TileDB Group object as for example returned by
 ##' \code{tiledb_group()}
 ##' @return A named List with all Metadata objects index
 ##' @export
@@ -329,12 +329,12 @@ tiledb_group_get_all_metadata <- function(grp) {
 
 ##' Add Member to TileDB Group
 ##'
-##' @param grp A TileDB Group object as for example returned by 
+##' @param grp A TileDB Group object as for example returned by
 ##' \code{tiledb_group()}
 ##' @param uri A character value with a new URI
-##' @param relative A logical value indicating whether URI is 
+##' @param relative A logical value indicating whether URI is
 ##' relative to the group
-##' @param name An optional character providing a name for the 
+##' @param name An optional character providing a name for the
 ##' object, defaults to \code{NULL}
 ##' @return The TileDB Group object, invisibly
 ##' @export
@@ -352,9 +352,9 @@ tiledb_group_add_member <- function(grp, uri, relative, name = NULL) {
 
 ##' Remove Member from TileDB Group
 ##'
-##' @param grp A TileDB Group object as for example returned by 
+##' @param grp A TileDB Group object as for example returned by
 ##' \code{tiledb_group()}
-##' @param uri A character value with a the URI of the member to 
+##' @param uri A character value with a the URI of the member to
 ##' be removed, or (if added with a name) the name of the member
 ##' @return The TileDB Group object, invisibly
 ##' @export
@@ -370,7 +370,7 @@ tiledb_group_remove_member <- function(grp, uri) {
 
 ##' Get Member Count from TileDB Group
 ##'
-##' @param grp A TileDB Group object as for example returned by 
+##' @param grp A TileDB Group object as for example returned by
 ##' \code{tiledb_group()}
 ##' @return The Count of Members in the TileDB Group object
 ##' @export
@@ -384,14 +384,14 @@ tiledb_group_member_count <- function(grp) {
 
 ##' Get a Member (Description) by Index from TileDB Group
 ##'
-##' This function returns a three-element character vector with the member 
+##' This function returns a three-element character vector with the member
 ##' object translated to character, uri, and optional name.
 ##'
-##' @param grp A TileDB Group object as for example returned by 
+##' @param grp A TileDB Group object as for example returned by
 ##' \code{tiledb_group()}
-##' @param idx A numeric value with the index of the metadata 
+##' @param idx A numeric value with the index of the metadata
 ##' object to be retrieved
-##' @return A character vector with three elements: the member 
+##' @return A character vector with three elements: the member
 ##' type, its uri, and name (or \code{""} if the member is unnamed).
 ##' @export
 tiledb_group_member <- function(grp, idx) {
@@ -405,10 +405,10 @@ tiledb_group_member <- function(grp, idx) {
 
 ##' Dump the TileDB Group to String
 ##'
-##' @param grp A TileDB Group object as for example returned by 
+##' @param grp A TileDB Group object as for example returned by
 ##' \code{tiledb_group()}
-##' @param recursive A logical value indicating whether a recursive 
-##' dump is desired, defaults to \sQuote{FALSE}. Note that recursive listings 
+##' @param recursive A logical value indicating whether a recursive
+##' dump is desired, defaults to \sQuote{FALSE}. Note that recursive listings
 ##' on remote object may be an expensive or slow operation.
 ##' @return A character string
 ##' @export
@@ -422,7 +422,7 @@ tiledb_group_member_dump <- function(grp, recursive = FALSE) {
 
 ##' Test if a Named Group is Using a Relative URI
 ##'
-##' @param grp A TileDB Group object as for example returned by 
+##' @param grp A TileDB Group object as for example returned by
 ##' \code{tiledb_group()}
 ##' @param name A character value with a group name
 ##' @return A boolean indicating whether the group uses a relative URI or not
@@ -447,10 +447,10 @@ setMethod("show", signature(object = "tiledb_group"), function(object) {
 
 #' Deletes all written data from a 'tiledb_group' object
 #'
-#' The group must be opened in \sQuote{MODIFY_EXCLUSIVE} mode, otherwise 
+#' The group must be opened in \sQuote{MODIFY_EXCLUSIVE} mode, otherwise
 #' the function will error out.
 #'
-#' @param grp A TileDB Group object as for example returned by 
+#' @param grp A TileDB Group object as for example returned by
 #' \code{tiledb_group()}
 #' @param uri Character variable with the URI of the group item to be deleted
 #' @param recursive A logical value indicating whether all data inside the


### PR DESCRIPTION
closes #779

### before:
```r
uri <- tempfile()
tiledb_group_create(uri)

grp <- tiledb_group(uri) # Defaults to READ
grp <- tiledb_group_close(grp)

tiledb_group_open(grp)   # Should default to READ
#> Error in type != "MODIFY_EXCLUSIVE" || tiledb_version(TRUE) >= "2.12.0": 'length = 3' in coercion to 'logical(1)'
```

### after:
```r
tiledb_group_open(grp)
#> filee887faf6ad3 GROUP
```