### PR TITLE
TileDB-R 0.33.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tiledb
 Type: Package
-Version: 0.32.0.9
+Version: 0.33.0
 Title: Modern Database Engine for Complex Data Based on Multi-Dimensional Arrays
 Authors@R: c(
   person("TileDB, Inc.", role = c("aut", "cph")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# tiledb (development version)
+# tiledb 0.33.0
 
 * This release of the R package builds against [TileDB 2.29.0](https://github.com/TileDB-Inc/TileDB/releases/tag/2.29.0), and has also been tested against earlier releases as well as the development version
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The most recent released version can be installed from
     > remotes::install_github("TileDB-Inc/TileDB-R")
     ...
     > library(tiledb)
-    TileDB R 0.32.0 with TileDB Embedded 2.28.0 on Ubuntu 24.04.
+    TileDB R 0.33.0 with TileDB Embedded 2.29.0 on Ubuntu 24.04.
     See https://tiledb.com for more information about TileDB.
     > help(package=tiledb)
 

--- a/vignettes/tiledb-mariadb-examples.Rmd
+++ b/vignettes/tiledb-mariadb-examples.Rmd
@@ -14,7 +14,7 @@ title: TileDB and (R)MariaDB Examples
 
 [TileDB](https://www.tiledb.com/) provides the *Universal Data Engine*
 that can be accessed in a variety of ways. The C/C++ library offered by
-[TileDB Embedded](https://www.tiledb.com/embedded) is one approach, and
+[TileDB Embedded](https://github.com/TileDB-Inc/TileDB) is one approach, and
 the [R package](https://github.com/TileDB-Inc/TileDB-R), as well as the
 [Python package](https://github.com/TileDB-Inc/TileDB-Py) and other
 language bindings use it. Another interface is provided by the [MariaDB

--- a/vignettes/tiledb-mariadb-examples.md
+++ b/vignettes/tiledb-mariadb-examples.md
@@ -12,7 +12,7 @@ css: "water.css"
 
 [TileDB](https://www.tiledb.com/) provides the _Universal Data Engine_ that
 can be accessed in a variety of ways. The C/C++ library offered by [TileDB
-Embedded](https://www.tiledb.com/embedded) is one approach, and the [R
+Embedded](https://github.com/TileDB-Inc/TileDB) is one approach, and the [R
 package](https://github.com/TileDB-Inc/TileDB-R), as well as the [Python
 package](https://github.com/TileDB-Inc/TileDB-Py) and other language
 bindings use it. Another interface is provided by the [MariaDB Integration


### PR DESCRIPTION
Currently testing on the CRAN winbuilder service

I believe that `NEWS.md` is regularly updated as part of each PR. Here's the full [changelog since 0.32.0](https://github.com/TileDB-Inc/TileDB-R/compare/0.32.0...f7792f1a90d0c1ea5d20c3e53da0266742ad8dfe). Please let me know if anything is missing.

cc: @cgiachalis 
