### PR TITLE
Remove calling `libtiledb_query_get_buffer_ptr` twice

### DIFF
--- a/R/TileDBArray.R
+++ b/R/TileDBArray.R
@@ -1061,7 +1061,6 @@ setMethod(
               if (has_dumpbuffers) {
                 vecbuf_to_shmem(x@dumpbuffers, name, buf, estsz, varnum)
               }
-              libtiledb_query_get_buffer_ptr(buf, asint64)[seq_len(estsz)]
               spdl::debug("[getResult] calling libtiledb_query_get_buffer_ptr")
               col <- libtiledb_query_get_buffer_ptr(buf, asint64)[seq_len(estsz)]
               if (!is.null(dictionaries[[name]])) { # if there is a dictionary


### PR DESCRIPTION
The PR removes duplicate calling of   `libtiledb_query_get_buffer_ptr` in `tiledb_array`' s `[` method. This appears in the in-lined function `getResults` (buffer extraction). See lines - 1064-1066

https://github.com/cgiachalis/TileDB-R/blob/841d447095910ba60a9f71fc4d7759baaec81818/R/TileDBArray.R#L1064-L1066