### PR TITLE
Use core 2.29.0

### DIFF
--- a/.github/workflows/valgrind.yaml
+++ b/.github/workflows/valgrind.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tag: [ release-2.26, release-2.27, release-2.28, main ]
+        tag: [ release-2.27, release-2.28, release-2.29, main ]
 
     steps:
     - name: Checkout

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tiledb
 Type: Package
-Version: 0.32.0.8
+Version: 0.32.0.9
 Title: Modern Database Engine for Complex Data Based on Multi-Dimensional Arrays
 Authors@R: c(
   person("TileDB, Inc.", role = c("aut", "cph")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # tiledb (development version)
 
+* This release of the R package builds against [TileDB 2.29.0](https://github.com/TileDB-Inc/TileDB/releases/tag/2.29.0), and has also been tested against earlier releases as well as the development version
+
 ## Improvements
 
 * Schema-dump output is no longer truncated in the case that there are any null fill values in the schema (@johnkerl in [#825](https://github.com/TileDB-Inc/TileDB-R/pull/825))

--- a/tools/tiledbVersion.txt
+++ b/tools/tiledbVersion.txt
@@ -1,2 +1,2 @@
-version: 2.28.0
-sha: 4764907
+version: 2.29.0
+sha: 958e736


### PR DESCRIPTION
Use [TileDB 2.29.0](https://github.com/TileDB-Inc/TileDB/releases/tag/2.29.0) and [rwinlib-tiledb 2.29.0](https://github.com/TileDB-Inc/rwinlib-tiledb/releases/tag/v2.29.0)

xref: https://github.com/TileDB-Inc/TileDB-R/pull/820, https://github.com/TileDB-Inc/rwinlib-tiledb/pull/4