### PR TITLE
Migrate GitHub Actions to Node24

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,7 +22,7 @@ jobs:
     name: ${{ matrix.os }} (${{ matrix.r }})
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: System
         run: |

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -14,7 +14,7 @@ jobs:
     container:
       image: rocker/r2u:latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: SessionInfo
         run: Rscript -e 'sessionInfo()'
       - name: System Dependencies
@@ -38,7 +38,7 @@ jobs:
     needs: dev
     if: failure() || cancelled()
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Create Issue if Build Fails
         uses: TileDB-Inc/github-actions/open-issue@main
         with:

--- a/.github/workflows/pkgconfig.yaml
+++ b/.github/workflows/pkgconfig.yaml
@@ -39,7 +39,7 @@ jobs:
       _R_TILEDB_LIBTILEDB_: ${{ matrix.vendored }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: r-lib/actions/setup-pandoc@v2
 

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -24,7 +24,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: r-lib/actions/setup-pandoc@v2
       - uses: r-lib/actions/setup-r@v2
         with:
@@ -39,7 +39,7 @@ jobs:
         shell: Rscript {0}
       - name: Deploy to GitHub pages
         if: github.event_name != 'pull_request'
-        uses: JamesIves/github-pages-deploy-action@v4.5.0
+        uses: JamesIves/github-pages-deploy-action@v4.8.0
         with:
           clean: false
           branch: gh-pages

--- a/.github/workflows/valgrind.yaml
+++ b/.github/workflows/valgrind.yaml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Install Dependencies
       run: sudo tools/ci/valgrind/installDependencies.sh

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -16,7 +16,7 @@ jobs:
         ]
     steps:
       - run: git config --global core.autocrlf false
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.r }}


### PR DESCRIPTION
The deadline to migrate to Node24 is June 2026

https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/