### PR TITLE
Update test to no longer expect deprecated query type MODIFY_EXCLUSIVE

### DIFF
--- a/inst/tinytest/test_group.R
+++ b/inst/tinytest/test_group.R
@@ -198,7 +198,12 @@ grp <- tiledb_group_close(grp)
 
 grp <- tiledb_group_open(grp, "MODIFY_EXCLUSIVE")
 expect_true(tiledb_group_is_open(grp))
-expect_equal(tiledb_group_query_type(grp), "MODIFY_EXCLUSIVE")
+if (tiledb_version(TRUE) > "2.30.0") {
+  expect_equal(tiledb_group_query_type(grp), "WRITE")
+} else {
+  expect_equal(tiledb_group_query_type(grp), "MODIFY_EXCLUSIVE")
+}
+
 tiledb_group_delete(grp, uri)
 
 if (tiledb_version(TRUE) >= "2.16.0") expect_error(grp <- tiledb_group(uri))  # no longer exists


### PR DESCRIPTION
Closes https://github.com/TileDB-Inc/TileDB-R/issues/863
Closes https://github.com/TileDB-Inc/centralized-tiledb-nightlies/issues/62

xref: https://github.com/TileDB-Inc/TileDB/pull/5721

As a limited first step to accommodate the recent change to use `TILEDB_WRITE` instead of `TILEDB_MODIFY_EXCLUSIVE`, I updated the tests to fix the failing nightly builds. The nightly build [passed](https://github.com/jdblischak/TileDB-R/actions/runs/20863097419) on a manual trigger on my fork.